### PR TITLE
Make clang-tutorial into test-suite

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,3 @@
 packages: hs-bindgen-patterns
 packages: hs-bindgen
 packages: hs-bindgen-libclang
-
-package hs-bindgen-libclang
-  flags: +build-clang-tutorial

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -3,7 +3,6 @@ packages: hs-bindgen
 packages: hs-bindgen-libclang
 
 package hs-bindgen-libclang
-  flags: +build-clang-tutorial
   ghc-options: -Werror
 
 package hs-bindgen

--- a/hs-bindgen-libclang/clang-tutorial/clang-tutorial.hs
+++ b/hs-bindgen-libclang/clang-tutorial/clang-tutorial.hs
@@ -93,5 +93,7 @@ tutorial fp = do
 
 main :: IO ()
 main = do
-    [fp] <- getArgs
-    tutorial fp
+    args <- getArgs
+    case args of
+        fp : _ -> tutorial fp
+        _      -> return ()

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -58,20 +58,13 @@ library
   include-dirs: cbits
   cc-options:   -Wall
 
-executable clang-tutorial
+test-suite clang-tutorial
   import:         lang
-  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
+  main-is:        clang-tutorial.hs
   hs-source-dirs: clang-tutorial
 
   build-depends:
       -- Internal dependencies
     , hs-bindgen-libclang
     , hs-bindgen-patterns
-
-  if !flag(build-clang-tutorial)
-    buildable: False
-
-flag build-clang-tutorial
-  description: Build the CLang tutorial (this is for internal debugging only)
-  default: False
-  manual: True


### PR DESCRIPTION
This is pattern I use often, make example executables into test-suites. This way they are not affecting cabal-install solver, so we don't need a flag. We only need to make sure they do something sensible without any arguments.

Another pattern I use is to name executable entry points as `executable.hs` (i.e. not `Main.hs`); as it's easy to end up with dozens of `Main.hs` files.