### PR TITLE
Bind to the `libclang` diagnostics API

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -52,6 +52,38 @@ enum WrapperResult {
 };
 
 /**
+ * Diagnostic reporting
+ */
+
+static inline void wrap_formatDiagnostic(CXDiagnostic Diagnostic, unsigned Options, CXString* result) {
+    *result = clang_formatDiagnostic(Diagnostic, Options);
+}
+
+static inline void wrap_getDiagnosticLocation(CXDiagnostic Diagnostic, CXSourceLocation* result) {
+    *result = clang_getDiagnosticLocation(Diagnostic);
+}
+
+static inline void wrap_getDiagnosticSpelling(CXDiagnostic Diagnostic, CXString* result) {
+    *result = clang_getDiagnosticSpelling(Diagnostic);
+}
+
+static inline void wrap_getDiagnosticOption(CXDiagnostic Diag, CXString* Disable, CXString* result) {
+    *result = clang_getDiagnosticOption(Diag, Disable);
+}
+
+static inline void wrap_getDiagnosticCategoryText(CXDiagnostic Diag, CXString* result) {
+    *result = clang_getDiagnosticCategoryText(Diag);
+}
+
+static inline void wrap_getDiagnosticRange(CXDiagnostic Diagnostic, unsigned Range, CXSourceRange* result) {
+    *result = clang_getDiagnosticRange(Diagnostic, Range);
+}
+
+static inline void wrap_getDiagnosticFixIt(CXDiagnostic Diagnostic, unsigned FixIt, CXSourceRange* ReplacementRange, CXString* result) {
+    *result = clang_getDiagnosticFixIt(Diagnostic, FixIt, ReplacementRange);
+}
+
+/**
  * Translation unit manipulation
  */
 

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -60,6 +60,7 @@ library
   exposed-modules:
       -- Additional utilities, without direct counterparts in libclang
       HsBindgen.Clang.Util.Classification
+      HsBindgen.Clang.Util.Diagnostics
       HsBindgen.Clang.Util.Fold
       HsBindgen.Clang.Util.SourceLoc
       HsBindgen.Clang.Util.Tokens

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Enums.hs
@@ -1,14 +1,16 @@
 -- | Haskell equivalent of C enums using in @libclang@
 --
--- This module should only be imported by "HsBingen.Clang.LowLevel".
+-- This module should only be imported by "HsBindgen.Clang.Core".
 module HsBindgen.Clang.Core.Enums (
     WrapperResult(..)
-  , CXTranslationUnit_Flag(..)
+  , CXTranslationUnit_Flags(..)
   , CXTypeKind(..)
   , CXChildVisitResult(..)
   , CXTypeLayoutError(..)
   , CXTokenKind(..)
   , CXCursorKind(..)
+  , CXDiagnosticDisplayOptions(..)
+  , CXDiagnosticSeverity(..)
   ) where
 
 {-------------------------------------------------------------------------------
@@ -61,10 +63,14 @@ data WrapperResult =
   CXTranslationUnit_Flag
 -------------------------------------------------------------------------------}
 
--- | Single flag of 'CXTranslationUnit_Flags'
+-- | Flags that control the creation of translation units.
+--
+-- The enumerators in this enumeration type are meant to be bitwise ORed
+-- together to specify which options should be used when constructing the
+-- translation unit.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__TRANSLATION__UNIT.html#gab1e4965c1ebe8e41d71e90203a723fe9>
-data CXTranslationUnit_Flag =
+data CXTranslationUnit_Flags =
     -- | Used to indicate that no special translation-unit options are needed.
     CXTranslationUnit_None
 
@@ -1180,4 +1186,87 @@ data CXCursorKind =
 
     -- | A code completion overload candidate.
   | CXCursor_OverloadCandidate
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
+
+{-------------------------------------------------------------------------------
+  CXDiagnosticDisplayOptions
+-------------------------------------------------------------------------------}
+
+-- | Options to control the display of diagnostics.
+--
+-- The values in this enum are meant to be combined to customize the behavior of
+-- 'clang_formatDiagnostic'.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__DIAG.html#ga0545c7c3ef36a397c44d142b0385b8d1>
+data CXDiagnosticDisplayOptions =
+    -- | Display the source-location information where the diagnostic was
+    -- located.
+    --
+    -- When set, diagnostics will be prefixed by the file, line, and
+    -- (optionally) column to which the diagnostic refers. For example,
+    --
+    -- > test.c:28: warning: extra tokens at end of #endif directive
+    --
+    -- This option corresponds to the clang flag @-fshow-source-location@.
+    CXDiagnostic_DisplaySourceLocation
+
+    -- | If displaying the source-location information of the diagnostic, also
+    -- include the column number.
+    --
+    -- | This option corresponds to the clang flag @-fshow-column@.
+  | CXDiagnostic_DisplayColumn
+
+    -- | If displaying the source-location information of the diagnostic, also
+    -- include information about source ranges in a machine-parsable format.
+    --
+    -- This option corresponds to the clang flag
+    -- @-fdiagnostics-print-source-range-info@.
+  | CXDiagnostic_DisplaySourceRanges
+
+    -- | Display the option name associated with this diagnostic, if any.
+    --
+    -- The option name displayed (e.g., @-Wconversion@) will be placed in
+    -- brackets after the diagnostic text. This option corresponds to the clang
+    -- flag @-fdiagnostics-show-option@.
+  | CXDiagnostic_DisplayOption
+
+    -- | Display the category number associated with this diagnostic, if any.
+    --
+    -- The category number is displayed within brackets after the diagnostic
+    -- text. This option corresponds to the clang flag
+    -- @-fdiagnostics-show-category=id@.
+  | CXDiagnostic_DisplayCategoryId
+
+    -- | Display the category name associated with this diagnostic, if any.
+    --
+    -- The category name is displayed within brackets after the diagnostic text.
+    -- This option corresponds to the clang flag
+    -- @-fdiagnostics-show-category=name@.
+  | CXDiagnostic_DisplayCategoryName
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
+
+{-------------------------------------------------------------------------------
+  CXDiagnosticSeverity
+-------------------------------------------------------------------------------}
+
+-- | Describes the severity of a particular diagnostic.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__DIAG.html#gabff210a02d448bf64e8aee79b2241370>
+data CXDiagnosticSeverity =
+    -- | A diagnostic that has been suppressed, e.g., by a command-line option.
+    CXDiagnostic_Ignored
+
+    -- | This diagnostic is a note that should be attached to the previous
+    -- (non-note) diagnostic.
+  | CXDiagnostic_Note
+
+    -- | This diagnostic indicates suspicious code that may not be wrong.
+  | CXDiagnostic_Warning
+
+    -- | This diagnostic indicates that the code is ill-formed.
+  | CXDiagnostic_Error
+
+    -- | This diagnostic indicates that the code is ill-formed such that future
+    -- parser recovery is unlikely to produce useful results.
+  | CXDiagnostic_Fatal
   deriving stock (Show, Eq, Ord, Enum, Bounded)

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Instances.hsc
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Core/Instances.hsc
@@ -66,7 +66,7 @@ instance IsSimpleEnum WrapperResult where
   CXTranslationUnit_Flag
 -------------------------------------------------------------------------------}
 
-instance IsSingleFlag CXTranslationUnit_Flag where
+instance IsSingleFlag CXTranslationUnit_Flags where
   flagToC CXTranslationUnit_None                                 = #const CXTranslationUnit_None
   flagToC CXTranslationUnit_DetailedPreprocessingRecord          = #const CXTranslationUnit_DetailedPreprocessingRecord
   flagToC CXTranslationUnit_Incomplete                           = #const CXTranslationUnit_Incomplete
@@ -784,5 +784,36 @@ instance IsSimpleEnum CXCursorKind where
   simpleFromC (#const CXCursor_StaticAssert)                                     = Just CXCursor_StaticAssert
   simpleFromC (#const CXCursor_FriendDecl)                                       = Just CXCursor_FriendDecl
   simpleFromC (#const CXCursor_OverloadCandidate)                                = Just CXCursor_OverloadCandidate
+
+  simpleFromC _otherwise = Nothing
+
+{-------------------------------------------------------------------------------
+  CXDiagnosticDisplayOptions
+-------------------------------------------------------------------------------}
+
+instance IsSingleFlag CXDiagnosticDisplayOptions where
+  flagToC CXDiagnostic_DisplaySourceLocation = #const CXDiagnostic_DisplaySourceLocation
+  flagToC CXDiagnostic_DisplayColumn         = #const CXDiagnostic_DisplayColumn
+  flagToC CXDiagnostic_DisplaySourceRanges   = #const CXDiagnostic_DisplaySourceRanges
+  flagToC CXDiagnostic_DisplayOption         = #const CXDiagnostic_DisplayOption
+  flagToC CXDiagnostic_DisplayCategoryId     = #const CXDiagnostic_DisplayCategoryId
+  flagToC CXDiagnostic_DisplayCategoryName   = #const CXDiagnostic_DisplayCategoryName
+
+{-------------------------------------------------------------------------------
+  CXDiagnosticSeverity
+-------------------------------------------------------------------------------}
+
+instance IsSimpleEnum CXDiagnosticSeverity where
+  simpleToC CXDiagnostic_Ignored  = #const CXDiagnostic_Ignored
+  simpleToC CXDiagnostic_Note     = #const CXDiagnostic_Note
+  simpleToC CXDiagnostic_Warning  = #const CXDiagnostic_Warning
+  simpleToC CXDiagnostic_Error    = #const CXDiagnostic_Error
+  simpleToC CXDiagnostic_Fatal    = #const CXDiagnostic_Fatal
+
+  simpleFromC (#const CXDiagnostic_Ignored) = Just CXDiagnostic_Ignored
+  simpleFromC (#const CXDiagnostic_Note)    = Just CXDiagnostic_Note
+  simpleFromC (#const CXDiagnostic_Warning) = Just CXDiagnostic_Warning
+  simpleFromC (#const CXDiagnostic_Error)   = Just CXDiagnostic_Error
+  simpleFromC (#const CXDiagnostic_Fatal)   = Just CXDiagnostic_Fatal
 
   simpleFromC _otherwise = Nothing

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Doxygen.hs
@@ -27,7 +27,7 @@ import HsBindgen.Clang.Doxygen.Enums
 import HsBindgen.Clang.Doxygen.Instances ()
 import HsBindgen.Clang.Doxygen.Structs
 import HsBindgen.Clang.Internal.ByValue
-import HsBindgen.Clang.Internal.CXString
+import HsBindgen.Clang.Internal.CXString ()
 import HsBindgen.Patterns
 
 {-------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_FullComment_getAsXML"
 clang_FullComment_getAsHTML :: CXComment -> IO ByteString
 clang_FullComment_getAsHTML comment =
     onHaskellHeap comment $ \comment' ->
-      packCXString $ wrap_FullComment_getAsHTML comment'
+      preallocate_ $ wrap_FullComment_getAsHTML comment'
 
 -- | Convert a given full parsed comment to an XML document.
 --
@@ -85,4 +85,4 @@ clang_FullComment_getAsHTML comment =
 clang_FullComment_getAsXML :: CXComment -> IO ByteString
 clang_FullComment_getAsXML comment =
     onHaskellHeap comment $ \comment' ->
-      packCXString $ wrap_FullComment_getAsXML comment'
+      preallocate_ $ wrap_FullComment_getAsXML comment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
@@ -12,8 +12,7 @@ module HsBindgen.Clang.Internal.ByValue (
   , onHaskellHeap
     -- * Preallocation
   , W(..)
-  , Preallocate -- opaque
-  , preallocate
+  , Preallocate(..)
   , preallocate_
   ) where
 
@@ -95,6 +94,7 @@ preallocate_ = fmap fst . preallocate
 instance HasKnownSize tag => Preallocate (OnHaskellHeap tag) where
   type Writing (OnHaskellHeap tag) = W tag
 
+  preallocate :: (W tag -> IO b) -> IO (OnHaskellHeap tag, b)
   preallocate f =
       mkByteArray# (knownSize @tag) OnHaskellHeap $ \arr ->
         f (W arr)

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
@@ -81,7 +81,7 @@ newtype W tag = W (MutableByteArray# RealWorld)
 --
 -- The definition of this class is not exported; instances are expected to be
 -- derived through newtype deriving.
-class LivesOnHaskellHeap a => Preallocate a where
+class Preallocate a where
   type Writing a :: UnliftedType
 
   -- | Preallocate a buffer

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Diagnostics.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Diagnostics.hs
@@ -1,0 +1,184 @@
+module HsBindgen.Clang.Util.Diagnostics (
+    Diagnostic(..)
+  , FixIt(..)
+  , getDiagnostics
+  , isError
+  ) where
+
+import Control.Exception
+import Data.ByteString (ByteString)
+import Foreign.C
+
+import HsBindgen.Clang.Core
+import HsBindgen.Clang.Util.SourceLoc (SourceLoc, SourceRange)
+import HsBindgen.Clang.Util.SourceLoc qualified as SourceLoc
+import HsBindgen.Patterns
+import Data.ByteString qualified as BS
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+data Diagnostic = Diagnostic {
+      -- | Formatted by @libclang@ in a manner that is suitable for display
+      diagnosticFormatted :: ByteString
+
+      -- | Severity
+    , diagnosticSeverity :: SimpleEnum CXDiagnosticSeverity
+
+      -- | Source location (where Clang would print the caret @^@)
+    , diagnosticLocation  :: SourceLoc
+
+      -- | Text of the diagnostic
+    , diagnosticSpelling  :: ByteString
+
+      -- | The command line option that enabled this diagnostic
+    , diagnosticOption :: Maybe ByteString
+
+      -- | The @libclang@ option to disable this option
+    , diagnosticDisabledBy :: Maybe ByteString
+
+      -- | Diagnostic category
+    , diagnosticCategory :: Int
+
+      -- | Rendered category
+    , diagnosticCategoryText :: ByteString
+
+      -- | Source range associated with the diagnostic
+      --
+      -- A diagnostic's source ranges highlight important elements in the source
+      -- code. On the command line, Clang displays source ranges by underlining
+      -- them with @~@ characters.
+    , diagnosticRanges :: [SourceRange]
+
+      -- | Fix-it hints
+    , diagnosticFixIts :: [FixIt]
+
+      -- | Child diagnostics
+    , diagnosticChildren  :: [Diagnostic]
+    }
+  deriving stock (Show)
+
+-- | Suggestion to fix the code
+--
+-- Fix-its are described in terms of a source range whose contents should be
+-- replaced by a string. This approach generalizes over three kinds of
+-- operations: removal of source code (the range covers the code to be removed
+-- and the replacement string is empty), replacement of source code (the range
+-- covers the code to be replaced and the replacement string provides the new
+-- code), and insertion (both the start and end of the range point at the
+-- insertion location, and the replacement string provides the text to insert).
+data FixIt = FixIt {
+      -- | Replacement range
+      --
+      -- The replacement range is the source range whose contents will be
+      -- replaced with the returned replacement string. Note that source ranges
+      -- are half-open ranges [a, b), so the source code should be replaced from
+      -- a and up to (but not including) b.
+      fixItRange :: SourceRange
+
+      -- | Text that should replace the source code
+    , fixItReplacement :: ByteString
+    }
+  deriving stock (Show)
+
+isError :: Diagnostic -> Bool
+isError diag =
+    case fromSimpleEnum (diagnosticSeverity diag) of
+      Right CXDiagnostic_Error -> True
+      Right CXDiagnostic_Fatal -> True
+      Left _unknownSeverity    -> True
+      Right _otherwise         -> False
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+getDiagnostics ::
+     CXTranslationUnit
+  -> Maybe (BitfieldEnum CXDiagnosticDisplayOptions)
+     -- ^ Display options for constructing 'diagnosticFormatted'
+     --
+     -- If 'Nothing', uses 'clang_defaultDiagnosticDisplayOptions'.
+  -> IO [Diagnostic]
+getDiagnostics unit mDisplayOptions = do
+    displayOptions <- case mDisplayOptions of
+                        Just displayOptions -> return displayOptions
+                        Nothing -> clang_defaultDiagnosticDisplayOptions
+    getAll unit clang_getNumDiagnostics $ getDiagnostic displayOptions
+
+{-------------------------------------------------------------------------------
+  Get all diagnostics
+-------------------------------------------------------------------------------}
+
+getDiagnostic ::
+     BitfieldEnum CXDiagnosticDisplayOptions
+  -> CXTranslationUnit
+  -> CUInt -> IO Diagnostic
+getDiagnostic displayOptions unit i =
+    bracket (clang_getDiagnostic unit i) clang_disposeDiagnostic $
+      reify displayOptions
+
+getDiagnosticInSet ::
+     BitfieldEnum CXDiagnosticDisplayOptions
+  -> CXDiagnosticSet -> CUInt -> IO Diagnostic
+getDiagnosticInSet displayOptions set i =
+    bracket (clang_getDiagnosticInSet set i) clang_disposeDiagnostic $
+      reify displayOptions
+
+reify ::
+     BitfieldEnum CXDiagnosticDisplayOptions
+  -> CXDiagnostic -> IO Diagnostic
+reify displayOptions diag = do
+    diagnosticFormatted    <- clang_formatDiagnostic diag displayOptions
+    diagnosticSeverity     <- clang_getDiagnosticSeverity diag
+    diagnosticLocation     <- SourceLoc.clang_getDiagnosticLocation diag
+    diagnosticSpelling     <- clang_getDiagnosticSpelling diag
+    (mOption, mDisabledBy) <- clang_getDiagnosticOption diag
+    diagnosticCategory     <- fromIntegral <$> clang_getDiagnosticCategory diag
+    diagnosticCategoryText <- clang_getDiagnosticCategoryText diag
+    diagnosticRanges       <- getAll diag clang_getDiagnosticNumRanges $
+                                SourceLoc.clang_getDiagnosticRange
+    diagnosticFixIts       <- getAll diag clang_getDiagnosticNumFixIts $
+                                getDiagnosticFixIt
+    diagnosticChildren     <- getChildDiagnostics displayOptions diag
+    return $ Diagnostic {
+          diagnosticFormatted
+        , diagnosticSeverity
+        , diagnosticLocation
+        , diagnosticSpelling
+        , diagnosticOption     = nonEmpty mOption
+        , diagnosticDisabledBy = nonEmpty mDisabledBy
+        , diagnosticCategory
+        , diagnosticCategoryText
+        , diagnosticRanges
+        , diagnosticFixIts
+        , diagnosticChildren
+        }
+  where
+    nonEmpty :: ByteString -> Maybe ByteString
+    nonEmpty bs
+      | BS.null bs = Nothing
+      | otherwise  = Just bs
+
+getChildDiagnostics ::
+     BitfieldEnum CXDiagnosticDisplayOptions
+  -> CXDiagnostic -> IO [Diagnostic]
+getChildDiagnostics displayOptions diag = do
+    set <- clang_getChildDiagnostics diag
+    getAll set clang_getNumDiagnosticsInSet $ getDiagnosticInSet displayOptions
+
+getDiagnosticFixIt :: CXDiagnostic -> CUInt -> IO FixIt
+getDiagnosticFixIt diag i =
+    uncurry FixIt <$> SourceLoc.clang_getDiagnosticFixIt diag i
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+getAll :: a -> (a -> IO CUInt) -> (a -> CUInt -> IO b) -> IO [b]
+getAll x getCount getElem = do
+    count <- getCount x
+    if count == 0
+      then return []
+      else mapM (getElem x) [0 .. pred count]

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
@@ -15,6 +15,9 @@ module HsBindgen.Clang.Util.SourceLoc (
   , clang_Cursor_getSpellingNameRange
   , clang_getCursorLocation
   , clang_getCursorExtent
+  , clang_getDiagnosticLocation
+  , clang_getDiagnosticRange
+  , clang_getDiagnosticFixIt
     -- * Low-level
   , toSourceLoc
   , toSourceRange
@@ -23,12 +26,16 @@ module HsBindgen.Clang.Util.SourceLoc (
 import Data.ByteString (ByteString)
 import Data.ByteString.UTF8 qualified as BS.UTF8
 import Data.List (intercalate)
+import Foreign.C
 
 import HsBindgen.Clang.Core qualified as Core
 import HsBindgen.Clang.Core hiding (
     clang_Cursor_getSpellingNameRange
   , clang_getCursorLocation
   , clang_getCursorExtent
+  , clang_getDiagnosticLocation
+  , clang_getDiagnosticRange
+  , clang_getDiagnosticFixIt
   )
 
 {-------------------------------------------------------------------------------
@@ -93,6 +100,22 @@ clang_getCursorLocation cursor =
 clang_getCursorExtent :: CXCursor -> IO SourceRange
 clang_getCursorExtent cursor =
     toSourceRange =<< Core.clang_getCursorExtent cursor
+
+clang_getDiagnosticLocation :: CXDiagnostic -> IO SourceLoc
+clang_getDiagnosticLocation diag =
+    toSourceLoc =<< Core.clang_getDiagnosticLocation diag
+
+clang_getDiagnosticRange :: CXDiagnostic -> CUInt -> IO SourceRange
+clang_getDiagnosticRange diag i =
+    toSourceRange =<< Core.clang_getDiagnosticRange diag i
+
+clang_getDiagnosticFixIt ::
+     CXDiagnostic
+  -> CUInt
+  -> IO (SourceRange, ByteString)
+clang_getDiagnosticFixIt diag i = do
+    (range, bs) <- Core.clang_getDiagnosticFixIt diag i
+    (,bs) <$> toSourceRange range
 
 {-------------------------------------------------------------------------------
   Internal auxiliary

--- a/hs-bindgen/examples/invalid_standard_types.h
+++ b/hs-bindgen/examples/invalid_standard_types.h
@@ -1,0 +1,9 @@
+#ifndef STANDARD_TYPES_H
+#define STANDARD_TYPES_H
+
+struct ContainsStandardTypes {
+        uint64_t field_uint64_t;
+        clock_t field_clock_t;
+};
+
+#endif

--- a/hs-bindgen/examples/nested_types.h
+++ b/hs-bindgen/examples/nested_types.h
@@ -4,6 +4,6 @@ struct foo {
 };
 
 struct bar {
-    foo foo1;
-    foo foo2;
+    struct foo foo1;
+    struct foo foo2;
 };

--- a/hs-bindgen/examples/standard_types.h
+++ b/hs-bindgen/examples/standard_types.h
@@ -1,0 +1,12 @@
+#ifndef STANDARD_TYPES_H
+#define STANDARD_TYPES_H
+
+#include <time.h>
+#include <stdint.h>
+
+struct ContainsStandardTypes {
+        uint64_t field_uint64_t;
+        clock_t field_clock_t;
+};
+
+#endif

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -20,6 +20,7 @@ import Control.Exception (bracket)
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS.Strict.Char8
 import Data.Tree
+import Foreign.C
 import GHC.Stack
 
 import HsBindgen.C.AST qualified as C
@@ -35,7 +36,6 @@ import HsBindgen.Clang.Util.SourceLoc qualified as SourceLoc
 import HsBindgen.Clang.Util.Tokens qualified as Tokens
 import HsBindgen.Patterns
 import HsBindgen.Util.Tracer
-import Foreign.C
 
 {-------------------------------------------------------------------------------
   General setup
@@ -47,11 +47,11 @@ withTranslationUnit ::
   -> (CXTranslationUnit -> IO r)
   -> IO r
 withTranslationUnit args fp kont = do
-    index  <- clang_createIndex DontDisplayDiagnostics
+    index  <- clang_createIndex DisplayDiagnostics
     unit   <- clang_parseTranslationUnit index fp args flags
     kont unit
   where
-    flags :: CXTranslationUnit_Flags
+    flags :: BitfieldEnum CXTranslationUnit_Flags
     flags = bitfieldEnum [
           CXTranslationUnit_SkipFunctionBodies
         , CXTranslationUnit_DetailedPreprocessingRecord

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -16,9 +16,10 @@ module HsBindgen.C.Parser (
   , ParseMsg(..)
   ) where
 
-import Control.Exception (bracket)
+import Control.Exception
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS.Strict.Char8
+import Data.List (partition)
 import Data.Tree
 import Foreign.C
 import GHC.Stack
@@ -30,6 +31,8 @@ import HsBindgen.Clang.Args
 import HsBindgen.Clang.Core
 import HsBindgen.Clang.Doxygen
 import HsBindgen.Clang.Util.Classification
+import HsBindgen.Clang.Util.Diagnostics (Diagnostic(..))
+import HsBindgen.Clang.Util.Diagnostics qualified as Diagnostics
 import HsBindgen.Clang.Util.Fold
 import HsBindgen.Clang.Util.SourceLoc (SourceLoc)
 import HsBindgen.Clang.Util.SourceLoc qualified as SourceLoc
@@ -41,15 +44,37 @@ import HsBindgen.Util.Tracer
   General setup
 -------------------------------------------------------------------------------}
 
+-- TODO: <https://github.com/well-typed/hs-bindgen/issues/174>
+-- We should have a pretty renderer for diagnostics. For now we rely on
+-- 'diagnosticFormatted'.
+data CErrors = CErrors [ByteString]
+  deriving stock (Show)
+  deriving anyclass (Exception)
+
+-- | Parse C file
+--
+-- Throws 'CErrors' if @libclang@ reported any errors in the C file.
 withTranslationUnit ::
      ClangArgs
   -> FilePath
   -> (CXTranslationUnit -> IO r)
   -> IO r
-withTranslationUnit args fp kont = do
-    index  <- clang_createIndex DisplayDiagnostics
+withTranslationUnit args fp k = do
+    index  <- clang_createIndex DontDisplayDiagnostics
     unit   <- clang_parseTranslationUnit index fp args flags
-    kont unit
+    diags  <- Diagnostics.getDiagnostics unit Nothing
+
+    let errors, warnings :: [Diagnostic]
+        (errors, warnings) = partition Diagnostics.isError diags
+
+    case errors of
+      [] -> do
+        -- TODO: <https://github.com/well-typed/hs-bindgen/issues/175>
+        -- We should print warnings only optionally.
+        print warnings
+        k unit
+      errs ->
+        throwIO $ CErrors $ map diagnosticFormatted errs
   where
     flags :: BitfieldEnum CXTranslationUnit_Flags
     flags = bitfieldEnum [


### PR DESCRIPTION
We don't currently render warnings and errors nicely (see #174), _but_, given

```c
struct ContainsStandardTypes {
        uint64_t field_uint64_t;
        clock_t field_clock_t;
};
```

we now get

```
hs-bindgen: CErrors [
    Diagnostic { 
      diagnosticFormatted = "examples/invalid_standard_types.h:5:9: error: unknown type name 'uint64_t'"
    , diagnosticSeverity = simpleEnum CXDiagnostic_Error
    , diagnosticLocation = "examples/invalid_standard_types.h:5:9"
    , diagnosticSpelling = "unknown type name 'uint64_t'"
    , diagnosticOption = Nothing 
    , diagnosticDisabledBy = Nothing
    , diagnosticCategory = 2
    , diagnosticCategoryText = "Semantic Issue"
    , diagnosticRanges = []
    , diagnosticFixIts = []
    , diagnosticChildren = []
  }
  ,Diagnostic {
      diagnosticFormatted = "examples/invalid_standard_types.h:6:9: error: unknown type name 'clock_t'"
    , diagnosticSeverity = simpleEnum CXDiagnostic_Error
    , diagnosticLocation = "examples/invalid_standard_types.h:6:9"
    , diagnosticSpelling = "unknown type name 'clock_t'"
    , diagnosticOption = Nothing
    , diagnosticDisabledBy = Nothing
    , diagnosticCategory = 2
    , diagnosticCategoryText = "Semantic Issue"
    , diagnosticRanges = []
    , diagnosticFixIts = []
    , diagnosticChildren = []
  }
]
```

(when ran through [`friendly`](https://hackage.haskell.org/package/friendly)). When we fix this by adding the relevant imports to the input header:

```c
#include <time.h>
#include <stdint.h>

struct ContainsStandardTypes {
        uint64_t field_uint64_t;
        clock_t field_clock_t;
};
```

then this now parses as

```haskell
Element {
    elementName = LibclangProvided "time.h"
  , elementKind = "inclusion directive"
  , elementTypeKind = "Invalid"
  , elementRawComment = ""
  , elementIsAnonymous = False
  , elementIsDefinition = False
}

Element {
    elementName = LibclangProvided "stdint.h"
  , elementKind = "inclusion directive"
  , elementTypeKind = "Invalid"
  , elementRawComment = ""
  , elementIsAnonymous = False
  , elementIsDefinition = False
}

Element {
    elementName = UserProvided "ContainsStandardTypes"
  , elementKind = "StructDecl"
  , elementTypeKind = "Record"
  , elementRawComment = ""
  , elementIsAnonymous = False
  , elementIsDefinition = True
}
|
+- Element {
       elementName = UserProvided "field_uint64_t"
     , elementKind = "FieldDecl"
     , elementTypeKind = "Elaborated"
     , elementRawComment = ""
     , elementIsAnonymous = False
     , elementIsDefinition = True
   }
|  |
|  `- Element {
          elementName = UserProvided "uint64_t"
        , elementKind = "TypeRef"
        , elementTypeKind = "Typedef"
        , elementRawComment = ""
        , elementIsAnonymous = False
        , elementIsDefinition = False
      }
|
`- Element {
    elementName = UserProvided "field_clock_t"
  , elementKind = "FieldDecl"
  , elementTypeKind = "Elaborated"
  , elementRawComment = ""
  , elementIsAnonymous = False
  , elementIsDefinition = True
}
   |
   `- Element {
          elementName = UserProvided "clock_t"
        , elementKind = "TypeRef"
        , elementTypeKind = "Typedef"
        , elementRawComment = ""
        , elementIsAnonymous = False
        , elementIsDefinition = False
      }
```

So we _do_ see the typedefs; turns out, the `int` that we were seeing for these fields prior to this PR were just a _default_ type, and we didn't realize because we weren't seeing the diagnostics.