### PR TITLE
Rename Typ to Type

### DIFF
--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -510,25 +510,25 @@ WrapCHeader
             StructField {
               fieldName = CName "foo",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "bar",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)}]},
       DeclTypedef
         Typedef {
           typedefName = CName
             "another_typedef_struct_t",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName
               "struct another_typedef_struct_t")},
       DeclEnum
         Enu {
           enumTag = Nothing,
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
           enumSizeof = 4,
@@ -544,19 +544,19 @@ WrapCHeader
         Typedef {
           typedefName = CName
             "another_typedef_enum_e",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName
               "enum another_typedef_enum_e")},
       DeclTypedef
         Typedef {
           typedefName = CName "a_type_t",
-          typedefType = TypPrim
+          typedefType = TypePrim
             (PrimIntegral
               (PrimInt Signed))},
       DeclTypedef
         Typedef {
           typedefName = CName "var_t",
-          typedefType = TypPrim
+          typedefType = TypePrim
             (PrimIntegral
               (PrimInt Signed))},
       DeclStruct
@@ -569,77 +569,77 @@ WrapCHeader
             StructField {
               fieldName = CName "field_0",
               fieldOffset = 0,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "bool")},
             StructField {
               fieldName = CName "field_1",
               fieldOffset = 8,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "uint8_t")},
             StructField {
               fieldName = CName "field_2",
               fieldOffset = 16,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "uint16_t")},
             StructField {
               fieldName = CName "field_3",
               fieldOffset = 32,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "uint32_t")},
             StructField {
               fieldName = CName "field_4",
               fieldOffset = 64,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName
                   "another_typedef_struct_t")},
             StructField {
               fieldName = CName "field_5",
               fieldOffset = 128,
-              fieldType = TypPointer
-                (TypElaborated
+              fieldType = TypePointer
+                (TypeElaborated
                   (CName
                     "another_typedef_struct_t"))},
             StructField {
               fieldName = CName "field_6",
               fieldOffset = 192,
-              fieldType = TypPointer
-                (TypPrim PrimVoid)},
+              fieldType = TypePointer
+                (TypePrim PrimVoid)},
             StructField {
               fieldName = CName "field_7",
               fieldOffset = 256,
-              fieldType = TypConstArray
+              fieldType = TypeConstArray
                 7
-                (TypElaborated
+                (TypeElaborated
                   (CName "uint32_t"))},
             StructField {
               fieldName = CName "field_8",
               fieldOffset = 480,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName
                   "another_typedef_enum_e")},
             StructField {
               fieldName = CName "field_9",
               fieldOffset = 512,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName
                   "another_typedef_enum_e")},
             StructField {
               fieldName = CName "field_10",
               fieldOffset = 640,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName
                   "another_typedef_enum_e")}]},
       DeclTypedef
         Typedef {
           typedefName = CName
             "a_typedef_struct_t",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName
               "struct a_typedef_struct")},
       DeclEnum
         Enu {
           enumTag = Nothing,
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimChar (Just Unsigned)),
           enumSizeof = 1,
           enumAlignment = 1,
@@ -660,12 +660,12 @@ WrapCHeader
         Typedef {
           typedefName = CName
             "a_typedef_enum_e",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName
               "enum a_typedef_enum_e")},
       DeclTypedef
         Typedef {
           typedefName = CName
             "callback_t",
-          typedefType = TypPointer
-            (TypPrim PrimVoid)}])
+          typedefType = TypePointer
+            (TypePrim PrimVoid)}])

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -21,7 +21,7 @@ WrapCHeader
       DeclEnum
         Enu {
           enumTag = Just (CName "first"),
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
           enumSizeof = 4,
@@ -36,7 +36,7 @@ WrapCHeader
       DeclEnum
         Enu {
           enumTag = Just (CName "second"),
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimIntegral (PrimInt Signed)),
           enumSizeof = 4,
           enumAlignment = 4,
@@ -53,7 +53,7 @@ WrapCHeader
       DeclEnum
         Enu {
           enumTag = Just (CName "same"),
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
           enumSizeof = 4,
@@ -68,7 +68,7 @@ WrapCHeader
       DeclEnum
         Enu {
           enumTag = Just (CName "packad"),
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimChar (Just Unsigned)),
           enumSizeof = 1,
           enumAlignment = 1,

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -4,8 +4,8 @@ WrapCHeader
       DeclTypedef
         Typedef {
           typedefName = CName "triple",
-          typedefType = TypConstArray
+          typedefType = TypeConstArray
             3
-            (TypPrim
+            (TypePrim
               (PrimIntegral
                 (PrimInt Signed)))}])

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -10,10 +10,10 @@ WrapCHeader
             StructField {
               fieldName = CName "sixty_four",
               fieldOffset = 0,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "uint64_t")},
             StructField {
               fieldName = CName "thirty_two",
               fieldOffset = 64,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "uint32_t")}]}])

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -4,7 +4,7 @@ WrapCHeader
       DeclTypedef
         Typedef {
           typedefName = CName "S1_t",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName "struct S1")},
       DeclStruct
         Struct {
@@ -15,7 +15,7 @@ WrapCHeader
             StructField {
               fieldName = CName "a",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))}]},
       DeclStruct
@@ -27,6 +27,6 @@ WrapCHeader
             StructField {
               fieldName = CName "a",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))}]}])

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -10,13 +10,13 @@ WrapCHeader
             StructField {
               fieldName = CName "i",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "c",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)}]},
       DeclStruct
         Struct {
@@ -27,10 +27,10 @@ WrapCHeader
             StructField {
               fieldName = CName "foo1",
               fieldOffset = 0,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "struct foo")},
             StructField {
               fieldName = CName "foo2",
               fieldOffset = 64,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "struct foo")}]}])

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -12,14 +12,14 @@ WrapCHeader
             StructField {
               fieldName = CName "ptrA",
               fieldOffset = 0,
-              fieldType = TypPointer
-                (TypElaborated
+              fieldType = TypePointer
+                (TypeElaborated
                   (CName "struct foo"))},
             StructField {
               fieldName = CName "ptrB",
               fieldOffset = 64,
-              fieldType = TypPointer
-                (TypElaborated
+              fieldType = TypePointer
+                (TypeElaborated
                   (CName "struct bar"))}]},
       DeclStruct
         Struct {

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -11,169 +11,169 @@ WrapCHeader
             StructField {
               fieldName = CName "c",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)},
             StructField {
               fieldName = CName "sc",
               fieldOffset = 8,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar (Just Signed))},
             StructField {
               fieldName = CName "uc",
               fieldOffset = 16,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar (Just Unsigned))},
             StructField {
               fieldName = CName "s",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed))},
             StructField {
               fieldName = CName "si",
               fieldOffset = 48,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed))},
             StructField {
               fieldName = CName "ss",
               fieldOffset = 64,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed))},
             StructField {
               fieldName = CName "ssi",
               fieldOffset = 80,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed))},
             StructField {
               fieldName = CName "us",
               fieldOffset = 96,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned))},
             StructField {
               fieldName = CName "usi",
               fieldOffset = 112,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned))},
             StructField {
               fieldName = CName "i",
               fieldOffset = 128,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "s2",
               fieldOffset = 160,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "si2",
               fieldOffset = 192,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "u",
               fieldOffset = 224,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned))},
             StructField {
               fieldName = CName "ui",
               fieldOffset = 256,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned))},
             StructField {
               fieldName = CName "l",
               fieldOffset = 320,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed))},
             StructField {
               fieldName = CName "li",
               fieldOffset = 384,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed))},
             StructField {
               fieldName = CName "sl",
               fieldOffset = 448,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed))},
             StructField {
               fieldName = CName "sli",
               fieldOffset = 512,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed))},
             StructField {
               fieldName = CName "ul",
               fieldOffset = 576,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned))},
             StructField {
               fieldName = CName "uli",
               fieldOffset = 640,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned))},
             StructField {
               fieldName = CName "ll",
               fieldOffset = 704,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed))},
             StructField {
               fieldName = CName "lli",
               fieldOffset = 768,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed))},
             StructField {
               fieldName = CName "sll",
               fieldOffset = 832,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed))},
             StructField {
               fieldName = CName "slli",
               fieldOffset = 896,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed))},
             StructField {
               fieldName = CName "ull",
               fieldOffset = 960,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned))},
             StructField {
               fieldName = CName "ulli",
               fieldOffset = 1024,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned))},
             StructField {
               fieldName = CName "f",
               fieldOffset = 1088,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimFloating PrimFloat)},
             StructField {
               fieldName = CName "d",
               fieldOffset = 1152,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimFloating PrimDouble)},
             StructField {
               fieldName = CName "ld",
               fieldOffset = 1280,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimFloating
                   PrimLongDouble)}]}])

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -10,13 +10,13 @@ WrapCHeader
             StructField {
               fieldName = CName "a",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)}]},
       DeclStruct
         Struct {
@@ -27,23 +27,23 @@ WrapCHeader
             StructField {
               fieldName = CName "a",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimFloating PrimFloat)}]},
       DeclTypedef
         Typedef {
           typedefName = CName "S2_t",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName "struct S2")},
       DeclStruct
         Struct {
@@ -54,12 +54,12 @@ WrapCHeader
             StructField {
               fieldName = CName "a",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)}]},
       DeclTypedef
         Typedef {
           typedefName = CName "S3_t",
-          typedefType = TypElaborated
+          typedefType = TypeElaborated
             (CName "struct S3_t")},
       DeclStruct
         Struct {
@@ -70,18 +70,18 @@ WrapCHeader
             StructField {
               fieldName = CName "b",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimChar Nothing)},
             StructField {
               fieldName = CName "a",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
-              fieldType = TypPointer
-                (TypPrim
+              fieldType = TypePointer
+                (TypePrim
                   (PrimIntegral
                     (PrimInt Signed)))}]}])

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -42,13 +42,13 @@ WrapCHeader
       DeclTypedef
         Typedef {
           typedefName = CName "T1",
-          typedefType = TypPrim
+          typedefType = TypePrim
             (PrimIntegral
               (PrimInt Signed))},
       DeclTypedef
         Typedef {
           typedefName = CName "T2",
-          typedefType = TypPrim
+          typedefType = TypePrim
             (PrimChar Nothing)},
       DeclStruct
         Struct {
@@ -60,20 +60,20 @@ WrapCHeader
             StructField {
               fieldName = CName "t1",
               fieldOffset = 0,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "T1")},
             StructField {
               fieldName = CName "t2",
               fieldOffset = 32,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "T2")},
             StructField {
               fieldName = CName "m1",
               fieldOffset = 64,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "M1")},
             StructField {
               fieldName = CName "m2",
               fieldOffset = 96,
-              fieldType = TypElaborated
+              fieldType = TypeElaborated
                 (CName "M2")}]}])

--- a/hs-bindgen/fixtures/typedefs.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedefs.tree-diff.txt
@@ -4,13 +4,13 @@ WrapCHeader
       DeclTypedef
         Typedef {
           typedefName = CName "myint",
-          typedefType = TypPrim
+          typedefType = TypePrim
             (PrimIntegral
               (PrimInt Signed))},
       DeclTypedef
         Typedef {
           typedefName = CName "intptr",
-          typedefType = TypPointer
-            (TypPrim
+          typedefType = TypePointer
+            (TypePrim
               (PrimIntegral
                 (PrimInt Signed)))}])

--- a/hs-bindgen/fixtures/unnamed-struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/unnamed-struct.tree-diff.txt
@@ -10,12 +10,12 @@ WrapCHeader
             StructField {
               fieldName = CName "foo",
               fieldOffset = 0,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))},
             StructField {
               fieldName = CName "bar",
               fieldOffset = 32,
-              fieldType = TypPrim
+              fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Signed))}]}])

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -21,7 +21,7 @@ WrapCHeader
       DeclEnum
         Enu {
           enumTag = Just (CName "MyEnum"),
-          enumType = TypPrim
+          enumType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
           enumSizeof = 4,

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -13,7 +13,7 @@ module HsBindgen.C.AST (
     -- * Names
   , CName(..)
     -- * Types
-  , Typ(..)
+  , Type(..)
     -- ** Primitive types
   , PrimType(..)
   , PrimIntType(..)

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -2,7 +2,7 @@
 --
 -- This is re-exported in "HsBindgen.C.AST".
 module HsBindgen.C.AST.Type (
-    Typ(..)
+    Type(..)
     -- * Primitive types
   , PrimType(..)
   , PrimIntType(..)
@@ -25,12 +25,13 @@ import HsBindgen.C.AST.Name
   Top-level
 -------------------------------------------------------------------------------}
 
-data Typ =
-    TypPrim PrimType
-  | TypStruct Struct
-  | TypPointer Typ
-  | TypConstArray Natural Typ
-  | TypElaborated Symbol
+-- | Type representing /usage/ of a type: field type, argument or result type etc.
+data Type =
+    TypePrim PrimType
+  | TypeStruct Struct
+  | TypePointer Type
+  | TypeConstArray Natural Type
+  | TypeElaborated Symbol
   -- todo | TypEnum Enum
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
@@ -134,7 +135,7 @@ data Struct = Struct {
 data StructField = StructField {
       fieldName   :: CName
     , fieldOffset :: Int -- ^ Offset in bits
-    , fieldType   :: Typ
+    , fieldType   :: Type
     }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
@@ -145,7 +146,7 @@ data StructField = StructField {
 
 data Enu = Enu {
       enumTag       :: Maybe CName
-    , enumType      :: Typ
+    , enumType      :: Type
     , enumSizeof    :: Int
     , enumAlignment :: Int
     , enumValues    :: [EnumValue]
@@ -166,7 +167,7 @@ data EnumValue = EnumValue {
 
 data Typedef = Typedef {
       typedefName :: CName
-    , typedefType :: Typ
+    , typedefType :: Type
     }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)

--- a/hs-bindgen/src/HsBindgen/C/Reparse/FieldDecl.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/FieldDecl.hs
@@ -9,5 +9,5 @@ import HsBindgen.C.Reparse.Infra
 import HsBindgen.C.Reparse.Type
 
 -- | Field declaration (in a struct)
-reparseFieldDecl :: Reparse (Typ, CName)
+reparseFieldDecl :: Reparse (Type, CName)
 reparseFieldDecl = (,) <$> reparseTypeUse <*> reparseName

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Type.hs
@@ -19,10 +19,10 @@ import HsBindgen.C.Reparse.Common
 -- | Reparse type use
 --
 -- TODO: This parser is quite minimal at the moment.
-reparseTypeUse :: Reparse Typ
+reparseTypeUse :: Reparse Type
 reparseTypeUse = choice [
-      TypPrim <$> reparsePrimType
-    , TypElaborated <$> reparseName
+      TypePrim <$> reparsePrimType
+    , TypeElaborated <$> reparseName
     ]
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -45,7 +45,7 @@ instance ToExpr C.SingleLoc
 instance ToExpr C.Struct
 instance ToExpr C.StructField
 instance ToExpr C.TokenSpelling
-instance ToExpr C.Typ
+instance ToExpr C.Type
 instance ToExpr C.Typedef
 
 instance ToExpr C.IntegerLiteral


### PR DESCRIPTION
This is straight forward renaming of `Typ` to `Type`... however `C.Macro` namespace also has `Type`, so there was a bit adjustment in translation logic.

I feel that macro stuff is so separate (and big), it deserves to live outside `C` namespace, in its own. It's not really C (at most C *preprocessor*), with our own type-system for it etc.