### PR TITLE
Parse typedefs

### DIFF
--- a/hs-bindgen/app/HsBindgen/Cmdline.hs
+++ b/hs-bindgen/app/HsBindgen/Cmdline.hs
@@ -46,31 +46,47 @@ parseSpec = subparser $ mconcat [
     , cmd "parse" parseCmdParse $ mconcat [
           progDesc "Parse C header (primarily for debugging hs-bindgen itself)"
         ]
+    , cmd "dump" parseCmdDump $ mconcat [
+          progDesc "Dump the libclang AST (primarily for development of hs-bindgen itself)"
+        ]
     ]
 
 parseCmdProcess :: Parser (Spec (IO ()))
 parseCmdProcess =
     Preprocess
-      <$> parsePrepareInput
+      <$> parseParseCHeader
       <*> parseTranslation
       <*> parseProcessHsOutput
 
 parseCmdParse :: Parser (Spec (IO ()))
 parseCmdParse =
     Preprocess
-      <$> parsePrepareInput
-      <*> pure ParseOnly
+      <$> parseParseCHeader
+      <*> pure NoTranslation
       <*> parseProcessCOutput
+
+parseCmdDump :: Parser (Spec (IO ()))
+parseCmdDump =
+    Preprocess
+      <$> parseDumpClangAST
+      <*> pure NoTranslation
+      <*> pure NoOutput
 
 {-------------------------------------------------------------------------------
   Prepare input
 -------------------------------------------------------------------------------}
 
-parsePrepareInput :: Parser (PrepareInput CHeader)
-parsePrepareInput =
+parseParseCHeader :: Parser (PrepareInput CHeader)
+parseParseCHeader =
     ParseCHeader
       <$> parseTracer
       <*> parseClangArgs
+      <*> parseInput
+
+parseDumpClangAST :: Parser (PrepareInput ())
+parseDumpClangAST =
+    DumpClangAST
+      <$> parseClangArgs
       <*> parseInput
 
 parseTracer :: Parser (Tracer IO String)

--- a/hs-bindgen/clang-tutorial/Main.hs
+++ b/hs-bindgen/clang-tutorial/Main.hs
@@ -45,7 +45,7 @@ tutorial fp = do
 
         -- Extracting the Cursor kind
 
-        cursor_type        <- clang_getCursorType current_cursor;
+        cursor_type        <- clang_getCursorType current_cursor
         type_kind_spelling <- clang_getTypeKindSpelling (cxtKind cursor_type)
         putStrLn $ concat [
             "  "

--- a/hs-bindgen/examples/simple_structs.h
+++ b/hs-bindgen/examples/simple_structs.h
@@ -9,4 +9,9 @@ typedef struct S2 {
     char a; 
     int b;
     float c;
-} S2;
+} S2_t;
+
+// anonymous struct with typedef
+typedef struct {
+    char a;
+} S3_t;

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -7,23 +7,28 @@
 --
 -- > import HsBindgen.C.AST qualified as C
 module HsBindgen.C.AST (
+    -- * Top-level
     Header(..)
   , Decl(..)
+    -- * Structs
   , Struct(..)
   , StructField(..)
+    -- * Types
+  , Typ(..)
   , PrimType(..)
+  , Typedef(..)
   ) where
 
 import GHC.Generics (Generic)
 import Text.Show.Pretty (PrettyVal)
 
 {-------------------------------------------------------------------------------
-  Definition
+  Top-level
 -------------------------------------------------------------------------------}
 
 -- | C header
 data Header = Header {
-      decls :: [Decl]
+      headerDecls :: [Decl]
     }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
@@ -31,14 +36,20 @@ data Header = Header {
 -- | Top-level declaration
 data Decl =
     DeclStruct Struct
+  | DeclTypedef Typedef
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
 
+{-------------------------------------------------------------------------------
+  Structs
+-------------------------------------------------------------------------------}
+
 -- | Definition of a struct
 data Struct = Struct {
-      sizeof    :: Int
-    , alignment :: Int
-    , fields    :: [StructField]
+      structName      :: String
+    , structSizeof    :: Int
+    , structAlignment :: Int
+    , structFields    :: [StructField]
     }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
@@ -47,6 +58,27 @@ data StructField = StructField {
       fieldName :: String
     , fieldType :: PrimType
     }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (PrettyVal)
+
+{-------------------------------------------------------------------------------
+  Typedefs
+-------------------------------------------------------------------------------}
+
+data Typedef = Typedef {
+      typedefName :: String
+    , typedefType :: Typ
+    }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (PrettyVal)
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+data Typ =
+    TypPrim PrimType
+  | TypStruct Struct
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
 

--- a/hs-bindgen/src/HsBindgen/C/Clang.hs
+++ b/hs-bindgen/src/HsBindgen/C/Clang.hs
@@ -272,7 +272,6 @@ clang_equalCursors a b =
     withForeignPtr b $ \b' ->
       (/= 0) <$> clang_equalCursors' a' b'
 
-
 {-------------------------------------------------------------------------------
   Traversing the AST with cursors
 

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -3,10 +3,15 @@
 -- Intended for qualified import.
 --
 -- > import Hsbindgen.C.Parser qualified as C
-module HsBindgen.C.Parser (parseHeader) where
+module HsBindgen.C.Parser (
+    parseHeader
+  , dumpClangAST
+  ) where
 
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Char8 qualified as BS.Strict.Char8
+import Foreign
+import GHC.Stack
 
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Clang
@@ -23,33 +28,73 @@ import HsBindgen.C.Clang.Fold
 parseHeader ::
      Tracer IO LogMsg
   -> ClangArgs -> FilePath -> IO C.Header
-parseHeader tracer args fp = do
+parseHeader tracer args fp =
+    C.Header <$> parseHeaderWith args fp (foldTopLevel tracer)
+
+parseHeaderWith ::
+     ClangArgs
+  -> FilePath
+  -> Fold a
+  -> IO [a]
+parseHeaderWith args fp fold = do
     index  <- clang_createIndex DontDisplayDiagnostics
     unit   <- clang_parseTranslationUnit index fp args flags
     cursor <- clang_getTranslationUnitCursor unit
 
-    C.Header <$> clang_fold cursor (topLevel tracer)
+    clang_fold cursor fold
   where
     flags :: CXTranslationUnit_Flags
     flags = bitfieldEnum [
           CXTranslationUnit_SkipFunctionBodies
         ]
 
-topLevel :: Tracer IO LogMsg -> Fold C.Decl
-topLevel tracer current = do
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+foldTopLevel :: Tracer IO LogMsg -> Fold C.Decl
+foldTopLevel tracer current = do
     cursorType <- clang_getCursorType current
     case fromSimpleEnum $ cxtKind cursorType of
       Right CXType_Record -> do
-        sizeof    <- fromIntegral <$> clang_Type_getSizeOf  cursorType
-        alignment <- fromIntegral <$> clang_Type_getAlignOf cursorType
-        let decl fields = C.DeclStruct C.Struct{sizeof, alignment, fields}
-        return $ Recurse (structFields tracer) (return . decl)
+        mkStruct <- parseStruct current
+        let mkDecl :: [C.StructField] -> IO (Maybe C.Decl)
+            mkDecl = return . Just . C.DeclStruct . mkStruct
+        return $ Recurse (foldStructFields tracer) mkDecl
+      Right CXType_Typedef -> do
+        mkTypedef <- parseTypedef current
+        let mkDecl :: [C.Typ] -> IO (Maybe C.Decl)
+            mkDecl [typ] = return $ Just (C.DeclTypedef $ mkTypedef typ)
+            mkDecl types = error $ "mkTypedef: unexpected " ++ show types
+        return $ Recurse (foldTyp tracer) mkDecl
       _otherwise -> do
-        traceWith tracer Warning $ Skipping (cxtKind cursorType)
+        traceWith tracer Warning $ Skipping callStack (cxtKind cursorType)
         return $ Continue Nothing
 
-structFields :: Tracer IO LogMsg -> Fold C.StructField
-structFields tracer current = do
+{-------------------------------------------------------------------------------
+  Structs
+-------------------------------------------------------------------------------}
+
+-- | Parse struct
+--
+-- Implementation note: It seems libclang will give us a name for the struct if
+-- the struct it a tag, but also when it's anonymous but the surrounding typedef
+-- has a name.
+parseStruct :: ForeignPtr CXCursor -> IO ([C.StructField] -> C.Struct)
+parseStruct current = do
+    cursorType      <- clang_getCursorType current
+    structName      <- decodeString <$> clang_getCursorDisplayName current
+    structSizeof    <- fromIntegral <$> clang_Type_getSizeOf  cursorType
+    structAlignment <- fromIntegral <$> clang_Type_getAlignOf cursorType
+    return $ \structFields -> C.Struct{
+        structName
+      , structSizeof
+      , structAlignment
+      , structFields
+      }
+
+foldStructFields :: Tracer IO LogMsg -> Fold C.StructField
+foldStructFields tracer current = do
     cursorType <- clang_getCursorType current
     case primType $ cxtKind cursorType of
       Just fieldType -> do
@@ -57,7 +102,32 @@ structFields tracer current = do
         let field = C.StructField{fieldName, fieldType}
         return $ Continue (Just field)
       _otherwise -> do
-        traceWith tracer Warning $ UnrecognizedStructField (cxtKind cursorType)
+        traceWith tracer Warning $ Skipping callStack (cxtKind cursorType)
+        return $ Continue Nothing
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+parseTypedef :: ForeignPtr CXCursor -> IO (C.Typ -> C.Typedef)
+parseTypedef current = do
+    typedefName <- decodeString <$> clang_getCursorDisplayName current
+    return $ \typedefType -> C.Typedef{
+          typedefName
+        , typedefType
+        }
+
+foldTyp :: Tracer IO LogMsg -> Fold C.Typ
+foldTyp tracer current = do
+    cursorType <- clang_getCursorType current
+    case fromSimpleEnum $ cxtKind cursorType of
+      Right CXType_Record -> do
+        mkStruct <- parseStruct current
+        let mkDecl :: [C.StructField] -> IO (Maybe C.Typ)
+            mkDecl = return . Just . C.TypStruct . mkStruct
+        return $ Recurse (foldStructFields tracer) mkDecl
+      _otherwise -> do
+        traceWith tracer Warning $ Skipping callStack (cxtKind cursorType)
         return $ Continue Nothing
 
 primType :: SimpleEnum CXTypeKind -> Maybe C.PrimType
@@ -69,8 +139,58 @@ primType = either (const Nothing) aux . fromSimpleEnum
     aux CXType_Float  = Just C.PrimFloat
     aux _             = Nothing
 
+{-------------------------------------------------------------------------------
+  Debugging
+-------------------------------------------------------------------------------}
+
+-- | Parse C header
+dumpClangAST :: ClangArgs -> FilePath -> IO ()
+dumpClangAST args fp = const () <$> parseHeaderWith args fp foldDumpAST
+
+-- | Fold that simply tries to dump the @libclang@ AST to the console
+--
+-- We can use this at the top-level in 'dumpClangAST', but it is also useful
+-- more locally when trying to figure out what the ATS looks like underneath
+-- a certain node. For example, suppose we are working on `foldTyp`, and we're
+-- not exactly sure what the @struct@ case looks like; we might temporarily use
+--
+-- > foldTyp :: Tracer IO LogMsg -> Fold C.Typ
+-- > foldTyp tracer current = do
+-- >     cursorType <- clang_getCursorType current
+-- >     case fromSimpleEnum $ cxtKind cursorType of
+-- >       Right CXType_Record -> do
+-- >         return $ recurse_ foldDumpAST
+--
+-- to see the AST under the @struct@ parent node.
+foldDumpAST :: Fold ()
+foldDumpAST = go 0
+  where
+    go :: Int -> Fold ()
+    go n current = do
+        displayName <- clang_getCursorDisplayName current
+        cursorType  <- clang_getCursorType current
+        typeKind    <- clang_getTypeKindSpelling (cxtKind cursorType)
+
+        putStrLn $ mconcat [
+            replicate (n * 2) ' '
+          , show displayName
+          , " :: "
+          , show typeKind
+          ]
+
+        return $ recurse_ (go (n + 1))
+
+{-------------------------------------------------------------------------------
+  Auxiliary: strings
+-------------------------------------------------------------------------------}
+
+-- | Decode string
+--
 -- TODO: <https://github.com/well-typed/hs-bindgen/issues/87>
 -- Deal with file encodings other than ASCII
+--
+-- TODO: <https://github.com/well-typed/hs-bindgen/issues/96>
+-- We could consider trying to deduplicate.
 decodeString :: Strict.ByteString -> String
 decodeString = BS.Strict.Char8.unpack
 
@@ -80,13 +200,8 @@ decodeString = BS.Strict.Char8.unpack
 
 data LogMsg =
     -- | We skipped over an element in the Clang AST we did not recognize
-    Skipping (SimpleEnum CXTypeKind)
-
-    -- | Struct contained an element we did not recognize
-  | UnrecognizedStructField (SimpleEnum CXTypeKind)
+    Skipping CallStack (SimpleEnum CXTypeKind)
 
 instance PrettyLogMsg LogMsg where
-  prettyLogMsg (Skipping kind) =
-    "Unrecognized top-level declaration: " ++ show kind
-  prettyLogMsg (UnrecognizedStructField kind) =
-    "Unrecognized struct field: " ++ show kind
+  prettyLogMsg (Skipping cs kind) =
+    "Skipping over " ++ show kind ++ " at " ++ prettyCallStack cs

--- a/hs-bindgen/src/HsBindgen/Spec.hs
+++ b/hs-bindgen/src/HsBindgen/Spec.hs
@@ -59,9 +59,22 @@ data Spec result where
 -------------------------------------------------------------------------------}
 
 data PrepareInput inp where
+  -- | Parse C header
+  --
+  -- This is the main way in which we prepare the input.
   ParseCHeader ::
        Tracer IO String
-    -> ClangArgs -> FilePath -> PrepareInput C.Header
+    -> ClangArgs
+    -> FilePath
+    -> PrepareInput C.Header
+
+  -- | Just dump the @libclang@ AST
+  --
+  -- Used only for development of @hs-bindgen@.
+  DumpClangAST ::
+       ClangArgs
+    -> FilePath
+    -> PrepareInput ()
 
 -- | @libclang@ command line arguments
 --
@@ -75,9 +88,9 @@ type ClangArgs = [String]
 -------------------------------------------------------------------------------}
 
 data Translation inp out where
-  ParseOnly  :: Translation C.Header C.Header
-  GenDecls   :: Translation C.Header [Hs.Decl Ann]
-  GenModule  :: HsModuleOpts -> Translation C.Header (Hs.Module Ann)
+  NoTranslation :: Translation a a
+  GenDecls      :: Translation C.Header [Hs.Decl Ann]
+  GenModule     :: HsModuleOpts -> Translation C.Header (Hs.Module Ann)
 
 data HsModuleOpts = HsModuleOpts {
       hsModuleName :: String
@@ -91,5 +104,6 @@ data HsModuleOpts = HsModuleOpts {
 -------------------------------------------------------------------------------}
 
 data ProcessOutput out where
+  NoOutput :: ProcessOutput ()
   PrettyC  :: ProcessOutput C.Header
   PrettyHs :: HsRenderOpts -> Maybe FilePath -> ProcessOutput (Hs.Module Ann)

--- a/hs-bindgen/src/HsBindgen/Spec/Execution.hs
+++ b/hs-bindgen/src/HsBindgen/Spec/Execution.hs
@@ -29,14 +29,16 @@ execSpec (GenSplice a b) = liftIO $
 prepareInput :: PrepareInput inp -> IO inp
 prepareInput (ParseCHeader tracer clangArgs fp) =
     C.parseHeader (contramap prettyLogMsg tracer) clangArgs fp
+prepareInput (DumpClangAST clangArgs fp) =
+    C.dumpClangAST clangArgs fp
 
 {-------------------------------------------------------------------------------
   Main mode
 -------------------------------------------------------------------------------}
 
 translate :: Translation inp out -> inp -> out
-translate ParseOnly        = id
-translate GenDecls         = generateDeclarations . C.decls
+translate NoTranslation    = id
+translate GenDecls         = generateDeclarations . C.headerDecls
 translate (GenModule opts) = generateModule opts
 
 {-------------------------------------------------------------------------------
@@ -46,3 +48,4 @@ translate (GenModule opts) = generateModule opts
 processOutput :: ProcessOutput out -> out -> IO ()
 processOutput PrettyC            = Pretty.dumpIO
 processOutput (PrettyHs opts fp) = Hs.renderIO opts fp
+processOutput NoOutput           = return


### PR DESCRIPTION
Also add a `dump` command line option for dumping the raw clang AST, and a small bugfix to the folding infrastructure (we weren't popping the stack at the end, thereby not processing all intermediate results).