### PR TITLE
More graceful failure

### DIFF
--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -386,11 +386,11 @@ mkStructField relPath unit path current = do
           tokens <- HighLevel.clang_tokenize relPath unit (multiLocExpansion <$> extent)
           case reparseWith reparseFieldDecl tokens of
             Left err ->
-              error $ "mkStructField: " ++ show err
+              fail $ "mkStructField: " ++ show err
             Right (fieldType, fieldName) -> do
               fieldOffset <- fromIntegral <$> clang_Cursor_getOffsetOfField current
               unless (fieldOffset `mod` 8 == 0) $
-                error "bit-fields not supported yet"
+                fail "bit-fields not supported yet"
               return $ Just StructField {
                   fieldName
                 , fieldOffset
@@ -405,7 +405,7 @@ mkStructField relPath unit path current = do
           fieldType   <- processTypeDeclRec relPath (DeclPathField fieldName path) unit ty
           fieldOffset <- fromIntegral <$> liftIO (clang_Cursor_getOffsetOfField current)
 
-          unless (fieldOffset `mod` 8 == 0) $ error "bit-fields not supported yet"
+          unless (fieldOffset `mod` 8 == 0) $ fail "bit-fields not supported yet"
 
           return $ Just StructField {
               fieldName

--- a/hs-bindgen/src/HsBindgen/Eff.hs
+++ b/hs-bindgen/src/HsBindgen/Eff.hs
@@ -24,7 +24,7 @@ import HsBindgen.Imports
 newtype Eff m a = Eff {
       getEff :: ReaderT (Support m) IO a
     }
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO)
+  deriving newtype (Functor, Applicative, Monad, MonadFail, MonadIO, MonadUnliftIO)
 
 wrapEff :: (Support m -> IO a) -> Eff m a
 wrapEff = Eff . ReaderT


### PR DESCRIPTION
`error` is simply wrong in `IO`-ish contexts. Use fail or throwIO.

cc @edsko @TravisCardwell 

Related to #340 (but doesn't fix it, as we have more `error`s in later stages).