### PR TITLE
Basic comment parsing support

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -52,6 +52,19 @@ CXString* wrap_malloc_getCursorSpelling(CXCursor* cursor) {
     return result;
 }
 
+CXString* wrap_malloc_Cursor_getRawCommentText(CXCursor* C) {
+    CXString* result = malloc(sizeof(CXString));
+    *result = clang_Cursor_getRawCommentText(*C);
+    return result;
+}
+
+CXString* wrap_malloc_Cursor_getBriefCommentText(CXCursor* C) {
+    CXString* result = malloc(sizeof(CXString));
+    *result = clang_Cursor_getBriefCommentText(*C);
+    return result;
+}
+
+
 /**
  * Type information for CXCursors
  */

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -31,6 +31,8 @@ unsigned wrap_malloc_visitChildren(CXCursor* parent, HsCXCursorVisitor visitor);
 
 CXString* wrap_malloc_getCursorDisplayName(CXCursor* cursor);
 CXString* wrap_malloc_getCursorSpelling(CXCursor* cursor);
+CXString* wrap_malloc_Cursor_getRawCommentText(CXCursor* C);
+CXString* wrap_malloc_Cursor_getBriefCommentText(CXCursor* C);
 
 /**
  * Type information for CXCursors

--- a/hs-bindgen-libclang/src/HsBindgen/C/Clang/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/C/Clang/Enums.hs
@@ -95,7 +95,7 @@ data CXTranslationUnit_Flag =
     -- | Sets the preprocessor in a mode for parsing a single file only.
   | CXTranslationUnit_SingleFileParse
 
-    -- | Used in combination with CXTranslationUnit_SkipFunctionBodies to
+    -- | Used in combination with 'CXTranslationUnit_SkipFunctionBodies' to
     -- constrain the skipping of function bodies to the preamble.
     --
     -- The function bodies of the main file are not skipped.

--- a/hs-bindgen/app/Main.hs
+++ b/hs-bindgen/app/Main.hs
@@ -20,5 +20,6 @@ main = do
         preprocess tracer clangArgs input moduleOpts renderOpts output
       ParseCHeader{input} ->
         prettyC =<< parseCHeader tracer clangArgs input
-      ShowClangAST{input} ->
-        putStr . drawForest =<< showClangAST clangArgs input
+      ShowClangAST{input} -> do
+        ast <- getClangAST clangArgs input
+        putStr . drawForest $ fmap (fmap show) ast

--- a/hs-bindgen/examples/comments.h
+++ b/hs-bindgen/examples/comments.h
@@ -1,0 +1,18 @@
+/**
+ * A struct with a Doxygen comment
+ */
+struct S4 {
+    /**
+     * A field preceded by a Doxygen comment
+     */
+    char a;
+
+    int b; /**< A field followed by a Doxygen comment */
+
+    /**
+     * A field that refers to another field
+     *
+     * See also @ref S4::a
+     */
+    float c;
+};

--- a/hs-bindgen/examples/simple_structs.h
+++ b/hs-bindgen/examples/simple_structs.h
@@ -6,7 +6,7 @@ struct S1 {
 
 // struct with typedef
 typedef struct S2 {
-    char a; 
+    char a;
     int b;
     float c;
 } S2_t;

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -18,7 +18,6 @@ module HsBindgen.Lib (
   , ParseMsg  -- opaque
   , ClangArgs
   , parseCHeader
-  , showClangAST
 
     -- * Translation
   , HsModuleOpts(..)
@@ -33,6 +32,10 @@ module HsBindgen.Lib (
 
     -- * Common pipelines
   , preprocess
+
+    -- * Debugging
+  , Element(..)
+  , getClangAST
 
     -- * Logging
   , Tracer
@@ -49,7 +52,7 @@ import Text.Show.Pretty qualified as Pretty
 
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Clang.Args
-import HsBindgen.C.Parser (ParseMsg)
+import HsBindgen.C.Parser (ParseMsg, Element(..))
 import HsBindgen.C.Parser qualified as C
 import HsBindgen.Hs.Annotation
 import HsBindgen.Hs.Render (HsRenderOpts(..))
@@ -93,12 +96,6 @@ parseCHeader ::
 parseCHeader tracer args fp =
     WrapCHeader . C.Header <$> C.parseHeaderWith args fp (C.foldDecls tracer)
 
--- | Show the raw @libclang@ AST
---
--- This is primarily for debugging.
-showClangAST :: ClangArgs -> FilePath -> IO (Forest String)
-showClangAST args fp = C.parseHeaderWith args fp C.foldShowAST
-
 {-------------------------------------------------------------------------------
   Translation
 -------------------------------------------------------------------------------}
@@ -137,4 +134,14 @@ preprocess ::
 preprocess tracer clangArgs inp modOpts renderOpts out = do
     modl <- genModule modOpts <$> parseCHeader tracer clangArgs inp
     prettyHs renderOpts out modl
+
+{-------------------------------------------------------------------------------
+  Debugging
+-------------------------------------------------------------------------------}
+
+-- | Show the raw @libclang@ AST
+--
+-- This is primarily for debugging.
+getClangAST :: ClangArgs -> FilePath -> IO (Forest Element)
+getClangAST args fp = C.parseHeaderWith args fp C.foldClangAST
 

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -16,17 +16,25 @@ main = do
         [ goldenVsStringDiff "simple_structs" diff "fixtures/simple_structs.dump.txt" $ do
             let fp = "examples/simple_structs.h"
                 args = []
-            res <- showClangAST args fp
+            res <- getClangAST args fp
 
             return $ LBS8.pack $ unlines $ concatMap treeToLines res
         ]
   where
     diff ref new = ["diff", "-u", ref, new]
 
-treeToLines :: Tree String -> [String]
+treeToLines :: Tree Element -> [String]
 treeToLines tree = go 0 tree [] where
-    go :: Int -> Tree String -> [String] -> [String]
-    go !n (Node l xs) next = (replicate (n * 2) ' ' ++ l) : foldr (go (n + 1)) next xs
+    go :: Int -> Tree Element -> [String] -> [String]
+    go !n (Node l xs) next = (replicate (n * 2) ' ' ++ showElem l) : foldr (go (n + 1)) next xs
+
+showElem :: Element -> [Char]
+showElem Element{elementDisplayName, elementTypeKindSpelling} = mconcat [
+      show elementDisplayName
+    , " :: "
+    , show elementTypeKindSpelling
+    ]
+
 
 -- | In multi-package projects @cabal run test-suite@ will run the test-suite
 -- from your current working directory (e.g. project root), which is often


### PR DESCRIPTION
We can probably do better than this for Doxygen specifically.

@phadej The fold that returns the raw `libclang` AST now returns a `Forest Element`, where `Element` is defined as

```haskell
data Element = Element {
      elementDisplayName      :: Strict.ByteString
    , elementTypeKind         :: SimpleEnum CXTypeKind
    , elementTypeKindSpelling :: Strict.ByteString
    , elementRawComment       :: Strict.ByteString
    , elementBriefComment     :: Strict.ByteString
    }
  deriving (Show)
```

I've added a `showElem` function to the golden tests that recovers the existing output, so the `fixtures` are not (yet) updated.