### PR TITLE
Issue #83: Better API for libclang command line arguments

### DIFF
--- a/hs-bindgen/app/HsBindgen/Cmdline.hs
+++ b/hs-bindgen/app/HsBindgen/Cmdline.hs
@@ -4,6 +4,7 @@ module HsBindgen.Cmdline (
   ) where
 
 import Data.Default
+import Data.Void (Void)
 import Options.Applicative
 
 import HsBindgen.Lib
@@ -102,10 +103,13 @@ parseVerbosity =
 
 parseClangArgs :: Parser ClangArgs
 parseClangArgs =
-    many $ strOption $ mconcat [
+    many $ option parseClangArg $ mconcat [
         long "clang-option"
       , help "Pass option to libclang"
       ]
+  where
+    parseClangArg :: ReadM Void
+    parseClangArg = maybeReader (\_ -> Nothing)
 
 parseInput :: Parser FilePath
 parseInput =

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -38,7 +38,7 @@ parseHeaderWith ::
   -> IO [a]
 parseHeaderWith args fp fold = do
     index  <- clang_createIndex DontDisplayDiagnostics
-    unit   <- clang_parseTranslationUnit index fp args flags
+    unit   <- clang_parseTranslationUnit index fp (prettyClangArgs args) flags
     cursor <- clang_getTranslationUnitCursor unit
 
     clang_fold cursor fold

--- a/hs-bindgen/src/HsBindgen/Spec.hs
+++ b/hs-bindgen/src/HsBindgen/Spec.hs
@@ -12,6 +12,7 @@ module HsBindgen.Spec (
     -- * Prepare input
   , PrepareInput(..)
   , ClangArgs
+  , prettyClangArgs
     -- * Translate
   , Translation(..)
   , HsModuleOpts(..)
@@ -20,6 +21,7 @@ module HsBindgen.Spec (
   , HsRenderOpts(..)
   ) where
 
+import Data.Void (Void, absurd)
 import Language.Haskell.Exts qualified as Hs
 import Language.Haskell.TH (Q)
 import Language.Haskell.TH qualified as TH
@@ -79,9 +81,15 @@ data PrepareInput inp where
 -- | @libclang@ command line arguments
 --
 -- TODO: <https://github.com/well-typed/hs-bindgen/issues/83>
--- We should have a proper data type instead of @[String]@ for the arguments
+-- We should have a proper data type instead of @[Void]@ for the arguments
 -- (part of #10 and #71).
-type ClangArgs = [String]
+--
+-- Currently there are no use for them, so [Void] ~ () works well.
+type ClangArgs = [Void]
+
+-- | Translate clang arguments to arguments passed to the library
+prettyClangArgs :: ClangArgs -> [String]
+prettyClangArgs = map absurd
 
 {-------------------------------------------------------------------------------
   Translation (this should be a pure function)


### PR DESCRIPTION
Technically this solves #83, as nothing breaks.

I think we should have some tests first. `tasty-golden` seems like a good idea.