### PR TITLE
Optimise ansi-diff more

### DIFF
--- a/ansi-diff/bench/ansi-diff-bench.hs
+++ b/ansi-diff/bench/ansi-diff-bench.hs
@@ -36,12 +36,6 @@ benchmarks =
 
         , env (readString "fixtures/primitive_types.th.old.txt") $ \old ->
           env (readString "fixtures/primitive_types.th.new.txt") $ \new ->
-          bench "ansi-diff.metric" $
-            whnf (uncurry AnsiDiff.metric)
-            (old, new)
-
-        , env (readString "fixtures/primitive_types.th.old.txt") $ \old ->
-          env (readString "fixtures/primitive_types.th.new.txt") $ \new ->
           bench "Diff" $
             nf (uncurry Diff.getDiff)
             (old, new)
@@ -64,12 +58,6 @@ benchmarks =
           env (readText "fixtures/primitive_types.hs.new.txt") $ \new ->
           bench "text-metrics" $
             whnf (uncurry Metrics.levenshtein)
-            (old, new)
-
-        , env (readString "fixtures/primitive_types.hs.old.txt") $ \old ->
-          env (readString "fixtures/primitive_types.hs.new.txt") $ \new ->
-          bench "ansi-diff.levenshtein" $
-            whnf (uncurry AnsiDiff.metric)
             (old, new)
 
         , env (readString "fixtures/primitive_types.hs.old.txt") $ \old ->

--- a/ansi-diff/test/ansi-diff-test.hs
+++ b/ansi-diff/test/ansi-diff-test.hs
@@ -2,20 +2,30 @@ module Main (main) where
 
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.QuickCheck ((===), counterexample)
+import Test.QuickCheck (counterexample)
 import Text.EditDistance qualified as ED
-import AnsiDiff qualified
+
+import AnsiDiff ()
+
+editDistanceNorm :: String -> String -> Int
+editDistanceNorm xs ys = ED.levenshteinDistance ED.defaultEditCosts xs ys
+
+-- | Lower bound for edit-distance:
+--
+-- consider two strings (lists) of separate lengths:
+-- the length difference is the least amount of added (or removed) elements.
+-- Only strings of equal length can be equal.
+--
+editDistanceNormLB :: [a] -> [a] -> Int
+editDistanceNormLB xs ys = max n m - min n m
+  where
+    !n = length xs
+    !m = length ys
 
 main :: IO ()
 main = defaultMain $ testGroup "ansi-diff"
-    [ testProperty "metric-less-edit-distance" $ \xs ys ->
-        let n = ED.levenshteinDistance ED.defaultEditCosts xs ys
-            m = AnsiDiff.metric xs ys
-        in counterexample (show (n, m)) $ m <= n
-
-    , testProperty "metric-zero" $ \xs ys ->
-        let n = ED.levenshteinDistance ED.defaultEditCosts xs ys
-            m = AnsiDiff.metric xs ys
-            f x = compare x 0
-        in f n === f m
+    [ testProperty "edit-distance-lb" $ \xs ys ->
+        let a = editDistanceNorm xs ys
+            b = editDistanceNormLB xs ys
+        in counterexample (show (a, b)) $ b <= a
     ]


### PR DESCRIPTION
Use lower-bound approximation of inter-line edit-distance, making diff-chunk coloring even faster.

The benchmark results (the benchmarks are just two examples, but hopefully they show a trend):
- `th` with has multiple lines, the `ansi-diff` doesn't add much on top of just `Diff`, and that's all is magnitude faster then (character based) levenshtein distance.
- `hs` is a single line, so we end up doing `edit-distance`, but in this particular example `edit-distance` seems to be faster than `text-metrics` (bitfiddling-Myers vs. Wagner-Fisher)

Having `ansi-diff` produce outputs in milliseconds range is great.

```
All
  th
    edit-distance: OK
      170  ms ± 6.6 ms
    text-metrics:  OK
      61.3 ms ± 3.1 ms
    Diff:          OK
      2.18 ms ± 118 μs
    ansidiff:      OK
      2.89 ms ± 231 μs
  hs
    edit-distance: OK
      4.30 ms ± 182 μs
    text-metrics:  OK
      42.1 ms ± 3.1 ms
    Diff:          OK
      899  μs ±  43 μs
    ansidiff:      OK
      5.49 ms ± 375 μs
```