### PR TITLE
Use `clang_getCursorSemanticParent`

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -26,6 +26,18 @@ unsigned wrap_equalCursors(CXCursor* a, CXCursor* b) {
     return clang_equalCursors(*a, *b);
 }
 
+CXCursor* wrap_malloc_getCursorSemanticParent(CXCursor* cursor) {
+    CXCursor* result = malloc(sizeof(CXCursor));
+    *result = clang_getCursorSemanticParent(*cursor);
+    return result;
+}
+
+CXCursor* wrap_malloc_getCursorLexicalParent(CXCursor* cursor) {
+    CXCursor* result = malloc(sizeof(CXCursor));
+    *result = clang_getCursorLexicalParent(*cursor);
+    return result;
+}
+
 /**
  * Traversing the AST with cursors
  */

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -26,6 +26,8 @@ CXString* wrap_malloc_TargetInfo_getTriple(CXTargetInfo Info);
 
 CXCursor* wrap_malloc_getTranslationUnitCursor(CXTranslationUnit unit);
 unsigned wrap_equalCursors(CXCursor* a, CXCursor* b);
+CXCursor* wrap_malloc_getCursorSemanticParent(CXCursor* cursor);
+CXCursor* wrap_malloc_getCursorLexicalParent(CXCursor* cursor);
 
 /**
  * Traversing the AST with cursors

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -172,12 +172,12 @@ parseEnum unit current = do
       }
 
 foldEnumValues :: HasCallStack => Tracer IO ParseMsg -> Fold C.EnumValue
-foldEnumValues tracer parent current = do
+foldEnumValues tracer _parent current = do
     cursorType <- clang_getCursorType current
     case primType $ cxtKind cursorType of
       Just _fieldType -> do
-        valueName <- decodeString <$> clang_getCursorDisplayName current
-        valueValue <- toInteger <$> clang_getEnumConstantDeclValue parent current
+        valueName  <- decodeString <$> clang_getCursorDisplayName     current
+        valueValue <- toInteger    <$> clang_getEnumConstantDeclValue current
         let field = C.EnumValue{valueName, valueValue}
         return $ Continue (Just field)
       _otherwise -> do


### PR DESCRIPTION
in `clang_getEnumConstantDeclValue` instead of asking the fold for the parent, so that the function is usable in more contexts.