### PR TITLE
Add clang_getNullCursor and nullCursor

### DIFF
--- a/hs-bindgen-libclang/cbits/clang_wrappers.h
+++ b/hs-bindgen-libclang/cbits/clang_wrappers.h
@@ -174,6 +174,10 @@ static inline enum CXCursorKind wrap_getCursorKind(const CXCursor* cursor) {
     return clang_getCursorKind(*cursor);
 }
 
+static inline void wrap_getNullCursor(CXCursor *result) {
+	*result = clang_getNullCursor();
+}
+
 static inline void wrap_getCursorKindSpelling(enum CXCursorKind Kind, CXString* result) {
     *result = clang_getCursorKindSpelling(Kind);
 }


### PR DESCRIPTION
```
HsBindgen.Clang.LowLevel.Core> nullCursor
[0x46, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
```