### PR TITLE
Update tree-diff, remove Eq CHeader instance

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -195,7 +195,7 @@ test-suite golden
     , tasty         ^>=1.5
     , tasty-hunit   ^>=0.10.2
     , temporary
-    , tree-diff     ^>=0.3.2
+    , tree-diff     ^>=0.3.4
     , utf8-string   ^>=1.0.2
 
 test-suite test-th

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -104,7 +104,7 @@ import HsBindgen.Util.Tracer
 newtype CHeader = WrapCHeader {
       unwrapCHeader :: C.Header
     }
-  deriving (Eq, Generic)
+  deriving (Generic)
 
 newtype HsModule = WrapHsModule {
       unwrapHsModule :: Backend.PP.HsModule


### PR DESCRIPTION
I didn't remove rest of Eq instances, IMO they should be. But not having `Eq CHeader` is enough to illustrate that we don't need them.