### PR TITLE
Add clang-syntax

### DIFF
--- a/clang-syntax
+++ b/clang-syntax
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+clang -Xclang -ast-dump -fsyntax-only "$@"


### PR DESCRIPTION
Our `clang-ast-dump` is nice, but `clang` has this feature built in:

![image](https://github.com/user-attachments/assets/f69b08ed-0c76-401e-92bd-19d431952fc8)
