### PR TITLE
Fix typos

### DIFF
--- a/alternatives/README.md
+++ b/alternatives/README.md
@@ -87,7 +87,7 @@ See https://ghc.gitlab.haskell.org/ghc/doc/users_guide/utils.html#writing-haskel
 
 The main point of `c2hs` is to allow users to write _high level_ bindings in
 a more convenient manner, by providing for certain types of abstractions.
-For example, where with `c2hs` or manual bindings, we end up having to write
+For example, where with `hsc2hs` or manual bindings, we end up having to write
 
 ```haskell
 alloca $ \ptr -> do
@@ -95,7 +95,7 @@ alloca $ \ptr -> do
   cShowStruct ptr
 ```
 
-but with `hsc2hs` we can capture this pattern
+but with `c2hs` we can capture this pattern
 
 ```haskell
 withAlloca :: Storable a => a -> (Ptr () -> IO r) -> IO r

--- a/hs-bindgen/src/HsBindgen/C/AST/Literal.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Literal.hs
@@ -25,7 +25,7 @@ data Literal a = Literal {
       -- unreadable in decimal.
       literalText  :: Text
 
-      -- | The (parsed) valeu of the literal
+      -- | The (parsed) value of the literal
     , literalValue :: a
     }
   deriving stock (Show, Eq, Generic)

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -48,7 +48,7 @@ data Typ =
 --
 -- 1. We could produce a field of type 'CInt' in the generated Haskell code
 -- 2. We could query @libclang@ to what choice it makes for the selected
---    target platform, and use 'CShort' or 'CLong' (or something else again.
+--    target platform, and use 'CShort' or 'CLong' (or something else) again.
 --
 -- Both options have advantages; most users will probably prefer (1), so that
 -- we generate a /single/ API, independent of implementation details. However,
@@ -59,7 +59,7 @@ data Typ =
 data PrimType =
     -- | @[signed | unsigned] char@
     --
-    -- The C standard distinguishes between /three/ kinds of @cha@: @char@,
+    -- The C standard distinguishes between /three/ kinds of @char@: @char@,
     -- @signed char@ and @unsigned char@. Unlike the other integer types,
     -- the interpretation of @char@ as either @signed char@ or @unsigned char@
     -- is implementation defined.


### PR DESCRIPTION
This commit just fixes minor typos in documentation/comments that I spotted while first looking over the project.  There are no changes to actual code.