### PR TITLE
Fix anonymous example

### DIFF
--- a/hs-bindgen/examples/anonymous.h
+++ b/hs-bindgen/examples/anonymous.h
@@ -5,5 +5,5 @@ struct S1 {
     int b;
   } c;
 
-  int c;
+  int d;
 };


### PR DESCRIPTION
The example had two fields named `c`, which is invalid.  This commit changes the name of the last field to `d`.