### PR TITLE
Add HasFlexibleArrayMember instance generation

### DIFF
--- a/hs-bindgen/examples/flam.h
+++ b/hs-bindgen/examples/flam.h
@@ -12,3 +12,10 @@ struct foo {
 		int y;
 	} bar[];
 };
+
+// offset and sizeof not the same
+struct diff {
+	long first;
+	char second;
+	char flam[];
+};

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -761,4 +761,323 @@
                   PokeByteOff
                     (Idx 2)
                     0
-                    (Idx 0)])))})]
+                    (Idx 0)])))}),
+  DeclData
+    Struct {
+      structName = HsName
+        "@NsTypeConstr"
+        "Diff",
+      structConstr = HsName
+        "@NsConstr"
+        "Diff",
+      structFields = [
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "diff_first",
+          fieldType = HsPrimType
+            HsPrimCLong,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "first",
+              fieldOffset = 0,
+              fieldType = TypePrim
+                (PrimIntegral
+                  (PrimLong Signed)),
+              fieldSourceLoc =
+              "examples/flam.h:18:7"}},
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "diff_second",
+          fieldType = HsPrimType
+            HsPrimCChar,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "second",
+              fieldOffset = 64,
+              fieldType = TypePrim
+                (PrimChar Nothing),
+              fieldSourceLoc =
+              "examples/flam.h:19:7"}}],
+      structOrigin =
+      StructOriginStruct
+        Struct {
+          structDeclPath = DeclPathStruct
+            (DeclNameTag (CName "diff"))
+            DeclPathTop,
+          structSizeof = 16,
+          structAlignment = 8,
+          structFields = [
+            StructField {
+              fieldName = CName "first",
+              fieldOffset = 0,
+              fieldType = TypePrim
+                (PrimIntegral
+                  (PrimLong Signed)),
+              fieldSourceLoc =
+              "examples/flam.h:18:7"},
+            StructField {
+              fieldName = CName "second",
+              fieldOffset = 64,
+              fieldType = TypePrim
+                (PrimChar Nothing),
+              fieldSourceLoc =
+              "examples/flam.h:19:7"}],
+          structFlam = Just
+            StructField {
+              fieldName = CName "flam",
+              fieldOffset = 72,
+              fieldType = TypePrim
+                (PrimChar Nothing),
+              fieldSourceLoc =
+              "examples/flam.h:20:7"},
+          structSourceLoc =
+          "examples/flam.h:17:8"}},
+  DeclInstance
+    (InstanceStorable
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Diff",
+        structConstr = HsName
+          "@NsConstr"
+          "Diff",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "diff_first",
+            fieldType = HsPrimType
+              HsPrimCLong,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "first",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral
+                    (PrimLong Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:18:7"}},
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "diff_second",
+            fieldType = HsPrimType
+              HsPrimCChar,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "second",
+                fieldOffset = 64,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:19:7"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathStruct
+              (DeclNameTag (CName "diff"))
+              DeclPathTop,
+            structSizeof = 16,
+            structAlignment = 8,
+            structFields = [
+              StructField {
+                fieldName = CName "first",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral
+                    (PrimLong Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:18:7"},
+              StructField {
+                fieldName = CName "second",
+                fieldOffset = 64,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:19:7"}],
+            structFlam = Just
+              StructField {
+                fieldName = CName "flam",
+                fieldOffset = 72,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:20:7"},
+            structSourceLoc =
+            "examples/flam.h:17:8"}}
+      StorableInstance {
+        storableSizeOf = 16,
+        storableAlignment = 8,
+        storablePeek = Lambda
+          (NameHint "ptr")
+          (Ap
+            (StructCon
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "Diff",
+                structConstr = HsName
+                  "@NsConstr"
+                  "Diff",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "diff_first",
+                    fieldType = HsPrimType
+                      HsPrimCLong,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "first",
+                        fieldOffset = 0,
+                        fieldType = TypePrim
+                          (PrimIntegral
+                            (PrimLong Signed)),
+                        fieldSourceLoc =
+                        "examples/flam.h:18:7"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "diff_second",
+                    fieldType = HsPrimType
+                      HsPrimCChar,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "second",
+                        fieldOffset = 64,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:19:7"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathStruct
+                      (DeclNameTag (CName "diff"))
+                      DeclPathTop,
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "first",
+                        fieldOffset = 0,
+                        fieldType = TypePrim
+                          (PrimIntegral
+                            (PrimLong Signed)),
+                        fieldSourceLoc =
+                        "examples/flam.h:18:7"},
+                      StructField {
+                        fieldName = CName "second",
+                        fieldOffset = 64,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:19:7"}],
+                    structFlam = Just
+                      StructField {
+                        fieldName = CName "flam",
+                        fieldOffset = 72,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:20:7"},
+                    structSourceLoc =
+                    "examples/flam.h:17:8"}})
+            [
+              PeekByteOff (Idx 0) 0,
+              PeekByteOff (Idx 0) 8]),
+        storablePoke = Lambda
+          (NameHint "ptr")
+          (Lambda
+            (NameHint "s")
+            (ElimStruct
+              (Idx 0)
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "Diff",
+                structConstr = HsName
+                  "@NsConstr"
+                  "Diff",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "diff_first",
+                    fieldType = HsPrimType
+                      HsPrimCLong,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "first",
+                        fieldOffset = 0,
+                        fieldType = TypePrim
+                          (PrimIntegral
+                            (PrimLong Signed)),
+                        fieldSourceLoc =
+                        "examples/flam.h:18:7"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "diff_second",
+                    fieldType = HsPrimType
+                      HsPrimCChar,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "second",
+                        fieldOffset = 64,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:19:7"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathStruct
+                      (DeclNameTag (CName "diff"))
+                      DeclPathTop,
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "first",
+                        fieldOffset = 0,
+                        fieldType = TypePrim
+                          (PrimIntegral
+                            (PrimLong Signed)),
+                        fieldSourceLoc =
+                        "examples/flam.h:18:7"},
+                      StructField {
+                        fieldName = CName "second",
+                        fieldOffset = 64,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:19:7"}],
+                    structFlam = Just
+                      StructField {
+                        fieldName = CName "flam",
+                        fieldOffset = 72,
+                        fieldType = TypePrim
+                          (PrimChar Nothing),
+                        fieldSourceLoc =
+                        "examples/flam.h:20:7"},
+                    structSourceLoc =
+                    "examples/flam.h:17:8"}}
+              (Add 2)
+              (Seq
+                [
+                  PokeByteOff (Idx 3) 0 (Idx 0),
+                  PokeByteOff
+                    (Idx 3)
+                    8
+                    (Idx 1)])))})]

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -219,6 +219,59 @@
                     (Idx 2)
                     0
                     (Idx 0)])))}),
+  DeclInstance
+    (InstanceHasFLAM
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Pascal",
+        structConstr = HsName
+          "@NsConstr"
+          "Pascal",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "pascal_len",
+            fieldType = HsPrimType
+              HsPrimCInt,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "len",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral (PrimInt Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:3:9"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathStruct
+              (DeclNameTag (CName "pascal"))
+              DeclPathTop,
+            structSizeof = 4,
+            structAlignment = 4,
+            structFields = [
+              StructField {
+                fieldName = CName "len",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral (PrimInt Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:3:9"}],
+            structFlam = Just
+              StructField {
+                fieldName = CName "data",
+                fieldOffset = 32,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:4:10"},
+            structSourceLoc =
+            "examples/flam.h:2:8"}}
+      (HsPrimType HsPrimCChar)
+      4),
   DeclData
     Struct {
       structName = HsName
@@ -762,6 +815,68 @@
                     (Idx 2)
                     0
                     (Idx 0)])))}),
+  DeclInstance
+    (InstanceHasFLAM
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Foo",
+        structConstr = HsName
+          "@NsConstr"
+          "Foo",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "foo_len",
+            fieldType = HsPrimType
+              HsPrimCInt,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "len",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral (PrimInt Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:9:6"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathStruct
+              (DeclNameTag (CName "foo"))
+              DeclPathTop,
+            structSizeof = 4,
+            structAlignment = 4,
+            structFields = [
+              StructField {
+                fieldName = CName "len",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral (PrimInt Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:9:6"}],
+            structFlam = Just
+              StructField {
+                fieldName = CName "bar",
+                fieldOffset = 32,
+                fieldType = TypeStruct
+                  (DeclPathStruct
+                    DeclNameNone
+                    (DeclPathField
+                      (CName "bar")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "foo"))
+                        DeclPathTop))),
+                fieldSourceLoc =
+                "examples/flam.h:13:4"},
+            structSourceLoc =
+            "examples/flam.h:8:8"}}
+      (HsTypRef
+        (HsName
+          "@NsTypeConstr"
+          "Foo_bar"))
+      4),
   DeclData
     Struct {
       structName = HsName
@@ -1080,4 +1195,81 @@
                   PokeByteOff
                     (Idx 3)
                     8
-                    (Idx 1)])))})]
+                    (Idx 1)])))}),
+  DeclInstance
+    (InstanceHasFLAM
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Diff",
+        structConstr = HsName
+          "@NsConstr"
+          "Diff",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "diff_first",
+            fieldType = HsPrimType
+              HsPrimCLong,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "first",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral
+                    (PrimLong Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:18:7"}},
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "diff_second",
+            fieldType = HsPrimType
+              HsPrimCChar,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "second",
+                fieldOffset = 64,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:19:7"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathStruct
+              (DeclNameTag (CName "diff"))
+              DeclPathTop,
+            structSizeof = 16,
+            structAlignment = 8,
+            structFields = [
+              StructField {
+                fieldName = CName "first",
+                fieldOffset = 0,
+                fieldType = TypePrim
+                  (PrimIntegral
+                    (PrimLong Signed)),
+                fieldSourceLoc =
+                "examples/flam.h:18:7"},
+              StructField {
+                fieldName = CName "second",
+                fieldOffset = 64,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:19:7"}],
+            structFlam = Just
+              StructField {
+                fieldName = CName "flam",
+                fieldOffset = 72,
+                fieldType = TypePrim
+                  (PrimChar Nothing),
+                fieldSourceLoc =
+                "examples/flam.h:20:7"},
+            structSourceLoc =
+            "examples/flam.h:17:8"}}
+      (HsPrimType HsPrimCChar)
+      9)]

--- a/hs-bindgen/fixtures/flam.pp.hs
+++ b/hs-bindgen/fixtures/flam.pp.hs
@@ -72,3 +72,28 @@ instance F.Storable Foo where
       \s1 ->
         case s1 of
           Foo foo_len2 -> F.pokeByteOff ptr0 0 foo_len2
+
+data Diff = Diff
+  { diff_first :: FC.CLong
+  , diff_second :: FC.CChar
+  }
+
+instance F.Storable Diff where
+
+  sizeOf = \_ -> 16
+
+  alignment = \_ -> 8
+
+  peek =
+    \ptr0 ->
+          pure Diff
+      <*> F.peekByteOff ptr0 0
+      <*> F.peekByteOff ptr0 8
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Diff diff_first2 diff_second3 ->
+               F.pokeByteOff ptr0 0 diff_first2
+            >> F.pokeByteOff ptr0 8 diff_second3

--- a/hs-bindgen/fixtures/flam.pp.hs
+++ b/hs-bindgen/fixtures/flam.pp.hs
@@ -4,6 +4,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified HsBindgen.Patterns.FlexibleArrayMember
 import Prelude ((<*>), (>>), pure)
 
 data Pascal = Pascal
@@ -26,6 +27,10 @@ instance F.Storable Pascal where
       \s1 ->
         case s1 of
           Pascal pascal_len2 -> F.pokeByteOff ptr0 0 pascal_len2
+
+instance HsBindgen.Patterns.FlexibleArrayMember.HasFlexibleArrayMember Pascal FC.CChar where
+
+  flexibleArrayMemberOffset = \_ty0 -> 4
 
 data Foo_bar = Foo_bar
   { foo_bar_x :: FC.CInt
@@ -73,6 +78,10 @@ instance F.Storable Foo where
         case s1 of
           Foo foo_len2 -> F.pokeByteOff ptr0 0 foo_len2
 
+instance HsBindgen.Patterns.FlexibleArrayMember.HasFlexibleArrayMember Foo Foo_bar where
+
+  flexibleArrayMemberOffset = \_ty0 -> 4
+
 data Diff = Diff
   { diff_first :: FC.CLong
   , diff_second :: FC.CChar
@@ -97,3 +106,7 @@ instance F.Storable Diff where
           Diff diff_first2 diff_second3 ->
                F.pokeByteOff ptr0 0 diff_first2
             >> F.pokeByteOff ptr0 8 diff_second3
+
+instance HsBindgen.Patterns.FlexibleArrayMember.HasFlexibleArrayMember Diff FC.CChar where
+
+  flexibleArrayMemberOffset = \_ty0 -> 9

--- a/hs-bindgen/fixtures/flam.rs
+++ b/hs-bindgen/fixtures/flam.rs
@@ -75,3 +75,18 @@ const _: () = {
     ["Offset of field: foo::len"][::std::mem::offset_of!(foo, len) - 0usize];
     ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 4usize];
 };
+#[repr(C)]
+#[derive(Debug)]
+pub struct diff {
+    pub first: ::std::os::raw::c_long,
+    pub second: ::std::os::raw::c_char,
+    pub flam: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of diff"][::std::mem::size_of::<diff>() - 16usize];
+    ["Alignment of diff"][::std::mem::align_of::<diff>() - 8usize];
+    ["Offset of field: diff::first"][::std::mem::offset_of!(diff, first) - 0usize];
+    ["Offset of field: diff::second"][::std::mem::offset_of!(diff, second) - 8usize];
+    ["Offset of field: diff::flam"][::std::mem::offset_of!(diff, flam) - 9usize];
+};

--- a/hs-bindgen/fixtures/flam.th.txt
+++ b/hs-bindgen/fixtures/flam.th.txt
@@ -20,3 +20,11 @@ instance Storable Foo
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 0;
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_len_3 -> pokeByteOff ptr_1 0 foo_len_3}}
+data Diff = Diff {diff_first :: CLong, diff_second :: CChar}
+instance Storable Diff
+    where {sizeOf = \_ -> 16;
+           alignment = \_ -> 8;
+           peek = \ptr_0 -> (pure Diff <*> peekByteOff ptr_0 0) <*> peekByteOff ptr_0 8;
+           poke = \ptr_1 -> \s_2 -> case s_2 of
+                                    {Diff diff_first_3
+                                          diff_second_4 -> pokeByteOff ptr_1 0 diff_first_3 >> pokeByteOff ptr_1 8 diff_second_4}}

--- a/hs-bindgen/fixtures/flam.th.txt
+++ b/hs-bindgen/fixtures/flam.th.txt
@@ -5,6 +5,8 @@ instance Storable Pascal
            peek = \ptr_0 -> pure Pascal <*> peekByteOff ptr_0 0;
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Pascal pascal_len_3 -> pokeByteOff ptr_1 0 pascal_len_3}}
+instance HasFlexibleArrayMember Pascal CChar
+    where {flexibleArrayMemberOffset = \_ty_0 -> 4}
 data Foo_bar = Foo_bar {foo_bar_x :: CInt, foo_bar_y :: CInt}
 instance Storable Foo_bar
     where {sizeOf = \_ -> 8;
@@ -20,6 +22,8 @@ instance Storable Foo
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 0;
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_len_3 -> pokeByteOff ptr_1 0 foo_len_3}}
+instance HasFlexibleArrayMember Foo Foo_bar
+    where {flexibleArrayMemberOffset = \_ty_0 -> 4}
 data Diff = Diff {diff_first :: CLong, diff_second :: CChar}
 instance Storable Diff
     where {sizeOf = \_ -> 16;
@@ -28,3 +32,5 @@ instance Storable Diff
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Diff diff_first_3
                                           diff_second_4 -> pokeByteOff ptr_1 0 diff_first_3 >> pokeByteOff ptr_1 8 diff_second_4}}
+instance HasFlexibleArrayMember Diff CChar
+    where {flexibleArrayMemberOffset = \_ty_0 -> 9}

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -85,4 +85,37 @@ WrapCHeader
               fieldSourceLoc =
               "examples/flam.h:13:4"},
           structSourceLoc =
-          "examples/flam.h:8:8"}])
+          "examples/flam.h:8:8"},
+      DeclStruct
+        Struct {
+          structDeclPath = DeclPathStruct
+            (DeclNameTag (CName "diff"))
+            DeclPathTop,
+          structSizeof = 16,
+          structAlignment = 8,
+          structFields = [
+            StructField {
+              fieldName = CName "first",
+              fieldOffset = 0,
+              fieldType = TypePrim
+                (PrimIntegral
+                  (PrimLong Signed)),
+              fieldSourceLoc =
+              "examples/flam.h:18:7"},
+            StructField {
+              fieldName = CName "second",
+              fieldOffset = 64,
+              fieldType = TypePrim
+                (PrimChar Nothing),
+              fieldSourceLoc =
+              "examples/flam.h:19:7"}],
+          structFlam = Just
+            StructField {
+              fieldName = CName "flam",
+              fieldOffset = 72,
+              fieldType = TypePrim
+                (PrimChar Nothing),
+              fieldSourceLoc =
+              "examples/flam.h:20:7"},
+          structSourceLoc =
+          "examples/flam.h:17:8"}])

--- a/hs-bindgen/src/HsBindgen/Backend/PP.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP.hs
@@ -35,6 +35,9 @@ iBits = HsImportModule "Data.Bits" (Just "DB")
 iConstantArray :: HsImportModule
 iConstantArray = HsImportModule "HsBindgen.ConstantArray" Nothing
 
+iFlexibleArrayMember :: HsImportModule
+iFlexibleArrayMember = HsImportModule "HsBindgen.Patterns.FlexibleArrayMember" Nothing
+
 -- | @Data.Void@ import module
 iDataVoid :: HsImportModule
 iDataVoid = HsImportModule "Data.Void" Nothing
@@ -138,6 +141,8 @@ resolveGlobal = \case
     Foreign_FunPtr       -> importQ iForeign "FunPtr"
     ConstantArray        -> importQ iConstantArray "ConstantArray"
     IO_type              -> importU iPrelude "IO"
+    HasFlexibleArrayMember_class -> importQ iFlexibleArrayMember "HasFlexibleArrayMember"
+    HasFlexibleArrayMember_offset -> importQ iFlexibleArrayMember "flexibleArrayMemberOffset"
 
     Eq_class         -> importQ iPrelude           "Eq"
     Ord_class        -> importQ iPrelude           "Ord"

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
@@ -104,11 +104,12 @@ instance Pretty SDecl where
 
     DInst Instance{..} -> vsep $
         hsep
-          [ "instance"
+          ([ "instance"
           , pretty (resolve instanceClass)
-          , pretty instanceType
-          , "where"
-          ]
+          ] ++
+          map pretty instanceArgs ++
+          [ "where"
+          ])
       : ( flip map instanceDecs $ \(name, expr) -> nest 2 $ fsep
             [ ppUnqualBackendName (resolve name) <+> char '='
             , nest 2 $ pretty expr

--- a/hs-bindgen/src/HsBindgen/GenTests/C.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests/C.hs
@@ -77,6 +77,7 @@ getTestHeaderDecls cFunPrefix = \case
             , CTestPreturbDecl  cFunPrefix structName cts
             ]
           Nothing -> []
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []
@@ -99,6 +100,7 @@ getTestSourceDefns cFunPrefix = \case
                 , CTestPreturbDefn  cFunPrefix structName cts fieldPs
                 ]
           Nothing -> []
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []

--- a/hs-bindgen/src/HsBindgen/GenTests/Hs.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests/Hs.hs
@@ -104,6 +104,7 @@ getFfiFunctions includeFile cFunPrefix = \case
         , FfiGenSeqC  includeFile cFunPrefix structName
         , FfiPreturb  includeFile cFunPrefix structName
         ]
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []
@@ -122,6 +123,7 @@ getOrphanInstances = \case
             , PreturbInstance       structName structConstr fieldNames
             , SameSemanticsInstance structName              fieldNames
             ]
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []
@@ -135,6 +137,7 @@ getTypeTests = \case
     Hs.DeclInstance instanceDecl -> case instanceDecl of
       Hs.InstanceStorable Hs.Struct{..} _storableInstance ->
         [TypeTest structName]
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []
@@ -147,6 +150,7 @@ getTestsFunNames = \case
     Hs.DeclPatSyn{} -> []
     Hs.DeclInstance instanceDecl -> case instanceDecl of
       Hs.InstanceStorable Hs.Struct{..} _storableInstance -> [structName]
+      Hs.InstanceHasFLAM {} -> []
     Hs.DeclNewtypeInstance{} -> []
     Hs.DeclForeignImport{} -> []
     Hs.DeclVar{} -> []

--- a/hs-bindgen/src/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST.hs
@@ -174,6 +174,7 @@ data TypeClass =
 type InstanceDecl :: Star
 data InstanceDecl where
     InstanceStorable :: Struct n -> StorableInstance -> InstanceDecl
+    InstanceHasFLAM  :: Struct n -> HsType -> Int -> InstanceDecl
 
 deriving instance Show InstanceDecl
 

--- a/hs-bindgen/src/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/AST.hs
@@ -48,6 +48,8 @@ data Global =
   | Foreign_FunPtr
   | ConstantArray
   | IO_type
+  | HasFlexibleArrayMember_class
+  | HasFlexibleArrayMember_offset
 
   | Eq_class
   | Ord_class
@@ -147,7 +149,7 @@ deriving stock instance Show (SType ctx)
 
 data Instance  = Instance {
       instanceClass :: Global
-    , instanceType  :: HsName NsTypeConstr
+    , instanceArgs  :: [ClosedType]
     , instanceDecs  :: [(Global, ClosedExpr)]
     }
   deriving stock (Show)

--- a/hs-bindgen/src/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/Translation.hs
@@ -36,6 +36,12 @@ translateDecl (Hs.DeclPatSyn ps) = translatePatSyn ps
 translateInstanceDecl :: Hs.InstanceDecl -> SDecl
 translateInstanceDecl (Hs.InstanceStorable struct i) =
     DInst $ translateStorableInstance struct i
+translateInstanceDecl (Hs.InstanceHasFLAM struct fty i) =
+    DInst Instance
+      { instanceClass = HasFlexibleArrayMember_class
+      , instanceArgs  = [TCon $ Hs.structName struct, translateType fty ]
+      , instanceDecs  = [(HasFlexibleArrayMember_offset, ELam "_ty" $ EIntegral (toInteger i) Nothing)]
+      }
 
 translateDeclData :: Hs.Struct n -> SDecl
 translateDeclData struct = DRecord $ Record
@@ -206,7 +212,7 @@ translateStorableInstance struct Hs.StorableInstance{..} = do
     let poke = lambda (lambda (translateElimStruct (doAll translatePokeByteOff))) storablePoke
     Instance
       { instanceClass = Storable_Storable
-      , instanceType  = Hs.structName struct
+      , instanceArgs  = [TCon $ Hs.structName struct]
       , instanceDecs  = [
             (Storable_sizeOf    , EUnusedLam $ EInt storableSizeOf)
           , (Storable_alignment , EUnusedLam $ EInt storableAlignment)

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -178,6 +178,8 @@ instance ToExpr Hs.InstanceDecl where
   toExpr = \case
     Hs.InstanceStorable struct inst ->
       Expr.App "InstanceStorable" [toExpr struct, toExpr inst]
+    Hs.InstanceHasFLAM struct fty i ->
+      Expr.App "InstanceHasFLAM" [toExpr struct, toExpr fty, toExpr i]
 
 instance ToExpr (t (S ctx)) => ToExpr (Hs.Lambda t ctx) where
   toExpr (Hs.Lambda name body) = Expr.App "Lambda" [toExpr name, toExpr body]


### PR DESCRIPTION
AFAICT, everything else can be built as part of `-runtime` library on top, i.e. `hs-bindgen` generation part for flams is done.