### PR TITLE
Code cleanup

### DIFF
--- a/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Fold.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/Util/Fold.hs
@@ -1,4 +1,6 @@
 -- | Higher-level bindings for traversing the API
+--
+-- Intended for unqualified import.
 module HsBindgen.Clang.Util.Fold (
     -- * Folds
     Fold

--- a/hs-bindgen/app/Main.hs
+++ b/hs-bindgen/app/Main.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
 import HsBindgen.App.Cmdline
-import HsBindgen.Bootstrap.Prelude (genPrelude)
 import HsBindgen.Lib
 
 {-------------------------------------------------------------------------------
@@ -19,34 +18,45 @@ main = do
 
 execMode :: Cmdline -> Tracer IO String -> Mode -> IO ()
 execMode cmdline tracer = \case
-    ModePreprocess{input, moduleOpts, renderOpts, output} ->
-      preprocess $ Preprocess {
-          preprocessTraceWarnings = contramap show tracer
-        , preprocessTraceSkipped  = contramap prettyLogMsg tracer
-        , preprocessPredicate     = cmdPredicate
-        , preprocessClangArgs     = cmdClangArgs
-        , preprocessInputPath     = input
-        , preprocessModuleOpts    = moduleOpts
-        , preprocessRenderOpts    = renderOpts
-        , preprocessOutputPath    = output
-        }
+    ModePreprocess{input, moduleOpts, renderOpts, output} -> do
+      cHeader <- parseC cmdline tracer input
+      let hsModl = genModule moduleOpts cHeader
+      prettyHs renderOpts output hsModl
     Dev devMode ->
       execDevMode cmdline tracer devMode
-  where
-    Cmdline{cmdPredicate, cmdClangArgs} = cmdline
 
 execDevMode :: Cmdline -> Tracer IO String -> DevMode -> IO ()
 execDevMode cmdline tracer = \case
-    DevModeParseCHeader fp -> do
-      cHeader <-
-        parseCHeader
-          (contramap show tracer)
-          (contramap prettyLogMsg tracer)
-          cmdPredicate
-          cmdClangArgs
-          fp
-      prettyC cHeader
-    DevModePrelude ->
-      genPrelude (prettyLogMsg `contramap` tracer)
+    DevModeParseCHeader fp ->
+      prettyC =<< parseC cmdline tracer fp
+    DevModePrelude fp -> do
+      _entries <- withC cmdline tracer fp $ bootstrapPrelude tracer
+      return ()
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+withC ::
+     Cmdline
+  -> Tracer IO String
+  -> FilePath
+  -> (CXTranslationUnit -> IO r)
+  -> IO r
+withC cmdline tracer fp =
+    withTranslationUnit traceWarnings (cmdClangArgs cmdline) fp
   where
-    Cmdline{cmdPredicate, cmdClangArgs} = cmdline
+    traceWarnings :: Tracer IO Diagnostic
+    traceWarnings = contramap show tracer
+
+parseC ::
+     Cmdline
+  -> Tracer IO String
+  -> FilePath
+  -> IO CHeader
+parseC cmdline tracer fp =
+    withC cmdline tracer fp $
+      parseCHeader traceSkipped (cmdPredicate cmdline)
+  where
+    traceSkipped :: Tracer IO Skipped
+    traceSkipped = (contramap prettyLogMsg tracer)

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -51,19 +51,24 @@ library
       HsBindgen.Lib
       HsBindgen.TH
   exposed-modules:
+      -- Exposed for the sake of tests
+      -- TODO: We should reconsider the proper way to export these.
+      HsBindgen.C.AST
+      HsBindgen.Hs.AST
+      HsBindgen.Util.PHOAS
+      HsBindgen.Backend.TH.Translation
+  other-modules:
       HsBindgen.Backend.Common
       HsBindgen.Backend.Common.Translation
       HsBindgen.Backend.HsSrcExts
       HsBindgen.Backend.HsSrcExts.Render
       HsBindgen.Backend.HsSrcExts.Translation
       HsBindgen.Backend.TH
-      HsBindgen.Backend.TH.Translation
-      HsBindgen.Bootstrap.Prelude
-      HsBindgen.C.AST
       HsBindgen.C.Fold
       HsBindgen.C.Fold.Common
       HsBindgen.C.Fold.Decl
       HsBindgen.C.Fold.DeclState
+      HsBindgen.C.Fold.Prelude
       HsBindgen.C.Fold.Type
       HsBindgen.C.Parser
       HsBindgen.C.Predicate
@@ -74,11 +79,9 @@ library
       HsBindgen.C.Reparse.Literal
       HsBindgen.C.Reparse.Macro
       HsBindgen.C.Reparse.Type
-      HsBindgen.Hs.AST
       HsBindgen.Hs.AST.Name
       HsBindgen.Translation.LowLevel
       HsBindgen.Util.Parsec
-      HsBindgen.Util.PHOAS
       HsBindgen.Util.Tracer
   other-modules:
       -- Re-exported through HsBindgen.C.AST
@@ -86,10 +89,6 @@ library
       HsBindgen.C.AST.Macro
       HsBindgen.C.AST.Name
       HsBindgen.C.AST.Type
-  other-modules:
-      Paths_hs_bindgen
-  autogen-modules:
-      Paths_hs_bindgen
   other-extensions:
       TemplateHaskellQuotes
   build-depends:
@@ -120,12 +119,16 @@ executable hs-bindgen
 
   other-modules:
       HsBindgen.App.Cmdline
+      Paths_hs_bindgen
+  autogen-modules:
+      Paths_hs_bindgen
   build-depends:
       -- Internal dependencies
     , hs-bindgen
   build-depends:
       -- Inherited dependencies
     , data-default
+    , filepath
   build-depends:
     , optparse-applicative >= 0.18 && < 0.19
 

--- a/hs-bindgen/src/HsBindgen/C/Fold.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold.hs
@@ -12,10 +12,16 @@ module HsBindgen.C.Fold (
   , DeclState
   , initDeclState
   , foldDecls
+    -- ** Debugging/development
+    -- *** Process the C prelude
+  , PreludeEntry
+  , GenPreludeMsg
+  , foldPrelude
     -- * Logging
   , Skipped
   ) where
 
 import HsBindgen.C.Fold.Common
 import HsBindgen.C.Fold.Decl
+import HsBindgen.C.Fold.Prelude
 import HsBindgen.Clang.Util.Fold

--- a/hs-bindgen/src/HsBindgen/Util/PHOAS.hs
+++ b/hs-bindgen/src/HsBindgen/Util/PHOAS.hs
@@ -16,6 +16,7 @@ module HsBindgen.Util.PHOAS (
   ) where
 
 import Data.Fin qualified as Fin
+import Data.Foldable
 import Data.Kind
 import Data.List (intersperse)
 import Data.Type.Nat
@@ -24,7 +25,6 @@ import Data.Vec.Lazy qualified as Vec
 import Generics.SOP
 import GHC.Generics qualified as GHC
 import GHC.Show
-import Data.Foldable
 
 {-------------------------------------------------------------------------------
   Main definitions


### PR DESCRIPTION
This reduces the surface of `HsBindgen.Lib` to a more orthogonal set of functions. We still need to reconsider the internal/external API divide, but that can come at a later stage.