### PR TITLE
Use ediffGolden1, drop tasty-golden in favour of our version everywhere

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -156,9 +156,8 @@ test-suite golden
     , directory     ^>=1.3.6.2
     , filepath      ^>=1.4.2.2 || ^>=1.5.2.0
     , tasty         ^>=1.5
-    , tasty-golden  ^>=2.3.5
     , tasty-hunit   ^>=0.10.2
-    , tree-diff     ^>=0.3.1
+    , tree-diff     ^>=0.3.2
     , syb           ^>=0.7.2.4
     , ansi-diff
     , utf8-string   ^>=1.0.2

--- a/hs-bindgen/tests/TastyGolden.hs
+++ b/hs-bindgen/tests/TastyGolden.hs
@@ -56,7 +56,7 @@ instance IsOption AcceptTests where
     parseValue = fmap AcceptTests . safeReadBool
     optionName = return "accept"
     optionHelp = return "Accept current results of golden tests"
-    optionCLParser = flagCLParser Nothing (AcceptTests True)
+    optionCLParser = flagCLParser (Just 'a') (AcceptTests True)
 
 instance IsTest GoldenSteps where
     run opts golden progress = runGoldenSteps golden progress opts

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -3,12 +3,12 @@
 
 module Main (main) where
 
-import Data.TreeDiff.Golden (ediffGolden)
+import Data.TreeDiff.Golden (ediffGolden1)
 import System.FilePath ((</>))
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.Golden.Advanced (goldenTest)
 import Test.Tasty.HUnit (testCase, (@?=))
 
+import TastyGolden (goldenTestSteps)
 import Orphans ()
 import Misc
 
@@ -55,13 +55,13 @@ main' packageRoot = defaultMain $ testGroup "golden"
 #endif
         ]
 
-    goldenTreeDiff name = ediffGolden goldenTest "treediff" ("fixtures" </> (name ++ ".tree-diff.txt")) $ do
-        -- TODO: there aren't ediffGolden variant for goldenTestSteps like signature... yet
-
+    goldenTreeDiff name = ediffGolden1 goldenTestSteps "treediff" ("fixtures" </> (name ++ ".tree-diff.txt")) $ \report -> do
         let fp = "examples" </> (name ++ ".h")
             args = clangArgs packageRoot
 
-        header <- parseC nullTracer args fp
+        let tracer = mkTracer report report report False
+
+        header <- parseC tracer args fp
         return header
 
     goldenHs name = goldenVsStringDiff_ "hs" ("fixtures" </> (name ++ ".hs")) $ \report -> do


### PR DESCRIPTION
This makes `--accept` work for `tree-diff` tests.