### PR TITLE
git: set line endings to lf by default

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[core]
+  eol = lf
+  autocrlf = false


### PR DESCRIPTION
This ensures that Git doesn't try to check out the golden tests from the testsuite with CRLF line-endings, which would cause the tests to fail.