### PR TITLE
Add Doxygen bindings and `clang-ast-dump`

### DIFF
--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -64,6 +64,26 @@ static inline void wrap_InlineCommandComment_getArgText(const CXComment* Comment
 }
 
 /**
+ * Comment type 'CXComment_BlockCommand'
+ */
+
+static inline void wrap_BlockCommandComment_getCommandName(const CXComment* Comment, CXString*  result) {
+    *result = clang_BlockCommandComment_getCommandName(*Comment);
+}
+
+static inline unsigned wrap_BlockCommandComment_getNumArgs(const CXComment* Comment) {
+    return clang_BlockCommandComment_getNumArgs(*Comment);
+}
+
+static inline void wrap_BlockCommandComment_getArgText(const CXComment* Comment, unsigned argIdx, CXString*  result) {
+    *result = clang_BlockCommandComment_getArgText(*Comment, argIdx);
+}
+
+static inline void wrap_BlockCommandComment_getParagraph(const CXComment* Comment, CXComment* result) {
+    *result = clang_BlockCommandComment_getParagraph(*Comment);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -64,6 +64,34 @@ static inline void wrap_InlineCommandComment_getArgText(const CXComment* Comment
 }
 
 /**
+ * Comment type 'CXComment_HTMLStartTag' and 'CXComment_HTMLEndTag'
+ */
+
+static inline void wrap_HTMLTagComment_getTagName(const CXComment* Comment, CXString*  result) {
+    *result = clang_HTMLTagComment_getTagName(*Comment);
+}
+
+static inline unsigned wrap_HTMLStartTagComment_isSelfClosing(const CXComment* Comment) {
+    return clang_HTMLStartTagComment_isSelfClosing(*Comment);
+}
+
+static inline unsigned wrap_HTMLStartTag_getNumAttrs(const CXComment* Comment) {
+    return clang_HTMLStartTag_getNumAttrs(*Comment);
+}
+
+static inline void wrap_HTMLStartTag_getAttrName(const CXComment* Comment, unsigned attrIdx, CXString*  result) {
+    *result = clang_HTMLStartTag_getAttrName(*Comment, attrIdx);
+}
+
+static inline void wrap_HTMLStartTag_getAttrValue(const CXComment* Comment, unsigned attrIdx, CXString*  result) {
+    *result = clang_HTMLStartTag_getAttrValue(*Comment, attrIdx);
+}
+
+static inline void wrap_HTMLTagComment_getAsString(const CXComment* Comment, CXString*  result) {
+    *result = clang_HTMLTagComment_getAsString(*Comment);
+}
+
+/**
  * Comment type 'CXComment_BlockCommand'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -3,6 +3,18 @@
 
 /**
  * Wrappers for the Doxygen API
+ *
+ * All functions that we use are wrapped.  Prefix `clang_` of the actual
+ * function name is replaced with `wrap_`.  This allows us to import the wrapped
+ * function via FFI and define the Haskell function with the actual function
+ * name within the same module.
+ *
+ * Wrapper functions of functions that return values of primitive types keep the
+ * same API.  Wrapper functions of functions that return values of non-primitive
+ * types use a `result` parameter instead.
+ *
+ * The LLVM codebase capitalizes parameter names.  Wrapper functions keep this
+ * convention for such parameters, while `result` is not capitalized.
  */
 
 #include <clang-c/Documentation.h>
@@ -23,8 +35,8 @@ static inline unsigned wrap_Comment_getNumChildren(const CXComment* Comment) {
     return clang_Comment_getNumChildren(*Comment);
 }
 
-static inline void wrap_Comment_getChild(const CXComment* Comment, unsigned childIdx, CXComment* result) {
-    *result = clang_Comment_getChild(*Comment, childIdx);
+static inline void wrap_Comment_getChild(const CXComment* Comment, unsigned ChildIdx, CXComment* result) {
+    *result = clang_Comment_getChild(*Comment, ChildIdx);
 }
 
 static inline unsigned wrap_Comment_isWhitespace(const CXComment* Comment) {
@@ -59,8 +71,8 @@ static inline unsigned wrap_InlineCommandComment_getNumArgs(const CXComment* Com
     return clang_InlineCommandComment_getNumArgs(*Comment);
 }
 
-static inline void wrap_InlineCommandComment_getArgText(const CXComment* Comment, unsigned argIdx, CXString* result) {
-    *result = clang_InlineCommandComment_getArgText(*Comment, argIdx);
+static inline void wrap_InlineCommandComment_getArgText(const CXComment* Comment, unsigned ArgIdx, CXString* result) {
+    *result = clang_InlineCommandComment_getArgText(*Comment, ArgIdx);
 }
 
 /**
@@ -79,12 +91,12 @@ static inline unsigned wrap_HTMLStartTag_getNumAttrs(const CXComment* Comment) {
     return clang_HTMLStartTag_getNumAttrs(*Comment);
 }
 
-static inline void wrap_HTMLStartTag_getAttrName(const CXComment* Comment, unsigned attrIdx, CXString*  result) {
-    *result = clang_HTMLStartTag_getAttrName(*Comment, attrIdx);
+static inline void wrap_HTMLStartTag_getAttrName(const CXComment* Comment, unsigned AttrIdx, CXString*  result) {
+    *result = clang_HTMLStartTag_getAttrName(*Comment, AttrIdx);
 }
 
-static inline void wrap_HTMLStartTag_getAttrValue(const CXComment* Comment, unsigned attrIdx, CXString*  result) {
-    *result = clang_HTMLStartTag_getAttrValue(*Comment, attrIdx);
+static inline void wrap_HTMLStartTag_getAttrValue(const CXComment* Comment, unsigned AttrIdx, CXString*  result) {
+    *result = clang_HTMLStartTag_getAttrValue(*Comment, AttrIdx);
 }
 
 static inline void wrap_HTMLTagComment_getAsString(const CXComment* Comment, CXString*  result) {
@@ -103,8 +115,8 @@ static inline unsigned wrap_BlockCommandComment_getNumArgs(const CXComment* Comm
     return clang_BlockCommandComment_getNumArgs(*Comment);
 }
 
-static inline void wrap_BlockCommandComment_getArgText(const CXComment* Comment, unsigned argIdx, CXString*  result) {
-    *result = clang_BlockCommandComment_getArgText(*Comment, argIdx);
+static inline void wrap_BlockCommandComment_getArgText(const CXComment* Comment, unsigned ArgIdx, CXString*  result) {
+    *result = clang_BlockCommandComment_getArgText(*Comment, ArgIdx);
 }
 
 static inline void wrap_BlockCommandComment_getParagraph(const CXComment* Comment, CXComment* result) {
@@ -151,8 +163,8 @@ static inline unsigned wrap_TParamCommandComment_getDepth(const CXComment* Comme
     return clang_TParamCommandComment_getDepth(*Comment);
 }
 
-static inline unsigned wrap_TParamCommandComment_getIndex(const CXComment* Comment, unsigned depth) {
-    return clang_TParamCommandComment_getIndex(*Comment, depth);
+static inline unsigned wrap_TParamCommandComment_getIndex(const CXComment* Comment, unsigned Depth) {
+    return clang_TParamCommandComment_getIndex(*Comment, Depth);
 }
 
 /**

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -20,6 +20,14 @@ static inline enum CXCommentKind wrap_Comment_getKind(const CXComment* Comment) 
 }
 
 /**
+ * Comment type 'CXComment_Text'
+ */
+
+static inline void wrap_TextComment_getText(const CXComment* Comment, CXString*  result) {
+    *result = clang_TextComment_getText(*Comment);
+}
+
+/**
  * Comment type 'CXComment_InlineCommand'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -108,6 +108,26 @@ static inline enum CXCommentParamPassDirection wrap_ParamCommandComment_getDirec
 }
 
 /**
+ * Comment type 'CXComment_TParamCommand'
+ */
+
+static inline void wrap_TParamCommandComment_getParamName(const CXComment* Comment, CXString*  result) {
+    *result = clang_TParamCommandComment_getParamName(*Comment);
+}
+
+static inline unsigned wrap_TParamCommandComment_isParamPositionValid(const CXComment* Comment) {
+    return clang_TParamCommandComment_isParamPositionValid(*Comment);
+}
+
+static inline unsigned wrap_TParamCommandComment_getDepth(const CXComment* Comment) {
+    return clang_TParamCommandComment_getDepth(*Comment);
+}
+
+static inline unsigned wrap_TParamCommandComment_getIndex(const CXComment* Comment, unsigned depth) {
+    return clang_TParamCommandComment_getIndex(*Comment, depth);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -19,6 +19,22 @@ static inline enum CXCommentKind wrap_Comment_getKind(const CXComment* Comment) 
     return clang_Comment_getKind(*Comment);
 }
 
+static inline unsigned wrap_Comment_getNumChildren(const CXComment* Comment) {
+    return clang_Comment_getNumChildren(*Comment);
+}
+
+static inline void wrap_Comment_getChild(const CXComment* Comment, unsigned childIdx, CXComment* result) {
+    *result = clang_Comment_getChild(*Comment, childIdx);
+}
+
+static inline unsigned wrap_Comment_isWhitespace(const CXComment* Comment) {
+    return clang_Comment_isWhitespace(*Comment);
+}
+
+static inline unsigned wrap_InlineContentComment_hasTrailingNewline(const CXComment* Comment) {
+    return clang_InlineContentComment_hasTrailingNewline(*Comment);
+}
+
 /**
  * Comment type 'CXComment_Text'
  */

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -84,6 +84,30 @@ static inline void wrap_BlockCommandComment_getParagraph(const CXComment* Commen
 }
 
 /**
+ * Comment type 'CXComment_ParamCommand'
+ */
+
+static inline void wrap_ParamCommandComment_getParamName(const CXComment* Comment, CXString*  result) {
+    *result = clang_ParamCommandComment_getParamName(*Comment);
+}
+
+static inline unsigned wrap_ParamCommandComment_isParamIndexValid(const CXComment* Comment) {
+    return clang_ParamCommandComment_isParamIndexValid(*Comment);
+}
+
+static inline unsigned wrap_ParamCommandComment_getParamIndex(const CXComment* Comment) {
+    return clang_ParamCommandComment_getParamIndex(*Comment);
+}
+
+static inline unsigned wrap_ParamCommandComment_isDirectionExplicit(const CXComment* Comment) {
+    return clang_ParamCommandComment_isDirectionExplicit(*Comment);
+}
+
+static inline enum CXCommentParamPassDirection wrap_ParamCommandComment_getDirection(const CXComment* Comment) {
+    return clang_ParamCommandComment_getDirection(*Comment);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -20,6 +20,26 @@ static inline enum CXCommentKind wrap_Comment_getKind(const CXComment* Comment) 
 }
 
 /**
+ * Comment type 'CXComment_InlineCommand'
+ */
+
+static inline void wrap_InlineCommandComment_getCommandName(const CXComment* Comment, CXString*  result) {
+    *result = clang_InlineCommandComment_getCommandName(*Comment);
+}
+
+static inline enum CXCommentInlineCommandRenderKind wrap_InlineCommandComment_getRenderKind(const CXComment* Comment) {
+    return clang_InlineCommandComment_getRenderKind(*Comment);
+}
+
+static inline unsigned wrap_InlineCommandComment_getNumArgs(const CXComment* Comment) {
+    return clang_InlineCommandComment_getNumArgs(*Comment);
+}
+
+static inline void wrap_InlineCommandComment_getArgText(const CXComment* Comment, unsigned argIdx, CXString* result) {
+    *result = clang_InlineCommandComment_getArgText(*Comment, argIdx);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -128,6 +128,14 @@ static inline unsigned wrap_TParamCommandComment_getIndex(const CXComment* Comme
 }
 
 /**
+ * Comment type 'CXComment_VerbatimBlockLine'
+ */
+
+static inline void wrap_VerbatimBlockLineComment_getText(const CXComment* Comment, CXString*  result) {
+    *result = clang_VerbatimBlockLineComment_getText(*Comment);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/cbits/doxygen_wrappers.h
+++ b/hs-bindgen-libclang/cbits/doxygen_wrappers.h
@@ -136,6 +136,14 @@ static inline void wrap_VerbatimBlockLineComment_getText(const CXComment* Commen
 }
 
 /**
+ * Comment type 'CXComment_VerbatimLine'
+ */
+
+static inline void wrap_VerbatimLineComment_getText(const CXComment* Comment, CXString*  result) {
+    *result = clang_VerbatimLineComment_getText(*Comment);
+}
+
+/**
  * Comment type 'CXComment_FullComment'
  */
 

--- a/hs-bindgen-libclang/clang-ast-dump/Main.hs
+++ b/hs-bindgen-libclang/clang-ast-dump/Main.hs
@@ -1,0 +1,323 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Functor.Identity
+import Foreign.C.Types (CUInt)
+
+import Data.Text qualified as T
+import Options.Applicative qualified as OA
+
+import HsBindgen.Clang.Args
+import HsBindgen.Clang.HighLevel qualified as HighLevel
+import HsBindgen.Clang.HighLevel.Types
+import HsBindgen.Clang.LowLevel.Core
+import HsBindgen.Clang.LowLevel.Doxygen
+import HsBindgen.Patterns
+
+{-------------------------------------------------------------------------------
+  Options
+-------------------------------------------------------------------------------}
+
+data Options = Options {
+      optComments :: Bool
+    , optExtents  :: Bool
+    , optFile     :: FilePath
+    , optKind     :: Bool
+    , optSameFile :: Bool
+    , optType     :: Bool
+    }
+
+{-------------------------------------------------------------------------------
+  Implementation
+-------------------------------------------------------------------------------}
+
+clangAstDump :: Options -> IO ()
+clangAstDump opts@Options{..} = do
+    putStrLn $ "## `" ++ optFile ++ "`"
+    putStrLn ""
+    index <- clang_createIndex DontDisplayDiagnostics
+    let clangOpts = bitfieldEnum [CXTranslationUnit_None]
+    unit <- clang_parseTranslationUnit index optFile defaultClangArgs clangOpts
+    rootCursor <- clang_getTranslationUnitCursor unit
+    void . runFoldIdentity . HighLevel.clang_visitChildren rootCursor $
+      \cursor -> do
+        (cursorFile, _, _) <- liftIO $
+          clang_getPresumedLocation =<< clang_getCursorLocation cursor
+        if optSameFile && cursorFile /= T.pack optFile
+          then pure $ Continue Nothing
+          else foldDecls opts cursor
+
+foldDecls :: Options -> CXCursor -> FoldM Identity (Next Identity ())
+foldDecls opts@Options{..} cursor = do
+    traceU_ 0 =<< liftIO (clang_getCursorDisplayName cursor)
+
+    semanticParent <- liftIO $ clang_getCursorSemanticParent cursor
+    lexicalParent  <- liftIO $ clang_getCursorLexicalParent  cursor
+    parentsEq      <- liftIO $ clang_equalCursors semanticParent lexicalParent
+    if parentsEq
+      then
+        traceWhen 1 "parent" (/= T.pack optFile)
+          =<< liftIO (clang_getCursorDisplayName semanticParent)
+      else do
+        traceU 1 "semantic parent"
+          =<< liftIO (clang_getCursorDisplayName semanticParent)
+        traceU 1 "lexical parent"
+          =<< liftIO (clang_getCursorDisplayName lexicalParent)
+
+    when optExtents $ do
+      extent <- liftIO $ clang_getCursorExtent cursor
+      (file, startLine, startCol) <- liftIO $
+        clang_getPresumedLocation =<< clang_getRangeStart extent
+      (_, endLine, endCol) <- liftIO $
+        clang_getPresumedLocation =<< clang_getRangeEnd extent
+      traceU 1 "extent" (file, (startLine, startCol), (endLine, endCol))
+
+    cursorKind <- liftIO $ clang_getCursorKind cursor
+    traceU 1 "cursor kind" cursorKind
+    isDecl <- liftIO $ clang_isDeclaration cursorKind
+    when optKind $
+      traceWhen 2 "declaration" id isDecl
+
+    cursorType <- liftIO $ clang_getCursorType cursor
+    let typeKind = cxtKind cursorType
+    traceU 1 "cursor type" =<< liftIO (clang_getTypeSpelling cursorType)
+    when optType $ do
+      traceU 2 "kind" $ fromSimpleEnum typeKind
+      traceU 3 "spelling" =<< liftIO (clang_getTypeKindSpelling typeKind)
+      traceU 2 "canonical"
+        =<< liftIO (clang_getTypeSpelling =<< clang_getCanonicalType cursorType)
+
+    when (isDecl && optComments) $ do
+      commentText <- liftIO $ clang_Cursor_getRawCommentText cursor
+      unless (T.null commentText) $ do
+        traceU 1 "comment" commentText
+        traceU 2 "brief" =<< liftIO (clang_Cursor_getBriefCommentText cursor)
+        liftIO $ dumpComment 2 Nothing =<< clang_Cursor_getParsedComment cursor
+
+    let doRecurse  = pure $ Recurse (foldDecls opts) (const Nothing)
+        --doContinue = pure $ Continue Nothing
+    case fromSimpleEnum cursorKind of
+      Right CXCursor_StructDecl      -> doRecurse
+      Right CXCursor_EnumDecl        -> doRecurse
+      Right CXCursor_TypedefDecl     -> doRecurse
+      Right CXCursor_MacroDefinition -> doRecurse
+      Right{} -> Continue Nothing <$ traceL 1 "CURSOR_KIND_NOT_IMPLEMENTED"
+      Left n  -> Continue Nothing <$ traceU 1 "CURSOR_KIND_ENUM_OUT_OF_RANGE" n
+
+dumpComment :: Int -> Maybe CUInt -> CXComment -> IO ()
+dumpComment level mIdx comment = do
+    commentKind <- clang_Comment_getKind comment
+    maybe (traceU level) (traceO level) mIdx "kind" $ fromSimpleEnum commentKind
+    traceWhen level1 "whitespace" id =<< clang_Comment_isWhitespace comment
+
+    case fromSimpleEnum commentKind of
+      Right CXComment_Null -> pure ()
+
+      Right CXComment_Text ->
+        traceU level1 "text" =<< clang_TextComment_getText comment
+
+      Right CXComment_InlineCommand -> do
+        traceU level1 "name"
+          =<< clang_InlineCommandComment_getCommandName comment
+        traceU level1 "render kind" . fromSimpleEnum
+          =<< clang_InlineCommandComment_getRenderKind comment
+        numArgs <- clang_InlineCommandComment_getNumArgs comment
+        when (numArgs > 0) $ do
+          traceU level1 "args" numArgs
+          forM_ [0 .. numArgs - 1] $ \i ->
+            traceO_ level2 i =<< clang_InlineCommandComment_getArgText comment i
+
+      Right CXComment_HTMLStartTag -> do
+        traceU level1 "name" =<< clang_HTMLTagComment_getTagName comment
+        traceWhen level1 "self-closing" id
+          =<< clang_HTMLStartTagComment_isSelfClosing comment
+        numAttrs <- clang_HTMLStartTag_getNumAttrs comment
+        when (numAttrs > 0) $ do
+          traceU level1 "attributes" numAttrs
+          forM_ [0 .. numAttrs - 1] $ \i -> do
+            traceO_ level2 i =<< clang_HTMLStartTag_getAttrName comment i
+            traceU level3 "value" =<< clang_HTMLStartTag_getAttrValue comment i
+
+      Right CXComment_HTMLEndTag -> do
+        traceU level1 "name" =<< clang_HTMLTagComment_getTagName comment
+
+      Right CXComment_Paragraph -> pure ()
+
+      Right CXComment_BlockCommand -> do
+        traceU level1 "name" =<<
+          clang_BlockCommandComment_getCommandName comment
+        numArgs <- clang_BlockCommandComment_getNumArgs comment
+        when (numArgs > 0) $ do
+          traceU level1 "args" numArgs
+          forM_ [0 .. numArgs - 1] $ \i ->
+            traceO_ level2 i =<< clang_BlockCommandComment_getArgText comment i
+        -- NOTE paragraph is also provided by children
+        -- para <- clang_BlockCommandComment_getParagraph comment
+        -- traceL level1 "paragraph"
+        -- dumpComment level2 Nothing para
+
+      Right CXComment_ParamCommand -> do
+        traceU level1 "name" =<< clang_ParamCommandComment_getParamName comment
+        traceU level1 "index"
+          =<< clang_ParamCommandComment_getParamIndex comment
+        traceUnless level2 "invalid" id
+          =<< clang_ParamCommandComment_isParamIndexValid comment
+        traceU level1 "direction" . fromSimpleEnum
+          =<< clang_ParamCommandComment_getDirection comment
+        traceU level2 "explicit"
+          =<< clang_ParamCommandComment_isDirectionExplicit comment
+
+      Right CXComment_TParamCommand -> do
+        traceU level1 "name" =<< clang_TParamCommandComment_getParamName comment
+        traceUnless level1 "position invalid" id
+          =<< clang_TParamCommandComment_isParamPositionValid comment
+        depth <- clang_TParamCommandComment_getDepth comment
+        traceU level1 "depth" depth
+        forM_ [0 .. depth] $ \i ->
+          traceO level2 i "index"
+            =<< clang_TParamCommandComment_getIndex comment i
+
+      Right CXComment_VerbatimBlockCommand -> pure ()
+
+      Right CXComment_VerbatimBlockLine ->
+        traceU level1 "text" =<< clang_VerbatimBlockLineComment_getText comment
+
+      Right CXComment_VerbatimLine ->
+        traceU level1 "text" =<< clang_VerbatimLineComment_getText comment
+
+      Right CXComment_FullComment -> do
+        traceUnless level "HTML" T.null =<< clang_FullComment_getAsHTML comment
+        traceUnless level "XML"  T.null =<< clang_FullComment_getAsXML  comment
+
+      Left n -> traceU level1 "COMMENT_KIND_ENUM_OUT_OF_RANGE" n
+
+    numChildren <- clang_Comment_getNumChildren comment
+    when (numChildren > 0) $ do
+      traceU level1 "children" numChildren
+      forM_ [0 .. numChildren - 1] $ \i ->
+        dumpComment level2 (Just i) =<< clang_Comment_getChild comment i
+  where
+    level1, level2, level3 :: Int
+    level1 = level + 1
+    level2 = level + 2
+    level3 = level + 3
+
+{-------------------------------------------------------------------------------
+  Trace Functions
+-------------------------------------------------------------------------------}
+
+-- | Trace Markdown list item (internal)
+--
+-- This function is not meant to be used directly.  Use one of the below
+-- functions instead.
+trace' :: (Show a, MonadIO m)
+  => Int           -- ^ indentation level, from 0
+  -> Maybe Int     -- ^ index of ordered list
+  -> Maybe String  -- ^ label
+  -> Maybe a       -- ^ value
+  -> m ()
+trace' level mIndex mLabel mValue = liftIO . putStrLn $ concat
+    [ replicate (level * 4) ' '
+    , maybe "* " ((++ ". ") . show) mIndex
+    , case (mLabel, mValue) of
+        (Just label, Just value) -> label ++ ": " ++ show value
+        (Just label, Nothing)    -> label
+        (Nothing,    Just value) -> show value
+        (Nothing,    Nothing)    -> ""
+    ]
+
+-- | Trace label (unordered)
+traceL :: MonadIO m
+  => Int     -- ^ indentation level, from 0
+  -> String  -- ^ label
+  -> m ()
+traceL level label = trace' @() level Nothing (Just label) Nothing
+
+-- | Trace value (unordered, no label)
+traceU_ :: (Show a, MonadIO m)
+  => Int  -- ^ indentation level, from 0
+  -> a    -- ^ value
+  -> m ()
+traceU_ level value = trace' level Nothing Nothing (Just value)
+
+-- | Trace value (unordered, with label)
+traceU :: (Show a, MonadIO m)
+  => Int     -- ^ indentation level, from 0
+  -> String  -- ^ label
+  -> a       -- ^ value
+  -> m ()
+traceU level label value = trace' level Nothing (Just label) (Just value)
+
+-- | Trace value (ordered, no label)
+traceO_ :: (Integral i, Show a, MonadIO m)
+  => Int  -- ^ indentation level, from 0
+  -> i    -- ^ index of ordered list
+  -> a    -- ^ value
+  -> m ()
+traceO_ level index value =
+    trace' level (Just $ fromIntegral index) Nothing (Just value)
+
+-- | Trace value (ordered, with label)
+traceO :: (Integral i, Show a, MonadIO m)
+  => Int     -- ^ indentation level, from 0
+  -> i       -- ^ index of ordered list
+  -> String  -- ^ label
+  -> a       -- ^ value
+  -> m ()
+traceO level index label value =
+    trace' level (Just $ fromIntegral index) (Just label) (Just value)
+
+-- | Trace value when predicate holds (unordered, with label)
+traceWhen :: (Show a, MonadIO m)
+  => Int          -- ^ indentation level, from 0
+  -> String       -- ^ label
+  -> (a -> Bool)  -- ^ predicate
+  -> a            -- ^ value
+  -> m ()
+traceWhen level label p value = when (p value) $ traceU level label value
+
+-- | Trace value when predicate does not hold (unordered, with label)
+traceUnless :: (Show a, MonadIO m)
+  => Int          -- ^ indentation level, from 0
+  -> String       -- ^ label
+  -> (a -> Bool)  -- ^ predicate
+  -> a            -- ^ value
+  -> m ()
+traceUnless level label p value = unless (p value) $ traceU level label value
+
+{-------------------------------------------------------------------------------
+  CLI
+-------------------------------------------------------------------------------}
+
+main :: IO ()
+main = clangAstDump =<< OA.execParser pinfo
+  where
+    pinfo :: OA.ParserInfo Options
+    pinfo = OA.info (OA.helper <*> parseOptions) $ mconcat
+      [ OA.fullDesc
+      , OA.progDesc "Clang AST dump"
+      , OA.failureCode 2
+      ]
+
+    parseOptions :: OA.Parser Options
+    parseOptions = do
+      optComments <- mkFlag "comments"  "show comments"
+      optExtents  <- mkFlag "extents"   "show extents"
+      optKind     <- mkFlag "kind"      "show kind details"
+      optSameFile <- mkFlag "same-file" "only show from specified file"
+      optType     <- mkFlag "type"      "show type details"
+      optFile     <- fileArgument
+      pure Options{..}
+
+    fileArgument :: OA.Parser FilePath
+    fileArgument = OA.strArgument $ mconcat
+      [ OA.metavar "FILE"
+      , OA.help "C (header) file to parse"
+      ]
+
+    mkFlag :: String -> String -> OA.Parser Bool
+    mkFlag flag doc = OA.switch $ OA.long flag <> OA.help doc

--- a/hs-bindgen-libclang/clang-ast-dump/README.md
+++ b/hs-bindgen-libclang/clang-ast-dump/README.md
@@ -1,0 +1,29 @@
+# `clang-ast-dump`
+
+This utility displays low-level details about the Clang AST.  It aids in the
+design of our Haskell types and the implementation of the translation from
+the Clang types to our Haskell types.
+
+## Usage
+
+All of the following commands are to be run in the project root.
+
+Display options:
+
+```
+$ cabal run clang-ast-dump -- --help
+```
+
+Run:
+
+```
+$ cabal run clang-ast-dump -- hs-bindgen/examples/comments.h
+```
+
+## Alternatives
+
+Official:
+
+```
+$ clang -Xclang -ast-dump foo.c
+```

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -97,6 +97,22 @@ library
   c-sources:
       cbits/clang_wrappers.c
 
+executable clang-ast-dump
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: clang-ast-dump
+
+  build-depends:
+      -- Internal dependencies
+    , hs-bindgen-libclang
+    , hs-bindgen-patterns
+  build-depends:
+      -- Inherited dependencies
+    , text
+  build-depends:
+      -- External dependencies
+    , optparse-applicative >= 0.18 && < 0.19
+
 test-suite clang-tutorial
   import:         lang
   type:           exitcode-stdio-1.0

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -24,6 +24,13 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_InlineCommandComment_getRenderKind
   , clang_InlineCommandComment_getNumArgs
   , clang_InlineCommandComment_getArgText
+    -- * Comment type 'CXComment_HTMLStartTag' and 'CXComment_HTMLEndTag'
+  , clang_HTMLTagComment_getTagName
+  , clang_HTMLStartTagComment_isSelfClosing
+  , clang_HTMLStartTag_getNumAttrs
+  , clang_HTMLStartTag_getAttrName
+  , clang_HTMLStartTag_getAttrValue
+  , clang_HTMLTagComment_getAsString
     -- * Comment type 'CXComment_BlockCommand'
   , clang_BlockCommandComment_getCommandName
   , clang_BlockCommandComment_getNumArgs
@@ -230,6 +237,98 @@ clang_InlineCommandComment_getArgText ::
 clang_InlineCommandComment_getArgText comment argIdx =
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_InlineCommandComment_getArgText comment' argIdx
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_HTMLStartTag' and 'CXComment_HTMLEndTag'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLTagComment_getTagName"
+  wrap_HTMLTagComment_getTagName :: R CXComment_ -> W CXString_ -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLStartTagComment_isSelfClosing"
+  wrap_HTMLStartTagComment_isSelfClosing :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLStartTag_getNumAttrs"
+  wrap_HTMLStartTag_getNumAttrs :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLStartTag_getAttrName"
+  wrap_HTMLStartTag_getAttrName :: R CXComment_ -> CUInt -> W CXString_ -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLStartTag_getAttrValue"
+  wrap_HTMLStartTag_getAttrValue ::
+       R CXComment_
+    -> CUInt
+    -> W CXString_
+    -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLTagComment_getAsString"
+  wrap_HTMLTagComment_getAsString :: R CXComment_ -> W CXString_ -> IO ()
+
+-- | Get the HTML tag name.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga55b84483c67c0629260b1534d4b3f80e>
+clang_HTMLTagComment_getTagName ::
+     CXComment
+  -- ^ a 'CXComment_HTMLStartTag' or 'CXComment_HTMLEndTag' AST node
+  -> IO Text
+clang_HTMLTagComment_getTagName comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_HTMLTagComment_getTagName comment'
+
+-- | Determine whether the tag is self-closing.
+--
+-- Example: @<br />@ is self-closing
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga052be5f208a0ef2f76e3e9923a96ef19>
+clang_HTMLStartTagComment_isSelfClosing ::
+     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> IO Bool
+clang_HTMLStartTagComment_isSelfClosing comment =
+    onHaskellHeap comment $ \comment' ->
+      cToBool <$> wrap_HTMLStartTagComment_isSelfClosing comment'
+
+-- | Get the number of attributes (name-value pairs) attached to the start tag.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaffb8098debd5b99c2345840a5f0e63e0>
+clang_HTMLStartTag_getNumAttrs ::
+     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> IO CUInt
+clang_HTMLStartTag_getNumAttrs comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_HTMLStartTag_getNumAttrs comment'
+
+-- | Get the name of the specified attribute.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga4bdf958af343477fc70eb2b4822cd006>
+clang_HTMLStartTag_getAttrName ::
+     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> CUInt     -- ^ attribute index (zero-based)
+  -> IO Text
+clang_HTMLStartTag_getAttrName comment attrIdx =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_HTMLStartTag_getAttrName comment' attrIdx
+
+-- | Get the value of the specified attribute.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gae674a07af38d28d67941c1c54909c5e8>
+clang_HTMLStartTag_getAttrValue ::
+     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> CUInt     -- ^ attribute index (zero-based)
+  -> IO Text
+clang_HTMLStartTag_getAttrValue comment attrIdx =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_HTMLStartTag_getAttrValue comment' attrIdx
+
+-- | Convert an HTML tag AST node to string.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga684a46f5993fe907016aba5dbe9d1d9e>
+clang_HTMLTagComment_getAsString ::
+     CXComment
+  -- ^ a 'CXComment_HTMLStartTag' or 'CXComment_HTMLEndTag' AST node
+  -> IO Text
+clang_HTMLTagComment_getAsString comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_HTMLTagComment_getAsString comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_BlockCommand'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -29,6 +29,12 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_BlockCommandComment_getNumArgs
   , clang_BlockCommandComment_getArgText
   , clang_BlockCommandComment_getParagraph
+    -- * Comment type 'CXComment_ParamCommand'
+  , clang_ParamCommandComment_getParamName
+  , clang_ParamCommandComment_isParamIndexValid
+  , clang_ParamCommandComment_getParamIndex
+  , clang_ParamCommandComment_isDirectionExplicit
+  , clang_ParamCommandComment_getDirection
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -276,6 +282,72 @@ clang_BlockCommandComment_getParagraph ::
 clang_BlockCommandComment_getParagraph comment =
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_BlockCommandComment_getParagraph comment'
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_ParamCommand'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_getParamName"
+  wrap_ParamCommandComment_getParamName :: R CXComment_ -> W CXString_ -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_isParamIndexValid"
+  wrap_ParamCommandComment_isParamIndexValid :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_getParamIndex"
+  wrap_ParamCommandComment_getParamIndex :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_isDirectionExplicit"
+  wrap_ParamCommandComment_isDirectionExplicit :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_getDirection"
+  wrap_ParamCommandComment_getDirection ::
+       R CXComment_
+    -> IO (SimpleEnum CXCommentParamPassDirection)
+
+-- | Get the parameter name.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaffd7aaf697c5eb3a3d2b508b5d806763>
+clang_ParamCommandComment_getParamName :: CXComment -> IO Text
+clang_ParamCommandComment_getParamName comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_ParamCommandComment_getParamName comment'
+
+-- | Determine whether the parameter that this AST node represents was found in
+-- the function prototype and @clang_ParamCommandComment_getParamIndex@ function
+-- will return a meaningful value.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga92e6422da2a3e428b4452a3e8955ff76>
+clang_ParamCommandComment_isParamIndexValid :: CXComment -> IO Bool
+clang_ParamCommandComment_isParamIndexValid comment =
+    onHaskellHeap comment $ \comment' ->
+      cToBool <$> wrap_ParamCommandComment_isParamIndexValid comment'
+
+-- | Get the zero-based parameter index in function prototype.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gad9d1dc9ebb52dcc9cb7da8ca4c23332a>
+clang_ParamCommandComment_getParamIndex :: CXComment -> IO CUInt
+clang_ParamCommandComment_getParamIndex comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_ParamCommandComment_getParamIndex comment'
+
+-- | Determine whether the parameter passing direction was specified explicitly
+-- in the comment.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaf68f19e83ca9b27aec7eb22b065620bd>
+clang_ParamCommandComment_isDirectionExplicit :: CXComment -> IO Bool
+clang_ParamCommandComment_isDirectionExplicit comment =
+    onHaskellHeap comment $ \comment' ->
+      cToBool <$> wrap_ParamCommandComment_isDirectionExplicit comment'
+
+-- | Get the parameter passing direction.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gac78b84734e9e6040a001a0036e6aa15c>
+clang_ParamCommandComment_getDirection ::
+     CXComment
+  -> IO (SimpleEnum CXCommentParamPassDirection)
+clang_ParamCommandComment_getDirection comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_ParamCommandComment_getDirection comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -40,6 +40,8 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_TParamCommandComment_isParamPositionValid
   , clang_TParamCommandComment_getDepth
   , clang_TParamCommandComment_getIndex
+    -- * Comment type 'CXComment_VerbatimBlockLine'
+  , clang_VerbatimBlockLineComment_getText
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -409,6 +411,21 @@ clang_TParamCommandComment_getIndex ::
 clang_TParamCommandComment_getIndex comment depth =
     onHaskellHeap comment $ \comment' ->
       wrap_TParamCommandComment_getIndex comment' depth
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_VerbatimBlockLine'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_VerbatimBlockLineComment_getText"
+  wrap_VerbatimBlockLineComment_getText :: R CXComment_ -> W CXString_ -> IO ()
+
+-- | Get the text contained in the AST node.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga599fad38a1c52917a2458ac10412969f>
+clang_VerbatimBlockLineComment_getText :: CXComment -> IO Text
+clang_VerbatimBlockLineComment_getText comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_VerbatimBlockLineComment_getText comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -80,7 +80,9 @@ clang_Cursor_getParsedComment cursor =
 -- | Get the type of an AST node of any kind
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gad7f2a27ab2f69abcb9442e05a21a130f>
-clang_Comment_getKind :: CXComment -> IO (SimpleEnum CXCommentKind)
+clang_Comment_getKind ::
+     CXComment -- ^ AST node of any kind
+  -> IO (SimpleEnum CXCommentKind)
 clang_Comment_getKind comment =
     onHaskellHeap comment $ \comment' ->
       wrap_Comment_getKind comment'
@@ -201,7 +203,10 @@ clang_InlineCommandComment_getNumArgs comment =
 -- | Get the text of the specified argument.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga6824f3cdcb42edbd143db77a657fe888>
-clang_InlineCommandComment_getArgText :: CXComment -> CUInt -> IO Text
+clang_InlineCommandComment_getArgText ::
+     CXComment
+  -> CUInt -- ^ argument index (zero-based)
+  -> IO Text
 clang_InlineCommandComment_getArgText comment argIdx =
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_InlineCommandComment_getArgText comment' argIdx

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -13,6 +13,8 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , CXCommentKind(..)
   , clang_Cursor_getParsedComment
   , clang_Comment_getKind
+    -- * Comment type 'CXComment_Text'
+  , clang_TextComment_getText
     -- * Comment type 'CXComment_InlineCommand'
   , clang_InlineCommandComment_getCommandName
   , clang_InlineCommandComment_getRenderKind
@@ -65,6 +67,21 @@ clang_Comment_getKind :: CXComment -> IO (SimpleEnum CXCommentKind)
 clang_Comment_getKind comment =
     onHaskellHeap comment $ \comment' ->
       wrap_Comment_getKind comment'
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_Text'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_TextComment_getText"
+  wrap_TextComment_getText :: R CXComment_ -> W CXString_ -> IO ()
+
+-- | Get the text contained in the AST node.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gae9a27e851356181beac36bbff6e638e2>
+clang_TextComment_getText :: CXComment -> IO Text
+clang_TextComment_getText comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_TextComment_getText comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_InlineCommand'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -20,6 +20,7 @@ module HsBindgen.Clang.LowLevel.Doxygen (
     -- * Comment type 'CXComment_Text'
   , clang_TextComment_getText
     -- * Comment type 'CXComment_InlineCommand'
+  , CXCommentInlineCommandRenderKind(..)
   , clang_InlineCommandComment_getCommandName
   , clang_InlineCommandComment_getRenderKind
   , clang_InlineCommandComment_getNumArgs
@@ -37,6 +38,7 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_BlockCommandComment_getArgText
   , clang_BlockCommandComment_getParagraph
     -- * Comment type 'CXComment_ParamCommand'
+  , CXCommentParamPassDirection(..)
   , clang_ParamCommandComment_getParamName
   , clang_ParamCommandComment_isParamIndexValid
   , clang_ParamCommandComment_getParamIndex

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -42,6 +42,8 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_TParamCommandComment_getIndex
     -- * Comment type 'CXComment_VerbatimBlockLine'
   , clang_VerbatimBlockLineComment_getText
+    -- * Comment type 'CXComment_VerbatimLine'
+  , clang_VerbatimLineComment_getText
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -426,6 +428,21 @@ clang_VerbatimBlockLineComment_getText :: CXComment -> IO Text
 clang_VerbatimBlockLineComment_getText comment =
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_VerbatimBlockLineComment_getText comment'
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_VerbatimLine'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_VerbatimLineComment_getText"
+  wrap_VerbatimLineComment_getText :: R CXComment_ -> W CXString_ -> IO ()
+
+-- | Get the text contained in the AST node.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga4eb1de9012b525f14051409427bd8eb2>
+clang_VerbatimLineComment_getText :: CXComment -> IO Text
+clang_VerbatimLineComment_getText comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_VerbatimLineComment_getText comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -13,6 +13,11 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , CXCommentKind(..)
   , clang_Cursor_getParsedComment
   , clang_Comment_getKind
+    -- * Comment type 'CXComment_InlineCommand'
+  , clang_InlineCommandComment_getCommandName
+  , clang_InlineCommandComment_getRenderKind
+  , clang_InlineCommandComment_getNumArgs
+  , clang_InlineCommandComment_getArgText
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -60,6 +65,66 @@ clang_Comment_getKind :: CXComment -> IO (SimpleEnum CXCommentKind)
 clang_Comment_getKind comment =
     onHaskellHeap comment $ \comment' ->
       wrap_Comment_getKind comment'
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_InlineCommand'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_InlineCommandComment_getCommandName"
+  wrap_InlineCommandComment_getCommandName ::
+       R CXComment_
+    -> W CXString_
+    -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_InlineCommandComment_getRenderKind"
+  wrap_InlineCommandComment_getRenderKind ::
+       R CXComment_
+    -> IO (SimpleEnum CXCommentInlineCommandRenderKind)
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_InlineCommandComment_getNumArgs"
+  wrap_InlineCommandComment_getNumArgs :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_InlineCommandComment_getArgText"
+  wrap_InlineCommandComment_getArgText ::
+       R CXComment_
+    -> CUInt
+    -> W CXString_
+    -> IO ()
+
+-- | Get the name of the inline command.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga77f5b160e7d73190ac518298c1e79d05>
+clang_InlineCommandComment_getCommandName :: CXComment -> IO Text
+clang_InlineCommandComment_getCommandName comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_InlineCommandComment_getCommandName comment'
+
+-- | Get the most appropriate rendering mode, chosen on command semantics in
+-- Doxygen.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga3dd54ce1288d09c408cac8c887da2ebd>
+clang_InlineCommandComment_getRenderKind ::
+     CXComment
+  -> IO (SimpleEnum CXCommentInlineCommandRenderKind)
+clang_InlineCommandComment_getRenderKind comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_InlineCommandComment_getRenderKind comment'
+
+-- | Get the number of command arguments.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga78db1049239be9649c2829cdeb83c544>
+clang_InlineCommandComment_getNumArgs :: CXComment -> IO CUInt
+clang_InlineCommandComment_getNumArgs comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_InlineCommandComment_getNumArgs comment'
+
+-- | Get the text of the specified argument.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga6824f3cdcb42edbd143db77a657fe888>
+clang_InlineCommandComment_getArgText :: CXComment -> CUInt -> IO Text
+clang_InlineCommandComment_getArgText comment argIdx =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_InlineCommandComment_getArgText comment' argIdx
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -24,6 +24,11 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_InlineCommandComment_getRenderKind
   , clang_InlineCommandComment_getNumArgs
   , clang_InlineCommandComment_getArgText
+    -- * Comment type 'CXComment_BlockCommand'
+  , clang_BlockCommandComment_getCommandName
+  , clang_BlockCommandComment_getNumArgs
+  , clang_BlockCommandComment_getArgText
+  , clang_BlockCommandComment_getParagraph
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -210,6 +215,67 @@ clang_InlineCommandComment_getArgText ::
 clang_InlineCommandComment_getArgText comment argIdx =
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_InlineCommandComment_getArgText comment' argIdx
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_BlockCommand'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_BlockCommandComment_getCommandName"
+  wrap_BlockCommandComment_getCommandName ::
+       R CXComment_
+    -> W CXString_
+    -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_BlockCommandComment_getNumArgs"
+  wrap_BlockCommandComment_getNumArgs :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_BlockCommandComment_getArgText"
+  wrap_BlockCommandComment_getArgText ::
+       R CXComment_
+    -> CUInt
+    -> W CXString_
+    -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_BlockCommandComment_getParagraph"
+  wrap_BlockCommandComment_getParagraph :: R CXComment_ -> W CXComment_ -> IO ()
+
+-- | Get the name of the block command.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga8fdde998537370477362a4f84bc03420>
+clang_BlockCommandComment_getCommandName :: CXComment -> IO Text
+clang_BlockCommandComment_getCommandName comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_BlockCommandComment_getCommandName comment'
+
+-- | Get the number of word-like arguments.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gacb447968ce9efdfdabbfca8918540cdf>
+clang_BlockCommandComment_getNumArgs :: CXComment -> IO CUInt
+clang_BlockCommandComment_getNumArgs comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_BlockCommandComment_getNumArgs comment'
+
+-- | Get the text of the specified word-like argument.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga9faf08601d88c809a9a97a9826051990>
+clang_BlockCommandComment_getArgText ::
+     CXComment
+  -> CUInt -- ^ argument index (zero-based)
+  -> IO Text
+clang_BlockCommandComment_getArgText comment argIdx =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_BlockCommandComment_getArgText comment' argIdx
+
+-- | Get the paragraph argument of the block command.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gac6f2ffc8fdbe9394bd4bb7d54327c968>
+clang_BlockCommandComment_getParagraph ::
+     CXComment
+  -- ^ a @CXComment_BlockCommand@ or @CXComment_VerbatimBlockCommand@ AST node
+  -> IO CXComment
+clang_BlockCommandComment_getParagraph comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_BlockCommandComment_getParagraph comment'
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen.hs
@@ -35,6 +35,11 @@ module HsBindgen.Clang.LowLevel.Doxygen (
   , clang_ParamCommandComment_getParamIndex
   , clang_ParamCommandComment_isDirectionExplicit
   , clang_ParamCommandComment_getDirection
+    -- * Comment type 'CXComment_TParamCommand'
+  , clang_TParamCommandComment_getParamName
+  , clang_TParamCommandComment_isParamPositionValid
+  , clang_TParamCommandComment_getDepth
+  , clang_TParamCommandComment_getIndex
     -- * Comment type 'CXComment_FullComment'
   , clang_FullComment_getAsHTML
   , clang_FullComment_getAsXML
@@ -348,6 +353,62 @@ clang_ParamCommandComment_getDirection ::
 clang_ParamCommandComment_getDirection comment =
     onHaskellHeap comment $ \comment' ->
       wrap_ParamCommandComment_getDirection comment'
+
+{-------------------------------------------------------------------------------
+  Comment type 'CXComment_TParamCommand'
+-------------------------------------------------------------------------------}
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_TParamCommandComment_getParamName"
+  wrap_TParamCommandComment_getParamName :: R CXComment_ -> W CXString_ -> IO ()
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_TParamCommandComment_isParamPositionValid"
+  wrap_TParamCommandComment_isParamPositionValid :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_TParamCommandComment_getDepth"
+  wrap_TParamCommandComment_getDepth :: R CXComment_ -> IO CUInt
+
+foreign import capi unsafe "doxygen_wrappers.h wrap_TParamCommandComment_getIndex"
+  wrap_TParamCommandComment_getIndex :: R CXComment_ -> CUInt -> IO CUInt
+
+-- | Get the template parameter name.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga01f61f1d0dabcaf806eb1b9f21e5e340>
+clang_TParamCommandComment_getParamName :: CXComment -> IO Text
+clang_TParamCommandComment_getParamName comment =
+    onHaskellHeap comment $ \comment' ->
+      preallocate_ $ wrap_TParamCommandComment_getParamName comment'
+
+-- | Determine whether the parameter that this AST node represents was found in
+-- the template parameter list and @clang_TParamCommandComment_getDepth@ and
+-- @clang_TParamCommandComment_getIndex@ functions will return a meaningful
+-- value.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga1f6e7538a646824f3dde65d634de753f>
+clang_TParamCommandComment_isParamPositionValid :: CXComment -> IO Bool
+clang_TParamCommandComment_isParamPositionValid comment =
+    onHaskellHeap comment $ \comment' ->
+      cToBool <$> wrap_TParamCommandComment_isParamPositionValid comment'
+
+-- | Get the zero-based nesting depth of this parameter in the template
+-- parameter list.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga88371156eeeb768d0d14eb5630b7c726>
+clang_TParamCommandComment_getDepth :: CXComment -> IO CUInt
+clang_TParamCommandComment_getDepth comment =
+    onHaskellHeap comment $ \comment' ->
+      wrap_TParamCommandComment_getDepth comment'
+
+-- | Get the zero-based parameter index in the template parameter list at a
+-- given nesting depth.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga0b91d26f02a476076b6dc5b5eea59a8f>
+clang_TParamCommandComment_getIndex ::
+     CXComment
+  -> CUInt -- ^ depth
+  -> IO CUInt
+clang_TParamCommandComment_getIndex comment depth =
+    onHaskellHeap comment $ \comment' ->
+      wrap_TParamCommandComment_getIndex comment' depth
 
 {-------------------------------------------------------------------------------
   Comment type 'CXComment_FullComment'

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
@@ -1,6 +1,7 @@
 module HsBindgen.Clang.LowLevel.Doxygen.Enums (
     CXCommentKind(..)
   , CXCommentInlineCommandRenderKind(..)
+  , CXCommentParamPassDirection(..)
   ) where
 
 -- | Describes the type of the comment AST node ('CXComment').
@@ -123,3 +124,16 @@ data CXCommentInlineCommandRenderKind =
     -- | Command argument should not be rendered (since it only defines an
     -- anchor).
   | CXCommentInlineCommandRenderKind_Anchor
+
+-- | Describes parameter passing direction for @\\param@ or @\\arg@ command.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gafadf6e52217ea74d1a014198df656ee1>
+data CXCommentParamPassDirection =
+    -- | The parameter is an input parameter.
+    CXCommentParamPassDirection_In
+
+    -- | The parameter is an output parameter.
+  | CXCommentParamPassDirection_Out
+
+    -- | The parameter is an input and output parameter.
+  | CXCommentParamPassDirection_InOut

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
@@ -124,6 +124,7 @@ data CXCommentInlineCommandRenderKind =
     -- | Command argument should not be rendered (since it only defines an
     -- anchor).
   | CXCommentInlineCommandRenderKind_Anchor
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
 
 -- | Describes parameter passing direction for @\\param@ or @\\arg@ command.
 --
@@ -137,3 +138,4 @@ data CXCommentParamPassDirection =
 
     -- | The parameter is an input and output parameter.
   | CXCommentParamPassDirection_InOut
+  deriving stock (Show, Eq, Ord, Enum, Bounded)

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Enums.hs
@@ -1,5 +1,6 @@
 module HsBindgen.Clang.LowLevel.Doxygen.Enums (
     CXCommentKind(..)
+  , CXCommentInlineCommandRenderKind(..)
   ) where
 
 -- | Describes the type of the comment AST node ('CXComment').
@@ -100,3 +101,25 @@ data CXCommentKind =
     -- | A full comment attached to a declaration, contains block content.
   | CXComment_FullComment
   deriving stock (Show, Eq, Ord, Enum, Bounded)
+
+-- | The most appropriate rendering mode for an inline command, chosen on
+-- command semantics in Doxygen.
+--
+-- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga23efacd9c1e4e286a9f9714e1720fdcf>
+data CXCommentInlineCommandRenderKind =
+    -- | Command argument should be rendered in a normal font.
+    CXCommentInlineCommandRenderKind_Normal
+
+    -- | Command argument should be rendered in a bold font.
+  | CXCommentInlineCommandRenderKind_Bold
+
+    -- | Command argument should be rendered in a monospaced font.
+  | CXCommentInlineCommandRenderKind_Monospaced
+
+    -- | Command argument should be rendered emphasized (typically italic
+    -- font).
+  | CXCommentInlineCommandRenderKind_Emphasized
+
+    -- | Command argument should not be rendered (since it only defines an
+    -- anchor).
+  | CXCommentInlineCommandRenderKind_Anchor

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Instances.hsc
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Doxygen/Instances.hsc
@@ -49,3 +49,37 @@ instance IsSimpleEnum CXCommentKind where
   simpleFromC (#const CXComment_FullComment)          = Just CXComment_FullComment
 
   simpleFromC _otherwise = Nothing
+
+{-------------------------------------------------------------------------------
+  CXCommentInlineCommandRenderKind
+-------------------------------------------------------------------------------}
+
+instance IsSimpleEnum CXCommentInlineCommandRenderKind where
+  simpleToC CXCommentInlineCommandRenderKind_Normal     = #const CXCommentInlineCommandRenderKind_Normal
+  simpleToC CXCommentInlineCommandRenderKind_Bold       = #const CXCommentInlineCommandRenderKind_Bold
+  simpleToC CXCommentInlineCommandRenderKind_Monospaced = #const CXCommentInlineCommandRenderKind_Monospaced
+  simpleToC CXCommentInlineCommandRenderKind_Emphasized = #const CXCommentInlineCommandRenderKind_Emphasized
+  simpleToC CXCommentInlineCommandRenderKind_Anchor     = #const CXCommentInlineCommandRenderKind_Anchor
+
+  simpleFromC (#const CXCommentInlineCommandRenderKind_Normal)     = Just CXCommentInlineCommandRenderKind_Normal
+  simpleFromC (#const CXCommentInlineCommandRenderKind_Bold)       = Just CXCommentInlineCommandRenderKind_Bold
+  simpleFromC (#const CXCommentInlineCommandRenderKind_Monospaced) = Just CXCommentInlineCommandRenderKind_Monospaced
+  simpleFromC (#const CXCommentInlineCommandRenderKind_Emphasized) = Just CXCommentInlineCommandRenderKind_Emphasized
+  simpleFromC (#const CXCommentInlineCommandRenderKind_Anchor)     = Just CXCommentInlineCommandRenderKind_Anchor
+
+  simpleFromC _otherwise = Nothing
+
+{-------------------------------------------------------------------------------
+  CXCommentParamPassDirection
+-------------------------------------------------------------------------------}
+
+instance IsSimpleEnum CXCommentParamPassDirection where
+  simpleToC CXCommentParamPassDirection_In    = #const CXCommentParamPassDirection_In
+  simpleToC CXCommentParamPassDirection_Out   = #const CXCommentParamPassDirection_Out
+  simpleToC CXCommentParamPassDirection_InOut = #const CXCommentParamPassDirection_InOut
+
+  simpleFromC (#const CXCommentParamPassDirection_In)    = Just CXCommentParamPassDirection_In
+  simpleFromC (#const CXCommentParamPassDirection_Out)   = Just CXCommentParamPassDirection_Out
+  simpleFromC (#const CXCommentParamPassDirection_InOut) = Just CXCommentParamPassDirection_InOut
+
+  simpleFromC _otherwise = Nothing


### PR DESCRIPTION
This PR includes:

* Wrappers, bindings, and Haskell functions for all of `clang-c/Documentation.h` *except for* the following:
    * `CXComment.ASTNode` and `CXComment.TranslationUnit` (not needed)
    * `CXAPISet`, `clang_createAPISet`, and `clang_disposeAPISet` (not needed)
    * `clang_getSymbolGraphForUSR` and `clang_getSymbolGraphForCursor` (not needed)
* An initial version of `clang-ast-dump`, as an executable in the `hs-bindgen-libclang` package.

The PR does *not* include reified Haskell types for the documentation cursor types.  I will do that in a separate PR.

I have tested locally against all supported GHC versions, to make sure that it works with the configured dependency bounds.

Please feel free to change `clang-ast-dump` as desired, of course.  It should be easy to add support for more cursor kinds, options, etc.

After merge, #212 should be ready to close.