### PR TITLE
Use `clang_getTypeSpelling` for symbol name

### DIFF
--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -26,8 +26,10 @@ WrapCHeader
             StructField {
               fieldName = CName "foo1",
               fieldOffset = 0,
-              fieldType = TypElaborated},
+              fieldType = TypElaborated
+                (CName "struct foo")},
             StructField {
               fieldName = CName "foo2",
               fieldOffset = 64,
-              fieldType = TypElaborated}]}])
+              fieldType = TypElaborated
+                (CName "struct foo")}]}])

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -29,10 +29,15 @@ data Typ =
     TypPrim PrimType
   | TypStruct Struct
   | TypPointer Typ
-  | TypElaborated -- TODO: reference into type symbol table.
+  | TypElaborated Symbol
   -- todo | TypEnum Enum
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
+
+-- | Reference into the type symbol table
+--
+-- TODO: for now this is simply the name of the C type.
+type Symbol = CName
 
 {-------------------------------------------------------------------------------
   Primitives types

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -245,7 +245,8 @@ parseType _tracer = go
             TypPointer <$> go ty'
 
           Right CXType_Elaborated -> do
-            return TypElaborated
+            name <- CName <$> clang_getTypeSpelling ty
+            return $ TypElaborated name
 
           _otherwise -> do
             throwIO $ UnrecognizedType (cxtKind ty)


### PR DESCRIPTION
We will probably use something different here, but for now this makes the parsed C code a bit more informative (and allows me to test better with typedefs vs macros).