### PR TITLE
Basic parser for macros

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -216,6 +216,10 @@ CXSourceRange* wrap_malloc_getTokenExtent(CXTranslationUnit TU, CXToken* Token) 
     return result;
 }
 
+void wrap_tokenize(CXTranslationUnit TU, CXSourceRange* Range, CXToken** Tokens, unsigned* NumTokens) {
+    clang_tokenize(TU, *Range, Tokens, NumTokens);
+}
+
 /**
  * Physical source locations
  */

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -19,7 +19,6 @@
 
 CXString* wrap_malloc_TargetInfo_getTriple(CXTargetInfo Info);
 
-
 /**
  * Cursor manipulations
  */
@@ -30,7 +29,6 @@ CXCursor* wrap_malloc_getCursorSemanticParent(CXCursor* cursor);
 CXCursor* wrap_malloc_getCursorLexicalParent(CXCursor* cursor);
 enum CXCursorKind wrap_getCursorKind(CXCursor* cursor);
 CXString* wrap_malloc_getCursorKindSpelling(enum CXCursorKind Kind);
-
 
 /**
  * Traversing the AST with cursors
@@ -88,6 +86,7 @@ CXTokenKind wrap_getTokenKind(CXToken* Token);
 CXString* wrap_malloc_getTokenSpelling(CXTranslationUnit TU, CXToken* Token);
 CXSourceLocation* wrap_malloc_getTokenLocation(CXTranslationUnit TU, CXToken* Token);
 CXSourceRange* wrap_malloc_getTokenExtent(CXTranslationUnit TU, CXToken* Token);
+void wrap_tokenize(CXTranslationUnit TU, CXSourceRange* Range, CXToken** Tokens, unsigned* NumTokens);
 
 /**
  * Physical source locations

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -51,7 +51,9 @@ library
       HsBindgen.Clang.Util.Classification
       HsBindgen.Clang.Util.Fold
       HsBindgen.Clang.Util.SourceLoc
+      HsBindgen.Clang.Util.Tokens
   other-modules:
+      HsBindgen.Clang.Core.Constants
       HsBindgen.Clang.Core.Enums
       HsBindgen.Clang.Core.Instances
       HsBindgen.Clang.Doxygen.Enums

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Constants.hsc
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Constants.hsc
@@ -1,0 +1,8 @@
+module HsBindgen.Clang.Core.Constants (
+    sizeof_CXToken
+  ) where
+
+#include <clang-c/Index.h>
+
+sizeof_CXToken :: Int
+sizeof_CXToken = #size CXToken

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Tokens.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Tokens.hs
@@ -1,0 +1,25 @@
+module HsBindgen.Clang.Util.Tokens (
+    clang_tokenize
+  ) where
+
+import Control.Exception
+import Control.Monad
+import Data.ByteString (ByteString)
+
+import HsBindgen.Clang.Core qualified as Core
+import HsBindgen.Clang.Core hiding (
+    clang_tokenize
+  )
+
+{-------------------------------------------------------------------------------
+  Token extraction and manipulation
+-------------------------------------------------------------------------------}
+
+-- | Get all tokens in the specified range
+clang_tokenize :: CXTranslationUnit -> CXSourceRange -> IO [ByteString]
+clang_tokenize unit range = do
+    bracket
+        (Core.clang_tokenize unit range)
+        (uncurry $ Core.clang_disposeTokens unit) $ \(array, numTokens) ->
+      forM [0 .. pred numTokens] $ \i ->
+        clang_getTokenSpelling unit (index_CXTokenArray array i)

--- a/hs-bindgen/examples/macro_functions.h
+++ b/hs-bindgen/examples/macro_functions.h
@@ -1,0 +1,2 @@
+#define INCR(x) x + 1
+#define ADD(x, y) x + y

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -1,6 +1,8 @@
 WrapCHeader
   (Header
     [
+      DeclMacro
+        (Macro [Token "ENUMS_H"]),
       DeclEnum
         Enu {
           enumTag = Just "first",

--- a/hs-bindgen/fixtures/macro_functions.dump.txt
+++ b/hs-bindgen/fixtures/macro_functions.dump.txt
@@ -1,0 +1,2 @@
+"macro definition" "INCR" :: "Invalid"
+"macro definition" "ADD" :: "Invalid"

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -1,0 +1,25 @@
+WrapCHeader
+  (Header
+    [
+      DeclMacro
+        (Macro
+          [
+            Token "INCR",
+            Token "(",
+            Token "x",
+            Token ")",
+            Token "x",
+            Token "+",
+            Token "1"]),
+      DeclMacro
+        (Macro
+          [
+            Token "ADD",
+            Token "(",
+            Token "x",
+            Token ",",
+            Token "y",
+            Token ")",
+            Token "x",
+            Token "+",
+            Token "y"])])

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -1,1 +1,6 @@
-WrapCHeader (Header [])
+WrapCHeader
+  (Header
+    [
+      DeclMacro
+        (Macro
+          [Token "MYFOO", Token "1"])])

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -20,10 +20,14 @@ module HsBindgen.C.AST (
   , Typ(..)
   , PrimType(..)
   , Typedef(..)
+    -- * Macros
+  , Token(..)
+  , Macro(..)
   ) where
 
+import Data.ByteString (ByteString)
 import GHC.Generics (Generic)
-import Text.Show.Pretty (PrettyVal)
+import Text.Show.Pretty (PrettyVal(..))
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -41,6 +45,7 @@ data Decl =
     DeclStruct Struct
   | DeclTypedef Typedef
   | DeclEnum Enu
+  | DeclMacro Macro
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
 
@@ -73,7 +78,7 @@ data Enu = Enu {
       enumTag       :: Maybe String
     , enumSizeof    :: Int
     , enumAlignment :: Int
-    , enumValues    :: [EnumValue] 
+    , enumValues    :: [EnumValue]
     }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
@@ -111,5 +116,32 @@ data PrimType =
     PrimInt   -- @int@
   | PrimChar  -- @char@
   | PrimFloat -- @float@
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (PrettyVal)
+
+{-------------------------------------------------------------------------------
+  Macros
+-------------------------------------------------------------------------------}
+
+newtype Token = Token ByteString
+  deriving stock (Show, Eq, Generic)
+
+instance PrettyVal Token where
+  prettyVal (Token t) = prettyVal (show t)
+
+-- | C macro definition
+--
+-- This is simply the list of tokens; for example,
+--
+-- > #define MYFOO 1
+-- > #define INCR(x) x + 1
+--
+-- are represented as
+--
+-- > Macro ["MYFOO", "1"]
+-- > Macro ["INCR", "(", "x", ")", "x", "+", "1"]
+--
+-- respectively.
+data Macro = Macro [Token]
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -16,3 +16,5 @@ instance ToExpr C.PrimType
 instance ToExpr C.StructField
 instance ToExpr C.Enu
 instance ToExpr C.EnumValue
+instance ToExpr C.Token
+instance ToExpr C.Macro

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -35,6 +35,7 @@ main = do
         , golden "enums"
         , golden "primitive_types"
         , golden "macros"
+        , golden "macro_functions"
         ]
   where
     diff ref new = ["diff", "-u", ref, new]


### PR DESCRIPTION
It seems that `libclang` cannot do much better than give us the raw list of tokens, but perhaps this is sufficient. See definition of `Macro` in `C/AST.hs` for example representations.