### PR TITLE
More macro parsing

### DIFF
--- a/hs-bindgen/examples/macros.h
+++ b/hs-bindgen/examples/macros.h
@@ -1,1 +1,4 @@
-#define MYFOO 1
+#define OBJECTLIKE1 1
+#define OBJECTLIKE2 ( 2 )
+#define OBJECTLIKE3 3 + 3
+#define OBJECTLIKE4 ( 4 + 4 )

--- a/hs-bindgen/fixtures/macros.dump.txt
+++ b/hs-bindgen/fixtures/macros.dump.txt
@@ -1,1 +1,4 @@
-"macro definition" "MYFOO" :: "Invalid"
+"macro definition" "OBJECTLIKE1" :: "Invalid"
+"macro definition" "OBJECTLIKE2" :: "Invalid"
+"macro definition" "OBJECTLIKE3" :: "Invalid"
+"macro definition" "OBJECTLIKE4" :: "Invalid"

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -10,6 +10,46 @@ WrapCHeader
                 "macros.h"],
               sourceLocLine = 1,
               sourceLocColumn = 9},
-            macroName = CName "MYFOO",
+            macroName = CName "OBJECTLIKE1",
             macroArgs = [],
-            macroBody = MTerm (MInt 1)})])
+            macroBody = MTerm (MInt 1)}),
+      DeclMacro
+        (Right
+          Macro {
+            macroLoc = SourceLoc {
+              sourceLocFile = [
+                "examples",
+                "macros.h"],
+              sourceLocLine = 2,
+              sourceLocColumn = 9},
+            macroName = CName "OBJECTLIKE2",
+            macroArgs = [],
+            macroBody = MTerm (MInt 2)}),
+      DeclMacro
+        (Right
+          Macro {
+            macroLoc = SourceLoc {
+              sourceLocFile = [
+                "examples",
+                "macros.h"],
+              sourceLocLine = 3,
+              sourceLocColumn = 9},
+            macroName = CName "OBJECTLIKE3",
+            macroArgs = [],
+            macroBody = MAdd
+              (MTerm (MInt 3))
+              (MTerm (MInt 3))}),
+      DeclMacro
+        (Right
+          Macro {
+            macroLoc = SourceLoc {
+              sourceLocFile = [
+                "examples",
+                "macros.h"],
+              sourceLocLine = 4,
+              sourceLocColumn = 9},
+            macroName = CName "OBJECTLIKE4",
+            macroArgs = [],
+            macroBody = MAdd
+              (MTerm (MInt 4))
+              (MTerm (MInt 4))})])

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -27,32 +27,32 @@ WrapCHeader
               fieldName = CName "s",
               fieldOffset = 32,
               fieldType = TypPrim
-                (PrimShortInt Signed)},
+                (PrimShort Signed)},
             StructField {
               fieldName = CName "si",
               fieldOffset = 48,
               fieldType = TypPrim
-                (PrimShortInt Signed)},
+                (PrimShort Signed)},
             StructField {
               fieldName = CName "ss",
               fieldOffset = 64,
               fieldType = TypPrim
-                (PrimShortInt Signed)},
+                (PrimShort Signed)},
             StructField {
               fieldName = CName "ssi",
               fieldOffset = 80,
               fieldType = TypPrim
-                (PrimShortInt Signed)},
+                (PrimShort Signed)},
             StructField {
               fieldName = CName "us",
               fieldOffset = 96,
               fieldType = TypPrim
-                (PrimShortInt Unsigned)},
+                (PrimShort Unsigned)},
             StructField {
               fieldName = CName "usi",
               fieldOffset = 112,
               fieldType = TypPrim
-                (PrimShortInt Unsigned)},
+                (PrimShort Unsigned)},
             StructField {
               fieldName = CName "i",
               fieldOffset = 128,

--- a/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
@@ -23,6 +23,7 @@ import System.FilePath (takeBaseName)
 import Text.Show.Pretty (PrettyVal)
 
 import HsBindgen.C.AST.Name
+import HsBindgen.C.AST.Type
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -80,6 +81,11 @@ data MTerm =
     --
     -- This might be a macro argument, or another marco.
   | MVar CName [MExpr]
+
+    -- | Type declaration
+    --
+    -- For now we only support primitive types.
+  | MType PrimType
 
     -- | Attribute
   | MAttr Attribute MTerm

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -68,7 +68,7 @@ data PrimType =
     PrimChar (Maybe PrimSign)
 
     -- | @[signed | unsigned] short [int]@
-  | PrimShortInt PrimSign
+  | PrimShort PrimSign
 
     -- | @[signed | unsigned] int@
   | PrimInt PrimSign

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -289,8 +289,8 @@ primType (Right kind) =
       CXType_Char_S     -> Just $ PrimChar     Nothing
       CXType_SChar      -> Just $ PrimChar     (Just Signed)
       CXType_UChar      -> Just $ PrimChar     (Just Unsigned)
-      CXType_Short      -> Just $ PrimShortInt Signed
-      CXType_UShort     -> Just $ PrimShortInt Unsigned
+      CXType_Short      -> Just $ PrimShort    Signed
+      CXType_UShort     -> Just $ PrimShort    Unsigned
       CXType_Int        -> Just $ PrimInt      Signed
       CXType_UInt       -> Just $ PrimInt      Unsigned
       CXType_Long       -> Just $ PrimLong     Signed

--- a/hs-bindgen/src/HsBindgen/C/Parser/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser/Macro.hs
@@ -8,6 +8,7 @@ module HsBindgen.C.Parser.Macro (
 import Control.Exception (Exception)
 import Control.Monad
 import Data.Bifunctor
+import Data.Char (isDigit, toLower)
 import Data.Functor.Identity
 import Data.List (intercalate)
 import Data.Text (Text)
@@ -17,7 +18,7 @@ import Text.Parsec.Combinator
 import Text.Parsec.Error
 import Text.Parsec.Expr
 import Text.Parsec.Pos qualified as Parsec
-import Text.Parsec.Prim (Parsec, (<?>), many, unexpected)
+import Text.Parsec.Prim (Parsec, (<?>), many, unexpected, try)
 import Text.Parsec.Prim qualified as Parsec
 import Text.Read (readMaybe)
 import Text.Show.Pretty (PrettyVal)
@@ -91,9 +92,16 @@ type Parser = Parsec [Token TokenSpelling] ParserState
 parseMacro :: Parser Macro
 parseMacro = do
     (macroLoc, macroName) <- parseMacroName
-    macroArgs <- option [] parseFormalArgs
-    macroBody <- parseMExpr
-    return Macro{macroLoc, macroName, macroArgs, macroBody}
+    choice [
+        -- When we see an opening bracket it might be the start of an argument
+        -- list, or it might be the start of the body, wrapped in parentheses.
+        try $ functionLike macroLoc macroName
+      , objectLike macroLoc macroName
+      ]
+  where
+    functionLike, objectLike :: SourceLoc -> CName -> Parser Macro
+    functionLike loc name = Macro loc name <$> parseFormalArgs <*> parseMExpr
+    objectLike   loc name = Macro loc name [] <$> parseMExpr
 
 parseMacroName :: Parser (SourceLoc, CName)
 parseMacroName = parseName
@@ -130,26 +138,31 @@ parseMTerm =
 parseVar :: Parser CName
 parseVar = snd <$> parseName
 
+-- | Parse integer literal
+--
+-- Reference: <https://en.cppreference.com/w/cpp/language/integer_literal>
 parseInteger :: Parser Integer
-parseInteger = tokenOfKind CXToken_Literal aux
+parseInteger = tokenOfKind CXToken_Literal (aux . Text.unpack)
   where
-    -- TODO: This is wrong, we should not parse C literals with Haskell rules
-    aux :: Text -> Maybe Integer
-    aux = readMaybe . dropSuffix . Text.unpack
+    aux :: String -> Maybe Integer
+    aux str
+      | isValidSuffix suffix
+      = readMaybe literal -- TODO: we should not parse C with Haskell rules
 
-    -- TODO: Should we preserve this suffix in some way..? are we losing info?
-    dropSuffix :: String -> String
-    dropSuffix str = reverse $
-       case reverse str of
-         'l':'l':xs -> xs
-         'L':'L':xs -> xs
-         'u':xs     -> xs
-         'U':xs     -> xs
-         'l':xs     -> xs
-         'L':xs     -> xs
-         'z':xs     -> xs
-         'Z':xs     -> xs
-         xs         -> xs
+      | otherwise
+      = Nothing
+      where
+        (literal, suffix) = span (\c -> isDigit c || c == 'x') str
+
+    -- TODO: Should we preserve the suffix information in some way?
+    isValidSuffix :: String -> Bool
+    isValidSuffix str = map toLower str `elem` [
+          ""
+        , "u"
+        ,  "l",   "ll",   "z"
+        , "ul",  "ull",  "uz"
+        ,  "lu",  "llu",  "zu"
+        ]
 
 {-------------------------------------------------------------------------------
   Attributes


### PR DESCRIPTION
There are a few cases we still need to handle, but after that we can parse most of the macros from the standard library, and the ones that we cannot we can safely ignore (not all macros are even parseable at all, of course, and not all macros are of interest to `hs-bindgen`).