### PR TITLE
Overhaul treatment of source locations

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.c
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.c
@@ -13,3 +13,13 @@ enum CXChildVisitResult wrap_visitor(CXCursor cursor, CXCursor parent, CXClientD
     WrapCXCursorVisitor visitor = client_data;
     return visitor(&cursor, &parent);
 }
+
+/**
+ * Debugging
+ */
+
+void clang_breakpoint(void) {
+    static int i = 0;
+    fprintf(stderr, "clang_breakpoint: %d\n", ++i);
+}
+

--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -217,6 +217,10 @@ static inline void wrap_getCursorKindSpelling(enum CXCursorKind Kind, CXString* 
     *result = clang_getCursorKindSpelling(Kind);
 }
 
+static inline CXTranslationUnit wrap_Cursor_getTranslationUnit(const CXCursor* cursor) {
+    return clang_Cursor_getTranslationUnit(*cursor);
+}
+
 /**
  * Traversing the AST with cursors
  *
@@ -419,8 +423,24 @@ static inline void wrap_getExpansionLocation(const CXSourceLocation* location, C
     clang_getExpansionLocation(*location, file, line, column, offset);
 }
 
+static inline void wrap_getPresumedLocation(const CXSourceLocation* location, CXString* filename, unsigned* line, unsigned* column) {
+    clang_getPresumedLocation(*location, filename, line, column);
+}
+
 static inline void wrap_getSpellingLocation(const CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset) {
     clang_getSpellingLocation(*location, file, line, column, offset);
+}
+
+static inline void wrap_getFileLocation(const CXSourceLocation* location, CXFile* file, unsigned* line, unsigned* column, unsigned* offset) {
+    clang_getFileLocation(*location, file, line, column, offset);
+}
+
+static inline void wrap_getLocation(CXTranslationUnit tu, CXFile file, unsigned line, unsigned column, CXSourceLocation* result) {
+    *result = clang_getLocation(tu, file, line, column);
+}
+
+static inline void wrap_getRange(const CXSourceLocation* begin, const CXSourceLocation* end, CXSourceRange* result) {
+    *result = clang_getRange(*begin, *end);
 }
 
 static inline int wrap_Location_isFromMainFile(const CXSourceLocation* location) {
@@ -447,5 +467,11 @@ static inline char* wrap_getCString(const CXString* string) {
 static inline void wrap_disposeString(const CXString* string) {
     clang_disposeString(*string);
 }
+
+/**
+ * Debugging
+ */
+
+void clang_breakpoint(void);
 
 #endif

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -65,6 +65,7 @@ library
       HsBindgen.Clang.Util.Diagnostics
       HsBindgen.Clang.Util.Fold
       HsBindgen.Clang.Util.SourceLoc
+      HsBindgen.Clang.Util.SourceLoc.Type
       HsBindgen.Clang.Util.Tokens
   other-modules:
       HsBindgen.Clang.Core.Enums

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Internal/ByValue.hs
@@ -104,7 +104,7 @@ class Preallocate a where
   -- See 'onHaskellHeap' for rationale.
   preallocate :: (Writing a -> IO r) -> IO (a, r)
 
-preallocate_ :: Preallocate  a => (Writing a -> IO ()) -> IO a
+preallocate_ :: Preallocate a => (Writing a -> IO ()) -> IO a
 preallocate_ = fmap fst . preallocate
 
 instance HasKnownSize tag => Preallocate (OnHaskellHeap tag) where

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Diagnostics.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Diagnostics.hs
@@ -11,7 +11,7 @@ import Data.Text qualified as Text
 import Foreign.C
 
 import HsBindgen.Clang.Core
-import HsBindgen.Clang.Util.SourceLoc (SourceLoc, SourceRange)
+import HsBindgen.Clang.Util.SourceLoc.Type
 import HsBindgen.Clang.Util.SourceLoc qualified as SourceLoc
 import HsBindgen.Patterns
 
@@ -27,7 +27,7 @@ data Diagnostic = Diagnostic {
     , diagnosticSeverity :: SimpleEnum CXDiagnosticSeverity
 
       -- | Source location (where Clang would print the caret @^@)
-    , diagnosticLocation  :: SourceLoc
+    , diagnosticLocation  :: MultiLoc
 
       -- | Text of the diagnostic
     , diagnosticSpelling  :: Text
@@ -49,7 +49,7 @@ data Diagnostic = Diagnostic {
       -- A diagnostic's source ranges highlight important elements in the source
       -- code. On the command line, Clang displays source ranges by underlining
       -- them with @~@ characters.
-    , diagnosticRanges :: [SourceRange]
+    , diagnosticRanges :: [Range MultiLoc]
 
       -- | Fix-it hints
     , diagnosticFixIts :: [FixIt]
@@ -76,7 +76,7 @@ data FixIt = FixIt {
       -- replaced with the returned replacement string. Note that source ranges
       -- are half-open ranges [a, b), so the source code should be replaced from
       -- a and up to (but not including) b.
-      fixItRange :: SourceRange
+      fixItRange :: Range MultiLoc
 
       -- | Text that should replace the source code
     , fixItReplacement :: Text

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc.hs
@@ -1,178 +1,183 @@
 -- | Utilities for working with source locations
 --
--- The functions in this module intentionally have the same names as the
--- corresponding functions in "HsBindgen.Clang.Core", and therefore the same
--- names as in @libclang@ itself.
---
 -- Intended for qualified import.
 --
--- > import HsBindgen.Clang.Util.SourceLoc (SourceLoc(..), SourceRange(..))
+-- > import HsBindgen.Clang.Util.SourceLoc.Type
 -- > import HsBindgen.Clang.Util.SourceLoc qualified as SourceLoc
 module HsBindgen.Clang.Util.SourceLoc (
-    SourcePath(..)
-  , SourceLoc(..)
-  , SourceRange(..)
-    -- * Construction
+    -- * Conversion
+    toMulti
+  , toRange
+  , fromSingle
+  , fromRange
+    -- * Get single location
+  , clang_getExpansionLocation
+  , clang_getPresumedLocation
+  , clang_getSpellingLocation
+  , clang_getFileLocation
+    -- * Convenience wrappers
+    -- * for @CXSourceLocation@
+  , clang_getDiagnosticLocation
+  , clang_getCursorLocation
+  , clang_getTokenLocation
+    -- ** for @CXSourceRange@
+  , clang_getDiagnosticRange
+  , clang_getDiagnosticFixIt
   , clang_Cursor_getSpellingNameRange
   , clang_getCursorExtent
-  , clang_getCursorLocation
-  , clang_getDiagnosticFixIt
-  , clang_getDiagnosticLocation
-  , clang_getDiagnosticRange
   , clang_getTokenExtent
-  , clang_getTokenLocation
-    -- * Low-level
-  , toSourcePath
-  , toSourceLoc
-  , toSourceRange
   ) where
 
-import Data.List (intercalate)
+import Control.Monad
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Foreign.C
-import GHC.Generics (Generic)
-import Text.Show.Pretty (PrettyVal(..))
 
 import HsBindgen.Clang.Core qualified as Core
-import HsBindgen.Clang.Core hiding (
-    clang_Cursor_getSpellingNameRange
-  , clang_getCursorExtent
-  , clang_getCursorLocation
-  , clang_getDiagnosticFixIt
-  , clang_getDiagnosticLocation
-  , clang_getDiagnosticRange
-  , clang_getTokenExtent
-  , clang_getTokenLocation
-  )
+import HsBindgen.Clang.Util.SourceLoc.Type
 
 {-------------------------------------------------------------------------------
-  Definition
+  Conversion
 -------------------------------------------------------------------------------}
 
--- | Paths as reported by @libclang@
---
--- Clang uses UTF-8 internally for everything, including paths, which is why
--- this is 'Text', not 'OsPath'. There might still be differences between
--- platforms of course (such as directory separators).
-newtype SourcePath = SourcePath {
-      getSourcePath :: Text
-    }
-  deriving newtype (Eq, Ord)
+toMulti :: Core.CXSourceLocation -> IO MultiLoc
+toMulti location = do
+    expansion <- clang_getExpansionLocation location
 
-data SourceLoc = SourceLoc {
-      sourceLocFile   :: !SourcePath
-    , sourceLocLine   :: !Int
-    , sourceLocColumn :: !Int
-    }
-  deriving stock (Eq, Ord, Generic)
+    let unlessIsExpanion :: SingleLoc -> Maybe SingleLoc
+        unlessIsExpanion loc = do
+            guard $ loc /= expansion
+            return loc
 
-data SourceRange = SourceRange {
-      sourceRangeStart :: !SourceLoc
-    , sourceRangeEnd   :: !SourceLoc
-    }
-  deriving stock (Eq, Ord, Generic)
+    MultiLoc expansion
+      <$> (unlessIsExpanion <$> clang_getPresumedLocation location)
+      <*> (unlessIsExpanion <$> clang_getSpellingLocation location)
+      <*> (unlessIsExpanion <$> clang_getFileLocation     location)
+
+toRange :: Core.CXSourceRange -> IO (Range MultiLoc)
+toRange = toRangeWith toMulti
+
+fromSingle :: Core.CXTranslationUnit -> SingleLoc -> IO Core.CXSourceLocation
+fromSingle unit SingleLoc{singleLocPath, singleLocLine, singleLocColumn} = do
+     file <- Core.clang_getFile unit (getSourcePath singleLocPath)
+     Core.clang_getLocation
+       unit
+       file
+       (fromIntegral singleLocLine)
+       (fromIntegral singleLocColumn)
+
+fromRange :: Core.CXTranslationUnit -> Range SingleLoc -> IO Core.CXSourceRange
+fromRange unit Range{rangeStart, rangeEnd} = do
+    rangeStart' <- fromSingle unit rangeStart
+    rangeEnd'   <- fromSingle unit rangeEnd
+    Core.clang_getRange rangeStart' rangeEnd'
 
 {-------------------------------------------------------------------------------
-  Show instances
-
-  These are defined so that we could, if we wanted to, also provide an inverse
-  'IsString' instance; this is the reason for the @show . pretty...@
+  Get single location
 -------------------------------------------------------------------------------}
 
-instance Show SourcePath where
-  show = show . getSourcePath
+clang_getExpansionLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getExpansionLocation location =
+    toSingle' =<< Core.clang_getExpansionLocation location
 
-instance Show SourceLoc where
-  show = show . prettySourceLoc True
+clang_getPresumedLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getPresumedLocation location =
+    toSingle <$> Core.clang_getPresumedLocation location
 
-instance Show SourceRange where
-  show = show . prettySourceRange
+clang_getSpellingLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getSpellingLocation location =
+    toSingle' =<< Core.clang_getSpellingLocation location
 
-instance PrettyVal SourcePath where
-  prettyVal = prettyVal . show
-
-instance PrettyVal SourceLoc where
-  prettyVal = prettyVal . show
-
-instance PrettyVal SourceRange where
-  prettyVal = prettyVal . show
-
-prettySourceLoc ::
-     Bool -- ^ Should we show the file?
-  -> SourceLoc -> String
-prettySourceLoc showFile (SourceLoc file line col) =
-    intercalate ":" . concat $ [
-        [ Text.unpack (getSourcePath file) | showFile ]
-      , [ show line, show col ]
-      ]
-
-prettySourceRange :: SourceRange -> String
-prettySourceRange (SourceRange start end) = concat [
-      prettySourceLoc True start
-    , "-"
-    , prettySourceLoc (sourceLocFile start /= sourceLocFile end) end
-    ]
+clang_getFileLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getFileLocation location =
+    toSingle' =<< Core.clang_getFileLocation location
 
 {-------------------------------------------------------------------------------
-  Construction
+  Convenience wrappers for @CXSourceLocation@
 -------------------------------------------------------------------------------}
 
-clang_Cursor_getSpellingNameRange :: CXCursor -> IO SourceRange
-clang_Cursor_getSpellingNameRange cursor =
-    toSourceRange =<< Core.clang_Cursor_getSpellingNameRange cursor 0 0
+-- | Retrieve the source location of the given diagnostic.
+clang_getDiagnosticLocation :: Core.CXDiagnostic -> IO MultiLoc
+clang_getDiagnosticLocation diagnostic =
+    toMulti =<< Core.clang_getDiagnosticLocation diagnostic
 
-clang_getCursorLocation :: CXCursor -> IO SourceLoc
+-- | Retrieve the physical location of the source constructor referenced by the
+-- given cursor.
+clang_getCursorLocation :: Core.CXCursor -> IO MultiLoc
 clang_getCursorLocation cursor =
-    toSourceLoc =<< Core.clang_getCursorLocation cursor
+    toMulti =<< Core.clang_getCursorLocation cursor
 
-clang_getCursorExtent :: CXCursor -> IO SourceRange
-clang_getCursorExtent cursor =
-    toSourceRange =<< Core.clang_getCursorExtent cursor
-
-clang_getDiagnosticLocation :: CXDiagnostic -> IO SourceLoc
-clang_getDiagnosticLocation diag =
-    toSourceLoc =<< Core.clang_getDiagnosticLocation diag
-
-clang_getDiagnosticRange :: CXDiagnostic -> CUInt -> IO SourceRange
-clang_getDiagnosticRange diag i =
-    toSourceRange =<< Core.clang_getDiagnosticRange diag i
-
-clang_getDiagnosticFixIt ::
-     CXDiagnostic
-  -> CUInt
-  -> IO (SourceRange, Text)
-clang_getDiagnosticFixIt diag i = do
-    (range, bs) <- Core.clang_getDiagnosticFixIt diag i
-    (,bs) <$> toSourceRange range
-
-clang_getTokenLocation :: CXTranslationUnit -> CXToken -> IO SourceLoc
+-- | Retrieve the source location of the given token.
+clang_getTokenLocation :: Core.CXTranslationUnit -> Core.CXToken -> IO MultiLoc
 clang_getTokenLocation unit token =
-    toSourceLoc =<< Core.clang_getTokenLocation unit token
-
-clang_getTokenExtent :: CXTranslationUnit -> CXToken -> IO SourceRange
-clang_getTokenExtent unit token =
-    toSourceRange =<< Core.clang_getTokenExtent unit token
+    toMulti =<< Core.clang_getTokenLocation unit token
 
 {-------------------------------------------------------------------------------
-  Internal auxiliary
+  Convenience wrappers for @CXSourceRange@
 -------------------------------------------------------------------------------}
 
-toSourcePath :: Text -> SourcePath
-toSourcePath = SourcePath
+-- | Retrieve a source range associated with the diagnostic.
+clang_getDiagnosticRange :: Core.CXDiagnostic -> CUInt -> IO (Range MultiLoc)
+clang_getDiagnosticRange diagnostic range =
+    toRange =<< Core.clang_getDiagnosticRange diagnostic range
 
-toSourceRange :: CXSourceRange -> IO SourceRange
-toSourceRange rng = do
-    begin <- clang_getRangeStart rng
-    end   <- clang_getRangeEnd   rng
-    SourceRange
-      <$> toSourceLoc begin
-      <*> toSourceLoc end
+-- | Retrieve the replacement information for a given fix-it.
+clang_getDiagnosticFixIt ::
+     Core.CXDiagnostic
+  -> CUInt
+  -> IO (Range MultiLoc, Text)
+clang_getDiagnosticFixIt diagnostic fixit = do
+    (range, replacement) <- Core.clang_getDiagnosticFixIt diagnostic fixit
+    (, replacement) <$> toRange range
 
-toSourceLoc :: CXSourceLocation -> IO SourceLoc
-toSourceLoc loc = do
-    (file, line, col, _bufOffset) <- clang_getSpellingLocation loc
-    SourceLoc
-      <$> (toSourcePath <$> clang_getFileName file)
-      <*> (pure $ fromIntegral line)
-      <*> (pure $ fromIntegral col)
+-- | Retrieve a range for a piece that forms the cursors spelling name.
+--
+-- TODO: This currently returns 'Range' 'SingleLoc' as I am assuming that the
+-- relevant part of the returned range is the /spelling/ location. That
+-- assumption may be false.
+clang_Cursor_getSpellingNameRange ::
+     Core.CXCursor
+  -> CUInt
+  -> CUInt
+  -> IO (Range SingleLoc)
+clang_Cursor_getSpellingNameRange cursor pieceIndex options = do
+    range <- Core.clang_Cursor_getSpellingNameRange cursor pieceIndex options
+    toRangeWith clang_getSpellingLocation range
+
+-- | Retrieve the physical extent of the source construct referenced by the
+-- given cursor.
+clang_getCursorExtent :: Core.CXCursor -> IO (Range MultiLoc)
+clang_getCursorExtent cursor =
+    toRange =<< Core.clang_getCursorExtent cursor
+
+-- | Retrieve a source range that covers the given token.
+clang_getTokenExtent ::
+     Core.CXTranslationUnit
+  -> Core.CXToken
+  -> IO (Range MultiLoc)
+clang_getTokenExtent unit token =
+    toRange =<< Core.clang_getTokenExtent unit token
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+toSingle :: (Text, CUInt, CUInt) -> SingleLoc
+toSingle (singleLocPath, singleLocLine, singleLocColumn) = SingleLoc{
+      singleLocPath   = SourcePath singleLocPath
+    , singleLocLine   = fromIntegral singleLocLine
+    , singleLocColumn = fromIntegral singleLocColumn
+    }
+
+toSingle' :: (Core.CXFile, CUInt, CUInt, CUInt) -> IO SingleLoc
+toSingle' (file, singleLocLine, singleLocColumn, _offset) = do
+    singleLocPath <- Core.clang_getFileName file
+    return $ toSingle (singleLocPath, singleLocLine, singleLocColumn)
+
+toRangeWith ::
+    (Core.CXSourceLocation -> IO a)
+  -> Core.CXSourceRange -> IO (Range a)
+toRangeWith f range =
+    Range
+      <$> (f =<< Core.clang_getRangeStart range)
+      <*> (f =<< Core.clang_getRangeEnd   range)
+

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc/Type.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/SourceLoc/Type.hs
@@ -1,0 +1,208 @@
+-- | Definition of the source location types
+--
+-- Intended for unqualified import (unlike "HsBindgen.Clang.Util.SourceLoc").
+-- We introduce this split so that these type can be exported (unqualified)
+-- from "HsBindgen.C.AST".
+module HsBindgen.Clang.Util.SourceLoc.Type (
+    -- * Definition
+    SourcePath(..)
+  , SingleLoc(..)
+  , MultiLoc(..)
+  , Range(..)
+  ) where
+
+import Data.List (intercalate)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import GHC.Generics (Generic)
+import Text.Show.Pretty (PrettyVal(..))
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Paths as reported by @libclang@
+--
+-- Clang uses UTF-8 internally for everything, including paths, which is why
+-- this is 'Text', not @OsPath@. There might still be differences between
+-- platforms of course (such as directory separators).
+newtype SourcePath = SourcePath {
+      getSourcePath :: Text
+    }
+  deriving newtype (Eq, Ord)
+
+-- | A /single/ location in a file
+--
+-- See 'MultiLoc' for additional discussion.
+data SingleLoc = SingleLoc {
+      singleLocPath   :: !SourcePath
+    , singleLocLine   :: !Int
+    , singleLocColumn :: !Int
+    }
+  deriving stock (Eq, Ord, Generic)
+
+-- | Multiple related source locations
+--
+-- 'Core.CXSourceLocation' in @libclang@ corresponds to @SourceLocation@ in
+-- @clang@, which can actually correspond to /multiple/ source locations in a
+-- file; for example, in a header file such as
+--
+-- > #define M1 int
+-- >
+-- > struct ExampleStruct {
+-- >   M1 m1;
+-- >   ^
+-- > };
+--
+-- then the source location at the caret (@^@) has an \"expansion location\",
+-- which is the position at the caret, and a \"spelling location\", which
+-- corresponds to the location of the @int@ token in the macro definition.
+--
+-- References:
+--
+-- * <https://clang.llvm.org/doxygen/classclang_1_1SourceLocation.html>
+-- * <https://clang.llvm.org/doxygen/classclang_1_1SourceManager.html>
+--   (@getExpansionLoc@, @getSpellingLoc@, @getDecomposedSpellingLoc@)
+data MultiLoc = MultiLoc {
+      -- | Expansion location
+      --
+      -- If the location refers into a macro expansion, this corresponds to the
+      -- location of the macro expansion.
+      --
+      -- See <https://clang.llvm.org/doxygen/group__CINDEX__LOCATIONS.html#gadee4bea0fa34550663e869f48550eb1f>
+      multiLocExpansion :: !SingleLoc
+
+      -- | Presumed location
+      --
+      -- The given source location as specified in a @#line@ directive.
+      --
+      -- See <https://clang.llvm.org/doxygen/group__CINDEX__LOCATIONS.html#ga03508d9c944feeb3877515a1b08d36f9>
+    , multiLocPresumed :: !(Maybe SingleLoc)
+
+      -- | Spelling location
+      --
+      -- If the location refers into a macro instantiation, this corresponds to
+      -- the /original/ location of the spelling in the source file.
+      --
+      -- /WARNING/: This field is only populated correctly from @llvm >= 191.0@;
+      -- prior to that this is equal to 'multiLocFile'.
+      -- See <https://github.com/llvm/llvm-project/pull/72400>.
+      --
+      -- See <https://clang.llvm.org/doxygen/group__CINDEX__LOCATIONS.html#ga01f1a342f7807ea742aedd2c61c46fa0>
+    , multiLocSpelling :: !(Maybe SingleLoc)
+
+      -- | File location
+      --
+      -- If the location refers into a macro expansion, this corresponds to the
+      -- location of the macro expansion.
+      -- If the location points at a macro argument, this corresponds to the
+      -- location of the use of the argument.
+      --
+      -- See <https://clang.llvm.org/doxygen/group__CINDEX__LOCATIONS.html#gae0ee9ff0ea04f2446832fc12a7fd2ac8>
+    , multiLocFile :: !(Maybe SingleLoc)
+    }
+  deriving stock (Eq, Ord, Generic)
+
+-- | Range
+--
+-- 'Core.CXSourceRange' corresponds to @SourceRange@ in @clang@
+-- <https://clang.llvm.org/doxygen/classclang_1_1SourceLocation.html>,
+-- and therefore to @Range MultiLoc@; see 'MultiLoc' for additional discussion.
+data Range a = Range {
+      rangeStart :: !a
+    , rangeEnd   :: !a
+    }
+  deriving stock (Eq, Ord, Generic)
+  deriving stock (Functor, Foldable, Traversable)
+
+{-------------------------------------------------------------------------------
+  Show instances
+
+  Technically speaking the validity of these instances depends on 'IsString'
+  instances which we do not (yet?) define.
+-------------------------------------------------------------------------------}
+
+instance Show SourcePath        where show = show . getSourcePath
+instance Show SingleLoc         where show = show . prettySingleLoc True
+instance Show MultiLoc          where show = show . prettyMultiLoc  True
+instance Show (Range SingleLoc) where show = show . prettyRangeSingleLoc
+instance Show (Range MultiLoc)  where show = show . prettyRangeMultiLoc
+
+deriving stock instance {-# OVERLAPPABLE #-} Show a => Show (Range a)
+
+{-------------------------------------------------------------------------------
+  Pretty-printing
+
+  These instances mimick the behaviour of @SourceLocation::print@ and
+  @SourceRange::print@ in @clang@.
+-------------------------------------------------------------------------------}
+
+type ShowFile = Bool
+
+prettySingleLoc :: ShowFile -> SingleLoc -> String
+prettySingleLoc showFile loc =
+    intercalate ":" . concat $ [
+        [ Text.unpack (getSourcePath singleLocPath) | showFile ]
+      , [ show singleLocLine
+        , show singleLocColumn
+        ]
+      ]
+  where
+    SingleLoc{singleLocPath, singleLocLine, singleLocColumn} = loc
+
+prettyMultiLoc :: ShowFile -> MultiLoc -> String
+prettyMultiLoc showFile multiLoc =
+    intercalate " " . concat $ [
+        [ prettySingleLoc showFile multiLocExpansion ]
+      , [ "<Presumed=" ++ aux loc ++ ">" | Just loc <- [multiLocPresumed] ]
+      , [ "<Spelling=" ++ aux loc ++ ">" | Just loc <- [multiLocSpelling] ]
+      , [ "<File="     ++ aux loc ++ ">" | Just loc <- [multiLocFile]     ]
+      ]
+  where
+    MultiLoc{
+        multiLocExpansion
+      , multiLocPresumed
+      , multiLocSpelling
+      , multiLocFile} = multiLoc
+
+    aux :: SingleLoc -> [Char]
+    aux loc =
+        prettySingleLoc
+          (singleLocPath loc /= singleLocPath multiLocExpansion)
+          loc
+
+prettyRangeSingleLoc :: Range SingleLoc -> String
+prettyRangeSingleLoc = prettySourceRangeWith
+      singleLocPath
+      prettySingleLoc
+
+prettyRangeMultiLoc :: Range MultiLoc -> String
+prettyRangeMultiLoc =
+    prettySourceRangeWith
+      (singleLocPath . multiLocExpansion)
+      prettyMultiLoc
+
+prettySourceRangeWith ::
+     (a -> SourcePath)
+  -> (ShowFile -> a -> String)
+  -> Range a -> String
+prettySourceRangeWith path pretty Range{rangeStart, rangeEnd} = concat [
+      "<"
+    , pretty True rangeStart
+    , "-"
+    , pretty (path rangeStart /= path rangeEnd) rangeEnd
+    , ">"
+    ]
+
+{-------------------------------------------------------------------------------
+  PrettyVal instances
+
+  These just piggy-back on the 'Show' instances.
+-------------------------------------------------------------------------------}
+
+instance PrettyVal SourcePath   where prettyVal = prettyVal . show
+instance PrettyVal SingleLoc where prettyVal = prettyVal . show
+instance PrettyVal MultiLoc  where prettyVal = prettyVal . show
+
+instance Show a => PrettyVal (Range a) where
+  prettyVal = prettyVal. show

--- a/hs-bindgen/app/HsBindgen/App/RenderComments.hs
+++ b/hs-bindgen/app/HsBindgen/App/RenderComments.hs
@@ -17,16 +17,16 @@ import HsBindgen.C.AST
 -------------------------------------------------------------------------------}
 
 -- | Generate HTML page with comments
-renderComments :: Forest (SourceLoc, Text, Maybe Text) -> Html
+renderComments :: Forest (MultiLoc, Text, Maybe Text) -> Html
 renderComments comments = H.docTypeHtml $
     H.body $ do
       mapM_ renderNode comments
 
-renderNode :: Tree (SourceLoc, Text, Maybe Text) -> Html
+renderNode :: Tree (MultiLoc, Text, Maybe Text) -> Html
 renderNode (Node (sourceLoc, name, mComment) children) = do
     H.b $ Blaze.text name
     " ("
-    toMarkup sourceLoc
+    toMarkup (multiLocExpansion sourceLoc)
     ")"
     mapM_ Blaze.text mComment
     H.div ! A.style "margin-left: 1em;" $ do
@@ -35,10 +35,10 @@ renderNode (Node (sourceLoc, name, mComment) children) = do
 instance ToMarkup SourcePath where
   toMarkup = Blaze.text . getSourcePath
 
-instance ToMarkup SourceLoc where
-  toMarkup SourceLoc{sourceLocFile, sourceLocLine, sourceLocColumn} = do
-      toMarkup sourceLocFile
+instance ToMarkup SingleLoc where
+  toMarkup SingleLoc{singleLocPath, singleLocLine, singleLocColumn} = do
+      toMarkup singleLocPath
       ":"
-      toMarkup sourceLocLine
+      toMarkup singleLocLine
       ":"
-      toMarkup sourceLocColumn
+      toMarkup singleLocColumn

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -4,12 +4,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "enums.h"],
-              sourceLocLine = 2,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "enums.h"],
+                singleLocLine = 2,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "ENUMS_H",
             macroArgs = [],
             macroBody = MTerm MEmpty}),

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -4,12 +4,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macro_functions.h"],
-              sourceLocLine = 1,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macro_functions.h"],
+                singleLocLine = 1,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "INCR",
             macroArgs = [CName "x"],
             macroBody = MAdd
@@ -22,12 +26,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macro_functions.h"],
-              sourceLocLine = 2,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macro_functions.h"],
+                singleLocLine = 2,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "ADD",
             macroArgs = [
               CName "x",

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -4,12 +4,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 1,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 1,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "OBJECTLIKE1",
             macroArgs = [],
             macroBody = MTerm
@@ -20,12 +24,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 2,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 2,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "OBJECTLIKE2",
             macroArgs = [],
             macroBody = MTerm
@@ -36,12 +44,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 3,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 3,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "OBJECTLIKE3",
             macroArgs = [],
             macroBody = MAdd
@@ -58,12 +70,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 4,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 4,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "OBJECTLIKE4",
             macroArgs = [],
             macroBody = MAdd
@@ -80,12 +96,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 6,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 6,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "MEANING_OF_LIFE1",
             macroArgs = [],
@@ -97,12 +117,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 7,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 7,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "MEANING_OF_LIFE2",
             macroArgs = [],
@@ -114,12 +138,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 8,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 8,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "MEANING_OF_LIFE3",
             macroArgs = [],
@@ -131,12 +159,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 9,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 9,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "MEANING_OF_LIFE4",
             macroArgs = [],
@@ -148,12 +180,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 10,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 10,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "MEANING_OF_LIFE5",
             macroArgs = [],
@@ -165,12 +201,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 12,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 12,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "LONG_INT_TOKEN1",
             macroArgs = [],
@@ -184,12 +224,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 13,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 13,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "LONG_INT_TOKEN2",
             macroArgs = [],
@@ -203,12 +247,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 14,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 14,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "LONG_INT_TOKEN3",
             macroArgs = [],
@@ -222,12 +270,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "macros.h"],
-              sourceLocLine = 15,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "macros.h"],
+                singleLocLine = 15,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName
               "LONG_INT_TOKEN4",
             macroArgs = [],

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -4,12 +4,16 @@ WrapCHeader
       DeclMacro
         (Right
           Macro {
-            macroLoc = SourceLoc {
-              sourceLocFile = [
-                "examples",
-                "uses_utf8.h"],
-              sourceLocLine = 2,
-              sourceLocColumn = 9},
+            macroLoc = MultiLoc {
+              multiLocExpansion = SingleLoc {
+                singleLocPath = [
+                  "examples",
+                  "uses_utf8.h"],
+                singleLocLine = 2,
+                singleLocColumn = 9},
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
             macroName = CName "USES_UTF8_H",
             macroArgs = [],
             macroBody = MTerm MEmpty}),

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -41,8 +41,9 @@ module HsBindgen.C.AST (
   , TokenSpelling(..)
     -- * Source locations
   , SourcePath(..)
-  , SourceLoc(..)
-  , SourceRange(..)
+  , SingleLoc(..)
+  , MultiLoc(..)
+  , Range(..)
   ) where
 
 import GHC.Generics (Generic)
@@ -53,8 +54,8 @@ import HsBindgen.C.AST.Macro
 import HsBindgen.C.AST.Name
 import HsBindgen.C.AST.Type
 import HsBindgen.C.Parser.Macro (UnrecognizedMacro(..))
-import HsBindgen.Clang.Util.SourceLoc
 import HsBindgen.Clang.Util.Tokens
+import HsBindgen.Clang.Util.SourceLoc.Type
 
 {-------------------------------------------------------------------------------
   Top-level

--- a/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
@@ -17,21 +17,21 @@ import Data.Char (toUpper)
 import Data.String
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
-import HsBindgen.Clang.Util.SourceLoc
-import HsBindgen.Clang.Util.Tokens
 import System.FilePath (takeBaseName)
 import Text.Show.Pretty (PrettyVal)
 
 import HsBindgen.C.AST.Literal
 import HsBindgen.C.AST.Name
 import HsBindgen.C.AST.Type
+import HsBindgen.Clang.Util.SourceLoc.Type
+import HsBindgen.Clang.Util.Tokens
 
 {-------------------------------------------------------------------------------
   Top-level
 -------------------------------------------------------------------------------}
 
 data Macro = Macro {
-      macroLoc  :: SourceLoc
+      macroLoc  :: MultiLoc
     , macroName :: CName
     , macroArgs :: [CName]
     , macroBody :: MExpr
@@ -142,7 +142,8 @@ isIncludeGuard Macro{macroLoc, macroName, macroArgs, macroBody} =
       ]
   where
     sourcePath :: FilePath
-    sourcePath = Text.unpack . getSourcePath $ sourceLocFile macroLoc
+    sourcePath = Text.unpack . getSourcePath . singleLocPath $
+                   multiLocExpansion macroLoc
 
     includeGuards :: [CName]
     includeGuards = possibleIncludeGuards (takeBaseName sourcePath)

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -75,7 +75,7 @@ import HsBindgen.C.Parser qualified as C
 import HsBindgen.C.Predicate (Predicate(..))
 import HsBindgen.Clang.Args
 import HsBindgen.Clang.Util.Diagnostics qualified as C (Diagnostic)
-import HsBindgen.Clang.Util.SourceLoc
+import HsBindgen.Clang.Util.SourceLoc.Type
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Translation.LowLevel qualified as LowLevel
 import HsBindgen.Util.Tracer
@@ -211,7 +211,7 @@ getComments ::
   -> Predicate
   -> ClangArgs
   -> FilePath
-  -> IO (Forest (SourceLoc, Text, Maybe Text))
+  -> IO (Forest (MultiLoc, Text, Maybe Text))
 getComments tracer predicate args fp =
     C.parseHeaderWith tracer args fp $
       C.foldComments predicate

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -32,10 +32,10 @@ instance ToExpr C.Header
 instance ToExpr C.Macro
 instance ToExpr C.MExpr
 instance ToExpr C.MTerm
+instance ToExpr C.MultiLoc
 instance ToExpr C.PrimSign
 instance ToExpr C.PrimType
-instance ToExpr C.SourceLoc
-instance ToExpr C.SourceRange
+instance ToExpr C.SingleLoc
 instance ToExpr C.Struct
 instance ToExpr C.StructField
 instance ToExpr C.TokenSpelling
@@ -43,8 +43,9 @@ instance ToExpr C.Typ
 instance ToExpr C.Typedef
 instance ToExpr C.UnrecognizedMacro
 
-instance ToExpr a => ToExpr (C.Token a)
 instance ToExpr a => ToExpr (C.Literal a)
+instance ToExpr a => ToExpr (C.Range a)
+instance ToExpr a => ToExpr (C.Token a)
 
 -- Construct platform-independent expression
 instance ToExpr C.SourcePath where


### PR DESCRIPTION
We are now much more precise; see discussion of `MultiLoc` in `src/HsBindgen/Clang/Util/SourceLoc/Type.hs` for details.

Frustratingly, `clang_getSpellingLocation` is actually broken prior to `llvm-19.1.0` (https://github.com/llvm/llvm-project/issues/28205, https://github.com/llvm/llvm-project/pull/72400). However, the new setup _does_ allow us to call `clang_tokenize` with the expansion location rather than the spelling location, which is the critical feature we need (similar to the workaround mentioned at https://github.com/llvm/llvm-project/issues/43451).