### PR TITLE
More `libclang` bindings for dealing with types

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -10,6 +10,47 @@
 
 #include <clang-c/Index.h>
 
+#include <stdio.h>
+
+enum WrapperResult {
+    /** The function is supported, but the call failed.
+     *
+     * This can be due to any number of reasons; a typical one is that an
+     * argument @CXType@ is invalid.
+     */
+    WrapperFailed = 0,
+
+    /** Wrapper was successful */
+    WrapperOk = 1,
+
+    /** LLVM is too old (older than version 11) */
+    WrapperLlvmTooOld  = -1,
+
+    /** We need at least LLVM version 11 */
+    WrapperNeedsLlvm11 = -11,
+
+    /** We need at least LLVM version 12 */
+    WrapperNeedsLlvm12 = -12,
+
+    /** We need at least LLVM version 13 */
+    WrapperNeedsLlvm13 = -13,
+
+    /** We need at least LLVM version 14 */
+    WrapperNeedsLlvm14 = -14,
+
+    /** We need at least LLVM version 15 */
+    WrapperNeedsLlvm15 = -15,
+
+    /** We need at least LLVM version 16 */
+    WrapperNeedsLlvm16 = -16,
+
+    /** We need at least LLVM version 17 */
+    WrapperNeedsLlvm17 = -17,
+
+    /** We need at least LLVM version 18 */
+    WrapperNeedsLlvm18 = -18,
+};
+
 /**
  * Translation unit manipulation
  */
@@ -152,6 +193,44 @@ static inline unsigned wrap_Cursor_isAnonymous(const CXCursor* C) {
 
 static inline long long wrap_getEnumConstantDeclValue(const CXCursor *C) {
     return clang_getEnumConstantDeclValue(*C);
+}
+
+static inline void wrap_getCanonicalType(const CXType* T, CXType* result) {
+    *result = clang_getCanonicalType(*T);
+}
+
+static inline void wrap_getTypedefName(const CXType* CT, CXString* result) {
+    *result = clang_getTypedefName(*CT);
+}
+
+static inline enum WrapperResult wrap_getUnqualifiedType(const CXType* CT, CXType* result) {
+    #if CINDEX_VERSION_MINOR >= 63
+        // clang_getUnqualifiedType segfaults when CT is invalid
+        if(CT->kind == CXType_Invalid) {
+            return WrapperFailed;
+        } else {
+            *result = clang_getUnqualifiedType(*CT);
+            return WrapperOk;
+        }
+    #else
+        return WrapperNeedsLlvm16;
+    #endif
+}
+
+static inline void wrap_getTypeDeclaration(const CXType* T, CXCursor* result) {
+    *result = clang_getTypeDeclaration(*T);
+}
+
+static inline void wrap_Type_getNamedType(const CXType* T, CXType* result) {
+    *result = clang_Type_getNamedType(*T);
+}
+
+static inline void wrap_Type_getModifiedType(const CXType* T, CXType* result) {
+    *result = clang_Type_getModifiedType(*T);
+}
+
+static inline void wrap_Type_getValueType(const CXType* CT, CXType* result) {
+    *result = clang_Type_getValueType(*CT);
 }
 
 /**

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Enums.hs
@@ -2,13 +2,60 @@
 --
 -- This module should only be imported by "HsBingen.Clang.LowLevel".
 module HsBindgen.Clang.Core.Enums (
-    CXTranslationUnit_Flag(..)
+    WrapperResult(..)
+  , CXTranslationUnit_Flag(..)
   , CXTypeKind(..)
   , CXChildVisitResult(..)
   , CXTypeLayoutError(..)
   , CXTokenKind(..)
   , CXCursorKind(..)
   ) where
+
+{-------------------------------------------------------------------------------
+  WrapperSupported
+-------------------------------------------------------------------------------}
+
+-- | Result from the wrapper itself
+--
+-- Most wrappers directly call the corresponding function from @libclang@, but
+-- some need to do some additional checks.
+data WrapperResult =
+    -- | The function is supported, but the call failed.
+    --
+    -- This can be due to any number of reasons; a typical one is that an
+    -- argument @CXType@ is invalid.
+    WrapperFailed
+
+    -- | Wrapper was successful
+  | WrapperOk
+
+    -- | LLVM is too old (older than version 11)
+  | WrapperLlvmTooOld
+
+    -- | We need at least LLVM version 11
+  | WrapperNeedsLlvm11
+
+    -- | We need at least LLVM version 12
+  | WrapperNeedsLlvm12
+
+    -- | We need at least LLVM version 13
+  | WrapperNeedsLlvm13
+
+    -- | We need at least LLVM version 14
+  | WrapperNeedsLlvm14
+
+    -- | We need at least LLVM version 15
+  | WrapperNeedsLlvm15
+
+    -- | We need at least LLVM version 16
+  | WrapperNeedsLlvm16
+
+    -- | We need at least LLVM version 17
+  | WrapperNeedsLlvm17
+
+    -- | We need at least LLVM version 18
+  | WrapperNeedsLlvm18
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
 
 {-------------------------------------------------------------------------------
   CXTranslationUnit_Flag

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Instances.hsc
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Instances.hsc
@@ -18,6 +18,7 @@ import HsBindgen.Clang.Internal.ByValue
 import HsBindgen.Patterns
 
 #include <clang-c/Index.h>
+#include "clang_wrappers.h"
 
 {-------------------------------------------------------------------------------
   HasKnownSize instances
@@ -29,6 +30,37 @@ instance HasKnownSize CXSourceRange_    where knownSize = #size CXSourceRange
 instance HasKnownSize CXString_         where knownSize = #size CXString
 instance HasKnownSize CXToken_          where knownSize = #size CXToken
 instance HasKnownSize CXType_           where knownSize = #size CXType
+
+{-------------------------------------------------------------------------------
+  WrapperResult
+-------------------------------------------------------------------------------}
+
+instance IsSimpleEnum WrapperResult where
+  simpleToC WrapperOk          = #const WrapperOk
+  simpleToC WrapperFailed      = #const WrapperFailed
+  simpleToC WrapperLlvmTooOld  = #const WrapperLlvmTooOld
+  simpleToC WrapperNeedsLlvm11 = #const WrapperNeedsLlvm11
+  simpleToC WrapperNeedsLlvm12 = #const WrapperNeedsLlvm12
+  simpleToC WrapperNeedsLlvm13 = #const WrapperNeedsLlvm13
+  simpleToC WrapperNeedsLlvm14 = #const WrapperNeedsLlvm14
+  simpleToC WrapperNeedsLlvm15 = #const WrapperNeedsLlvm15
+  simpleToC WrapperNeedsLlvm16 = #const WrapperNeedsLlvm16
+  simpleToC WrapperNeedsLlvm17 = #const WrapperNeedsLlvm17
+  simpleToC WrapperNeedsLlvm18 = #const WrapperNeedsLlvm18
+
+  simpleFromC (#const WrapperOk)          = Just WrapperOk
+  simpleFromC (#const WrapperFailed)      = Just WrapperFailed
+  simpleFromC (#const WrapperLlvmTooOld)  = Just WrapperLlvmTooOld
+  simpleFromC (#const WrapperNeedsLlvm11) = Just WrapperNeedsLlvm11
+  simpleFromC (#const WrapperNeedsLlvm12) = Just WrapperNeedsLlvm12
+  simpleFromC (#const WrapperNeedsLlvm13) = Just WrapperNeedsLlvm13
+  simpleFromC (#const WrapperNeedsLlvm14) = Just WrapperNeedsLlvm14
+  simpleFromC (#const WrapperNeedsLlvm15) = Just WrapperNeedsLlvm15
+  simpleFromC (#const WrapperNeedsLlvm16) = Just WrapperNeedsLlvm16
+  simpleFromC (#const WrapperNeedsLlvm17) = Just WrapperNeedsLlvm17
+  simpleFromC (#const WrapperNeedsLlvm18) = Just WrapperNeedsLlvm18
+
+  simpleFromC _otherwise = Nothing
 
 {-------------------------------------------------------------------------------
   CXTranslationUnit_Flag

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
@@ -51,7 +51,7 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_Comment_getKind"
 clang_Cursor_getParsedComment :: CXCursor -> IO CXComment
 clang_Cursor_getParsedComment cursor =
     onHaskellHeap cursor $ \cursor' ->
-      preallocate $ wrap_Cursor_getParsedComment cursor'
+      preallocate_ $ wrap_Cursor_getParsedComment cursor'
 
 -- | Get the type of an AST node of any kind
 --

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/CXString.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/CXString.hs
@@ -25,7 +25,7 @@ import HsBindgen.Clang.Internal.ByValue
 -- | Pack 'CXString'
 packCXString :: (W CXString_ -> IO ()) -> IO ByteString
 packCXString allocStr =
-    bracket (preallocate allocStr) clang_disposeString $ \str -> do
+    bracket (preallocate_ allocStr) clang_disposeString $ \str -> do
       cstr <- clang_getCString str
       if cstr == nullPtr
         then return BS.Strict.empty


### PR DESCRIPTION
This isn't _quite_ right yet, as `clang_getUnqualifiedType` is only available on `libclang-16` and higher. We have three options here:

1. Don't bind to it at all, side-step the problem. Not a great option, it's useful to be able to experiment with this at least when trying to figure out how to get more info out of `libclang`.
2. Define the wrapper `wrap_getUnqualifiedType` even if `clang_getUnqualifiedType` is not defined, and have it return `NULL` (or some other error value), and throw a runtime exception if `clang_getUnqualifiedType` is called but `libclang` is too old. Doesn't feel terribly Haskell-y, but may have some advantages.
3. Somehow make the Haskell API dependent on the `libclang` version. I'm not totally sure how to do this; we can use `CPP` obviously in the Haskell module, but how do we make (some version of) `CINDEX_VERSION_MINOR` available?

@phadej Do you have an opinion on this? And if you feel that (3) is the best option, do you know how to actually do it?