### PR TITLE
Remove Eq instances for Hs AST (#351)

### DIFF
--- a/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
@@ -52,5 +52,5 @@ data HsType =
   | HsFunPtr HsType
   | HsIO HsType
   | HsFun HsType HsType
-  deriving stock (Eq, Generic, Show)
+  deriving stock (Generic, Show)
 


### PR DESCRIPTION
This commit removes the Eq instances that were added in the following commits:

* `916ab6dc` Add Hs AST Eq instances, test using tree-diff
* `a02d5d28` Improve Eq Hs instances
* `5243b337` Improve Eq Hs instances (2)

Note that `ApEq` in `HsBindgen.Util.TestEquality` is *not* removed.

Discussion: https://github.com/well-typed/hs-bindgen/pull/348