### PR TITLE
Add HsBindgen.Imports module with some common imports

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -83,6 +83,7 @@ library
       HsBindgen.C.Reparse.Macro
       HsBindgen.C.Reparse.Type
       HsBindgen.C.Tc.Macro
+      HsBindgen.Imports
       HsBindgen.Pretty.Orphans
       HsBindgen.Hs.AST.Name
       HsBindgen.Hs.AST.Type

--- a/hs-bindgen/src/HsBindgen/Backend/Common.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/Common.hs
@@ -14,8 +14,7 @@ module HsBindgen.Backend.Common (
   , Fresh(..)
   ) where
 
-import Data.Kind
-
+import HsBindgen.Imports
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Util.PHOAS
@@ -25,10 +24,10 @@ import HsBindgen.Util.PHOAS
 -------------------------------------------------------------------------------}
 
 class BackendRep be where
-  type Name be :: Type
-  type Expr be :: Type
-  type Decl be :: Type
-  type Ty   be :: Type
+  type Name be :: Star
+  type Expr be :: Star
+  type Decl be :: Star
+  type Ty   be :: Star -- TOOD: rename Ty to Type
 
   resolve :: be -> Global   -> Name be  -- ^ Resolve name
   mkExpr  :: be -> SExpr be -> Expr be  -- ^ Construct expression
@@ -104,7 +103,7 @@ data Newtype be = Newtype {
 -------------------------------------------------------------------------------}
 
 class (BackendRep be, Monad (M be)) => Backend be where
-  data M be :: Type -> Type
+  data M be :: Star -> Star
 
   -- | Pick fresh variable
   --

--- a/hs-bindgen/src/HsBindgen/Backend/Common/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/Common/Translation.hs
@@ -4,7 +4,6 @@
 module HsBindgen.Backend.Common.Translation (toBE) where
 
 import Data.Foldable
-import Data.Kind
 import Data.Vec.Lazy (Vec(..))
 
 import HsBindgen.Backend.Common
@@ -12,13 +11,14 @@ import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Util.PHOAS
+import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------
   Translate to backend-specific type
 -------------------------------------------------------------------------------}
 
 class Backend be => ToBE be (a :: PHOAS) where
-  type Rep be a :: Type
+  type Rep be a :: Star
   type Rep be a = Expr be
 
   toBE :: be -> a (Fresh be) -> M be (Rep be a)

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
@@ -9,12 +9,11 @@ module HsBindgen.Backend.PP.Render (
   , renderIO
   ) where
 
-import Data.Default
 import Data.List qualified as List
-import Data.Maybe
 import Data.Text qualified as Text
 import System.IO
 
+import HsBindgen.Imports
 import HsBindgen.Backend.Common
 import HsBindgen.Backend.PP
 import HsBindgen.Backend.PP.Render.Internal

--- a/hs-bindgen/src/HsBindgen/Backend/TH.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH.hs
@@ -6,7 +6,6 @@ module HsBindgen.Backend.TH (
   , runM
   ) where
 
-import Data.Kind (Type)
 import Data.Text qualified as Text
 import Data.Void qualified
 import Foreign.C.Types qualified
@@ -16,6 +15,7 @@ import Language.Haskell.TH (Quote)
 import Language.Haskell.TH qualified as TH
 
 import HsBindgen.Backend.Common
+import HsBindgen.Imports
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Util.PHOAS
@@ -24,7 +24,7 @@ import HsBindgen.Util.PHOAS
   Backend definition
 -------------------------------------------------------------------------------}
 
-type BE :: (Type -> Type) -> Type
+type BE :: (Star -> Star) -> Star
 data BE q = BE
 
 instance TH.Quote q => BackendRep (BE q) where

--- a/hs-bindgen/src/HsBindgen/C/Fold/Common.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Common.hs
@@ -12,12 +12,10 @@ module HsBindgen.C.Fold.Common (
   , continue
   ) where
 
-import Control.Exception
-import Control.Monad.IO.Class
-import Data.Text (Text)
-import Data.Tree
+import Data.Tree (Tree (Node))
 import GHC.Stack
 
+import HsBindgen.Imports
 import HsBindgen.C.AST
 import HsBindgen.C.Predicate (Predicate)
 import HsBindgen.C.Predicate qualified as Predicate

--- a/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
@@ -6,9 +6,9 @@ module HsBindgen.C.Fold.Decl (
   ) where
 
 import Control.Monad.State
-import Data.Maybe (catMaybes)
 import GHC.Stack
 
+import HsBindgen.Imports
 import HsBindgen.C.AST
 import HsBindgen.C.Fold.Common
 import HsBindgen.C.Fold.DeclState

--- a/hs-bindgen/src/HsBindgen/C/Fold/DeclState.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/DeclState.hs
@@ -8,12 +8,10 @@ module HsBindgen.C.Fold.DeclState (
   , containsMacroExpansion
   ) where
 
-import Data.Maybe (fromMaybe)
-import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Set (Set)
 import Data.Set qualified as Set
 
+import HsBindgen.Imports
 import HsBindgen.Clang.HighLevel.Types
 import HsBindgen.C.AST (CName)
 import HsBindgen.C.Tc.Macro (QuantTy)

--- a/hs-bindgen/src/HsBindgen/C/Fold/Prelude.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Prelude.hs
@@ -4,12 +4,9 @@ module HsBindgen.C.Fold.Prelude (
   , foldPrelude
   ) where
 
-import Control.Exception
-import Control.Monad.Identity
-import Control.Monad.IO.Class
-import Data.Text (Text)
 import Data.Text qualified as Text
 
+import HsBindgen.Imports
 import HsBindgen.C.Reparse
 import HsBindgen.Clang.HighLevel qualified as HighLevel
 import HsBindgen.Clang.HighLevel.Types

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -12,11 +12,9 @@ module HsBindgen.C.Parser (
   , foldTranslationUnitWith
   ) where
 
-import Control.Exception
-import Control.Monad
 import Data.List (partition)
-import Data.Text (Text)
 
+import HsBindgen.Imports
 import HsBindgen.Clang.Args
 import HsBindgen.Clang.HighLevel qualified as HighLevel
 import HsBindgen.Clang.HighLevel.Types

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Common.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Common.hs
@@ -7,9 +7,9 @@ module HsBindgen.C.Reparse.Common (
   , reparseAttribute
   ) where
 
-import Control.Monad
 import Text.Parsec hiding (token)
 
+import HsBindgen.Imports
 import HsBindgen.C.AST
 import HsBindgen.C.Reparse.Infra
 import HsBindgen.Clang.LowLevel.Core

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Infra.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Infra.hs
@@ -23,11 +23,7 @@ module HsBindgen.C.Reparse.Infra (
   , anythingMatchingBrackets
   ) where
 
-import Control.Exception (Exception)
-import Control.Monad
-import Data.Bifunctor
 import Data.List (intercalate)
-import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import Text.Parsec hiding (token, tokens)
@@ -35,6 +31,7 @@ import Text.Parsec qualified as Parsec
 import Text.Parsec.Pos
 import Text.Show.Pretty (PrettyVal)
 
+import HsBindgen.Imports
 import HsBindgen.Clang.HighLevel.Types
 import HsBindgen.Clang.LowLevel.Core
 import HsBindgen.Patterns

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Literal.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Literal.hs
@@ -4,14 +4,13 @@ module HsBindgen.C.Reparse.Literal (
   , reparseLiteralFloating
   ) where
 
-import Control.Monad (void)
 import Data.Char (toLower, ord)
-import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Scientific qualified as Scientific
 import Text.Parsec
 import Text.Show.Pretty (PrettyVal)
 import GHC.Generics
 
+import HsBindgen.Imports
 import HsBindgen.C.Reparse.Infra
 import HsBindgen.Util.Parsec
 import HsBindgen.C.AST.Type

--- a/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
@@ -28,22 +28,14 @@ module HsBindgen.C.Tc.Macro
   where
 
 -- base
-import Control.Arrow
-  ( first )
-import Control.Monad
-  ( ap )
 import Control.Monad.ST
   ( ST, runST )
-import Data.Coerce
-  ( coerce )
-import Data.Foldable
-  ( toList, traverse_ )
 import Data.Kind qualified as Hs
 import Data.List
   ( intercalate, intersect )
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe
-  ( fromJust, catMaybes )
+  ( fromJust )
 import Data.Monoid
   ( Any (..), Ap(..) )
 import Data.STRef
@@ -60,14 +52,8 @@ import GHC.Exts
   ( Int(I#), dataToTag# )
 
 -- containers
-import Data.IntMap.Strict
-  ( IntMap )
 import Data.IntMap.Strict qualified as IntMap
-import Data.IntSet
-  ( IntSet )
 import Data.IntSet qualified as IntSet
-import Data.Map.Strict
-  ( Map )
 import Data.Map.Strict qualified as Map
 
 -- fin
@@ -94,8 +80,6 @@ import Text.Show.Pretty
 import Text.Show.Pretty qualified as Pretty
 
 -- text
-import Data.Text
-  ( Text )
 import Data.Text qualified as Text
 
 -- vec
@@ -104,6 +88,7 @@ import Data.Vec.Lazy
 import Data.Vec.Lazy qualified as Vec
 
 -- hs-bindgen
+import HsBindgen.Imports
 import HsBindgen.C.AST.Literal
   ( IntegerLiteral(..), FloatingLiteral(..) )
 import HsBindgen.C.AST.Macro

--- a/hs-bindgen/src/HsBindgen/Hs/AST/Name.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST/Name.hs
@@ -43,13 +43,12 @@ module HsBindgen.Hs.AST.Name (
   ) where
 
 import Data.Char qualified as Char
-import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String
-import Data.Text (Text)
 import Data.Text qualified as T
-import Numeric
+import Numeric (showHex)
 
+import HsBindgen.Imports
 import HsBindgen.C.AST (CName(..))
 import HsBindgen.Util.PHOAS (ShowOpen (..))
 

--- a/hs-bindgen/src/HsBindgen/Imports.hs
+++ b/hs-bindgen/src/HsBindgen/Imports.hs
@@ -1,0 +1,36 @@
+-- | Common imports
+module HsBindgen.Imports (
+    module X,
+    Star,
+) where
+
+import Data.Kind qualified
+
+import Control.Exception as X (Exception, throwIO, bracket)
+import Control.Monad as X (void, ap, forM_, guard)
+import Control.Monad.Identity as X (Identity (..))
+import Control.Monad.IO.Class as X (MonadIO (liftIO))
+import Data.Bifunctor as X (Bifunctor (bimap, first, second))
+import Data.Coerce as X (coerce)
+import Data.Default as X (Default (def))
+import Data.Foldable as X (Foldable (foldl', toList), traverse_)
+import Data.Maybe as X (catMaybes, mapMaybe, fromMaybe)
+import Data.String as X (IsString (fromString))
+
+-- types
+import Data.IntMap.Strict as X (IntMap)
+import Data.IntSet as X (IntSet)
+import Data.Map.Strict as X (Map)
+import Data.Set as X (Set)
+import Data.Text as X (Text)
+
+-- these are nice to be always available while developing,
+-- without needing to add/remove imports.
+import Debug.Trace as X (traceShowId, traceShow, traceM)
+
+-- | @Type@ is very clashy name: there's TH.Type, we may want to use Type for
+-- representation of C types, etc.
+--
+-- Let's use Star to refer to Haskell's kind.
+type Star = Data.Kind.Type
+

--- a/hs-bindgen/src/HsBindgen/Translation/LowLevel.hs
+++ b/hs-bindgen/src/HsBindgen/Translation/LowLevel.hs
@@ -11,13 +11,11 @@
 --   <https://github.com/well-typed/hs-bindgen/milestone/3>
 module HsBindgen.Translation.LowLevel (generateDeclarations) where
 
-import Data.Foldable
-import Data.Kind
-import Data.Maybe
 import Data.Type.Nat
 import Data.Vec.Lazy (Vec (..))
 import Data.Vec.Lazy qualified as Vec
 
+import HsBindgen.Imports
 import HsBindgen.C.AST qualified as C
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Util.PHOAS
@@ -36,7 +34,7 @@ generateDeclarations = getList . toHs
   Translation
 -------------------------------------------------------------------------------}
 
-class ToHs (a :: Type) where
+class ToHs (a :: Star) where
   type InHs a :: PHOAS
   toHs :: a -> InHs a f
 

--- a/hs-bindgen/src/HsBindgen/Util/PHOAS.hs
+++ b/hs-bindgen/src/HsBindgen/Util/PHOAS.hs
@@ -17,7 +17,6 @@ module HsBindgen.Util.PHOAS (
 
 import Data.Fin qualified as Fin
 import Data.Foldable
-import Data.Kind
 import Data.List (intersperse)
 import Data.Type.Nat
 import Data.Vec.Lazy (Vec(..))
@@ -26,11 +25,13 @@ import Generics.SOP
 import GHC.Generics qualified as GHC
 import GHC.Show
 
+import HsBindgen.Imports
+
 {-------------------------------------------------------------------------------
   Main definitions
 -------------------------------------------------------------------------------}
 
-type PHOAS = (Type -> Type) -> Type
+type PHOAS = (Star -> Star) -> Star
 
 -- | Bound name
 data Bound
@@ -65,7 +66,7 @@ newtype Unique a = Unique Int
 showUnique :: Unique a -> ShowS
 showUnique (Unique u) = showString "x" . showsPrec 0 u
 
-class ShowOpen (term :: Type) where
+class ShowOpen (term :: Star) where
   -- | Show open term
   --
   -- Precondition: all bound variables already present in the term must be


### PR DESCRIPTION
... the project become big enough, that managing imports becomes a chore.

Having more utilityies easily available without needing to adjust imports (even if tool does that) allows to concentrate on actual problems.

The controversial change may be the `type Star = Data.Kind.Type`. IMHO, the C (or/and generate Hs) `Type` is more common than host Haskell `Type`, so that has to give up it's valuable name. I have written `Typ` or `Ty` way too many times, these should be `Type`.