### PR TITLE
Add a non-linux simple CI workflow

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -1,0 +1,92 @@
+# Simple CI for non-linux setups
+name: Simple
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  native:
+    name: "Simple: GHC ${{ matrix.ghc }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        ghc: ['9.2.8']
+      fail-fast: false
+    timeout-minutes:
+      60
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: '3.12.1.0'
+
+      - name: ghc-pkg dump
+        run: ghc-pkg list
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14"
+          directory: ${{ runner.temp }}/llvm
+          env: false
+
+      - name: Debug
+        shell: bash
+        run: echo "$LLVM_PATH"
+
+      - name: Debug2
+        shell: bash
+        run: ls "$LLVM_PATH"
+
+      - name: Debug3
+        shell: bash
+        run: ls "$LLVM_PATH/bin"
+
+      - name: LLVM_CONFIG
+        shell: bash
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: echo "LLVM_CONFIG=$LLVM_PATH/bin/llvm-config" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: cabal.project
+        run: cp cabal.project.ci cabal.project
+
+      - name: Dry build (for cache key)
+        run: cabal build all --enable-tests --dry-run
+
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dist-newstyle/cache/plan.json') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+
+      - name: Dependencies
+        run: cabal build all --enable-tests --only-dependencies
+
+      - name: Build
+        run: cabal build all --enable-tests
+
+      - name: Test
+        run: cabal test all --enable-tests --test-show-details=direct
+
+      - name: Save cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dist-newstyle/cache/plan.json') }}
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}

--- a/hs-bindgen-libclang/configure
+++ b/hs-bindgen-libclang/configure
@@ -649,6 +649,7 @@ LIBOBJS
 HS_BINDGEN_INCLUDEDIR
 HS_BINDGEN_LIBDIR
 HS_BINDGEN_EXTRA_LIBS
+LLVM_PATH
 LLVM_CONFIG
 OBJEXT
 EXEEXT
@@ -707,7 +708,9 @@ CC
 CFLAGS
 LDFLAGS
 LIBS
-CPPFLAGS'
+CPPFLAGS
+LLVM_CONFIG
+LLVM_PATH'
 
 
 # Initialize some variables set by options.
@@ -1331,6 +1334,8 @@ Some influential environment variables:
   LIBS        libraries to pass to the linker, e.g. -l<library>
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
+  LLVM_CONFIG Location of llvm-config
+  LLVM_PATH   Location of LLVM installation
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -3209,6 +3214,11 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+
+
+
+
+
 # Extract the first word of "llvm-config", so it can be a program name with args.
 set dummy llvm-config; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -3254,27 +3264,56 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-if test ! -x "$LLVM_CONFIG"; then
-  as_fn_error $? "Could not find llvm-config" "$LINENO" 5
+if test -z "$LLVM_CONFIG"; then
+  if test -z "$LLVM_PATH"; then
+    as_fn_error $? "could not find llvm-config" "$LINENO" 5
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: could not find llvm-config; using LLVM_PATH=$LLVM_PATH" >&5
+printf "%s\n" "$as_me: could not find llvm-config; using LLVM_PATH=$LLVM_PATH" >&6;}
+  fi
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM version" >&5
+printf %s "checking LLVM version... " >&6; }
 
-# TODO: Use https://www.gnu.org/software/autoconf-archive/ax_compare_version.html
-# to compare version
+if test -z "$LLVM_CONFIG"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipped" >&5
+printf "%s\n" "skipped" >&6; }
+else
+LLVM_VERSION="$("$LLVM_CONFIG" --version)"
+if test $? == 0; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LLVM_VERSION" >&5
+printf "%s\n" "$LLVM_VERSION" >&6; }
+  else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: error" >&5
+printf "%s\n" "error" >&6; }
+  as_fn_error $? "could not run llvm-config" "$LINENO" 5
+fi
+fi
+
 
 HS_BINDGEN_EXTRA_LIBS="clang"
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM library directory" >&5
 printf %s "checking LLVM library directory... " >&6; }
-HS_BINDGEN_LIBDIR=$(llvm-config --libdir)
+if test -z "$LLVM_CONFIG"; then
+HS_BINDGEN_LIBDIR="$LLVM_PATH/lib"
+else
+HS_BINDGEN_LIBDIR="$("$LLVM_CONFIG" --libdir)";
+fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $HS_BINDGEN_LIBDIR" >&5
 printf "%s\n" "$HS_BINDGEN_LIBDIR" >&6; }
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM include directory" >&5
 printf %s "checking LLVM include directory... " >&6; }
-HS_BINDGEN_INCLUDEDIR=$(llvm-config --includedir)
+if test -z "$LLVM_CONFIG"; then
+HS_BINDGEN_INCLUDEDIR="$LLVM_PATH/include"
+else
+HS_BINDGEN_INCLUDEDIR="$("$LLVM_CONFIG" --includedir)"
+fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $HS_BINDGEN_INCLUDEDIR" >&5
 printf "%s\n" "$HS_BINDGEN_INCLUDEDIR" >&6; }
+
 
 LIBS="$LIBS -l$HS_BINDGEN_EXTRA_LIBS"
 LDFLAGS="$LDFLAGS -L$HS_BINDGEN_LIBDIR"
@@ -3362,6 +3401,7 @@ then :
 else $as_nop
   as_fn_error $? "Cannot link against libclang" "$LINENO" 5
 fi
+
 
 
 

--- a/hs-bindgen-libclang/configure.ac
+++ b/hs-bindgen-libclang/configure.ac
@@ -3,30 +3,72 @@ AC_INIT([hs-bindgen-libclang],[0.1.0])
 AC_CONFIG_MACRO_DIRS([m4])
 
 AC_PROG_CC
+
+dnl The discovery logic is following
+dnl * look for llvm-config (LLVM_CONFIG if set, in PATH otherwise)
+dnl * if not found
+dnl   - if LLVM_PATH is set, use it (skip version check)
+dnl   - otherwise fail.
+
+AC_ARG_VAR(LLVM_CONFIG, [Location of llvm-config])
+AC_ARG_VAR(LLVM_PATH, [Location of LLVM installation])
+
 AC_PATH_PROG([LLVM_CONFIG],[llvm-config],[])
-if test ! -x "$LLVM_CONFIG"; then
-  AC_MSG_ERROR([Could not find llvm-config])
+if test -z "$LLVM_CONFIG"; then
+  if test -z "$LLVM_PATH"; then
+    AC_MSG_ERROR([could not find llvm-config])
+  else
+    AC_MSG_NOTICE([could not find llvm-config; using LLVM_PATH=$LLVM_PATH])
+  fi
 fi
 
-# TODO: Use https://www.gnu.org/software/autoconf-archive/ax_compare_version.html
-# to compare version
+dnl This also checks that we can run LLVM_CONFIG
+AC_MSG_CHECKING([LLVM version])
+
+if test -z "$LLVM_CONFIG"; then
+  AC_MSG_RESULT([skipped])
+else
+LLVM_VERSION="$("$LLVM_CONFIG" --version)"
+if test $? == 0; then
+  AC_MSG_RESULT([$LLVM_VERSION])
+  dnl TODO: Use https://www.gnu.org/software/autoconf-archive/ax_compare_version.html to compare version
+else
+  AC_MSG_RESULT([error])
+  AC_MSG_ERROR([could not run llvm-config])
+fi
+fi
+
+dnl LIBS/LIBDIR/INCLUDEDIR
 
 HS_BINDGEN_EXTRA_LIBS="clang"
 
 AC_MSG_CHECKING([LLVM library directory])
-HS_BINDGEN_LIBDIR=$(llvm-config --libdir)
+if test -z "$LLVM_CONFIG"; then
+HS_BINDGEN_LIBDIR="$LLVM_PATH/lib"
+else
+HS_BINDGEN_LIBDIR="$("$LLVM_CONFIG" --libdir)";
+fi
 AC_MSG_RESULT($HS_BINDGEN_LIBDIR)
 
 AC_MSG_CHECKING([LLVM include directory])
-HS_BINDGEN_INCLUDEDIR=$(llvm-config --includedir)
+if test -z "$LLVM_CONFIG"; then
+HS_BINDGEN_INCLUDEDIR="$LLVM_PATH/include"
+else
+HS_BINDGEN_INCLUDEDIR="$("$LLVM_CONFIG" --includedir)"
+fi
 AC_MSG_RESULT($HS_BINDGEN_INCLUDEDIR)
 
+dnl Runtime checks
+
+dnl Set some C related environment variables for further tests
 LIBS="$LIBS -l$HS_BINDGEN_EXTRA_LIBS"
 LDFLAGS="$LDFLAGS -L$HS_BINDGEN_LIBDIR"
 CPPFLAGS="$CPPFLAGS -I$HS_BINDGEN_INCLUDEDIR"
 
 AC_CHECK_HEADER([clang-c/Index.h],[],[AC_MSG_ERROR([Cannot find libclang headers])])
 AC_CHECK_LIB([clang], [clang_createIndex],[],[AC_MSG_ERROR([Cannot link against libclang])])
+
+dnl Substitution
 
 AC_SUBST([HS_BINDGEN_EXTRA_LIBS])
 AC_SUBST([HS_BINDGEN_LIBDIR])


### PR DESCRIPTION
Resolves #117
Resolves #102

```
dnl The discovery logic is following
dnl * look for llvm-config (LLVM_CONFIG if set, in PATH otherwise)
dnl * if not found
dnl   - if LLVM_PATH is set, use it (skip version check)
dnl   - otherwise fail.
```