### PR TITLE
More libclang bindings

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -61,6 +61,16 @@ CXString* wrap_malloc_Cursor_getBriefCommentText(CXCursor* C) {
     return result;
 }
 
+unsigned wrap_isCursorDefinition(CXCursor *C) {
+    return clang_isCursorDefinition(*C);
+}
+
+CXSourceRange* wrap_malloc_Cursor_getSpellingNameRange(CXCursor *C, unsigned pieceIndex, unsigned options) {
+    CXSourceRange* result = malloc(sizeof(CXSourceRange));
+    *result = clang_Cursor_getSpellingNameRange(*C, pieceIndex, options);
+    return result;
+}
+
 
 /**
  * Type information for CXCursors
@@ -102,6 +112,15 @@ long long wrap_Type_getAlignOf(CXType* T) {
     return clang_Type_getAlignOf(*T);
 }
 
+unsigned wrap_Type_isTransparentTagTypedef(CXType *T) {
+    return clang_Type_isTransparentTagTypedef(*T);
+}
+
+unsigned wrap_Cursor_isAnonymous(CXCursor* C) {
+    return clang_Cursor_isAnonymous(*C);
+}
+
+
 /**
  * Mapping between cursors and source code
  */
@@ -132,6 +151,20 @@ void wrap_getExpansionLocation(CXSourceLocation* location, CXFile* file, unsigne
     clang_getExpansionLocation(*location, file, line, column, offset);
 }
 
+void wrap_getSpellingLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset) {
+    clang_getSpellingLocation(*location, file, line, column, offset);
+}
+
+/**
+ * File manipulation routines
+ */
+
+CXString* wrap_malloc_getFileName(CXFile SFile) {
+    CXString* result = malloc(sizeof(CXString));
+    *result = clang_getFileName(SFile);
+    return result;
+}
+
 /**
  * String manipulation routines
  */
@@ -143,4 +176,3 @@ const char * wrap_getCString (CXString* string) {
 void wrap_disposeString(CXString* string) {
     clang_disposeString(*string);
 }
-

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -36,6 +36,8 @@ CXString* wrap_malloc_getCursorDisplayName(CXCursor* cursor);
 CXString* wrap_malloc_getCursorSpelling(CXCursor* cursor);
 CXString* wrap_malloc_Cursor_getRawCommentText(CXCursor* C);
 CXString* wrap_malloc_Cursor_getBriefCommentText(CXCursor* C);
+unsigned wrap_isCursorDefinition(CXCursor *C);
+CXSourceRange* wrap_malloc_Cursor_getSpellingNameRange(CXCursor *C, unsigned pieceIndex, unsigned options);
 
 /**
  * Type information for CXCursors
@@ -48,7 +50,8 @@ CXString* wrap_malloc_getTypeSpelling(CXType* CT);
 CXType* wrap_malloc_getPointeeType(CXType* T);
 long long wrap_Type_getSizeOf(CXType* T);
 long long wrap_Type_getAlignOf(CXType* T);
-
+unsigned wrap_Type_isTransparentTagTypedef(CXType *T);
+unsigned wrap_Cursor_isAnonymous(CXCursor* C);
 
 /**
  * Mapping between cursors and source code
@@ -63,6 +66,13 @@ CXSourceRange* wrap_malloc_getCursorExtent(CXCursor *);
 CXSourceLocation* wrap_malloc_getRangeStart(CXSourceRange* range);
 CXSourceLocation* wrap_malloc_getRangeEnd(CXSourceRange* range);
 void wrap_getExpansionLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset);
+void wrap_getSpellingLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset);
+
+/**
+ * File manipulation routines
+ */
+
+CXString* wrap_malloc_getFileName(CXFile SFile);
 
 /**
  * String manipulation routines

--- a/hs-bindgen-libclang/clang-tutorial/clang-tutorial.hs
+++ b/hs-bindgen-libclang/clang-tutorial/clang-tutorial.hs
@@ -7,7 +7,7 @@ import Control.Monad
 import System.Environment
 
 import HsBindgen.Clang.Core
-import HsBindgen.Clang.Util
+import HsBindgen.Clang.Core.Util
 import HsBindgen.Patterns
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -42,17 +42,18 @@ library
   exposed-modules:
       HsBindgen.Clang.Args
       HsBindgen.Clang.Core
+      HsBindgen.Clang.Core.Util
+      HsBindgen.Clang.Core.Util.Fold
+      HsBindgen.Clang.Core.Util.SourceLoc
       HsBindgen.Clang.Doxygen
-      HsBindgen.Clang.Fold
-      HsBindgen.Clang.Util
   other-modules:
       HsBindgen.Clang.Core.Enums
       HsBindgen.Clang.Core.Instances
       HsBindgen.Clang.Doxygen.Enums
       HsBindgen.Clang.Doxygen.Instances
-      HsBindgen.Clang.Util.Bindings
-      HsBindgen.Clang.Util.CXString
-      HsBindgen.Clang.Util.FFI
+      HsBindgen.Clang.Internal.Bindings
+      HsBindgen.Clang.Internal.CXString
+      HsBindgen.Clang.Internal.FFI
   build-depends:
       -- Internal dependencies
     , hs-bindgen-patterns

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util.hs
@@ -1,7 +1,7 @@
 -- | Utility functions for use with the @libclang@ low-level bindings
 --
 -- This is part of the @hs-bindgen-libclang@ public API.
-module HsBindgen.Clang.Util (
+module HsBindgen.Clang.Core.Util (
     -- * Classifying types
     isPointerType
   , isRecordType

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util/Fold.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util/Fold.hs
@@ -1,5 +1,5 @@
 -- | Higher-level bindings for traversing the API
-module HsBindgen.Clang.Fold (
+module HsBindgen.Clang.Core.Util.Fold (
     Fold
   , Next(..)
   , clang_fold

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util/SourceLoc.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Util/SourceLoc.hs
@@ -1,0 +1,75 @@
+-- | Utilities for working with source locations
+--
+-- The functions in this module intentionally have the same names as the
+-- corresponding functions in "HsBindgen.Clang.Core", and therefore the same
+-- names as in @libclang@ itself.
+--
+-- Intended for qualified import.
+--
+-- > import HsBindgen.Clang.Core.Util.SourceLoc (SourceLoc(..), SourceRange(..))
+-- > import HsBindgen.Clang.Core.Util.SourceLoc qualified as SourceLoc
+module HsBindgen.Clang.Core.Util.SourceLoc (
+    SourceLoc(..)
+  , SourceRange(..)
+    -- * Construction
+  , clang_Cursor_getSpellingNameRange
+  , clang_getCursorExtent
+  ) where
+
+import Data.ByteString qualified as Strict (ByteString)
+import Foreign
+
+import HsBindgen.Clang.Core qualified as Core
+import HsBindgen.Clang.Core hiding (
+    clang_Cursor_getSpellingNameRange
+  , clang_getCursorExtent
+  )
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+data SourceLoc = SourceLoc {
+      sourceLocFile   :: !Strict.ByteString
+    , sourceLocLine   :: !Int
+    , sourceLocColumn :: !Int
+    }
+  deriving stock (Show, Eq, Ord)
+
+data SourceRange = SourceRange {
+      sourceRangeStart :: !SourceLoc
+    , sourceRangeEnd   :: !SourceLoc
+    }
+  deriving stock (Show, Eq, Ord)
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+clang_Cursor_getSpellingNameRange :: ForeignPtr CXCursor -> IO SourceRange
+clang_Cursor_getSpellingNameRange cursor =
+    toSourceRange =<< Core.clang_Cursor_getSpellingNameRange cursor 0 0
+
+clang_getCursorExtent :: ForeignPtr CXCursor -> IO SourceRange
+clang_getCursorExtent cursor =
+    toSourceRange =<< Core.clang_getCursorExtent cursor
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+toSourceRange :: ForeignPtr CXSourceRange -> IO SourceRange
+toSourceRange rng = do
+    begin <- clang_getRangeStart rng
+    end   <- clang_getRangeEnd   rng
+    SourceRange
+      <$> toSourceLoc begin
+      <*> toSourceLoc end
+
+toSourceLoc :: ForeignPtr CXSourceLocation -> IO SourceLoc
+toSourceLoc loc = do
+    (file, line, col, _bufOffset) <- clang_getSpellingLocation loc
+    SourceLoc
+      <$> clang_getFileName file
+      <*> pure (fromIntegral line)
+      <*> pure (fromIntegral col)

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
@@ -27,8 +27,8 @@ import Foreign.C
 import HsBindgen.Clang.Core
 import HsBindgen.Clang.Doxygen.Enums
 import HsBindgen.Clang.Doxygen.Instances ()
-import HsBindgen.Clang.Util.Bindings
-import HsBindgen.Clang.Util.CXString
+import HsBindgen.Clang.Internal.Bindings
+import HsBindgen.Clang.Internal.CXString
 import HsBindgen.Patterns
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/Bindings.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/Bindings.hs
@@ -1,9 +1,10 @@
 -- | Internal utilities for creating the bindings
-module HsBindgen.Clang.Util.Bindings (
+module HsBindgen.Clang.Internal.Bindings (
     -- * Memory management
     attachFinalizer
-    -- * Checking return values
+    -- * Dealing with return values
   , CallFailed(..)
+  , cToBool
   , ensure
   , ensureNotNull
   ) where
@@ -24,8 +25,12 @@ attachFinalizer :: Ptr a -> IO (ForeignPtr a)
 attachFinalizer ptr = Concurrent.newForeignPtr ptr $ free ptr
 
 {-------------------------------------------------------------------------------
-  Check return values
+  Dealing with return values
 -------------------------------------------------------------------------------}
+
+cToBool :: CUInt -> Bool
+cToBool 0 = False
+cToBool _ = True
 
 -- | Check that an (integral) result from @libclang@ function is not an error
 ensure ::
@@ -60,4 +65,3 @@ ensureNotNull call = do
       throwIO $ CallFailed stack
     else
       return ptr
-

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/CXString.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/CXString.hs
@@ -3,7 +3,7 @@
 -- | Dealing with @CXString@
 --
 -- This is internal API; the public API deals with strict bytestrings only.
-module HsBindgen.Clang.Util.CXString (
+module HsBindgen.Clang.Internal.CXString (
     CXString
   , packCXString
   ) where

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/FFI.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/FFI.hs
@@ -1,5 +1,5 @@
 -- | Internal utilities for working with the C FFI
-module HsBindgen.Clang.Util.FFI (
+module HsBindgen.Clang.Internal.FFI (
     withCStrings
   ) where
 
@@ -19,4 +19,3 @@ withCStrings = \args k ->
     go (x:xs) k = withCString x  $ \x'  ->
                   go          xs $ \xs' ->
                   k (x' : xs')
-

--- a/hs-bindgen/examples/anonymous.h
+++ b/hs-bindgen/examples/anonymous.h
@@ -1,0 +1,9 @@
+// Struct containing an anonymous inner struct
+struct S1 {
+  struct {
+    int a;
+    int b;
+  } c;
+
+  int c;
+};


### PR DESCRIPTION
This is a failed attempt at two things:

1. Distinguish between the _tag_ of a struct (which may be absent) and the name of the surrounding typedef. In llvm18 the struct tag (at least when using `clang_getCursorSpelling` or `clang_getCursorDisplayName`) is set to the name of the surrounding typedef, which is causing some compatibility trouble against different llvm vesions (https://github.com/well-typed/hs-bindgen/pull/110#issuecomment-2306844665). So far the only way that I've found to figure out if this name is a "fake" name is by asking for the source location, then looking up that source location in the file, and looking at what's there; for "fake" names, the source location will point to the `struct` keyword instead of the actual name. But this feels a bit ugly. Neither `clang_Type_isTransparentTagTypedef` nor `clang_Cursor_isAnonymous` seems to help here; since the docs of the former refer to `NS_ENUM`, perhaps that is an Objective C thing; the latter refers to structs that are truly anonymous (see `examples/anonymous.h` for an example).
2. Distinguish between the definition of a struct, and its reference in a typedef, for example as in

    ```c
    typedef struct {
        char a;
    } S3_t;
    ```
  
    When we fold over this AST, we see this struct definition twice; first as a standalone thing, and then repeated inside the body of the `typedef`. I was hoping that we'd be able to use `clang_isCursorDefinition` to distinguish between these two cases, but it seems to report `True` for absolutely everything.


    