### PR TITLE
First step towards macros

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -152,6 +152,12 @@ unsigned wrap_Cursor_isAnonymous(CXCursor* C) {
  * Mapping between cursors and source code
  */
 
+CXSourceLocation* wrap_malloc_getCursorLocation(CXCursor* C) {
+    CXSourceLocation* result = malloc(sizeof(CXSourceLocation));
+    *result = clang_getCursorLocation(*C);
+    return result;
+}
+
 CXSourceRange* wrap_malloc_getCursorExtent(CXCursor* C) {
     CXSourceRange* result = malloc(sizeof(CXSourceRange));
     *result = clang_getCursorExtent(*C);
@@ -210,6 +216,10 @@ void wrap_getExpansionLocation(CXSourceLocation* location, CXFile* file, unsigne
 
 void wrap_getSpellingLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset) {
     clang_getSpellingLocation(*location, file, line, column, offset);
+}
+
+int wrap_Location_isFromMainFile(CXSourceLocation* location) {
+    return clang_Location_isFromMainFile(*location);
 }
 
 /**

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -71,6 +71,7 @@ static inline long long wrap_getEnumConstantDeclValue(CXCursor *C) {
  * Mapping between cursors and source code
  */
 
+CXSourceLocation* wrap_malloc_getCursorLocation(CXCursor* C);
 CXSourceRange* wrap_malloc_getCursorExtent(CXCursor* C);
 
 /**
@@ -91,6 +92,7 @@ CXSourceLocation* wrap_malloc_getRangeStart(CXSourceRange* range);
 CXSourceLocation* wrap_malloc_getRangeEnd(CXSourceRange* range);
 void wrap_getExpansionLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset);
 void wrap_getSpellingLocation(CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset);
+int wrap_Location_isFromMainFile(CXSourceLocation* location);
 
 /**
  * File manipulation routines

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/Bindings.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/Bindings.hs
@@ -63,7 +63,7 @@ instance (Coercible p (ForeignPtr a), Coercible u (Ptr a))
   Dealing with return values
 -------------------------------------------------------------------------------}
 
-cToBool :: CUInt -> Bool
+cToBool :: (Num a, Eq a) => a -> Bool
 cToBool 0 = False
 cToBool _ = True
 

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
@@ -13,6 +13,7 @@ module HsBindgen.Clang.Util.SourceLoc (
   , SourceRange(..)
     -- * Construction
   , clang_Cursor_getSpellingNameRange
+  , clang_getCursorLocation
   , clang_getCursorExtent
   ) where
 
@@ -23,6 +24,7 @@ import Data.List (intercalate)
 import HsBindgen.Clang.Core qualified as Core
 import HsBindgen.Clang.Core hiding (
     clang_Cursor_getSpellingNameRange
+  , clang_getCursorLocation
   , clang_getCursorExtent
   )
 
@@ -80,6 +82,10 @@ prettySourceRange (SourceRange start end) = concat [
 clang_Cursor_getSpellingNameRange :: CXCursor -> IO SourceRange
 clang_Cursor_getSpellingNameRange cursor =
     toSourceRange =<< Core.clang_Cursor_getSpellingNameRange cursor 0 0
+
+clang_getCursorLocation :: CXCursor -> IO SourceLoc
+clang_getCursorLocation cursor =
+    toSourceLoc =<< Core.clang_getCursorLocation cursor
 
 clang_getCursorExtent :: CXCursor -> IO SourceRange
 clang_getCursorExtent cursor =

--- a/hs-bindgen/app/HsBindgen/Cmdline.hs
+++ b/hs-bindgen/app/HsBindgen/Cmdline.hs
@@ -28,6 +28,7 @@ getCmdline = execParser opts
 -- | Command line arguments
 data Cmdline = Cmdline {
       verbosity :: Bool
+    , predicate :: Predicate
     , clangArgs :: ClangArgs
     , mode      :: Mode
     }
@@ -61,6 +62,7 @@ parseCmdline :: Parser Cmdline
 parseCmdline =
     Cmdline
       <$> parseVerbosity
+      <*> parsePredicate
       <*> parseClangArgs
       <*> parseMode
 
@@ -94,6 +96,30 @@ parseModeDumpClangAST :: Parser Mode
 parseModeDumpClangAST =
     ShowClangAST
       <$> parseInput
+
+parsePredicate :: Parser Predicate
+parsePredicate = fmap aux . many . asum $ [
+      flag' SelectAll $ mconcat [
+          long "select-all"
+        , help "Process all elements"
+        ]
+    , fmap SelectByFileName $ strOption $ mconcat [
+          long "select-by-filename"
+        , help "Match filename against PCRE"
+        ]
+    , fmap SelectByElementName $ strOption $ mconcat [
+          long "select-by-element-name"
+        , help "Match element name against PCRE"
+        ]
+    , flag' SelectFromMainFile $ mconcat [
+          long "select-from-main-file"
+        , help "Only process elements from the main file (this is the default)"
+        ]
+    ]
+  where
+    aux :: [Predicate] -> Predicate
+    aux [] = SelectFromMainFile
+    aux ps = mconcat ps
 
 {-------------------------------------------------------------------------------
   Prepare input

--- a/hs-bindgen/app/Main.hs
+++ b/hs-bindgen/app/Main.hs
@@ -9,6 +9,7 @@ main :: IO ()
 main = do
     Cmdline{
         verbosity
+      , predicate
       , mode
       , clangArgs
       } <- getCmdline
@@ -17,9 +18,9 @@ main = do
 
     case mode of
       Preprocess{input, moduleOpts, renderOpts, output} ->
-        preprocess tracer clangArgs input moduleOpts renderOpts output
+        preprocess tracer predicate clangArgs input moduleOpts renderOpts output
       ParseCHeader{input} ->
-        prettyC =<< parseCHeader tracer clangArgs input
+        prettyC =<< parseCHeader tracer predicate clangArgs input
       ShowClangAST{input} -> do
-        ast <- getClangAST clangArgs input
+        ast <- getClangAST predicate clangArgs input
         putStr . drawForest $ fmap (fmap show) ast

--- a/hs-bindgen/fixtures/enums.dump.txt
+++ b/hs-bindgen/fixtures/enums.dump.txt
@@ -1,3 +1,4 @@
+"ENUMS_H" :: "Invalid"
 "first" :: "Enum"
   "FIRST1" :: "Int"
   "FIRST2" :: "Int"

--- a/hs-bindgen/fixtures/macros.dump.txt
+++ b/hs-bindgen/fixtures/macros.dump.txt
@@ -1,0 +1,1 @@
+"MYFOO" :: "Invalid"

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -43,6 +43,7 @@ library
   exposed-modules:
       HsBindgen.C.AST
       HsBindgen.C.Parser
+      HsBindgen.C.Predicate
       HsBindgen.Hs.Annotation
       HsBindgen.Hs.Render
       HsBindgen.Translation.LowLevel
@@ -53,14 +54,16 @@ library
     , hs-bindgen-libclang
   build-depends:
       -- External dependencies
-    , bytestring       >= 0.11 && < 0.13
-    , contra-tracer    >= 0.2  && < 0.3
-    , containers       >= 0.6.5.1 && <0.8
-    , data-default     >= 0.7  && < 0.8
-    , haskell-src-exts >= 1.23 && < 1.24
-    , haskell-src-meta >= 0.8  && < 0.9
-    , pretty-show      >= 1.10 && < 1.11
-    , template-haskell >= 2.18 && < 2.23
+    , bytestring         >= 0.11    && < 0.13
+    , containers         >= 0.6.5.1 && < 0.8
+    , contra-tracer      >= 0.2     && < 0.3
+    , data-default       >= 0.7     && < 0.8
+    , haskell-src-exts   >= 1.23    && < 1.24
+    , haskell-src-meta   >= 0.8     && < 0.9
+    , mtl                >= 2.2     && < 2.4
+    , pretty-show        >= 1.10    && < 1.11
+    , regex-pcre-builtin >= 0.95    && < 0.96
+    , template-haskell   >= 2.18    && < 2.23
 
 executable hs-bindgen
   import:         lang

--- a/hs-bindgen/src/HsBindgen/C/Predicate.hs
+++ b/hs-bindgen/src/HsBindgen/C/Predicate.hs
@@ -1,0 +1,125 @@
+-- | Select definitions from the C header
+--
+-- Intended for qualified import.
+--
+-- > import HsBindgen.C.Predicate (Predicate(..))
+-- > import HsBindgen.C.Predicate qualified as Predicate
+module HsBindgen.C.Predicate (
+    Predicate(..)
+  , Regex -- opaque
+    -- * Execution (this is internal API)
+  , match
+  ) where
+
+import Control.Monad
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
+import Control.Monad.IO.Class
+import Data.ByteString (ByteString)
+import Data.String
+import Text.Regex.PCRE qualified as PCRE
+
+import HsBindgen.Clang.Core
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Select which definitions in the C header(s) we want to keep
+data Predicate =
+    -- | The filter that always matches
+    --
+    -- Used to define @mempty@.
+    SelectAll
+
+    -- | Logical conjunction
+    --
+    -- Used to define the 'Semigroup' instance.
+  | SelectIfBoth Predicate Predicate
+
+    -- | Check if the definition is from the \"main\" file
+    --
+    -- Corresponds directly to @clang_Location_isFromMainFile@ in @libclang@;
+    -- <https://clang.llvm.org/doxygen/group__CINDEX__LOCATIONS.html#gacb4ca7b858d66f0205797ae84cc4e8f2>.
+  | SelectFromMainFile
+
+    -- | Match filename against regex
+  | SelectByFileName Regex
+
+    -- | Match element against regex
+  | SelectByElementName Regex
+  deriving (Show)
+
+instance Semigroup Predicate where
+  (<>) = SelectIfBoth
+
+instance Monoid Predicate where
+  mempty = SelectAll
+
+{-------------------------------------------------------------------------------
+  Matching
+
+  NOTE: This is internal API (users construct filters, but don't use them).
+-------------------------------------------------------------------------------}
+
+-- | Match filter
+--
+-- If the filter does not match, we report the reason why.
+match :: CXCursor -> Predicate -> IO (Either String ())
+match current = runExceptT . go
+  where
+    go :: Predicate -> ExceptT String IO ()
+    go SelectAll      = return ()
+    go (SelectIfBoth p q) = go p >> go q
+
+    go SelectFromMainFile = do
+        isFromMainFile <- liftIO $ do
+          location <- clang_getCursorLocation current
+          clang_Location_isFromMainFile location
+        unless isFromMainFile $
+          throwError $ "Not from the main file"
+
+    go (SelectByFileName re) = do
+        filename <- liftIO $ do
+          location <- clang_getCursorLocation current
+          (file, _line, _col, _offset) <- clang_getSpellingLocation location
+          clang_getFileName file
+        unless (matchTest re filename) $
+          throwError $ mconcat [
+              "File name "
+            , show filename
+            , " does not match "
+            , show re
+            ]
+
+    go (SelectByElementName re) = do
+        elementName <- liftIO $ clang_getCursorSpelling current
+        unless (matchTest re elementName) $ do
+          throwError $ mconcat [
+              "Element name "
+            , show elementName
+            , " does not match "
+            , show re
+            ]
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: regexs
+-------------------------------------------------------------------------------}
+
+-- | Perl-compatible regular expression
+data Regex = Regex {
+      regexString   :: String
+    , regexCompiled :: PCRE.Regex
+    }
+
+-- | Validatity of the 'Show' instance depends on the 'IsString' instance
+instance Show Regex where
+  show = show . regexString
+
+instance IsString Regex where
+  fromString regexString = Regex{regexString, regexCompiled}
+    where
+      regexCompiled :: PCRE.Regex
+      regexCompiled = PCRE.makeRegex regexString
+
+matchTest :: Regex -> ByteString -> Bool
+matchTest = PCRE.matchTest . regexCompiled

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -13,10 +13,14 @@ import HsBindgen.Util.Tracer
 -- We need to think about how we want to handle configuration in TH mode.
 generateBindingsFor :: FilePath -> Q [Dec]
 generateBindingsFor fp = liftIO $
-    genDecls <$> parseCHeader tracer args fp
+    genDecls <$> parseCHeader tracer p args fp
   where
     tracer :: Tracer IO ParseMsg
     tracer = contramap prettyLogMsg $ mkTracerQ False
 
+    p :: Predicate
+    p = SelectFromMainFile
+
     args :: ClangArgs
     args = []
+

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -51,7 +51,7 @@ main = do
         let fp = "examples" </> (name ++ ".h")
             args = ["-target", "x86_64-pc-linux-gnu"]
 
-        res <- getClangAST args fp
+        res <- getClangAST SelectFromMainFile args fp
 
         return $ LBS8.pack $ unlines $ concatMap treeToLines res
 
@@ -59,7 +59,7 @@ main = do
         let fp = "examples" </> (name ++ ".h")
             args = ["-target", "x86_64-pc-linux-gnu"]
 
-        header <- parseCHeader nullTracer args fp
+        header <- parseCHeader nullTracer SelectFromMainFile args fp
         return header
 
     goldenTH name = goldenVsStringDiff "th" diff ("fixtures" </> (name ++ ".th.txt")) $ do
@@ -68,7 +68,7 @@ main = do
         let fp = "examples" </> (name ++ ".h")
             args = ["-target", "x86_64-pc-linux-gnu"]
 
-        header <- parseCHeader nullTracer args fp
+        header <- parseCHeader nullTracer SelectFromMainFile args fp
         let decls = genDecls header
 
         return $ LBS8.pack $ unlines $ map (show . ppr) decls


### PR DESCRIPTION
By passing `CXTranslationUnit_DetailedPreprocessingRecord` it seems we can get (some?) information about `#define`s from `libclang`. Not sure exactly how much, yet: enabling this option also means we see a bunch of stuff that comes from some kind of `libclang` Prelude (definitions such as `__GNUC__`). For this reason, this also implements a  basic form of selection (a first step towards issue #12).