### PR TITLE
Make terser ToExpr SingleLoc instance

### DIFF
--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/anonymous.h:4:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -40,12 +36,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9}}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:5:9"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -64,30 +56,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/anonymous.h:4:9"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:5:9"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 3,
-            singleLocColumn = 3}}},
+          structSourceLoc =
+          "examples/anonymous.h:3:3"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -111,12 +91,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/anonymous.h:4:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -130,12 +106,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 9}}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:5:9"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -154,30 +126,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/anonymous.h:4:9"},
               StructField {
                 fieldName = CName "b",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 9}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:5:9"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "anonymous.h"],
-              singleLocLine = 3,
-              singleLocColumn = 3}}}
+            structSourceLoc =
+            "examples/anonymous.h:3:3"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -206,12 +166,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:4:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -225,12 +181,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:5:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -249,30 +201,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:4:9"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:5:9"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 3}}})
+                    structSourceLoc =
+                    "examples/anonymous.h:3:3"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -303,12 +243,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:4:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -322,12 +258,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:5:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -346,30 +278,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:4:9"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:5:9"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 3}}}
+                    structSourceLoc =
+                    "examples/anonymous.h:3:3"}}
               (Add 2)
               (Seq
                 [
@@ -406,12 +326,8 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 6,
-                singleLocColumn = 5}}},
+              fieldSourceLoc =
+              "examples/anonymous.h:6:5"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -425,12 +341,8 @@
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 8,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:8:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -451,30 +363,18 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 6,
-                singleLocColumn = 5}},
+              fieldSourceLoc =
+              "examples/anonymous.h:6:5"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 8,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:8:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/anonymous.h:2:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -504,12 +404,8 @@
                       (DeclPathStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 5}}},
+                fieldSourceLoc =
+                "examples/anonymous.h:6:5"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -523,12 +419,8 @@
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:8:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -549,30 +441,18 @@
                       (DeclPathStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 5}},
+                fieldSourceLoc =
+                "examples/anonymous.h:6:5"},
               StructField {
                 fieldName = CName "d",
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:8:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "anonymous.h"],
-              singleLocLine = 2,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/anonymous.h:2:8"}}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -607,12 +487,8 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:6:5"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -626,12 +502,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:8:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -652,30 +524,18 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:6:5"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:8:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/anonymous.h:2:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -712,12 +572,8 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:6:5"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -731,12 +587,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:8:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -757,30 +609,18 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:6:5"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:8:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/anonymous.h:2:8"}}
               (Add 2)
               (Seq
                 [
@@ -811,12 +651,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 16,
-                singleLocColumn = 11}}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:16:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -839,19 +675,11 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 16,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:16:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 15,
-            singleLocColumn = 5}}},
+          structSourceLoc =
+          "examples/anonymous.h:15:5"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -875,12 +703,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 11}}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:16:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -903,19 +727,11 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 11}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:16:11"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "anonymous.h"],
-              singleLocLine = 15,
-              singleLocColumn = 5}}}
+            structSourceLoc =
+            "examples/anonymous.h:15:5"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -944,12 +760,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:16:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -972,19 +784,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:16:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 5}}})
+                    structSourceLoc =
+                    "examples/anonymous.h:15:5"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1013,12 +817,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:16:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1041,19 +841,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:16:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 5}}}
+                    structSourceLoc =
+                    "examples/anonymous.h:15:5"}}
               (Add 1)
               (Seq
                 [
@@ -1083,12 +875,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/anonymous.h:14:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1114,12 +902,8 @@
                         (DeclPathStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 17,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:17:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1138,12 +922,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/anonymous.h:14:9"},
             StructField {
               fieldName = CName "deep",
               fieldOffset = 32,
@@ -1159,19 +939,11 @@
                         (DeclPathStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 17,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:17:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 13,
-            singleLocColumn = 3}}},
+          structSourceLoc =
+          "examples/anonymous.h:13:3"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1195,12 +967,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 14,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/anonymous.h:14:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1226,12 +994,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 17,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:17:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1250,12 +1014,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 14,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/anonymous.h:14:9"},
               StructField {
                 fieldName = CName "deep",
                 fieldOffset = 32,
@@ -1271,19 +1031,11 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 17,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:17:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "anonymous.h"],
-              singleLocLine = 13,
-              singleLocColumn = 3}}}
+            structSourceLoc =
+            "examples/anonymous.h:13:3"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1312,12 +1064,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:14:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1343,12 +1091,8 @@
                                   (DeclPathStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:17:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1367,12 +1111,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:14:9"},
                       StructField {
                         fieldName = CName "deep",
                         fieldOffset = 32,
@@ -1388,19 +1128,11 @@
                                   (DeclPathStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:17:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 13,
-                      singleLocColumn = 3}}})
+                    structSourceLoc =
+                    "examples/anonymous.h:13:3"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1431,12 +1163,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:14:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1462,12 +1190,8 @@
                                   (DeclPathStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:17:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1486,12 +1210,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:14:9"},
                       StructField {
                         fieldName = CName "deep",
                         fieldOffset = 32,
@@ -1507,19 +1227,11 @@
                                   (DeclPathStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:17:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 13,
-                      singleLocColumn = 3}}}
+                    structSourceLoc =
+                    "examples/anonymous.h:13:3"}}
               (Add 2)
               (Seq
                 [
@@ -1558,12 +1270,8 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 18,
-                singleLocColumn = 5}}},
+              fieldSourceLoc =
+              "examples/anonymous.h:18:5"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1577,12 +1285,8 @@
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 20,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:20:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1603,30 +1307,18 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 18,
-                singleLocColumn = 5}},
+              fieldSourceLoc =
+              "examples/anonymous.h:18:5"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 20,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:20:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 12,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/anonymous.h:12:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1658,12 +1350,8 @@
                       (DeclPathStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 18,
-                  singleLocColumn = 5}}},
+                fieldSourceLoc =
+                "examples/anonymous.h:18:5"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1677,12 +1365,8 @@
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 20,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:20:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1703,30 +1387,18 @@
                       (DeclPathStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 18,
-                  singleLocColumn = 5}},
+                fieldSourceLoc =
+                "examples/anonymous.h:18:5"},
               StructField {
                 fieldName = CName "d",
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "anonymous.h"],
-                  singleLocLine = 20,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/anonymous.h:20:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "anonymous.h"],
-              singleLocLine = 12,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/anonymous.h:12:8"}}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1763,12 +1435,8 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 5}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:18:5"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1782,12 +1450,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:20:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1808,30 +1472,18 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 5}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:18:5"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:20:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 12,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/anonymous.h:12:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1870,12 +1522,8 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 5}}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:18:5"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1889,12 +1537,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:20:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1915,30 +1559,18 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 5}},
+                        fieldSourceLoc =
+                        "examples/anonymous.h:18:5"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "anonymous.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/anonymous.h:20:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "anonymous.h"],
-                      singleLocLine = 12,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/anonymous.h:12:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -18,30 +18,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/anonymous.h:4:9"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:5:9"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 3,
-            singleLocColumn = 3}},
+          structSourceLoc =
+          "examples/anonymous.h:3:3"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -61,30 +49,18 @@ WrapCHeader
                     (DeclPathStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 6,
-                singleLocColumn = 5}},
+              fieldSourceLoc =
+              "examples/anonymous.h:6:5"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 8,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:8:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/anonymous.h:2:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -106,19 +82,11 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 16,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:16:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 15,
-            singleLocColumn = 5}},
+          structSourceLoc =
+          "examples/anonymous.h:15:5"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -136,12 +104,8 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/anonymous.h:14:9"},
             StructField {
               fieldName = CName "deep",
               fieldOffset = 32,
@@ -157,19 +121,11 @@ WrapCHeader
                         (DeclPathStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 17,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:17:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 13,
-            singleLocColumn = 3}},
+          structSourceLoc =
+          "examples/anonymous.h:13:3"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -189,27 +145,15 @@ WrapCHeader
                     (DeclPathStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 18,
-                singleLocColumn = 5}},
+              fieldSourceLoc =
+              "examples/anonymous.h:18:5"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "anonymous.h"],
-                singleLocLine = 20,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/anonymous.h:20:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "anonymous.h"],
-            singleLocLine = 12,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/anonymous.h:12:8"}])

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -18,12 +18,8 @@
       NewtypeOriginMacro
         Macro {
           macroLoc = MultiLoc {
-            multiLocExpansion = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "bool.h"],
-              singleLocLine = 13,
-              singleLocColumn = 9},
+            multiLocExpansion =
+            "examples/bool.h:13:9",
             multiLocPresumed = Nothing,
             multiLocSpelling = Nothing,
             multiLocFile = Nothing},
@@ -52,12 +48,8 @@
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 2,
-                singleLocColumn = 11}}},
+              fieldSourceLoc =
+              "examples/bool.h:2:11"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -70,12 +62,8 @@
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 3,
-                singleLocColumn = 11}}}],
+              fieldSourceLoc =
+              "examples/bool.h:3:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -89,29 +77,17 @@
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 2,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/bool.h:2:11"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 3,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/bool.h:3:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/bool.h:1:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -134,12 +110,8 @@
                 fieldName = CName "x",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 11}}},
+                fieldSourceLoc =
+                "examples/bool.h:2:11"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -152,12 +124,8 @@
                 fieldName = CName "y",
                 fieldOffset = 8,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 11}}}],
+                fieldSourceLoc =
+                "examples/bool.h:3:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -171,29 +139,17 @@
                 fieldName = CName "x",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 11}},
+                fieldSourceLoc =
+                "examples/bool.h:2:11"},
               StructField {
                 fieldName = CName "y",
                 fieldOffset = 8,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 11}}],
+                fieldSourceLoc =
+                "examples/bool.h:3:11"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "bool.h"],
-              singleLocLine = 1,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/bool.h:1:8"}}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -221,12 +177,8 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:2:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -239,12 +191,8 @@
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:3:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -258,29 +206,17 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/bool.h:2:11"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:3:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/bool.h:1:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -310,12 +246,8 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:2:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -328,12 +260,8 @@
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:3:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -347,29 +275,17 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/bool.h:2:11"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:3:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/bool.h:1:8"}}
               (Add 2)
               (Seq
                 [
@@ -399,12 +315,8 @@
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/bool.h:9:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -417,12 +329,8 @@
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 10,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/bool.h:10:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -436,29 +344,17 @@
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/bool.h:9:10"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 10,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/bool.h:10:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 8,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/bool.h:8:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -481,12 +377,8 @@
                 fieldName = CName "x",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/bool.h:9:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -499,12 +391,8 @@
                 fieldName = CName "y",
                 fieldOffset = 8,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/bool.h:10:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -518,29 +406,17 @@
                 fieldName = CName "x",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/bool.h:9:10"},
               StructField {
                 fieldName = CName "y",
                 fieldOffset = 8,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/bool.h:10:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "bool.h"],
-              singleLocLine = 8,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/bool.h:8:8"}}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -568,12 +444,8 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:9:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -586,12 +458,8 @@
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:10:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -605,29 +473,17 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/bool.h:9:10"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:10:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/bool.h:8:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -657,12 +513,8 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:9:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -675,12 +527,8 @@
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:10:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -694,29 +542,17 @@
                         fieldName = CName "x",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/bool.h:9:10"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:10:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/bool.h:8:8"}}
               (Add 2)
               (Seq
                 [
@@ -747,12 +583,8 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/bool.h:16:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -766,12 +598,8 @@
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 17,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/bool.h:17:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -786,30 +614,18 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/bool.h:16:10"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 17,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/bool.h:17:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 15,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/bool.h:15:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -833,12 +649,8 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "BOOL"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/bool.h:16:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -852,12 +664,8 @@
                 fieldOffset = 8,
                 fieldType = TypeTypedef
                   (CName "BOOL"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 17,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/bool.h:17:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -872,30 +680,18 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "BOOL"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/bool.h:16:10"},
               StructField {
                 fieldName = CName "y",
                 fieldOffset = 8,
                 fieldType = TypeTypedef
                   (CName "BOOL"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "bool.h"],
-                  singleLocLine = 17,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/bool.h:17:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "bool.h"],
-              singleLocLine = 15,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/bool.h:15:8"}}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -924,12 +720,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:16:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -943,12 +735,8 @@
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:17:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -963,30 +751,18 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/bool.h:16:10"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:17:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/bool.h:15:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -1017,12 +793,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/bool.h:16:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1036,12 +808,8 @@
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:17:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1056,30 +824,18 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/bool.h:16:10"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "BOOL"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "bool.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/bool.h:17:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "bool.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/bool.h:15:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 13,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/bool.h:13:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -19,12 +15,8 @@ WrapCHeader
             macroBody = MTerm
               (MType PrimBool)},
           macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 13,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/bool.h:13:9"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -37,29 +29,17 @@ WrapCHeader
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 2,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/bool.h:2:11"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 3,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/bool.h:3:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/bool.h:1:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -72,29 +52,17 @@ WrapCHeader
               fieldName = CName "x",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/bool.h:9:10"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 10,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/bool.h:10:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 8,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/bool.h:8:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -108,27 +76,15 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/bool.h:16:10"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "BOOL"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "bool.h"],
-                singleLocLine = 17,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/bool.h:17:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "bool.h"],
-            singleLocLine = 15,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/bool.h:15:8"}])

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -166,12 +166,8 @@
             (TypeTypedef (CName "int32_t")),
           functionHeader =
           "distilled_lib_1.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 71,
-            singleLocColumn = 9}}},
+          functionSourceLoc =
+          "examples/distilled_lib_1.h:71:9"}},
   DeclData
     Struct {
       structName = HsName
@@ -194,12 +190,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 22}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:22"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -213,12 +205,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 32}}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:32"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -235,30 +223,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:22"},
             StructField {
               fieldName = CName "bar",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 32}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:32"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 8,
-            singleLocColumn = 9}}},
+          structSourceLoc =
+          "examples/distilled_lib_1.h:8:9"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -282,12 +258,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 22}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:8:22"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -301,12 +273,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 32}}}],
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:8:32"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -323,30 +291,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 22}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:8:22"},
               StructField {
                 fieldName = CName "bar",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 32}}],
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:8:32"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "distilled_lib_1.h"],
-              singleLocLine = 8,
-              singleLocColumn = 9}}}
+            structSourceLoc =
+            "examples/distilled_lib_1.h:8:9"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -375,12 +331,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -394,12 +346,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 32}}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:32"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -416,30 +364,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:22"},
                       StructField {
                         fieldName = CName "bar",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 32}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 9}}})
+                    structSourceLoc =
+                    "examples/distilled_lib_1.h:8:9"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -470,12 +406,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -489,12 +421,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 32}}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:32"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -511,30 +439,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:22"},
                       StructField {
                         fieldName = CName "bar",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 32}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 9}}}
+                    structSourceLoc =
+                    "examples/distilled_lib_1.h:8:9"}}
               (Add 2)
               (Seq
                 [
@@ -572,27 +488,15 @@
             EnumValue {
               valueName = CName "FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 9,
-                singleLocColumn = 16}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:9:16"},
             EnumValue {
               valueName = CName "BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 9,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 9,
-            singleLocColumn = 9}}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:9:21"}],
+          enumSourceLoc =
+          "examples/distilled_lib_1.h:9:9"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -623,27 +527,15 @@
               EnumValue {
                 valueName = CName "FOO",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 16}},
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:9:16"},
               EnumValue {
                 valueName = CName "BAR",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 21}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "distilled_lib_1.h"],
-              singleLocLine = 9,
-              singleLocColumn = 9}}}
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:9:21"}],
+            enumSourceLoc =
+            "examples/distilled_lib_1.h:9:9"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -679,27 +571,15 @@
                       EnumValue {
                         valueName = CName "FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 16}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:9:16"},
                       EnumValue {
                         valueName = CName "BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 9}}})
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:9:21"}],
+                    enumSourceLoc =
+                    "examples/distilled_lib_1.h:9:9"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -735,27 +615,15 @@
                       EnumValue {
                         valueName = CName "FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 16}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:9:16"},
                       EnumValue {
                         valueName = CName "BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 9}}}
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:9:21"}],
+                    enumSourceLoc =
+                    "examples/distilled_lib_1.h:9:9"}}
               (Add 1)
               (Seq
                 [
@@ -780,12 +648,8 @@
         EnumValue {
           valueName = CName "FOO",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 9,
-            singleLocColumn = 16}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:9:16"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -803,12 +667,8 @@
         EnumValue {
           valueName = CName "BAR",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 9,
-            singleLocColumn = 21}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:9:21"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -830,12 +690,8 @@
           typedefName = CName "a_type_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 13,
-            singleLocColumn = 13}}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:13:13"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -862,12 +718,8 @@
           typedefName = CName "var_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 14,
-            singleLocColumn = 13}}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:14:13"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -894,14 +746,8 @@
           typedefName = CName "uint8_t",
           typedefType = TypePrim
             (PrimChar (Just Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 121,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:121:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -929,14 +775,8 @@
           typedefType = TypePrim
             (PrimIntegral
               (PrimShort Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 126,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:126:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -964,14 +804,8 @@
           typedefType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 131,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:131:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -998,12 +832,8 @@
               fieldName = CName "field_0",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 36,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:36:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1019,12 +849,8 @@
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "uint8_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 37,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:37:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1040,12 +866,8 @@
               fieldOffset = 16,
               fieldType = TypeTypedef
                 (CName "uint16_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 38,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:38:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1061,12 +883,8 @@
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 39,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:39:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1086,12 +904,8 @@
                     (CName
                       "another_typedef_struct_t"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 40,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:40:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1113,12 +927,8 @@
                       (CName
                         "another_typedef_struct_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 41,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:41:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1132,12 +942,8 @@
               fieldOffset = 192,
               fieldType = TypePointer
                 (TypePrim PrimVoid),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 42,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:42:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1157,12 +963,8 @@
                 7
                 (TypeTypedef
                   (CName "uint32_t")),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 43,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:43:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1179,12 +981,8 @@
               fieldType = TypeEnum
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 44,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:44:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1201,12 +999,8 @@
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 45,
-                singleLocColumn = 31}}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:45:31"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1223,12 +1017,8 @@
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 46,
-                singleLocColumn = 31}}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:46:31"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1243,45 +1033,29 @@
               fieldName = CName "field_0",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 36,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:36:31"},
             StructField {
               fieldName = CName "field_1",
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "uint8_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 37,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:37:31"},
             StructField {
               fieldName = CName "field_2",
               fieldOffset = 16,
               fieldType = TypeTypedef
                 (CName "uint16_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 38,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:38:31"},
             StructField {
               fieldName = CName "field_3",
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 39,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:39:31"},
             StructField {
               fieldName = CName "field_4",
               fieldOffset = 64,
@@ -1291,12 +1065,8 @@
                     (CName
                       "another_typedef_struct_t"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 40,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:40:31"},
             StructField {
               fieldName = CName "field_5",
               fieldOffset = 128,
@@ -1307,23 +1077,15 @@
                       (CName
                         "another_typedef_struct_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 41,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:41:31"},
             StructField {
               fieldName = CName "field_6",
               fieldOffset = 192,
               fieldType = TypePointer
                 (TypePrim PrimVoid),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 42,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:42:31"},
             StructField {
               fieldName = CName "field_7",
               fieldOffset = 256,
@@ -1331,55 +1093,35 @@
                 7
                 (TypeTypedef
                   (CName "uint32_t")),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 43,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:43:31"},
             StructField {
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldType = TypeEnum
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 44,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:44:31"},
             StructField {
               fieldName = CName "field_9",
               fieldOffset = 512,
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 45,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:45:31"},
             StructField {
               fieldName = CName "field_10",
               fieldOffset = 640,
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 46,
-                singleLocColumn = 31}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 34,
-            singleLocColumn = 16}}},
+          structSourceLoc =
+          "examples/distilled_lib_1.h:34:16"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1402,12 +1144,8 @@
                 fieldName = CName "field_0",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 36,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:36:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1423,12 +1161,8 @@
                 fieldOffset = 8,
                 fieldType = TypeTypedef
                   (CName "uint8_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 37,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:37:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1444,12 +1178,8 @@
                 fieldOffset = 16,
                 fieldType = TypeTypedef
                   (CName "uint16_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 38,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:38:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1465,12 +1195,8 @@
                 fieldOffset = 32,
                 fieldType = TypeTypedef
                   (CName "uint32_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 39,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:39:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1490,12 +1216,8 @@
                       (CName
                         "another_typedef_struct_t"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 40,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:40:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1517,12 +1239,8 @@
                         (CName
                           "another_typedef_struct_t"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 41,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:41:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1536,12 +1254,8 @@
                 fieldOffset = 192,
                 fieldType = TypePointer
                   (TypePrim PrimVoid),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 42,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:42:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1561,12 +1275,8 @@
                   7
                   (TypeTypedef
                     (CName "uint32_t")),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 43,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:43:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1583,12 +1293,8 @@
                 fieldType = TypeEnum
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 44,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:44:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1605,12 +1311,8 @@
                 fieldType = TypeTypedef
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 45,
-                  singleLocColumn = 31}}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:45:31"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1627,12 +1329,8 @@
                 fieldType = TypeTypedef
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 46,
-                  singleLocColumn = 31}}}],
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:46:31"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1647,45 +1345,29 @@
                 fieldName = CName "field_0",
                 fieldOffset = 0,
                 fieldType = TypePrim PrimBool,
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 36,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:36:31"},
               StructField {
                 fieldName = CName "field_1",
                 fieldOffset = 8,
                 fieldType = TypeTypedef
                   (CName "uint8_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 37,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:37:31"},
               StructField {
                 fieldName = CName "field_2",
                 fieldOffset = 16,
                 fieldType = TypeTypedef
                   (CName "uint16_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 38,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:38:31"},
               StructField {
                 fieldName = CName "field_3",
                 fieldOffset = 32,
                 fieldType = TypeTypedef
                   (CName "uint32_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 39,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:39:31"},
               StructField {
                 fieldName = CName "field_4",
                 fieldOffset = 64,
@@ -1695,12 +1377,8 @@
                       (CName
                         "another_typedef_struct_t"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 40,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:40:31"},
               StructField {
                 fieldName = CName "field_5",
                 fieldOffset = 128,
@@ -1711,23 +1389,15 @@
                         (CName
                           "another_typedef_struct_t"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 41,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:41:31"},
               StructField {
                 fieldName = CName "field_6",
                 fieldOffset = 192,
                 fieldType = TypePointer
                   (TypePrim PrimVoid),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 42,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:42:31"},
               StructField {
                 fieldName = CName "field_7",
                 fieldOffset = 256,
@@ -1735,55 +1405,35 @@
                   7
                   (TypeTypedef
                     (CName "uint32_t")),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 43,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:43:31"},
               StructField {
                 fieldName = CName "field_8",
                 fieldOffset = 480,
                 fieldType = TypeEnum
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 44,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:44:31"},
               StructField {
                 fieldName = CName "field_9",
                 fieldOffset = 512,
                 fieldType = TypeTypedef
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 45,
-                  singleLocColumn = 31}},
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:45:31"},
               StructField {
                 fieldName = CName "field_10",
                 fieldOffset = 640,
                 fieldType = TypeTypedef
                   (CName
                     "another_typedef_enum_e"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 46,
-                  singleLocColumn = 31}}],
+                fieldSourceLoc =
+                "examples/distilled_lib_1.h:46:31"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "distilled_lib_1.h"],
-              singleLocLine = 34,
-              singleLocColumn = 16}}}
+            structSourceLoc =
+            "examples/distilled_lib_1.h:34:16"}}
       StorableInstance {
         storableSizeOf = 140,
         storableAlignment = 1,
@@ -1811,12 +1461,8 @@
                         fieldName = CName "field_0",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 36,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:36:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1832,12 +1478,8 @@
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "uint8_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:37:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1853,12 +1495,8 @@
                         fieldOffset = 16,
                         fieldType = TypeTypedef
                           (CName "uint16_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:38:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1874,12 +1512,8 @@
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:39:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1899,12 +1533,8 @@
                               (CName
                                 "another_typedef_struct_t"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 40,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:40:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1926,12 +1556,8 @@
                                 (CName
                                   "another_typedef_struct_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 41,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:41:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1945,12 +1571,8 @@
                         fieldOffset = 192,
                         fieldType = TypePointer
                           (TypePrim PrimVoid),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 42,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:42:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1970,12 +1592,8 @@
                           7
                           (TypeTypedef
                             (CName "uint32_t")),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 43,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:43:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1992,12 +1610,8 @@
                         fieldType = TypeEnum
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 44,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:44:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2014,12 +1628,8 @@
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 45,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:45:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2036,12 +1646,8 @@
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 46,
-                          singleLocColumn = 31}}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:46:31"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -2056,45 +1662,29 @@
                         fieldName = CName "field_0",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 36,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:36:31"},
                       StructField {
                         fieldName = CName "field_1",
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "uint8_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:37:31"},
                       StructField {
                         fieldName = CName "field_2",
                         fieldOffset = 16,
                         fieldType = TypeTypedef
                           (CName "uint16_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:38:31"},
                       StructField {
                         fieldName = CName "field_3",
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:39:31"},
                       StructField {
                         fieldName = CName "field_4",
                         fieldOffset = 64,
@@ -2104,12 +1694,8 @@
                               (CName
                                 "another_typedef_struct_t"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 40,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:40:31"},
                       StructField {
                         fieldName = CName "field_5",
                         fieldOffset = 128,
@@ -2120,23 +1706,15 @@
                                 (CName
                                   "another_typedef_struct_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 41,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:41:31"},
                       StructField {
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
                           (TypePrim PrimVoid),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 42,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:42:31"},
                       StructField {
                         fieldName = CName "field_7",
                         fieldOffset = 256,
@@ -2144,55 +1722,35 @@
                           7
                           (TypeTypedef
                             (CName "uint32_t")),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 43,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:43:31"},
                       StructField {
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldType = TypeEnum
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 44,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:44:31"},
                       StructField {
                         fieldName = CName "field_9",
                         fieldOffset = 512,
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 45,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:45:31"},
                       StructField {
                         fieldName = CName "field_10",
                         fieldOffset = 640,
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 46,
-                          singleLocColumn = 31}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 34,
-                      singleLocColumn = 16}}})
+                    structSourceLoc =
+                    "examples/distilled_lib_1.h:34:16"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -2231,12 +1789,8 @@
                         fieldName = CName "field_0",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 36,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:36:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2252,12 +1806,8 @@
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "uint8_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:37:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2273,12 +1823,8 @@
                         fieldOffset = 16,
                         fieldType = TypeTypedef
                           (CName "uint16_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:38:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2294,12 +1840,8 @@
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:39:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2319,12 +1861,8 @@
                               (CName
                                 "another_typedef_struct_t"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 40,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:40:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2346,12 +1884,8 @@
                                 (CName
                                   "another_typedef_struct_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 41,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:41:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2365,12 +1899,8 @@
                         fieldOffset = 192,
                         fieldType = TypePointer
                           (TypePrim PrimVoid),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 42,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:42:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2390,12 +1920,8 @@
                           7
                           (TypeTypedef
                             (CName "uint32_t")),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 43,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:43:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2412,12 +1938,8 @@
                         fieldType = TypeEnum
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 44,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:44:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2434,12 +1956,8 @@
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 45,
-                          singleLocColumn = 31}}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:45:31"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2456,12 +1974,8 @@
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 46,
-                          singleLocColumn = 31}}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:46:31"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -2476,45 +1990,29 @@
                         fieldName = CName "field_0",
                         fieldOffset = 0,
                         fieldType = TypePrim PrimBool,
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 36,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:36:31"},
                       StructField {
                         fieldName = CName "field_1",
                         fieldOffset = 8,
                         fieldType = TypeTypedef
                           (CName "uint8_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:37:31"},
                       StructField {
                         fieldName = CName "field_2",
                         fieldOffset = 16,
                         fieldType = TypeTypedef
                           (CName "uint16_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:38:31"},
                       StructField {
                         fieldName = CName "field_3",
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:39:31"},
                       StructField {
                         fieldName = CName "field_4",
                         fieldOffset = 64,
@@ -2524,12 +2022,8 @@
                               (CName
                                 "another_typedef_struct_t"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 40,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:40:31"},
                       StructField {
                         fieldName = CName "field_5",
                         fieldOffset = 128,
@@ -2540,23 +2034,15 @@
                                 (CName
                                   "another_typedef_struct_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 41,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:41:31"},
                       StructField {
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
                           (TypePrim PrimVoid),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 42,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:42:31"},
                       StructField {
                         fieldName = CName "field_7",
                         fieldOffset = 256,
@@ -2564,55 +2050,35 @@
                           7
                           (TypeTypedef
                             (CName "uint32_t")),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 43,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:43:31"},
                       StructField {
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldType = TypeEnum
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 44,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:44:31"},
                       StructField {
                         fieldName = CName "field_9",
                         fieldOffset = 512,
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 45,
-                          singleLocColumn = 31}},
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:45:31"},
                       StructField {
                         fieldName = CName "field_10",
                         fieldOffset = 640,
                         fieldType = TypeTypedef
                           (CName
                             "another_typedef_enum_e"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 46,
-                          singleLocColumn = 31}}],
+                        fieldSourceLoc =
+                        "examples/distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 34,
-                      singleLocColumn = 16}}}
+                    structSourceLoc =
+                    "examples/distilled_lib_1.h:34:16"}}
               (Add 11)
               (Seq
                 [
@@ -2657,12 +2123,8 @@
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 47,
-            singleLocColumn = 3}}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:47:3"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -2696,45 +2158,25 @@
             EnumValue {
               valueName = CName "ENUM_CASE_0",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 62,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:62:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_1",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 63,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:63:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_2",
               valueValue = 2,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 64,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:64:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_3",
               valueValue = 3,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 65,
-                singleLocColumn = 3}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 60,
-            singleLocColumn = 9}}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:65:3"}],
+          enumSourceLoc =
+          "examples/distilled_lib_1.h:60:9"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2764,45 +2206,25 @@
               EnumValue {
                 valueName = CName "ENUM_CASE_0",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 62,
-                  singleLocColumn = 3}},
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:62:3"},
               EnumValue {
                 valueName = CName "ENUM_CASE_1",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 63,
-                  singleLocColumn = 3}},
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:63:3"},
               EnumValue {
                 valueName = CName "ENUM_CASE_2",
                 valueValue = 2,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 64,
-                  singleLocColumn = 3}},
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:64:3"},
               EnumValue {
                 valueName = CName "ENUM_CASE_3",
                 valueValue = 3,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "distilled_lib_1.h"],
-                  singleLocLine = 65,
-                  singleLocColumn = 3}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "distilled_lib_1.h"],
-              singleLocLine = 60,
-              singleLocColumn = 9}}}
+                valueSourceLoc =
+                "examples/distilled_lib_1.h:65:3"}],
+            enumSourceLoc =
+            "examples/distilled_lib_1.h:60:9"}}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -2837,45 +2259,25 @@
                       EnumValue {
                         valueName = CName "ENUM_CASE_0",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 62,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:62:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_1",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 63,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:63:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_2",
                         valueValue = 2,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 64,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:64:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_3",
                         valueValue = 3,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 65,
-                          singleLocColumn = 3}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 60,
-                      singleLocColumn = 9}}})
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:65:3"}],
+                    enumSourceLoc =
+                    "examples/distilled_lib_1.h:60:9"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2910,45 +2312,25 @@
                       EnumValue {
                         valueName = CName "ENUM_CASE_0",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 62,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:62:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_1",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 63,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:63:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_2",
                         valueValue = 2,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 64,
-                          singleLocColumn = 3}},
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:64:3"},
                       EnumValue {
                         valueName = CName "ENUM_CASE_3",
                         valueValue = 3,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "distilled_lib_1.h"],
-                          singleLocLine = 65,
-                          singleLocColumn = 3}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 60,
-                      singleLocColumn = 9}}}
+                        valueSourceLoc =
+                        "examples/distilled_lib_1.h:65:3"}],
+                    enumSourceLoc =
+                    "examples/distilled_lib_1.h:60:9"}}
               (Add 1)
               (Seq
                 [
@@ -2973,12 +2355,8 @@
         EnumValue {
           valueName = CName "ENUM_CASE_0",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 62,
-            singleLocColumn = 3}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:62:3"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2996,12 +2374,8 @@
         EnumValue {
           valueName = CName "ENUM_CASE_1",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 63,
-            singleLocColumn = 3}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:63:3"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3019,12 +2393,8 @@
         EnumValue {
           valueName = CName "ENUM_CASE_2",
           valueValue = 2,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 64,
-            singleLocColumn = 3}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:64:3"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3042,12 +2412,8 @@
         EnumValue {
           valueName = CName "ENUM_CASE_3",
           valueValue = 3,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 65,
-            singleLocColumn = 3}}},
+          valueSourceLoc =
+          "examples/distilled_lib_1.h:65:3"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -3069,14 +2435,8 @@
           typedefName = CName "int32_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 106,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:106:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -3120,12 +2480,8 @@
                 TypeTypedef (CName "uint32_t")]
               (TypeTypedef
                 (CName "uint32_t"))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 76,
-            singleLocColumn = 19}}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:76:19"}},
   DeclNewtypeInstance
     Storable
     (HsName

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 10,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:10:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -24,22 +20,14 @@ WrapCHeader
                   integerLiteralValue = 5})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 10,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:10:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 11,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:11:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -53,22 +41,14 @@ WrapCHeader
                   integerLiteralValue = 3})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 11,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:11:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 12,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:12:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -83,12 +63,8 @@ WrapCHeader
                   integerLiteralValue = 4})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 12,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:12:9"},
       DeclMacro
         (MacroReparseError
           ReparseError {
@@ -105,22 +81,14 @@ WrapCHeader
                   "PACK_START",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 9},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:9",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 19},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:19",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -132,22 +100,14 @@ WrapCHeader
                   "_Pragma",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 24},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:24",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 31},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:31",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -159,22 +119,14 @@ WrapCHeader
                   "(",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 31},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:31",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 32},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:32",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -186,22 +138,14 @@ WrapCHeader
                   "\"pack(1)\"",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 32},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:32",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 41},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:41",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -213,22 +157,14 @@ WrapCHeader
                   ")",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 41},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:41",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 17,
-                      singleLocColumn = 42},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:17:42",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -250,22 +186,14 @@ WrapCHeader
                   "PACK_FINISH",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 9},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:9",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 20},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:20",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -277,22 +205,14 @@ WrapCHeader
                   "_Pragma",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 24},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:24",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 31},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:31",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -304,22 +224,14 @@ WrapCHeader
                   "(",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 31},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:31",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 32},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:32",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -331,22 +243,14 @@ WrapCHeader
                   "\"pack()\"",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 32},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:32",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 40},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:40",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -358,22 +262,14 @@ WrapCHeader
                   ")",
                 tokenExtent = Range {
                   rangeStart = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 40},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:40",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing},
                   rangeEnd = MultiLoc {
-                    multiLocExpansion = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "distilled_lib_1.h"],
-                      singleLocLine = 18,
-                      singleLocColumn = 41},
+                    multiLocExpansion =
+                    "examples/distilled_lib_1.h:18:41",
                     multiLocPresumed = Nothing,
                     multiLocSpelling = Nothing,
                     multiLocFile = Nothing}},
@@ -383,12 +279,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 25,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:25:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -404,22 +296,14 @@ WrapCHeader
                         "packed",
                       tokenExtent = Range {
                         rangeStart = MultiLoc {
-                          multiLocExpansion = SingleLoc {
-                            singleLocPath = [
-                              "examples",
-                              "distilled_lib_1.h"],
-                            singleLocLine = 25,
-                            singleLocColumn = 34},
+                          multiLocExpansion =
+                          "examples/distilled_lib_1.h:25:34",
                           multiLocPresumed = Nothing,
                           multiLocSpelling = Nothing,
                           multiLocFile = Nothing},
                         rangeEnd = MultiLoc {
-                          multiLocExpansion = SingleLoc {
-                            singleLocPath = [
-                              "examples",
-                              "distilled_lib_1.h"],
-                            singleLocLine = 25,
-                            singleLocColumn = 40},
+                          multiLocExpansion =
+                          "examples/distilled_lib_1.h:25:40",
                           multiLocPresumed = Nothing,
                           multiLocSpelling = Nothing,
                           multiLocFile = Nothing}},
@@ -427,22 +311,14 @@ WrapCHeader
                         501}])
                 MEmpty)},
           macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 25,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:25:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 52,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:52:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -456,22 +332,14 @@ WrapCHeader
                   integerLiteralValue = 0})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 52,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:52:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 53,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:53:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -485,22 +353,14 @@ WrapCHeader
                     (PrimInt Unsigned),
                   integerLiteralValue = 20560})},
           macroDeclMacroTy = "UInt",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 53,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:53:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 54,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:54:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -514,22 +374,14 @@ WrapCHeader
                   integerLiteralValue = 2})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 54,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:54:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 55,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/distilled_lib_1.h:55:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -543,12 +395,8 @@ WrapCHeader
                   integerLiteralValue = 13398})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 55,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/distilled_lib_1.h:55:9"},
       DeclFunction
         Function {
           functionName = CName "some_fun",
@@ -562,12 +410,8 @@ WrapCHeader
             (TypeTypedef (CName "int32_t")),
           functionHeader =
           "distilled_lib_1.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 71,
-            singleLocColumn = 9}},
+          functionSourceLoc =
+          "examples/distilled_lib_1.h:71:9"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -583,30 +427,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:22"},
             StructField {
               fieldName = CName "bar",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 8,
-                singleLocColumn = 32}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:8:32"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 8,
-            singleLocColumn = 9}},
+          structSourceLoc =
+          "examples/distilled_lib_1.h:8:9"},
       DeclEnum
         Enu {
           enumTag = CName
@@ -620,90 +452,52 @@ WrapCHeader
             EnumValue {
               valueName = CName "FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 9,
-                singleLocColumn = 16}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:9:16"},
             EnumValue {
               valueName = CName "BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 9,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 9,
-            singleLocColumn = 9}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:9:21"}],
+          enumSourceLoc =
+          "examples/distilled_lib_1.h:9:9"},
       DeclTypedef
         Typedef {
           typedefName = CName "a_type_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 13,
-            singleLocColumn = 13}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:13:13"},
       DeclTypedef
         Typedef {
           typedefName = CName "var_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 14,
-            singleLocColumn = 13}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:14:13"},
       DeclTypedef
         Typedef {
           typedefName = CName "uint8_t",
           typedefType = TypePrim
             (PrimChar (Just Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 121,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:121:25"},
       DeclTypedef
         Typedef {
           typedefName = CName "uint16_t",
           typedefType = TypePrim
             (PrimIntegral
               (PrimShort Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 126,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:126:25"},
       DeclTypedef
         Typedef {
           typedefName = CName "uint32_t",
           typedefType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 131,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:131:25"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -717,45 +511,29 @@ WrapCHeader
               fieldName = CName "field_0",
               fieldOffset = 0,
               fieldType = TypePrim PrimBool,
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 36,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:36:31"},
             StructField {
               fieldName = CName "field_1",
               fieldOffset = 8,
               fieldType = TypeTypedef
                 (CName "uint8_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 37,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:37:31"},
             StructField {
               fieldName = CName "field_2",
               fieldOffset = 16,
               fieldType = TypeTypedef
                 (CName "uint16_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 38,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:38:31"},
             StructField {
               fieldName = CName "field_3",
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 39,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:39:31"},
             StructField {
               fieldName = CName "field_4",
               fieldOffset = 64,
@@ -765,12 +543,8 @@ WrapCHeader
                     (CName
                       "another_typedef_struct_t"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 40,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:40:31"},
             StructField {
               fieldName = CName "field_5",
               fieldOffset = 128,
@@ -781,23 +555,15 @@ WrapCHeader
                       (CName
                         "another_typedef_struct_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 41,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:41:31"},
             StructField {
               fieldName = CName "field_6",
               fieldOffset = 192,
               fieldType = TypePointer
                 (TypePrim PrimVoid),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 42,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:42:31"},
             StructField {
               fieldName = CName "field_7",
               fieldOffset = 256,
@@ -805,55 +571,35 @@ WrapCHeader
                 7
                 (TypeTypedef
                   (CName "uint32_t")),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 43,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:43:31"},
             StructField {
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldType = TypeEnum
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 44,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:44:31"},
             StructField {
               fieldName = CName "field_9",
               fieldOffset = 512,
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 45,
-                singleLocColumn = 31}},
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:45:31"},
             StructField {
               fieldName = CName "field_10",
               fieldOffset = 640,
               fieldType = TypeTypedef
                 (CName
                   "another_typedef_enum_e"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 46,
-                singleLocColumn = 31}}],
+              fieldSourceLoc =
+              "examples/distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 34,
-            singleLocColumn = 16}},
+          structSourceLoc =
+          "examples/distilled_lib_1.h:34:16"},
       DeclTypedef
         Typedef {
           typedefName = CName
@@ -863,12 +609,8 @@ WrapCHeader
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 47,
-            singleLocColumn = 3}},
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:47:3"},
       DeclEnum
         Enu {
           enumTag = CName
@@ -881,58 +623,32 @@ WrapCHeader
             EnumValue {
               valueName = CName "ENUM_CASE_0",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 62,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:62:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_1",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 63,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:63:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_2",
               valueValue = 2,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 64,
-                singleLocColumn = 3}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:64:3"},
             EnumValue {
               valueName = CName "ENUM_CASE_3",
               valueValue = 3,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "distilled_lib_1.h"],
-                singleLocLine = 65,
-                singleLocColumn = 3}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 60,
-            singleLocColumn = 9}},
+              valueSourceLoc =
+              "examples/distilled_lib_1.h:65:3"}],
+          enumSourceLoc =
+          "examples/distilled_lib_1.h:60:9"},
       DeclTypedef
         Typedef {
           typedefName = CName "int32_t",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 106,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:106:25"},
       DeclTypedef
         Typedef {
           typedefName = CName
@@ -944,9 +660,5 @@ WrapCHeader
                 TypeTypedef (CName "uint32_t")]
               (TypeTypedef
                 (CName "uint32_t"))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "distilled_lib_1.h"],
-            singleLocLine = 76,
-            singleLocColumn = 19}}])
+          typedefSourceLoc =
+          "examples/distilled_lib_1.h:76:19"}])

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -27,27 +27,15 @@
             EnumValue {
               valueName = CName "FIRST1",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 5,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:5:5"},
             EnumValue {
               valueName = CName "FIRST2",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 6,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 4,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:6:5"}],
+          enumSourceLoc =
+          "examples/enums.h:4:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -77,27 +65,15 @@
               EnumValue {
                 valueName = CName "FIRST1",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 5}},
+                valueSourceLoc =
+                "examples/enums.h:5:5"},
               EnumValue {
                 valueName = CName "FIRST2",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 5}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 4,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:6:5"}],
+            enumSourceLoc =
+            "examples/enums.h:4:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -132,27 +108,15 @@
                       EnumValue {
                         valueName = CName "FIRST1",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:5:5"},
                       EnumValue {
                         valueName = CName "FIRST2",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:6:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:4:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -187,27 +151,15 @@
                       EnumValue {
                         valueName = CName "FIRST1",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:5:5"},
                       EnumValue {
                         valueName = CName "FIRST2",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:6:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:4:6"}}
               (Add 1)
               (Seq
                 [
@@ -232,12 +184,8 @@
         EnumValue {
           valueName = CName "FIRST1",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 5,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:5:5"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -255,12 +203,8 @@
         EnumValue {
           valueName = CName "FIRST2",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 6,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:6:5"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -288,36 +232,20 @@
             EnumValue {
               valueName = CName "SECOND_A",
               valueValue = `-1`,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 10,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:10:5"},
             EnumValue {
               valueName = CName "SECOND_B",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 11,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:11:5"},
             EnumValue {
               valueName = CName "SECOND_C",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 12,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 9,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:12:5"}],
+          enumSourceLoc =
+          "examples/enums.h:9:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -346,36 +274,20 @@
               EnumValue {
                 valueName = CName "SECOND_A",
                 valueValue = `-1`,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 5}},
+                valueSourceLoc =
+                "examples/enums.h:10:5"},
               EnumValue {
                 valueName = CName "SECOND_B",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 5}},
+                valueSourceLoc =
+                "examples/enums.h:11:5"},
               EnumValue {
                 valueName = CName "SECOND_C",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 12,
-                  singleLocColumn = 5}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 9,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:12:5"}],
+            enumSourceLoc =
+            "examples/enums.h:9:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -409,36 +321,20 @@
                       EnumValue {
                         valueName = CName "SECOND_A",
                         valueValue = `-1`,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:10:5"},
                       EnumValue {
                         valueName = CName "SECOND_B",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:11:5"},
                       EnumValue {
                         valueName = CName "SECOND_C",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:12:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:9:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -472,36 +368,20 @@
                       EnumValue {
                         valueName = CName "SECOND_A",
                         valueValue = `-1`,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:10:5"},
                       EnumValue {
                         valueName = CName "SECOND_B",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:11:5"},
                       EnumValue {
                         valueName = CName "SECOND_C",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:12:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:9:6"}}
               (Add 1)
               (Seq
                 [
@@ -526,12 +406,8 @@
         EnumValue {
           valueName = CName "SECOND_A",
           valueValue = `-1`,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 10,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:10:5"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -549,12 +425,8 @@
         EnumValue {
           valueName = CName "SECOND_B",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 11,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:11:5"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -572,12 +444,8 @@
         EnumValue {
           valueName = CName "SECOND_C",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 12,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:12:5"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -606,27 +474,15 @@
             EnumValue {
               valueName = CName "SAME_A",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 16,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:16:5"},
             EnumValue {
               valueName = CName "SAME_B",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 17,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 15,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:17:5"}],
+          enumSourceLoc =
+          "examples/enums.h:15:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -656,27 +512,15 @@
               EnumValue {
                 valueName = CName "SAME_A",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 5}},
+                valueSourceLoc =
+                "examples/enums.h:16:5"},
               EnumValue {
                 valueName = CName "SAME_B",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 17,
-                  singleLocColumn = 5}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 15,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:17:5"}],
+            enumSourceLoc =
+            "examples/enums.h:15:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -711,27 +555,15 @@
                       EnumValue {
                         valueName = CName "SAME_A",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:16:5"},
                       EnumValue {
                         valueName = CName "SAME_B",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:17:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:15:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -766,27 +598,15 @@
                       EnumValue {
                         valueName = CName "SAME_A",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:16:5"},
                       EnumValue {
                         valueName = CName "SAME_B",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 17,
-                          singleLocColumn = 5}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:17:5"}],
+                    enumSourceLoc =
+                    "examples/enums.h:15:6"}}
               (Add 1)
               (Seq
                 [
@@ -811,12 +631,8 @@
         EnumValue {
           valueName = CName "SAME_A",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 16,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:16:5"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -834,12 +650,8 @@
         EnumValue {
           valueName = CName "SAME_B",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 17,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:17:5"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -867,36 +679,20 @@
             EnumValue {
               valueName = CName "PACKED_A",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:21:5"},
             EnumValue {
               valueName = CName "PACKED_B",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 15}},
+              valueSourceLoc =
+              "examples/enums.h:21:15"},
             EnumValue {
               valueName = CName "PACKED_C",
               valueValue = 2,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 25}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 20,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:21:25"}],
+          enumSourceLoc =
+          "examples/enums.h:20:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -925,36 +721,20 @@
               EnumValue {
                 valueName = CName "PACKED_A",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 5}},
+                valueSourceLoc =
+                "examples/enums.h:21:5"},
               EnumValue {
                 valueName = CName "PACKED_B",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 15}},
+                valueSourceLoc =
+                "examples/enums.h:21:15"},
               EnumValue {
                 valueName = CName "PACKED_C",
                 valueValue = 2,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 25}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 20,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:21:25"}],
+            enumSourceLoc =
+            "examples/enums.h:20:6"}}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -988,36 +768,20 @@
                       EnumValue {
                         valueName = CName "PACKED_A",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:21:5"},
                       EnumValue {
                         valueName = CName "PACKED_B",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 15}},
+                        valueSourceLoc =
+                        "examples/enums.h:21:15"},
                       EnumValue {
                         valueName = CName "PACKED_C",
                         valueValue = 2,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 25}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 20,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:21:25"}],
+                    enumSourceLoc =
+                    "examples/enums.h:20:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1051,36 +815,20 @@
                       EnumValue {
                         valueName = CName "PACKED_A",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 5}},
+                        valueSourceLoc =
+                        "examples/enums.h:21:5"},
                       EnumValue {
                         valueName = CName "PACKED_B",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 15}},
+                        valueSourceLoc =
+                        "examples/enums.h:21:15"},
                       EnumValue {
                         valueName = CName "PACKED_C",
                         valueValue = 2,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 25}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 20,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:21:25"}],
+                    enumSourceLoc =
+                    "examples/enums.h:20:6"}}
               (Add 1)
               (Seq
                 [
@@ -1105,12 +853,8 @@
         EnumValue {
           valueName = CName "PACKED_A",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 21,
-            singleLocColumn = 5}}},
+          valueSourceLoc =
+          "examples/enums.h:21:5"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1128,12 +872,8 @@
         EnumValue {
           valueName = CName "PACKED_B",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 21,
-            singleLocColumn = 15}}},
+          valueSourceLoc =
+          "examples/enums.h:21:15"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1151,12 +891,8 @@
         EnumValue {
           valueName = CName "PACKED_C",
           valueValue = 2,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 21,
-            singleLocColumn = 25}}},
+          valueSourceLoc =
+          "examples/enums.h:21:25"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1185,27 +921,15 @@
             EnumValue {
               valueName = CName "A_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 24,
-                singleLocColumn = 16}},
+              valueSourceLoc =
+              "examples/enums.h:24:16"},
             EnumValue {
               valueName = CName "A_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 24,
-                singleLocColumn = 23}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 24,
-            singleLocColumn = 9}}},
+              valueSourceLoc =
+              "examples/enums.h:24:23"}],
+          enumSourceLoc =
+          "examples/enums.h:24:9"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1235,27 +959,15 @@
               EnumValue {
                 valueName = CName "A_FOO",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 24,
-                  singleLocColumn = 16}},
+                valueSourceLoc =
+                "examples/enums.h:24:16"},
               EnumValue {
                 valueName = CName "A_BAR",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 24,
-                  singleLocColumn = 23}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 24,
-              singleLocColumn = 9}}}
+                valueSourceLoc =
+                "examples/enums.h:24:23"}],
+            enumSourceLoc =
+            "examples/enums.h:24:9"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1290,27 +1002,15 @@
                       EnumValue {
                         valueName = CName "A_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 16}},
+                        valueSourceLoc =
+                        "examples/enums.h:24:16"},
                       EnumValue {
                         valueName = CName "A_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 23}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 24,
-                      singleLocColumn = 9}}})
+                        valueSourceLoc =
+                        "examples/enums.h:24:23"}],
+                    enumSourceLoc =
+                    "examples/enums.h:24:9"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1345,27 +1045,15 @@
                       EnumValue {
                         valueName = CName "A_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 16}},
+                        valueSourceLoc =
+                        "examples/enums.h:24:16"},
                       EnumValue {
                         valueName = CName "A_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 23}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 24,
-                      singleLocColumn = 9}}}
+                        valueSourceLoc =
+                        "examples/enums.h:24:23"}],
+                    enumSourceLoc =
+                    "examples/enums.h:24:9"}}
               (Add 1)
               (Seq
                 [
@@ -1390,12 +1078,8 @@
         EnumValue {
           valueName = CName "A_FOO",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 24,
-            singleLocColumn = 16}}},
+          valueSourceLoc =
+          "examples/enums.h:24:16"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1413,12 +1097,8 @@
         EnumValue {
           valueName = CName "A_BAR",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 24,
-            singleLocColumn = 23}}},
+          valueSourceLoc =
+          "examples/enums.h:24:23"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1447,27 +1127,15 @@
             EnumValue {
               valueName = CName "B_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 26,
-                singleLocColumn = 22}},
+              valueSourceLoc =
+              "examples/enums.h:26:22"},
             EnumValue {
               valueName = CName "B_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 26,
-                singleLocColumn = 29}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 26,
-            singleLocColumn = 14}}},
+              valueSourceLoc =
+              "examples/enums.h:26:29"}],
+          enumSourceLoc =
+          "examples/enums.h:26:14"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1497,27 +1165,15 @@
               EnumValue {
                 valueName = CName "B_FOO",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 26,
-                  singleLocColumn = 22}},
+                valueSourceLoc =
+                "examples/enums.h:26:22"},
               EnumValue {
                 valueName = CName "B_BAR",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 26,
-                  singleLocColumn = 29}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 26,
-              singleLocColumn = 14}}}
+                valueSourceLoc =
+                "examples/enums.h:26:29"}],
+            enumSourceLoc =
+            "examples/enums.h:26:14"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1552,27 +1208,15 @@
                       EnumValue {
                         valueName = CName "B_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 22}},
+                        valueSourceLoc =
+                        "examples/enums.h:26:22"},
                       EnumValue {
                         valueName = CName "B_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 29}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 26,
-                      singleLocColumn = 14}}})
+                        valueSourceLoc =
+                        "examples/enums.h:26:29"}],
+                    enumSourceLoc =
+                    "examples/enums.h:26:14"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1607,27 +1251,15 @@
                       EnumValue {
                         valueName = CName "B_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 22}},
+                        valueSourceLoc =
+                        "examples/enums.h:26:22"},
                       EnumValue {
                         valueName = CName "B_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 29}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 26,
-                      singleLocColumn = 14}}}
+                        valueSourceLoc =
+                        "examples/enums.h:26:29"}],
+                    enumSourceLoc =
+                    "examples/enums.h:26:14"}}
               (Add 1)
               (Seq
                 [
@@ -1652,12 +1284,8 @@
         EnumValue {
           valueName = CName "B_FOO",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 26,
-            singleLocColumn = 22}}},
+          valueSourceLoc =
+          "examples/enums.h:26:22"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1675,12 +1303,8 @@
         EnumValue {
           valueName = CName "B_BAR",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 26,
-            singleLocColumn = 29}}},
+          valueSourceLoc =
+          "examples/enums.h:26:29"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1709,27 +1333,15 @@
             EnumValue {
               valueName = CName "C_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 28,
-                singleLocColumn = 14}},
+              valueSourceLoc =
+              "examples/enums.h:28:14"},
             EnumValue {
               valueName = CName "C_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 28,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 28,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:28:21"}],
+          enumSourceLoc =
+          "examples/enums.h:28:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1759,27 +1371,15 @@
               EnumValue {
                 valueName = CName "C_FOO",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 28,
-                  singleLocColumn = 14}},
+                valueSourceLoc =
+                "examples/enums.h:28:14"},
               EnumValue {
                 valueName = CName "C_BAR",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 28,
-                  singleLocColumn = 21}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 28,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:28:21"}],
+            enumSourceLoc =
+            "examples/enums.h:28:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1814,27 +1414,15 @@
                       EnumValue {
                         valueName = CName "C_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 14}},
+                        valueSourceLoc =
+                        "examples/enums.h:28:14"},
                       EnumValue {
                         valueName = CName "C_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 28,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:28:21"}],
+                    enumSourceLoc =
+                    "examples/enums.h:28:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1869,27 +1457,15 @@
                       EnumValue {
                         valueName = CName "C_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 14}},
+                        valueSourceLoc =
+                        "examples/enums.h:28:14"},
                       EnumValue {
                         valueName = CName "C_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 28,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:28:21"}],
+                    enumSourceLoc =
+                    "examples/enums.h:28:6"}}
               (Add 1)
               (Seq
                 [
@@ -1914,12 +1490,8 @@
         EnumValue {
           valueName = CName "C_FOO",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 28,
-            singleLocColumn = 14}}},
+          valueSourceLoc =
+          "examples/enums.h:28:14"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1937,12 +1509,8 @@
         EnumValue {
           valueName = CName "C_BAR",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 28,
-            singleLocColumn = 21}}},
+          valueSourceLoc =
+          "examples/enums.h:28:21"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1971,27 +1539,15 @@
             EnumValue {
               valueName = CName "D_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 31,
-                singleLocColumn = 14}},
+              valueSourceLoc =
+              "examples/enums.h:31:14"},
             EnumValue {
               valueName = CName "D_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 31,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 31,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/enums.h:31:21"}],
+          enumSourceLoc =
+          "examples/enums.h:31:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2021,27 +1577,15 @@
               EnumValue {
                 valueName = CName "D_FOO",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 14}},
+                valueSourceLoc =
+                "examples/enums.h:31:14"},
               EnumValue {
                 valueName = CName "D_BAR",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "enums.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 21}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "enums.h"],
-              singleLocLine = 31,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/enums.h:31:21"}],
+            enumSourceLoc =
+            "examples/enums.h:31:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2076,27 +1620,15 @@
                       EnumValue {
                         valueName = CName "D_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 14}},
+                        valueSourceLoc =
+                        "examples/enums.h:31:14"},
                       EnumValue {
                         valueName = CName "D_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 31,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/enums.h:31:21"}],
+                    enumSourceLoc =
+                    "examples/enums.h:31:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2131,27 +1663,15 @@
                       EnumValue {
                         valueName = CName "D_FOO",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 14}},
+                        valueSourceLoc =
+                        "examples/enums.h:31:14"},
                       EnumValue {
                         valueName = CName "D_BAR",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "enums.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 21}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "enums.h"],
-                      singleLocLine = 31,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/enums.h:31:21"}],
+                    enumSourceLoc =
+                    "examples/enums.h:31:6"}}
               (Add 1)
               (Seq
                 [
@@ -2176,12 +1696,8 @@
         EnumValue {
           valueName = CName "D_FOO",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 31,
-            singleLocColumn = 14}}},
+          valueSourceLoc =
+          "examples/enums.h:31:14"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2199,12 +1715,8 @@
         EnumValue {
           valueName = CName "D_BAR",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 31,
-            singleLocColumn = 21}}},
+          valueSourceLoc =
+          "examples/enums.h:31:21"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -2228,12 +1740,8 @@
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
             (CName "enumD"),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 32,
-            singleLocColumn = 20}}},
+          typedefSourceLoc =
+          "examples/enums.h:32:20"}},
   DeclNewtypeInstance
     Storable
     (HsName

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/enums.h:2:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -18,12 +14,8 @@ WrapCHeader
             macroArgs = [],
             macroBody = MTerm MEmpty},
           macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 2,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/enums.h:2:9"},
       DeclEnum
         Enu {
           enumTag = CName "first",
@@ -36,27 +28,15 @@ WrapCHeader
             EnumValue {
               valueName = CName "FIRST1",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 5,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:5:5"},
             EnumValue {
               valueName = CName "FIRST2",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 6,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 4,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:6:5"}],
+          enumSourceLoc =
+          "examples/enums.h:4:6"},
       DeclEnum
         Enu {
           enumTag = CName "second",
@@ -68,36 +48,20 @@ WrapCHeader
             EnumValue {
               valueName = CName "SECOND_A",
               valueValue = `-1`,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 10,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:10:5"},
             EnumValue {
               valueName = CName "SECOND_B",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 11,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:11:5"},
             EnumValue {
               valueName = CName "SECOND_C",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 12,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 9,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:12:5"}],
+          enumSourceLoc =
+          "examples/enums.h:9:6"},
       DeclEnum
         Enu {
           enumTag = CName "same",
@@ -110,27 +74,15 @@ WrapCHeader
             EnumValue {
               valueName = CName "SAME_A",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 16,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:16:5"},
             EnumValue {
               valueName = CName "SAME_B",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 17,
-                singleLocColumn = 5}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 15,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:17:5"}],
+          enumSourceLoc =
+          "examples/enums.h:15:6"},
       DeclEnum
         Enu {
           enumTag = CName "packad",
@@ -142,36 +94,20 @@ WrapCHeader
             EnumValue {
               valueName = CName "PACKED_A",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 5}},
+              valueSourceLoc =
+              "examples/enums.h:21:5"},
             EnumValue {
               valueName = CName "PACKED_B",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 15}},
+              valueSourceLoc =
+              "examples/enums.h:21:15"},
             EnumValue {
               valueName = CName "PACKED_C",
               valueValue = 2,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 21,
-                singleLocColumn = 25}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 20,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:21:25"}],
+          enumSourceLoc =
+          "examples/enums.h:20:6"},
       DeclEnum
         Enu {
           enumTag = CName "enumA",
@@ -184,27 +120,15 @@ WrapCHeader
             EnumValue {
               valueName = CName "A_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 24,
-                singleLocColumn = 16}},
+              valueSourceLoc =
+              "examples/enums.h:24:16"},
             EnumValue {
               valueName = CName "A_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 24,
-                singleLocColumn = 23}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 24,
-            singleLocColumn = 9}},
+              valueSourceLoc =
+              "examples/enums.h:24:23"}],
+          enumSourceLoc =
+          "examples/enums.h:24:9"},
       DeclEnum
         Enu {
           enumTag = CName "enumB",
@@ -217,27 +141,15 @@ WrapCHeader
             EnumValue {
               valueName = CName "B_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 26,
-                singleLocColumn = 22}},
+              valueSourceLoc =
+              "examples/enums.h:26:22"},
             EnumValue {
               valueName = CName "B_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 26,
-                singleLocColumn = 29}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 26,
-            singleLocColumn = 14}},
+              valueSourceLoc =
+              "examples/enums.h:26:29"}],
+          enumSourceLoc =
+          "examples/enums.h:26:14"},
       DeclEnum
         Enu {
           enumTag = CName "enumC",
@@ -250,27 +162,15 @@ WrapCHeader
             EnumValue {
               valueName = CName "C_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 28,
-                singleLocColumn = 14}},
+              valueSourceLoc =
+              "examples/enums.h:28:14"},
             EnumValue {
               valueName = CName "C_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 28,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 28,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:28:21"}],
+          enumSourceLoc =
+          "examples/enums.h:28:6"},
       DeclEnum
         Enu {
           enumTag = CName "enumD",
@@ -283,35 +183,19 @@ WrapCHeader
             EnumValue {
               valueName = CName "D_FOO",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 31,
-                singleLocColumn = 14}},
+              valueSourceLoc =
+              "examples/enums.h:31:14"},
             EnumValue {
               valueName = CName "D_BAR",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "enums.h"],
-                singleLocLine = 31,
-                singleLocColumn = 21}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 31,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/enums.h:31:21"}],
+          enumSourceLoc =
+          "examples/enums.h:31:6"},
       DeclTypedef
         Typedef {
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
             (CName "enumD"),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "enums.h"],
-            singleLocLine = 32,
-            singleLocColumn = 20}}])
+          typedefSourceLoc =
+          "examples/enums.h:32:20"}])

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -24,12 +24,8 @@
             (TypePrim
               (PrimIntegral
                 (PrimInt Signed))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "fixedarray.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}}},
+          typedefSourceLoc =
+          "examples/fixedarray.h:1:13"}},
   DeclNewtypeInstance
     Storable
     (HsName

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -9,9 +9,5 @@ WrapCHeader
             (TypePrim
               (PrimIntegral
                 (PrimInt Signed))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "fixedarray.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}}])
+          typedefSourceLoc =
+          "examples/fixedarray.h:1:13"}])

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -21,14 +21,8 @@
           typedefType = TypePrim
             (PrimIntegral
               (PrimLong Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 136,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:136:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -56,14 +50,8 @@
           typedefType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 131,
-            singleLocColumn = 25}}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:131:25"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -93,12 +81,8 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "uint64_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 4,
-                singleLocColumn = 11}}},
+              fieldSourceLoc =
+              "examples/fixedwidth.h:4:11"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -114,12 +98,8 @@
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 5,
-                singleLocColumn = 11}}}],
+              fieldSourceLoc =
+              "examples/fixedwidth.h:5:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -134,30 +114,18 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "uint64_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 4,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/fixedwidth.h:4:11"},
             StructField {
               fieldName = CName "thirty_two",
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 5,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/fixedwidth.h:5:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "fixedwidth.h"],
-            singleLocLine = 3,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/fixedwidth.h:3:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -183,12 +151,8 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "uint64_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "fixedwidth.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 11}}},
+                fieldSourceLoc =
+                "examples/fixedwidth.h:4:11"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -204,12 +168,8 @@
                 fieldOffset = 64,
                 fieldType = TypeTypedef
                   (CName "uint32_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "fixedwidth.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 11}}}],
+                fieldSourceLoc =
+                "examples/fixedwidth.h:5:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -224,30 +184,18 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "uint64_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "fixedwidth.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 11}},
+                fieldSourceLoc =
+                "examples/fixedwidth.h:4:11"},
               StructField {
                 fieldName = CName "thirty_two",
                 fieldOffset = 64,
                 fieldType = TypeTypedef
                   (CName "uint32_t"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "fixedwidth.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 11}}],
+                fieldSourceLoc =
+                "examples/fixedwidth.h:5:11"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "fixedwidth.h"],
-              singleLocLine = 3,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/fixedwidth.h:3:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -278,12 +226,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "uint64_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:4:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -299,12 +243,8 @@
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -319,30 +259,18 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "uint64_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:4:11"},
                       StructField {
                         fieldName = CName "thirty_two",
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:5:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "fixedwidth.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/fixedwidth.h:3:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -375,12 +303,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "uint64_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:4:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -396,12 +320,8 @@
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -416,30 +336,18 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "uint64_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:4:11"},
                       StructField {
                         fieldName = CName "thirty_two",
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "uint32_t"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "fixedwidth.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/fixedwidth.h:5:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "fixedwidth.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/fixedwidth.h:3:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -7,28 +7,16 @@ WrapCHeader
           typedefType = TypePrim
             (PrimIntegral
               (PrimLong Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 136,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:136:25"},
       DeclTypedef
         Typedef {
           typedefName = CName "uint32_t",
           typedefType = TypePrim
             (PrimIntegral
               (PrimInt Unsigned)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "musl-include",
-              "x86_64",
-              "bits",
-              "alltypes.h"],
-            singleLocLine = 131,
-            singleLocColumn = 25}},
+          typedefSourceLoc =
+          "musl-include/x86_64/bits/alltypes.h:131:25"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -42,27 +30,15 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "uint64_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 4,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/fixedwidth.h:4:11"},
             StructField {
               fieldName = CName "thirty_two",
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "uint32_t"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "fixedwidth.h"],
-                singleLocLine = 5,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/fixedwidth.h:5:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "fixedwidth.h"],
-            singleLocLine = 3,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/fixedwidth.h:3:8"}])

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}}}],
+              fieldSourceLoc =
+              "examples/flam.h:3:9"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -41,30 +37,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/flam.h:3:9"}],
           structFlam = Just
             StructField {
               fieldName = CName "data",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 4,
-                singleLocColumn = 10}},
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}}},
+              fieldSourceLoc =
+              "examples/flam.h:4:10"},
+          structSourceLoc =
+          "examples/flam.h:2:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -88,12 +72,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 9}}}],
+                fieldSourceLoc =
+                "examples/flam.h:3:9"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -108,30 +88,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 9}}],
+                fieldSourceLoc =
+                "examples/flam.h:3:9"}],
             structFlam = Just
               StructField {
                 fieldName = CName "data",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 10}},
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "flam.h"],
-              singleLocLine = 2,
-              singleLocColumn = 8}}}
+                fieldSourceLoc =
+                "examples/flam.h:4:10"},
+            structSourceLoc =
+            "examples/flam.h:2:8"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -160,12 +128,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:3:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -180,30 +144,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:3:9"}],
                     structFlam = Just
                       StructField {
                         fieldName = CName "data",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}},
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}})
+                        fieldSourceLoc =
+                        "examples/flam.h:4:10"},
+                    structSourceLoc =
+                    "examples/flam.h:2:8"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -232,12 +184,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:3:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -252,30 +200,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:3:9"}],
                     structFlam = Just
                       StructField {
                         fieldName = CName "data",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}},
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}}
+                        fieldSourceLoc =
+                        "examples/flam.h:4:10"},
+                    structSourceLoc =
+                    "examples/flam.h:2:8"}}
               (Add 1)
               (Seq
                 [
@@ -305,12 +241,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 11,
-                singleLocColumn = 7}}},
+              fieldSourceLoc =
+              "examples/flam.h:11:7"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -324,12 +256,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 12,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/flam.h:12:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -348,30 +276,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 11,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/flam.h:11:7"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 12,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/flam.h:12:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 10,
-            singleLocColumn = 2}}},
+          structSourceLoc =
+          "examples/flam.h:10:2"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -395,12 +311,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 7}}},
+                fieldSourceLoc =
+                "examples/flam.h:11:7"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -414,12 +326,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 12,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/flam.h:12:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -438,30 +346,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 7}},
+                fieldSourceLoc =
+                "examples/flam.h:11:7"},
               StructField {
                 fieldName = CName "y",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 12,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/flam.h:12:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "flam.h"],
-              singleLocLine = 10,
-              singleLocColumn = 2}}}
+            structSourceLoc =
+            "examples/flam.h:10:2"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -490,12 +386,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/flam.h:11:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -509,12 +401,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:12:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -533,30 +421,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/flam.h:11:7"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:12:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 10,
-                      singleLocColumn = 2}}})
+                    structSourceLoc =
+                    "examples/flam.h:10:2"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -587,12 +463,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/flam.h:11:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -606,12 +478,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:12:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -630,30 +498,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/flam.h:11:7"},
                       StructField {
                         fieldName = CName "y",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:12:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 10,
-                      singleLocColumn = 2}}}
+                    structSourceLoc =
+                    "examples/flam.h:10:2"}}
               (Add 2)
               (Seq
                 [
@@ -684,12 +540,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}}}],
+              fieldSourceLoc =
+              "examples/flam.h:9:6"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -704,12 +556,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}}],
+              fieldSourceLoc =
+              "examples/flam.h:9:6"}],
           structFlam = Just
             StructField {
               fieldName = CName "bar",
@@ -722,18 +570,10 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 13,
-                singleLocColumn = 4}},
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 8,
-            singleLocColumn = 8}}},
+              fieldSourceLoc =
+              "examples/flam.h:13:4"},
+          structSourceLoc =
+          "examples/flam.h:8:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -757,12 +597,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 6}}}],
+                fieldSourceLoc =
+                "examples/flam.h:9:6"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -777,12 +613,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 6}}],
+                fieldSourceLoc =
+                "examples/flam.h:9:6"}],
             structFlam = Just
               StructField {
                 fieldName = CName "bar",
@@ -795,18 +627,10 @@
                       (DeclPathStruct
                         (DeclNameTag (CName "foo"))
                         DeclPathTop))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "flam.h"],
-                  singleLocLine = 13,
-                  singleLocColumn = 4}},
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "flam.h"],
-              singleLocLine = 8,
-              singleLocColumn = 8}}}
+                fieldSourceLoc =
+                "examples/flam.h:13:4"},
+            structSourceLoc =
+            "examples/flam.h:8:8"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -835,12 +659,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:9:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -855,12 +675,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:9:6"}],
                     structFlam = Just
                       StructField {
                         fieldName = CName "bar",
@@ -873,18 +689,10 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 13,
-                          singleLocColumn = 4}},
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 8}}})
+                        fieldSourceLoc =
+                        "examples/flam.h:13:4"},
+                    structSourceLoc =
+                    "examples/flam.h:8:8"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -913,12 +721,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:9:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -933,12 +737,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}],
+                        fieldSourceLoc =
+                        "examples/flam.h:9:6"}],
                     structFlam = Just
                       StructField {
                         fieldName = CName "bar",
@@ -951,18 +751,10 @@
                               (DeclPathStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "flam.h"],
-                          singleLocLine = 13,
-                          singleLocColumn = 4}},
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "flam.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 8}}}
+                        fieldSourceLoc =
+                        "examples/flam.h:13:4"},
+                    structSourceLoc =
+                    "examples/flam.h:8:8"}}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -14,30 +14,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/flam.h:3:9"}],
           structFlam = Just
             StructField {
               fieldName = CName "data",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 4,
-                singleLocColumn = 10}},
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}},
+              fieldSourceLoc =
+              "examples/flam.h:4:10"},
+          structSourceLoc =
+          "examples/flam.h:2:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -55,30 +43,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 11,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/flam.h:11:7"},
             StructField {
               fieldName = CName "y",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 12,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/flam.h:12:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 10,
-            singleLocColumn = 2}},
+          structSourceLoc =
+          "examples/flam.h:10:2"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -92,12 +68,8 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}}],
+              fieldSourceLoc =
+              "examples/flam.h:9:6"}],
           structFlam = Just
             StructField {
               fieldName = CName "bar",
@@ -110,15 +82,7 @@ WrapCHeader
                     (DeclPathStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "flam.h"],
-                singleLocLine = 13,
-                singleLocColumn = 4}},
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "flam.h"],
-            singleLocLine = 8,
-            singleLocColumn = 8}}])
+              fieldSourceLoc =
+              "examples/flam.h:13:4"},
+          structSourceLoc =
+          "examples/flam.h:8:8"}])

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 4,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:4:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -41,19 +37,11 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 4,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:4:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 3,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/forward_declaration.h:3:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -77,12 +65,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "forward_declaration.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/forward_declaration.h:4:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -97,19 +81,11 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "forward_declaration.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/forward_declaration.h:4:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "forward_declaration.h"],
-              singleLocLine = 3,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/forward_declaration.h:3:8"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -138,12 +114,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:4:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -158,19 +130,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:4:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "forward_declaration.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/forward_declaration.h:3:8"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -199,12 +163,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:4:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -219,19 +179,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:4:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "forward_declaration.h"],
-                      singleLocLine = 3,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/forward_declaration.h:3:8"}}
               (Add 1)
               (Seq
                 [
@@ -262,12 +214,8 @@
             (DeclPathStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 1,
-            singleLocColumn = 19}}},
+          typedefSourceLoc =
+          "examples/forward_declaration.h:1:19"}},
   DeclNewtypeInstance
     Storable
     (HsName "@NsTypeConstr" "S1_t"),
@@ -293,12 +241,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:10:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -313,19 +257,11 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:10:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/forward_declaration.h:9:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -349,12 +285,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "forward_declaration.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 7}}}],
+                fieldSourceLoc =
+                "examples/forward_declaration.h:10:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -369,19 +301,11 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "forward_declaration.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 7}}],
+                fieldSourceLoc =
+                "examples/forward_declaration.h:10:7"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "forward_declaration.h"],
-              singleLocLine = 9,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/forward_declaration.h:9:8"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -410,12 +334,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:10:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -430,19 +350,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:10:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "forward_declaration.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/forward_declaration.h:9:8"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -471,12 +383,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:10:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -491,19 +399,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "forward_declaration.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}],
+                        fieldSourceLoc =
+                        "examples/forward_declaration.h:10:7"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "forward_declaration.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/forward_declaration.h:9:8"}}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -14,19 +14,11 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 4,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:4:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 3,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/forward_declaration.h:3:8"},
       DeclTypedef
         Typedef {
           typedefName = CName "S1_t",
@@ -34,12 +26,8 @@ WrapCHeader
             (DeclPathStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 1,
-            singleLocColumn = 19}},
+          typedefSourceLoc =
+          "examples/forward_declaration.h:1:19"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -53,16 +41,8 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "forward_declaration.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}}],
+              fieldSourceLoc =
+              "examples/forward_declaration.h:10:7"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "forward_declaration.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/forward_declaration.h:9:8"}])

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 1,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:1:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -28,22 +24,14 @@ WrapCHeader
                       integerLiteralValue = 1})]},
           macroDeclMacroTy =
           "(forall a. Integral a => (a -> a))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 1,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:1:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:2:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -58,22 +46,14 @@ WrapCHeader
                 MTerm (MVar (CName "y") [])]},
           macroDeclMacroTy =
           "(forall a. Num a => (a -> a -> a))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 2,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:2:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:4:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -83,22 +63,14 @@ WrapCHeader
               (MVar (CName "X") [])},
           macroDeclMacroTy =
           "(forall a. (a -> a))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 4,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:4:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:5:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -110,22 +82,14 @@ WrapCHeader
               (MVar (CName "X") [])},
           macroDeclMacroTy =
           "(forall a b. (a -> b -> a))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 5,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:5:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 7,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:7:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -140,22 +104,14 @@ WrapCHeader
                 MTerm (MVar (CName "Y") [])]},
           macroDeclMacroTy =
           "(forall a. Ord a => (a -> a -> Bool))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 7,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:7:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 8,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:8:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -180,22 +136,14 @@ WrapCHeader
                     MTerm (MVar (CName "Y") [])]]},
           macroDeclMacroTy =
           "(ULLong -> ULLong -> ULLong)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 8,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:8:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 9,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:9:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -220,22 +168,14 @@ WrapCHeader
                     MTerm (MVar (CName "Y") [])]]},
           macroDeclMacroTy =
           "(forall a. Bits a => (a -> ULLong -> a))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 9,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:9:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 11,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:11:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -259,22 +199,14 @@ WrapCHeader
                           (MVar (CName "X") [])])])},
           macroDeclMacroTy =
           "(forall a b. Integral b => (a -> b -> b))",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 11,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:11:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 13,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:13:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -299,22 +231,14 @@ WrapCHeader
                           integerLiteralValue = 12})]]},
           macroDeclMacroTy =
           "(UInt -> UInt -> UInt)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 13,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:13:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macro_functions.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macro_functions.h:14:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -342,9 +266,5 @@ WrapCHeader
                 MTerm (MVar (CName "Y") [])]},
           macroDeclMacroTy =
           "(Float -> Float -> Float)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macro_functions.h"],
-            singleLocLine = 14,
-            singleLocColumn = 9}}])
+          macroDeclSourceLoc =
+          "examples/macro_functions.h:14:9"}])

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 1,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:1:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -24,22 +20,14 @@ WrapCHeader
                   integerLiteralValue = 1})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 1,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:1:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:2:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -53,22 +41,14 @@ WrapCHeader
                   integerLiteralValue = 2})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 2,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:2:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:3:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -91,22 +71,14 @@ WrapCHeader
                       integerLiteralValue = 3})]},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 3,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:3:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:4:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -129,22 +101,14 @@ WrapCHeader
                       integerLiteralValue = 4})]},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 4,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:4:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 6,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:6:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -159,22 +123,14 @@ WrapCHeader
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 6,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:6:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 7,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:7:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -189,22 +145,14 @@ WrapCHeader
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 7,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:7:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 8,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:8:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -219,22 +167,14 @@ WrapCHeader
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 8,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:8:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 9,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:9:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -249,22 +189,14 @@ WrapCHeader
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 9,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:9:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 10,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:10:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -279,22 +211,14 @@ WrapCHeader
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
           "(forall a. Integral a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 10,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:10:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 12,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:12:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -311,22 +235,14 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy = "ULLong",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 12,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:12:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 13,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:13:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -343,22 +259,14 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy = "ULLong",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 13,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:13:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:14:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -375,22 +283,14 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy = "ULLong",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 14,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:14:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 15,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:15:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -407,22 +307,14 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy = "ULLong",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 15,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:15:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 20,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:20:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -439,22 +331,14 @@ WrapCHeader
                   110000.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 20,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:20:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 21,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:21:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -471,22 +355,14 @@ WrapCHeader
                   1.2e-2})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 21,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:21:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 22,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:22:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -503,22 +379,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   1.3e-2})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 22,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:22:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 24,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:24:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -535,22 +403,14 @@ WrapCHeader
                   21.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 24,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:24:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 25,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:25:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -567,22 +427,14 @@ WrapCHeader
                   2200.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 25,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:25:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 26,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:26:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -599,22 +451,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   23.0})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 26,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:26:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 28,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:28:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -631,22 +475,14 @@ WrapCHeader
                   31.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 28,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:28:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 29,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:29:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -663,22 +499,14 @@ WrapCHeader
                   0.32})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 29,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:29:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 30,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:30:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -695,22 +523,14 @@ WrapCHeader
                   33.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 30,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:30:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 31,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:31:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -727,22 +547,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   3.4e-3})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 31,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:31:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 33,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:33:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -759,22 +571,14 @@ WrapCHeader
                   650000.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 33,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:33:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 34,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:34:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -791,22 +595,14 @@ WrapCHeader
                   6.6e-2})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 34,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:34:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 35,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:35:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -824,22 +620,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   6.7e-2})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 35,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:35:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 37,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:37:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -856,22 +644,14 @@ WrapCHeader
                   81.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 37,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:37:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 38,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:38:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -889,22 +669,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   82.0})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 38,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:38:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 40,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:40:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -922,22 +694,14 @@ WrapCHeader
                   15520.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 40,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:40:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 41,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:41:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -954,22 +718,14 @@ WrapCHeader
                   98.0})},
           macroDeclMacroTy =
           "(forall a. Fractional a => a)",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 41,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:41:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 42,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:42:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -987,22 +743,14 @@ WrapCHeader
                   floatingLiteralDoubleValue =
                   9.9e-3})},
           macroDeclMacroTy = "Float",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "macros.h"],
-            singleLocLine = 42,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/macros.h:42:9"},
       DeclMacro
         MacroTcError {
           macroTcErrorMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 45,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:45:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -1034,12 +782,8 @@ WrapCHeader
         MacroTcError {
           macroTcErrorMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "macros.h"],
-                singleLocLine = 46,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/macros.h:46:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/nested_types.h:2:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -40,12 +36,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:3:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -60,30 +52,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/nested_types.h:2:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:3:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "nested_types.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/nested_types.h:1:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -107,12 +87,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/nested_types.h:2:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -126,12 +102,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/nested_types.h:3:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -146,30 +118,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/nested_types.h:2:9"},
               StructField {
                 fieldName = CName "c",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/nested_types.h:3:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "nested_types.h"],
-              singleLocLine = 1,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/nested_types.h:1:8"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -198,12 +158,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:2:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -217,12 +173,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:3:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -237,30 +189,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:2:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:3:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "nested_types.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/nested_types.h:1:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -291,12 +231,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:2:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -310,12 +246,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:3:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -330,30 +262,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:2:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:3:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "nested_types.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/nested_types.h:1:8"}}
               (Add 2)
               (Seq
                 [
@@ -386,12 +306,8 @@
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 16}}},
+              fieldSourceLoc =
+              "examples/nested_types.h:7:16"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -407,12 +323,8 @@
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 16}}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:8:16"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -429,12 +341,8 @@
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 16}},
+              fieldSourceLoc =
+              "examples/nested_types.h:7:16"},
             StructField {
               fieldName = CName "foo2",
               fieldOffset = 64,
@@ -442,19 +350,11 @@
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 16}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:8:16"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "nested_types.h"],
-            singleLocLine = 6,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/nested_types.h:6:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -480,12 +380,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 7,
-                  singleLocColumn = 16}}},
+                fieldSourceLoc =
+                "examples/nested_types.h:7:16"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -501,12 +397,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 16}}}],
+                fieldSourceLoc =
+                "examples/nested_types.h:8:16"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -523,12 +415,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 7,
-                  singleLocColumn = 16}},
+                fieldSourceLoc =
+                "examples/nested_types.h:7:16"},
               StructField {
                 fieldName = CName "foo2",
                 fieldOffset = 64,
@@ -536,19 +424,11 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "nested_types.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 16}}],
+                fieldSourceLoc =
+                "examples/nested_types.h:8:16"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "nested_types.h"],
-              singleLocLine = 6,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/nested_types.h:6:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -579,12 +459,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 16}}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:7:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -600,12 +476,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 16}}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -622,12 +494,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 16}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:7:16"},
                       StructField {
                         fieldName = CName "foo2",
                         fieldOffset = 64,
@@ -635,19 +503,11 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 16}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:8:16"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "nested_types.h"],
-                      singleLocLine = 6,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/nested_types.h:6:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -680,12 +540,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 16}}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:7:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -701,12 +557,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 16}}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -723,12 +575,8 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 16}},
+                        fieldSourceLoc =
+                        "examples/nested_types.h:7:16"},
                       StructField {
                         fieldName = CName "foo2",
                         fieldOffset = 64,
@@ -736,19 +584,11 @@
                           (DeclPathStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "nested_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 16}}],
+                        fieldSourceLoc =
+                        "examples/nested_types.h:8:16"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "nested_types.h"],
-                      singleLocLine = 6,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/nested_types.h:6:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -14,30 +14,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/nested_types.h:2:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:3:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "nested_types.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/nested_types.h:1:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -53,12 +41,8 @@ WrapCHeader
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 16}},
+              fieldSourceLoc =
+              "examples/nested_types.h:7:16"},
             StructField {
               fieldName = CName "foo2",
               fieldOffset = 64,
@@ -66,16 +50,8 @@ WrapCHeader
                 (DeclPathStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "nested_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 16}}],
+              fieldSourceLoc =
+              "examples/nested_types.h:8:16"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "nested_types.h"],
-            singleLocLine = 6,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/nested_types.h:6:8"}])

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -27,12 +27,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 5,
-                singleLocColumn = 17}}},
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:5:17"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -50,12 +46,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 6,
-                singleLocColumn = 17}}}],
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:6:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -73,12 +65,8 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 5,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:5:17"},
             StructField {
               fieldName = CName "ptrB",
               fieldOffset = 64,
@@ -87,19 +75,11 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 6,
-                singleLocColumn = 17}}],
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:6:17"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 4,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/opaque_declaration.h:4:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -127,12 +107,8 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "opaque_declaration.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 17}}},
+                fieldSourceLoc =
+                "examples/opaque_declaration.h:5:17"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -150,12 +126,8 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "opaque_declaration.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 17}}}],
+                fieldSourceLoc =
+                "examples/opaque_declaration.h:6:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -173,12 +145,8 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "opaque_declaration.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 17}},
+                fieldSourceLoc =
+                "examples/opaque_declaration.h:5:17"},
               StructField {
                 fieldName = CName "ptrB",
                 fieldOffset = 64,
@@ -187,19 +155,11 @@
                     (DeclPathStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "opaque_declaration.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 17}}],
+                fieldSourceLoc =
+                "examples/opaque_declaration.h:6:17"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "opaque_declaration.h"],
-              singleLocLine = 4,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/opaque_declaration.h:4:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -232,12 +192,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:5:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -255,12 +211,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 17}}}],
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -278,12 +230,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:5:17"},
                       StructField {
                         fieldName = CName "ptrB",
                         fieldOffset = 64,
@@ -292,19 +240,11 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 17}}],
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "opaque_declaration.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/opaque_declaration.h:4:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -339,12 +279,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:5:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -362,12 +298,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 17}}}],
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -385,12 +317,8 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:5:17"},
                       StructField {
                         fieldName = CName "ptrB",
                         fieldOffset = 64,
@@ -399,19 +327,11 @@
                             (DeclPathStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "opaque_declaration.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 17}}],
+                        fieldSourceLoc =
+                        "examples/opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "opaque_declaration.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/opaque_declaration.h:4:8"}}
               (Add 2)
               (Seq
                 [
@@ -439,12 +359,8 @@
           structAlignment = 1,
           structFields = [],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/opaque_declaration.h:9:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -465,12 +381,8 @@
             structAlignment = 1,
             structFields = [],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "opaque_declaration.h"],
-              singleLocLine = 9,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/opaque_declaration.h:9:8"}}
       StorableInstance {
         storableSizeOf = 0,
         storableAlignment = 1,
@@ -496,12 +408,8 @@
                     structAlignment = 1,
                     structFields = [],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "opaque_declaration.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/opaque_declaration.h:9:8"}})
             []),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -527,12 +435,8 @@
                     structAlignment = 1,
                     structFields = [],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "opaque_declaration.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/opaque_declaration.h:9:8"}}
               (Add 0)
               (Seq [])))}),
   DeclEmpty

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -5,12 +5,7 @@ WrapCHeader
         OpaqueStruct {
           opaqueStructTag = CName "foo",
           opaqueStructSourceLoc =
-          SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}},
+          "examples/opaque_declaration.h:1:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -27,12 +22,8 @@ WrapCHeader
                   (DeclPathStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 5,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:5:17"},
             StructField {
               fieldName = CName "ptrB",
               fieldOffset = 64,
@@ -41,19 +32,11 @@ WrapCHeader
                   (DeclPathStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "opaque_declaration.h"],
-                singleLocLine = 6,
-                singleLocColumn = 17}}],
+              fieldSourceLoc =
+              "examples/opaque_declaration.h:6:17"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 4,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/opaque_declaration.h:4:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -63,19 +46,10 @@ WrapCHeader
           structAlignment = 1,
           structFields = [],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/opaque_declaration.h:9:8"},
       DeclOpaqueEnum
         OpaqueEnum {
           opaqueEnumTag = CName "quu",
           opaqueEnumSourceLoc =
-          SingleLoc {
-            singleLocPath = [
-              "examples",
-              "opaque_declaration.h"],
-            singleLocLine = 11,
-            singleLocColumn = 6}}])
+          "examples/opaque_declaration.h:11:6"}])

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:2:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -40,12 +36,8 @@
               fieldOffset = 8,
               fieldType = TypePrim
                 (PrimChar (Just Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 17}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:3:17"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -59,12 +51,8 @@
               fieldOffset = 16,
               fieldType = TypePrim
                 (PrimChar (Just Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 4,
-                singleLocColumn = 19}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:4:19"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -79,12 +67,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 6,
-                singleLocColumn = 11}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:6:11"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -99,12 +83,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 15}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:7:15"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -119,12 +99,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 18}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:8:18"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -139,12 +115,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 9,
-                singleLocColumn = 22}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:9:22"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -159,12 +131,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:11:20"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -179,12 +147,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 12,
-                singleLocColumn = 24}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:12:24"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -198,12 +162,8 @@
               fieldOffset = 128,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:14:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -217,12 +177,8 @@
               fieldOffset = 160,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 15,
-                singleLocColumn = 12}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:15:12"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -236,12 +192,8 @@
               fieldOffset = 192,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 16,
-                singleLocColumn = 16}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:16:16"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -256,12 +208,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 18,
-                singleLocColumn = 14}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:18:14"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -276,12 +224,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 19,
-                singleLocColumn = 18}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:19:18"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -296,12 +240,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 21,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:21:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -316,12 +256,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 22,
-                singleLocColumn = 14}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:22:14"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -336,12 +272,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 23,
-                singleLocColumn = 17}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:23:17"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -356,12 +288,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 24,
-                singleLocColumn = 21}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:24:21"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -376,12 +304,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 26,
-                singleLocColumn = 19}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:26:19"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -396,12 +320,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 27,
-                singleLocColumn = 23}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:27:23"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -416,12 +336,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 29,
-                singleLocColumn = 15}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:29:15"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -436,12 +352,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 30,
-                singleLocColumn = 19}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:30:19"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -456,12 +368,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 31,
-                singleLocColumn = 22}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:31:22"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -476,12 +384,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 32,
-                singleLocColumn = 26}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:32:26"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -496,12 +400,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 34,
-                singleLocColumn = 24}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:34:24"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -516,12 +416,8 @@
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 35,
-                singleLocColumn = 28}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:35:28"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -535,12 +431,8 @@
               fieldOffset = 1088,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 37,
-                singleLocColumn = 11}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:37:11"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -554,12 +446,8 @@
               fieldOffset = 1152,
               fieldType = TypePrim
                 (PrimFloating PrimDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 38,
-                singleLocColumn = 12}}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:38:12"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -573,12 +461,8 @@
               fieldOffset = 1280,
               fieldType = TypePrim
                 (PrimFloating PrimLongDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 39,
-                singleLocColumn = 17}}}],
+              fieldSourceLoc =
+              "examples/primitive_types.h:39:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -594,347 +478,227 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:2:10"},
             StructField {
               fieldName = CName "sc",
               fieldOffset = 8,
               fieldType = TypePrim
                 (PrimChar (Just Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:3:17"},
             StructField {
               fieldName = CName "uc",
               fieldOffset = 16,
               fieldType = TypePrim
                 (PrimChar (Just Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 4,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:4:19"},
             StructField {
               fieldName = CName "s",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 6,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:6:11"},
             StructField {
               fieldName = CName "si",
               fieldOffset = 48,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 15}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:7:15"},
             StructField {
               fieldName = CName "ss",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:8:18"},
             StructField {
               fieldName = CName "ssi",
               fieldOffset = 80,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 9,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:9:22"},
             StructField {
               fieldName = CName "us",
               fieldOffset = 96,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:11:20"},
             StructField {
               fieldName = CName "usi",
               fieldOffset = 112,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 12,
-                singleLocColumn = 24}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:12:24"},
             StructField {
               fieldName = CName "i",
               fieldOffset = 128,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:14:9"},
             StructField {
               fieldName = CName "s2",
               fieldOffset = 160,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 15,
-                singleLocColumn = 12}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:15:12"},
             StructField {
               fieldName = CName "si2",
               fieldOffset = 192,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 16,
-                singleLocColumn = 16}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:16:16"},
             StructField {
               fieldName = CName "u",
               fieldOffset = 224,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 18,
-                singleLocColumn = 14}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:18:14"},
             StructField {
               fieldName = CName "ui",
               fieldOffset = 256,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 19,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:19:18"},
             StructField {
               fieldName = CName "l",
               fieldOffset = 320,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 21,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:21:10"},
             StructField {
               fieldName = CName "li",
               fieldOffset = 384,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 22,
-                singleLocColumn = 14}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:22:14"},
             StructField {
               fieldName = CName "sl",
               fieldOffset = 448,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 23,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:23:17"},
             StructField {
               fieldName = CName "sli",
               fieldOffset = 512,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 24,
-                singleLocColumn = 21}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:24:21"},
             StructField {
               fieldName = CName "ul",
               fieldOffset = 576,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 26,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:26:19"},
             StructField {
               fieldName = CName "uli",
               fieldOffset = 640,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 27,
-                singleLocColumn = 23}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:27:23"},
             StructField {
               fieldName = CName "ll",
               fieldOffset = 704,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 29,
-                singleLocColumn = 15}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:29:15"},
             StructField {
               fieldName = CName "lli",
               fieldOffset = 768,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 30,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:30:19"},
             StructField {
               fieldName = CName "sll",
               fieldOffset = 832,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 31,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:31:22"},
             StructField {
               fieldName = CName "slli",
               fieldOffset = 896,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 32,
-                singleLocColumn = 26}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:32:26"},
             StructField {
               fieldName = CName "ull",
               fieldOffset = 960,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 34,
-                singleLocColumn = 24}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:34:24"},
             StructField {
               fieldName = CName "ulli",
               fieldOffset = 1024,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 35,
-                singleLocColumn = 28}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:35:28"},
             StructField {
               fieldName = CName "f",
               fieldOffset = 1088,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 37,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:37:11"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 1152,
               fieldType = TypePrim
                 (PrimFloating PrimDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 38,
-                singleLocColumn = 12}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:38:12"},
             StructField {
               fieldName = CName "ld",
               fieldOffset = 1280,
               fieldType = TypePrim
                 (PrimFloating PrimLongDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 39,
-                singleLocColumn = 17}}],
+              fieldSourceLoc =
+              "examples/primitive_types.h:39:17"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "primitive_types.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/primitive_types.h:1:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -958,12 +722,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:2:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -977,12 +737,8 @@
                 fieldOffset = 8,
                 fieldType = TypePrim
                   (PrimChar (Just Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 17}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:3:17"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -996,12 +752,8 @@
                 fieldOffset = 16,
                 fieldType = TypePrim
                   (PrimChar (Just Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 19}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:4:19"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1016,12 +768,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 11}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:6:11"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1036,12 +784,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 7,
-                  singleLocColumn = 15}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:7:15"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1056,12 +800,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 18}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:8:18"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1076,12 +816,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 22}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:9:22"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1096,12 +832,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 20}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:11:20"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1116,12 +848,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 12,
-                  singleLocColumn = 24}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:12:24"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1135,12 +863,8 @@
                 fieldOffset = 128,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 14,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:14:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1154,12 +878,8 @@
                 fieldOffset = 160,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 15,
-                  singleLocColumn = 12}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:15:12"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1173,12 +893,8 @@
                 fieldOffset = 192,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 16}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:16:16"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1193,12 +909,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimInt Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 18,
-                  singleLocColumn = 14}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:18:14"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1213,12 +925,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimInt Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 19,
-                  singleLocColumn = 18}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:19:18"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1233,12 +941,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:21:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1253,12 +957,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 22,
-                  singleLocColumn = 14}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:22:14"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1273,12 +973,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 23,
-                  singleLocColumn = 17}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:23:17"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1293,12 +989,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 24,
-                  singleLocColumn = 21}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:24:21"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1313,12 +1005,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 26,
-                  singleLocColumn = 19}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:26:19"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1333,12 +1021,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 27,
-                  singleLocColumn = 23}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:27:23"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1353,12 +1037,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 29,
-                  singleLocColumn = 15}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:29:15"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1373,12 +1053,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 30,
-                  singleLocColumn = 19}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:30:19"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1393,12 +1069,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 22}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:31:22"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1413,12 +1085,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 32,
-                  singleLocColumn = 26}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:32:26"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1433,12 +1101,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 34,
-                  singleLocColumn = 24}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:34:24"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1453,12 +1117,8 @@
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 35,
-                  singleLocColumn = 28}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:35:28"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1472,12 +1132,8 @@
                 fieldOffset = 1088,
                 fieldType = TypePrim
                   (PrimFloating PrimFloat),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 37,
-                  singleLocColumn = 11}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:37:11"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1491,12 +1147,8 @@
                 fieldOffset = 1152,
                 fieldType = TypePrim
                   (PrimFloating PrimDouble),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 38,
-                  singleLocColumn = 12}}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:38:12"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1510,12 +1162,8 @@
                 fieldOffset = 1280,
                 fieldType = TypePrim
                   (PrimFloating PrimLongDouble),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 39,
-                  singleLocColumn = 17}}}],
+                fieldSourceLoc =
+                "examples/primitive_types.h:39:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1531,347 +1179,227 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:2:10"},
               StructField {
                 fieldName = CName "sc",
                 fieldOffset = 8,
                 fieldType = TypePrim
                   (PrimChar (Just Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 17}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:3:17"},
               StructField {
                 fieldName = CName "uc",
                 fieldOffset = 16,
                 fieldType = TypePrim
                   (PrimChar (Just Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 19}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:4:19"},
               StructField {
                 fieldName = CName "s",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 11}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:6:11"},
               StructField {
                 fieldName = CName "si",
                 fieldOffset = 48,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 7,
-                  singleLocColumn = 15}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:7:15"},
               StructField {
                 fieldName = CName "ss",
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 18}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:8:18"},
               StructField {
                 fieldName = CName "ssi",
                 fieldOffset = 80,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 22}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:9:22"},
               StructField {
                 fieldName = CName "us",
                 fieldOffset = 96,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 20}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:11:20"},
               StructField {
                 fieldName = CName "usi",
                 fieldOffset = 112,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimShort Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 12,
-                  singleLocColumn = 24}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:12:24"},
               StructField {
                 fieldName = CName "i",
                 fieldOffset = 128,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 14,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:14:9"},
               StructField {
                 fieldName = CName "s2",
                 fieldOffset = 160,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 15,
-                  singleLocColumn = 12}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:15:12"},
               StructField {
                 fieldName = CName "si2",
                 fieldOffset = 192,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 16}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:16:16"},
               StructField {
                 fieldName = CName "u",
                 fieldOffset = 224,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimInt Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 18,
-                  singleLocColumn = 14}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:18:14"},
               StructField {
                 fieldName = CName "ui",
                 fieldOffset = 256,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimInt Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 19,
-                  singleLocColumn = 18}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:19:18"},
               StructField {
                 fieldName = CName "l",
                 fieldOffset = 320,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:21:10"},
               StructField {
                 fieldName = CName "li",
                 fieldOffset = 384,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 22,
-                  singleLocColumn = 14}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:22:14"},
               StructField {
                 fieldName = CName "sl",
                 fieldOffset = 448,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 23,
-                  singleLocColumn = 17}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:23:17"},
               StructField {
                 fieldName = CName "sli",
                 fieldOffset = 512,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 24,
-                  singleLocColumn = 21}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:24:21"},
               StructField {
                 fieldName = CName "ul",
                 fieldOffset = 576,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 26,
-                  singleLocColumn = 19}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:26:19"},
               StructField {
                 fieldName = CName "uli",
                 fieldOffset = 640,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 27,
-                  singleLocColumn = 23}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:27:23"},
               StructField {
                 fieldName = CName "ll",
                 fieldOffset = 704,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 29,
-                  singleLocColumn = 15}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:29:15"},
               StructField {
                 fieldName = CName "lli",
                 fieldOffset = 768,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 30,
-                  singleLocColumn = 19}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:30:19"},
               StructField {
                 fieldName = CName "sll",
                 fieldOffset = 832,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 22}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:31:22"},
               StructField {
                 fieldName = CName "slli",
                 fieldOffset = 896,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 32,
-                  singleLocColumn = 26}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:32:26"},
               StructField {
                 fieldName = CName "ull",
                 fieldOffset = 960,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 34,
-                  singleLocColumn = 24}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:34:24"},
               StructField {
                 fieldName = CName "ulli",
                 fieldOffset = 1024,
                 fieldType = TypePrim
                   (PrimIntegral
                     (PrimLongLong Unsigned)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 35,
-                  singleLocColumn = 28}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:35:28"},
               StructField {
                 fieldName = CName "f",
                 fieldOffset = 1088,
                 fieldType = TypePrim
                   (PrimFloating PrimFloat),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 37,
-                  singleLocColumn = 11}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:37:11"},
               StructField {
                 fieldName = CName "d",
                 fieldOffset = 1152,
                 fieldType = TypePrim
                   (PrimFloating PrimDouble),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 38,
-                  singleLocColumn = 12}},
+                fieldSourceLoc =
+                "examples/primitive_types.h:38:12"},
               StructField {
                 fieldName = CName "ld",
                 fieldOffset = 1280,
                 fieldType = TypePrim
                   (PrimFloating PrimLongDouble),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "primitive_types.h"],
-                  singleLocLine = 39,
-                  singleLocColumn = 17}}],
+                fieldSourceLoc =
+                "examples/primitive_types.h:39:17"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "primitive_types.h"],
-              singleLocLine = 1,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/primitive_types.h:1:8"}}
       StorableInstance {
         storableSizeOf = 176,
         storableAlignment = 16,
@@ -1900,12 +1428,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:2:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1919,12 +1443,8 @@
                         fieldOffset = 8,
                         fieldType = TypePrim
                           (PrimChar (Just Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:3:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1938,12 +1458,8 @@
                         fieldOffset = 16,
                         fieldType = TypePrim
                           (PrimChar (Just Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:4:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1958,12 +1474,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:6:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1978,12 +1490,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 15}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:7:15"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1998,12 +1506,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:8:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2018,12 +1522,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:9:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2038,12 +1538,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:11:20"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2058,12 +1554,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 24}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:12:24"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2077,12 +1569,8 @@
                         fieldOffset = 128,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:14:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2096,12 +1584,8 @@
                         fieldOffset = 160,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 12}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:15:12"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2115,12 +1599,8 @@
                         fieldOffset = 192,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 16}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:16:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2135,12 +1615,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 14}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:18:14"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2155,12 +1631,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 19,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:19:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2175,12 +1647,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:21:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2195,12 +1663,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 14}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:22:14"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2215,12 +1679,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 23,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:23:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2235,12 +1695,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 21}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:24:21"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2255,12 +1711,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:26:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2275,12 +1727,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 23}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:27:23"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2295,12 +1743,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 29,
-                          singleLocColumn = 15}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:29:15"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2315,12 +1759,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 30,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:30:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2335,12 +1775,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:31:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2355,12 +1791,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 32,
-                          singleLocColumn = 26}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:32:26"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2375,12 +1807,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 34,
-                          singleLocColumn = 24}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:34:24"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2395,12 +1823,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 35,
-                          singleLocColumn = 28}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:35:28"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2414,12 +1838,8 @@
                         fieldOffset = 1088,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:37:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2433,12 +1853,8 @@
                         fieldOffset = 1152,
                         fieldType = TypePrim
                           (PrimFloating PrimDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 12}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:38:12"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2452,12 +1868,8 @@
                         fieldOffset = 1280,
                         fieldType = TypePrim
                           (PrimFloating PrimLongDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 17}}}],
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:39:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -2473,347 +1885,227 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:2:10"},
                       StructField {
                         fieldName = CName "sc",
                         fieldOffset = 8,
                         fieldType = TypePrim
                           (PrimChar (Just Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:3:17"},
                       StructField {
                         fieldName = CName "uc",
                         fieldOffset = 16,
                         fieldType = TypePrim
                           (PrimChar (Just Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:4:19"},
                       StructField {
                         fieldName = CName "s",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:6:11"},
                       StructField {
                         fieldName = CName "si",
                         fieldOffset = 48,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 15}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:7:15"},
                       StructField {
                         fieldName = CName "ss",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:8:18"},
                       StructField {
                         fieldName = CName "ssi",
                         fieldOffset = 80,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:9:22"},
                       StructField {
                         fieldName = CName "us",
                         fieldOffset = 96,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:11:20"},
                       StructField {
                         fieldName = CName "usi",
                         fieldOffset = 112,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 24}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:12:24"},
                       StructField {
                         fieldName = CName "i",
                         fieldOffset = 128,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:14:9"},
                       StructField {
                         fieldName = CName "s2",
                         fieldOffset = 160,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 12}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:15:12"},
                       StructField {
                         fieldName = CName "si2",
                         fieldOffset = 192,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 16}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:16:16"},
                       StructField {
                         fieldName = CName "u",
                         fieldOffset = 224,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 14}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:18:14"},
                       StructField {
                         fieldName = CName "ui",
                         fieldOffset = 256,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 19,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:19:18"},
                       StructField {
                         fieldName = CName "l",
                         fieldOffset = 320,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:21:10"},
                       StructField {
                         fieldName = CName "li",
                         fieldOffset = 384,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 14}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:22:14"},
                       StructField {
                         fieldName = CName "sl",
                         fieldOffset = 448,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 23,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:23:17"},
                       StructField {
                         fieldName = CName "sli",
                         fieldOffset = 512,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 21}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:24:21"},
                       StructField {
                         fieldName = CName "ul",
                         fieldOffset = 576,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:26:19"},
                       StructField {
                         fieldName = CName "uli",
                         fieldOffset = 640,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 23}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:27:23"},
                       StructField {
                         fieldName = CName "ll",
                         fieldOffset = 704,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 29,
-                          singleLocColumn = 15}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:29:15"},
                       StructField {
                         fieldName = CName "lli",
                         fieldOffset = 768,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 30,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:30:19"},
                       StructField {
                         fieldName = CName "sll",
                         fieldOffset = 832,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:31:22"},
                       StructField {
                         fieldName = CName "slli",
                         fieldOffset = 896,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 32,
-                          singleLocColumn = 26}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:32:26"},
                       StructField {
                         fieldName = CName "ull",
                         fieldOffset = 960,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 34,
-                          singleLocColumn = 24}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:34:24"},
                       StructField {
                         fieldName = CName "ulli",
                         fieldOffset = 1024,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 35,
-                          singleLocColumn = 28}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:35:28"},
                       StructField {
                         fieldName = CName "f",
                         fieldOffset = 1088,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:37:11"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 1152,
                         fieldType = TypePrim
                           (PrimFloating PrimDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 12}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:38:12"},
                       StructField {
                         fieldName = CName "ld",
                         fieldOffset = 1280,
                         fieldType = TypePrim
                           (PrimFloating PrimLongDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 17}}],
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:39:17"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "primitive_types.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/primitive_types.h:1:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -2871,12 +2163,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:2:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2890,12 +2178,8 @@
                         fieldOffset = 8,
                         fieldType = TypePrim
                           (PrimChar (Just Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:3:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2909,12 +2193,8 @@
                         fieldOffset = 16,
                         fieldType = TypePrim
                           (PrimChar (Just Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:4:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2929,12 +2209,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:6:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2949,12 +2225,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 15}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:7:15"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2969,12 +2241,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:8:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2989,12 +2257,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:9:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3009,12 +2273,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:11:20"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3029,12 +2289,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 24}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:12:24"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3048,12 +2304,8 @@
                         fieldOffset = 128,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:14:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3067,12 +2319,8 @@
                         fieldOffset = 160,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 12}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:15:12"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3086,12 +2334,8 @@
                         fieldOffset = 192,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 16}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:16:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3106,12 +2350,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 14}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:18:14"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3126,12 +2366,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 19,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:19:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3146,12 +2382,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:21:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3166,12 +2398,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 14}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:22:14"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3186,12 +2414,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 23,
-                          singleLocColumn = 17}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:23:17"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3206,12 +2430,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 21}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:24:21"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3226,12 +2446,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:26:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3246,12 +2462,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 23}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:27:23"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3266,12 +2478,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 29,
-                          singleLocColumn = 15}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:29:15"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3286,12 +2494,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 30,
-                          singleLocColumn = 19}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:30:19"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3306,12 +2510,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 22}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:31:22"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3326,12 +2526,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 32,
-                          singleLocColumn = 26}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:32:26"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3346,12 +2542,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 34,
-                          singleLocColumn = 24}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:34:24"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3366,12 +2558,8 @@
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 35,
-                          singleLocColumn = 28}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:35:28"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3385,12 +2573,8 @@
                         fieldOffset = 1088,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 11}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:37:11"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3404,12 +2588,8 @@
                         fieldOffset = 1152,
                         fieldType = TypePrim
                           (PrimFloating PrimDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 12}}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:38:12"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -3423,12 +2603,8 @@
                         fieldOffset = 1280,
                         fieldType = TypePrim
                           (PrimFloating PrimLongDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 17}}}],
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:39:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -3444,347 +2620,227 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:2:10"},
                       StructField {
                         fieldName = CName "sc",
                         fieldOffset = 8,
                         fieldType = TypePrim
                           (PrimChar (Just Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:3:17"},
                       StructField {
                         fieldName = CName "uc",
                         fieldOffset = 16,
                         fieldType = TypePrim
                           (PrimChar (Just Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:4:19"},
                       StructField {
                         fieldName = CName "s",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:6:11"},
                       StructField {
                         fieldName = CName "si",
                         fieldOffset = 48,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 7,
-                          singleLocColumn = 15}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:7:15"},
                       StructField {
                         fieldName = CName "ss",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:8:18"},
                       StructField {
                         fieldName = CName "ssi",
                         fieldOffset = 80,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:9:22"},
                       StructField {
                         fieldName = CName "us",
                         fieldOffset = 96,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:11:20"},
                       StructField {
                         fieldName = CName "usi",
                         fieldOffset = 112,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimShort Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 12,
-                          singleLocColumn = 24}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:12:24"},
                       StructField {
                         fieldName = CName "i",
                         fieldOffset = 128,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 14,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:14:9"},
                       StructField {
                         fieldName = CName "s2",
                         fieldOffset = 160,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 12}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:15:12"},
                       StructField {
                         fieldName = CName "si2",
                         fieldOffset = 192,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 16}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:16:16"},
                       StructField {
                         fieldName = CName "u",
                         fieldOffset = 224,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 18,
-                          singleLocColumn = 14}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:18:14"},
                       StructField {
                         fieldName = CName "ui",
                         fieldOffset = 256,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimInt Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 19,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:19:18"},
                       StructField {
                         fieldName = CName "l",
                         fieldOffset = 320,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:21:10"},
                       StructField {
                         fieldName = CName "li",
                         fieldOffset = 384,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 14}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:22:14"},
                       StructField {
                         fieldName = CName "sl",
                         fieldOffset = 448,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 23,
-                          singleLocColumn = 17}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:23:17"},
                       StructField {
                         fieldName = CName "sli",
                         fieldOffset = 512,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 24,
-                          singleLocColumn = 21}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:24:21"},
                       StructField {
                         fieldName = CName "ul",
                         fieldOffset = 576,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 26,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:26:19"},
                       StructField {
                         fieldName = CName "uli",
                         fieldOffset = 640,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 23}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:27:23"},
                       StructField {
                         fieldName = CName "ll",
                         fieldOffset = 704,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 29,
-                          singleLocColumn = 15}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:29:15"},
                       StructField {
                         fieldName = CName "lli",
                         fieldOffset = 768,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 30,
-                          singleLocColumn = 19}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:30:19"},
                       StructField {
                         fieldName = CName "sll",
                         fieldOffset = 832,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 22}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:31:22"},
                       StructField {
                         fieldName = CName "slli",
                         fieldOffset = 896,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 32,
-                          singleLocColumn = 26}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:32:26"},
                       StructField {
                         fieldName = CName "ull",
                         fieldOffset = 960,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 34,
-                          singleLocColumn = 24}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:34:24"},
                       StructField {
                         fieldName = CName "ulli",
                         fieldOffset = 1024,
                         fieldType = TypePrim
                           (PrimIntegral
                             (PrimLongLong Unsigned)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 35,
-                          singleLocColumn = 28}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:35:28"},
                       StructField {
                         fieldName = CName "f",
                         fieldOffset = 1088,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 37,
-                          singleLocColumn = 11}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:37:11"},
                       StructField {
                         fieldName = CName "d",
                         fieldOffset = 1152,
                         fieldType = TypePrim
                           (PrimFloating PrimDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 38,
-                          singleLocColumn = 12}},
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:38:12"},
                       StructField {
                         fieldName = CName "ld",
                         fieldOffset = 1280,
                         fieldType = TypePrim
                           (PrimFloating PrimLongDouble),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "primitive_types.h"],
-                          singleLocLine = 39,
-                          singleLocColumn = 17}}],
+                        fieldSourceLoc =
+                        "examples/primitive_types.h:39:17"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "primitive_types.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/primitive_types.h:1:8"}}
               (Add 29)
               (Seq
                 [

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -15,344 +15,224 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 2,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:2:10"},
             StructField {
               fieldName = CName "sc",
               fieldOffset = 8,
               fieldType = TypePrim
                 (PrimChar (Just Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 3,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:3:17"},
             StructField {
               fieldName = CName "uc",
               fieldOffset = 16,
               fieldType = TypePrim
                 (PrimChar (Just Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 4,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:4:19"},
             StructField {
               fieldName = CName "s",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 6,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:6:11"},
             StructField {
               fieldName = CName "si",
               fieldOffset = 48,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 7,
-                singleLocColumn = 15}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:7:15"},
             StructField {
               fieldName = CName "ss",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 8,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:8:18"},
             StructField {
               fieldName = CName "ssi",
               fieldOffset = 80,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 9,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:9:22"},
             StructField {
               fieldName = CName "us",
               fieldOffset = 96,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:11:20"},
             StructField {
               fieldName = CName "usi",
               fieldOffset = 112,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimShort Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 12,
-                singleLocColumn = 24}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:12:24"},
             StructField {
               fieldName = CName "i",
               fieldOffset = 128,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 14,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:14:9"},
             StructField {
               fieldName = CName "s2",
               fieldOffset = 160,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 15,
-                singleLocColumn = 12}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:15:12"},
             StructField {
               fieldName = CName "si2",
               fieldOffset = 192,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 16,
-                singleLocColumn = 16}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:16:16"},
             StructField {
               fieldName = CName "u",
               fieldOffset = 224,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 18,
-                singleLocColumn = 14}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:18:14"},
             StructField {
               fieldName = CName "ui",
               fieldOffset = 256,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimInt Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 19,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:19:18"},
             StructField {
               fieldName = CName "l",
               fieldOffset = 320,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 21,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:21:10"},
             StructField {
               fieldName = CName "li",
               fieldOffset = 384,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 22,
-                singleLocColumn = 14}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:22:14"},
             StructField {
               fieldName = CName "sl",
               fieldOffset = 448,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 23,
-                singleLocColumn = 17}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:23:17"},
             StructField {
               fieldName = CName "sli",
               fieldOffset = 512,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 24,
-                singleLocColumn = 21}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:24:21"},
             StructField {
               fieldName = CName "ul",
               fieldOffset = 576,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 26,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:26:19"},
             StructField {
               fieldName = CName "uli",
               fieldOffset = 640,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 27,
-                singleLocColumn = 23}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:27:23"},
             StructField {
               fieldName = CName "ll",
               fieldOffset = 704,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 29,
-                singleLocColumn = 15}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:29:15"},
             StructField {
               fieldName = CName "lli",
               fieldOffset = 768,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 30,
-                singleLocColumn = 19}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:30:19"},
             StructField {
               fieldName = CName "sll",
               fieldOffset = 832,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 31,
-                singleLocColumn = 22}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:31:22"},
             StructField {
               fieldName = CName "slli",
               fieldOffset = 896,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 32,
-                singleLocColumn = 26}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:32:26"},
             StructField {
               fieldName = CName "ull",
               fieldOffset = 960,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 34,
-                singleLocColumn = 24}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:34:24"},
             StructField {
               fieldName = CName "ulli",
               fieldOffset = 1024,
               fieldType = TypePrim
                 (PrimIntegral
                   (PrimLongLong Unsigned)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 35,
-                singleLocColumn = 28}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:35:28"},
             StructField {
               fieldName = CName "f",
               fieldOffset = 1088,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 37,
-                singleLocColumn = 11}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:37:11"},
             StructField {
               fieldName = CName "d",
               fieldOffset = 1152,
               fieldType = TypePrim
                 (PrimFloating PrimDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 38,
-                singleLocColumn = 12}},
+              fieldSourceLoc =
+              "examples/primitive_types.h:38:12"},
             StructField {
               fieldName = CName "ld",
               fieldOffset = 1280,
               fieldType = TypePrim
                 (PrimFloating PrimLongDouble),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "primitive_types.h"],
-                singleLocLine = 39,
-                singleLocColumn = 17}}],
+              fieldSourceLoc =
+              "examples/primitive_types.h:39:17"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "primitive_types.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/primitive_types.h:1:8"}])

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 2,
-                singleLocColumn = 7}}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:2:7"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -47,12 +43,8 @@
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 3,
-                singleLocColumn = 27}}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:3:27"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -68,12 +60,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 2,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:2:7"},
             StructField {
               fieldName = CName "next",
               fieldOffset = 64,
@@ -83,19 +71,11 @@
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 3,
-                singleLocColumn = 27}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:3:27"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 1,
-            singleLocColumn = 16}}},
+          structSourceLoc =
+          "examples/recursive_struct.h:1:16"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -119,12 +99,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 7}}},
+                fieldSourceLoc =
+                "examples/recursive_struct.h:2:7"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -145,12 +121,8 @@
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 27}}}],
+                fieldSourceLoc =
+                "examples/recursive_struct.h:3:27"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -166,12 +138,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 2,
-                  singleLocColumn = 7}},
+                fieldSourceLoc =
+                "examples/recursive_struct.h:2:7"},
               StructField {
                 fieldName = CName "next",
                 fieldOffset = 64,
@@ -181,19 +149,11 @@
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 27}}],
+                fieldSourceLoc =
+                "examples/recursive_struct.h:3:27"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "recursive_struct.h"],
-              singleLocLine = 1,
-              singleLocColumn = 16}}}
+            structSourceLoc =
+            "examples/recursive_struct.h:1:16"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -222,12 +182,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:2:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -248,12 +204,8 @@
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 27}}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -269,12 +221,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:2:7"},
                       StructField {
                         fieldName = CName "next",
                         fieldOffset = 64,
@@ -284,19 +232,11 @@
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 27}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:3:27"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "recursive_struct.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 16}}})
+                    structSourceLoc =
+                    "examples/recursive_struct.h:1:16"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -327,12 +267,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:2:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -353,12 +289,8 @@
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 27}}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -374,12 +306,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 2,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:2:7"},
                       StructField {
                         fieldName = CName "next",
                         fieldOffset = 64,
@@ -389,19 +317,11 @@
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 27}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:3:27"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "recursive_struct.h"],
-                      singleLocLine = 1,
-                      singleLocColumn = 16}}}
+                    structSourceLoc =
+                    "examples/recursive_struct.h:1:16"}}
               (Add 2)
               (Seq
                 [
@@ -437,12 +357,8 @@
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 4,
-            singleLocColumn = 3}}},
+          typedefSourceLoc =
+          "examples/recursive_struct.h:4:3"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -470,12 +386,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:10:7"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -496,12 +408,8 @@
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:11:20"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -517,12 +425,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:10:7"},
             StructField {
               fieldName = CName "next",
               fieldOffset = 64,
@@ -532,19 +436,11 @@
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:11:20"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/recursive_struct.h:9:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -568,12 +464,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 7}}},
+                fieldSourceLoc =
+                "examples/recursive_struct.h:10:7"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -594,12 +486,8 @@
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 20}}}],
+                fieldSourceLoc =
+                "examples/recursive_struct.h:11:20"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -615,12 +503,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 7}},
+                fieldSourceLoc =
+                "examples/recursive_struct.h:10:7"},
               StructField {
                 fieldName = CName "next",
                 fieldOffset = 64,
@@ -630,19 +514,11 @@
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "recursive_struct.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 20}}],
+                fieldSourceLoc =
+                "examples/recursive_struct.h:11:20"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "recursive_struct.h"],
-              singleLocLine = 9,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/recursive_struct.h:9:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -671,12 +547,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:10:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -697,12 +569,8 @@
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -718,12 +586,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:10:7"},
                       StructField {
                         fieldName = CName "next",
                         fieldOffset = 64,
@@ -733,19 +597,11 @@
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:11:20"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "recursive_struct.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/recursive_struct.h:9:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -776,12 +632,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:10:7"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -802,12 +654,8 @@
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -823,12 +671,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 7}},
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:10:7"},
                       StructField {
                         fieldName = CName "next",
                         fieldOffset = 64,
@@ -838,19 +682,11 @@
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "recursive_struct.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 20}}],
+                        fieldSourceLoc =
+                        "examples/recursive_struct.h:11:20"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "recursive_struct.h"],
-                      singleLocLine = 9,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/recursive_struct.h:9:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -15,12 +15,8 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 2,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:2:7"},
             StructField {
               fieldName = CName "next",
               fieldOffset = 64,
@@ -30,19 +26,11 @@ WrapCHeader
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 3,
-                singleLocColumn = 27}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:3:27"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 1,
-            singleLocColumn = 16}},
+          structSourceLoc =
+          "examples/recursive_struct.h:1:16"},
       DeclTypedef
         Typedef {
           typedefName = CName
@@ -52,12 +40,8 @@ WrapCHeader
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 4,
-            singleLocColumn = 3}},
+          typedefSourceLoc =
+          "examples/recursive_struct.h:4:3"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -72,12 +56,8 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 10,
-                singleLocColumn = 7}},
+              fieldSourceLoc =
+              "examples/recursive_struct.h:10:7"},
             StructField {
               fieldName = CName "next",
               fieldOffset = 64,
@@ -87,16 +67,8 @@ WrapCHeader
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "recursive_struct.h"],
-                singleLocLine = 11,
-                singleLocColumn = 20}}],
+              fieldSourceLoc =
+              "examples/recursive_struct.h:11:20"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "recursive_struct.h"],
-            singleLocLine = 9,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/recursive_struct.h:9:8"}])

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -23,12 +23,8 @@
               (PrimFloating PrimDouble)),
           functionHeader =
           "simple_func.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_func.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}}},
+          functionSourceLoc =
+          "examples/simple_func.h:1:8"}},
   DeclForeignImport
     ForeignImportDecl {
       foreignImportName = HsName
@@ -62,9 +58,5 @@
               (PrimFloating PrimDouble)),
           functionHeader =
           "simple_func.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_func.h"],
-            singleLocLine = 3,
-            singleLocColumn = 22}}}]
+          functionSourceLoc =
+          "examples/simple_func.h:3:22"}}]

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -12,12 +12,8 @@ WrapCHeader
               (PrimFloating PrimDouble)),
           functionHeader =
           "simple_func.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_func.h"],
-            singleLocLine = 1,
-            singleLocColumn = 8}},
+          functionSourceLoc =
+          "examples/simple_func.h:1:8"},
       DeclFunction
         Function {
           functionName = CName "bad_fma",
@@ -33,9 +29,5 @@ WrapCHeader
               (PrimFloating PrimDouble)),
           functionHeader =
           "simple_func.h",
-          functionSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_func.h"],
-            singleLocLine = 3,
-            singleLocColumn = 22}}])
+          functionSourceLoc =
+          "examples/simple_func.h:3:22"}])

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -21,12 +21,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:3:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -40,12 +36,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 4,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:4:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -60,30 +52,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:3:9"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 4,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:4:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/simple_structs.h:2:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -107,12 +87,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:3:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -126,12 +102,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:4:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -146,30 +118,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 3,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:3:9"},
               StructField {
                 fieldName = CName "b",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 4,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:4:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 2,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/simple_structs.h:2:8"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -198,12 +158,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:3:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -217,12 +173,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:4:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -237,30 +189,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:3:9"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:4:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:2:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -291,12 +231,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:3:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -310,12 +246,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:4:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -330,30 +262,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 3,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:3:9"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 4,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:4:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 2,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:2:8"}}
               (Add 2)
               (Seq
                 [
@@ -384,12 +304,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:9:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -403,12 +319,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 10,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:10:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -422,12 +334,8 @@
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 11,
-                singleLocColumn = 11}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:11:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -442,41 +350,25 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:9:10"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 10,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:10:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 11,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:11:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 8,
-            singleLocColumn = 16}}},
+          structSourceLoc =
+          "examples/simple_structs.h:8:16"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -500,12 +392,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:9:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -519,12 +407,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:10:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -538,12 +422,8 @@
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimFloating PrimFloat),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 11}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:11:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -558,41 +438,25 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:9:10"},
               StructField {
                 fieldName = CName "b",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:10:9"},
               StructField {
                 fieldName = CName "c",
                 fieldOffset = 64,
                 fieldType = TypePrim
                   (PrimFloating PrimFloat),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 11}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:11:11"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 8,
-              singleLocColumn = 16}}}
+            structSourceLoc =
+            "examples/simple_structs.h:8:16"}}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -621,12 +485,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:9:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -640,12 +500,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:10:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -659,12 +515,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:11:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -679,41 +531,25 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:9:10"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:10:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:11:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 16}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:8:16"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -745,12 +581,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:9:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -764,12 +596,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:10:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -783,12 +611,8 @@
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 11}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:11:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -803,41 +627,25 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:9:10"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:10:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 64,
                         fieldType = TypePrim
                           (PrimFloating PrimFloat),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 11}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:11:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 8,
-                      singleLocColumn = 16}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:8:16"}}
               (Add 3)
               (Seq
                 [
@@ -870,12 +678,8 @@
             (DeclPathStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 12,
-            singleLocColumn = 3}}},
+          typedefSourceLoc =
+          "examples/simple_structs.h:12:3"}},
   DeclNewtypeInstance
     Storable
     (HsName "@NsTypeConstr" "S2_t"),
@@ -901,12 +705,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:16:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -921,19 +721,11 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:16:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 15,
-            singleLocColumn = 9}}},
+          structSourceLoc =
+          "examples/simple_structs.h:15:9"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -957,12 +749,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:16:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -977,19 +765,11 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:16:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 15,
-              singleLocColumn = 9}}}
+            structSourceLoc =
+            "examples/simple_structs.h:15:9"}}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -1018,12 +798,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:16:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1038,19 +814,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:16:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 9}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:15:9"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1079,12 +847,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:16:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1099,19 +863,11 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:16:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 15,
-                      singleLocColumn = 9}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:15:9"}}
               (Add 1)
               (Seq
                 [
@@ -1141,12 +897,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 20,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:20:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1160,12 +912,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 21,
-                singleLocColumn = 9}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:21:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1181,12 +929,8 @@
                 (TypePrim
                   (PrimIntegral
                     (PrimInt Signed))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 22,
-                singleLocColumn = 10}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:22:10"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1201,23 +945,15 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 20,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:20:10"},
             StructField {
               fieldName = CName "a",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 21,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:21:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
@@ -1225,19 +961,11 @@
                 (TypePrim
                   (PrimIntegral
                     (PrimInt Signed))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 22,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:22:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 19,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/simple_structs.h:19:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1261,12 +989,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 20,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:20:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1280,12 +1004,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 9}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:21:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1301,12 +1021,8 @@
                   (TypePrim
                     (PrimIntegral
                       (PrimInt Signed))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 22,
-                  singleLocColumn = 10}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:22:10"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1321,23 +1037,15 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 20,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:20:10"},
               StructField {
                 fieldName = CName "a",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 21,
-                  singleLocColumn = 9}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:21:9"},
               StructField {
                 fieldName = CName "c",
                 fieldOffset = 64,
@@ -1345,19 +1053,11 @@
                   (TypePrim
                     (PrimIntegral
                       (PrimInt Signed))),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 22,
-                  singleLocColumn = 10}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:22:10"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 19,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/simple_structs.h:19:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1386,12 +1086,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:20:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1405,12 +1101,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:21:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1426,12 +1118,8 @@
                           (TypePrim
                             (PrimIntegral
                               (PrimInt Signed))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:22:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1446,23 +1134,15 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:20:10"},
                       StructField {
                         fieldName = CName "a",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:21:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 64,
@@ -1470,19 +1150,11 @@
                           (TypePrim
                             (PrimIntegral
                               (PrimInt Signed))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:22:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 19,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:19:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -1514,12 +1186,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:20:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1533,12 +1201,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 9}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:21:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1554,12 +1218,8 @@
                           (TypePrim
                             (PrimIntegral
                               (PrimInt Signed))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 10}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:22:10"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1574,23 +1234,15 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 20,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:20:10"},
                       StructField {
                         fieldName = CName "a",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 21,
-                          singleLocColumn = 9}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:21:9"},
                       StructField {
                         fieldName = CName "c",
                         fieldOffset = 64,
@@ -1598,19 +1250,11 @@
                           (TypePrim
                             (PrimIntegral
                               (PrimInt Signed))),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 22,
-                          singleLocColumn = 10}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:22:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 19,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:19:8"}}
               (Add 3)
               (Seq
                 [
@@ -1642,12 +1286,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 27,
-                singleLocColumn = 10}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:27:10"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -1661,12 +1301,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 28,
-                singleLocColumn = 9}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:28:9"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1681,30 +1317,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 27,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:27:10"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 28,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:28:9"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 26,
-            singleLocColumn = 16}}},
+          structSourceLoc =
+          "examples/simple_structs.h:26:16"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1728,12 +1352,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 27,
-                  singleLocColumn = 10}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:27:10"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -1747,12 +1367,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 28,
-                  singleLocColumn = 9}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:28:9"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1767,30 +1383,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 27,
-                  singleLocColumn = 10}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:27:10"},
               StructField {
                 fieldName = CName "b",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 28,
-                  singleLocColumn = 9}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:28:9"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 26,
-              singleLocColumn = 16}}}
+            structSourceLoc =
+            "examples/simple_structs.h:26:16"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1819,12 +1423,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:27:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1838,12 +1438,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:28:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1858,30 +1454,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:27:10"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:28:9"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 26,
-                      singleLocColumn = 16}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:26:16"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1912,12 +1496,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 10}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:27:10"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -1931,12 +1511,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 9}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:28:9"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1951,30 +1527,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 27,
-                          singleLocColumn = 10}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:27:10"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 28,
-                          singleLocColumn = 9}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:28:9"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 26,
-                      singleLocColumn = 16}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:26:16"}}
               (Add 2)
               (Seq
                 [
@@ -2005,12 +1569,8 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 18}}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:18"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -2024,12 +1584,8 @@
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 25}}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:25"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -2044,30 +1600,18 @@
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:18"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 25}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:25"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 31,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/simple_structs.h:31:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2091,12 +1635,8 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 18}}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:31:18"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -2110,12 +1650,8 @@
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 25}}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:31:25"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -2130,30 +1666,18 @@
                 fieldOffset = 0,
                 fieldType = TypePrim
                   (PrimChar Nothing),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 18}},
+                fieldSourceLoc =
+                "examples/simple_structs.h:31:18"},
               StructField {
                 fieldName = CName "b",
                 fieldOffset = 32,
                 fieldType = TypePrim
                   (PrimIntegral (PrimInt Signed)),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "simple_structs.h"],
-                  singleLocLine = 31,
-                  singleLocColumn = 25}}],
+                fieldSourceLoc =
+                "examples/simple_structs.h:31:25"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "simple_structs.h"],
-              singleLocLine = 31,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/simple_structs.h:31:8"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2182,12 +1706,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2201,12 +1721,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 25}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -2221,30 +1737,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:18"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 25}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:25"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 31,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/simple_structs.h:31:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2275,12 +1779,8 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 18}}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:18"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -2294,12 +1794,8 @@
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 25}}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -2314,30 +1810,18 @@
                         fieldOffset = 0,
                         fieldType = TypePrim
                           (PrimChar Nothing),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 18}},
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:18"},
                       StructField {
                         fieldName = CName "b",
                         fieldOffset = 32,
                         fieldType = TypePrim
                           (PrimIntegral (PrimInt Signed)),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "simple_structs.h"],
-                          singleLocLine = 31,
-                          singleLocColumn = 25}}],
+                        fieldSourceLoc =
+                        "examples/simple_structs.h:31:25"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "simple_structs.h"],
-                      singleLocLine = 31,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/simple_structs.h:31:8"}}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -14,30 +14,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 3,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:3:9"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 4,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:4:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 2,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/simple_structs.h:2:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -51,41 +39,25 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 9,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:9:10"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 10,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:10:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
               fieldType = TypePrim
                 (PrimFloating PrimFloat),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 11,
-                singleLocColumn = 11}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:11:11"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 8,
-            singleLocColumn = 16}},
+          structSourceLoc =
+          "examples/simple_structs.h:8:16"},
       DeclTypedef
         Typedef {
           typedefName = CName "S2_t",
@@ -93,12 +65,8 @@ WrapCHeader
             (DeclPathStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 12,
-            singleLocColumn = 3}},
+          typedefSourceLoc =
+          "examples/simple_structs.h:12:3"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -112,19 +80,11 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 16,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:16:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 15,
-            singleLocColumn = 9}},
+          structSourceLoc =
+          "examples/simple_structs.h:15:9"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -138,23 +98,15 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 20,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:20:10"},
             StructField {
               fieldName = CName "a",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 21,
-                singleLocColumn = 9}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:21:9"},
             StructField {
               fieldName = CName "c",
               fieldOffset = 64,
@@ -162,19 +114,11 @@ WrapCHeader
                 (TypePrim
                   (PrimIntegral
                     (PrimInt Signed))),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 22,
-                singleLocColumn = 10}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:22:10"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 19,
-            singleLocColumn = 8}},
+          structSourceLoc =
+          "examples/simple_structs.h:19:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -188,30 +132,18 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 27,
-                singleLocColumn = 10}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:27:10"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 28,
-                singleLocColumn = 9}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:28:9"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 26,
-            singleLocColumn = 16}},
+          structSourceLoc =
+          "examples/simple_structs.h:26:16"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -225,27 +157,15 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypePrim
                 (PrimChar Nothing),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 18}},
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:18"},
             StructField {
               fieldName = CName "b",
               fieldOffset = 32,
               fieldType = TypePrim
                 (PrimIntegral (PrimInt Signed)),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "simple_structs.h"],
-                singleLocLine = 31,
-                singleLocColumn = 25}}],
+              fieldSourceLoc =
+              "examples/simple_structs.h:31:25"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "simple_structs.h"],
-            singleLocLine = 31,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/simple_structs.h:31:8"}])

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -18,12 +18,8 @@
       NewtypeOriginMacro
         Macro {
           macroLoc = MultiLoc {
-            multiLocExpansion = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "typedef_vs_macro.h"],
-              singleLocLine = 4,
-              singleLocColumn = 9},
+            multiLocExpansion =
+            "examples/typedef_vs_macro.h:4:9",
             multiLocPresumed = Nothing,
             multiLocSpelling = Nothing,
             multiLocFile = Nothing},
@@ -52,12 +48,8 @@
       NewtypeOriginMacro
         Macro {
           macroLoc = MultiLoc {
-            multiLocExpansion = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "typedef_vs_macro.h"],
-              singleLocLine = 5,
-              singleLocColumn = 9},
+            multiLocExpansion =
+            "examples/typedef_vs_macro.h:5:9",
             multiLocPresumed = Nothing,
             multiLocSpelling = Nothing,
             multiLocFile = Nothing},
@@ -86,12 +78,8 @@
           typedefName = CName "T1",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}}},
+          typedefSourceLoc =
+          "examples/typedef_vs_macro.h:1:13"}},
   DeclNewtypeInstance
     Storable
     (HsName "@NsTypeConstr" "T1"),
@@ -116,12 +104,8 @@
           typedefName = CName "T2",
           typedefType = TypePrim
             (PrimChar Nothing),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 2,
-            singleLocColumn = 14}}},
+          typedefSourceLoc =
+          "examples/typedef_vs_macro.h:2:14"}},
   DeclNewtypeInstance
     Storable
     (HsName "@NsTypeConstr" "T2"),
@@ -147,12 +131,8 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "T1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 8,
-                singleLocColumn = 6}}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:8:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -166,12 +146,8 @@
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "T2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:9:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -185,12 +161,8 @@
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "M1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 10,
-                singleLocColumn = 6}}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:10:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -204,12 +176,8 @@
               fieldOffset = 96,
               fieldType = TypeTypedef
                 (CName "M2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 11,
-                singleLocColumn = 6}}}],
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:11:6"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -225,52 +193,32 @@
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "T1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 8,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:8:6"},
             StructField {
               fieldName = CName "t2",
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "T2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:9:6"},
             StructField {
               fieldName = CName "m1",
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "M1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 10,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:10:6"},
             StructField {
               fieldName = CName "m2",
               fieldOffset = 96,
               fieldType = TypeTypedef
                 (CName "M2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 11,
-                singleLocColumn = 6}}],
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:11:6"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 7,
-            singleLocColumn = 8}}},
+          structSourceLoc =
+          "examples/typedef_vs_macro.h:7:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -294,12 +242,8 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "T1"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 6}}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:8:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -313,12 +257,8 @@
                 fieldOffset = 32,
                 fieldType = TypeTypedef
                   (CName "T2"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 6}}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:9:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -332,12 +272,8 @@
                 fieldOffset = 64,
                 fieldType = TypeTypedef
                   (CName "M1"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 6}}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:10:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -351,12 +287,8 @@
                 fieldOffset = 96,
                 fieldType = TypeTypedef
                   (CName "M2"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 6}}}],
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:11:6"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -372,52 +304,32 @@
                 fieldOffset = 0,
                 fieldType = TypeTypedef
                   (CName "T1"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 8,
-                  singleLocColumn = 6}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:8:6"},
               StructField {
                 fieldName = CName "t2",
                 fieldOffset = 32,
                 fieldType = TypeTypedef
                   (CName "T2"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 9,
-                  singleLocColumn = 6}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:9:6"},
               StructField {
                 fieldName = CName "m1",
                 fieldOffset = 64,
                 fieldType = TypeTypedef
                   (CName "M1"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 10,
-                  singleLocColumn = 6}},
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:10:6"},
               StructField {
                 fieldName = CName "m2",
                 fieldOffset = 96,
                 fieldType = TypeTypedef
                   (CName "M2"),
-                fieldSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typedef_vs_macro.h"],
-                  singleLocLine = 11,
-                  singleLocColumn = 6}}],
+                fieldSourceLoc =
+                "examples/typedef_vs_macro.h:11:6"}],
             structFlam = Nothing,
-            structSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "typedef_vs_macro.h"],
-              singleLocLine = 7,
-              singleLocColumn = 8}}}
+            structSourceLoc =
+            "examples/typedef_vs_macro.h:7:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -446,12 +358,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "T1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:8:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -465,12 +373,8 @@
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "T2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:9:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -484,12 +388,8 @@
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "M1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:10:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -503,12 +403,8 @@
                         fieldOffset = 96,
                         fieldType = TypeTypedef
                           (CName "M2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 6}}}],
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:11:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -524,52 +420,32 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "T1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:8:6"},
                       StructField {
                         fieldName = CName "t2",
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "T2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:9:6"},
                       StructField {
                         fieldName = CName "m1",
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "M1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:10:6"},
                       StructField {
                         fieldName = CName "m2",
                         fieldOffset = 96,
                         fieldType = TypeTypedef
                           (CName "M2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 6}}],
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:11:6"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "typedef_vs_macro.h"],
-                      singleLocLine = 7,
-                      singleLocColumn = 8}}})
+                    structSourceLoc =
+                    "examples/typedef_vs_macro.h:7:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -602,12 +478,8 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "T1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:8:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -621,12 +493,8 @@
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "T2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:9:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -640,12 +508,8 @@
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "M1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 6}}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:10:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -659,12 +523,8 @@
                         fieldOffset = 96,
                         fieldType = TypeTypedef
                           (CName "M2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 6}}}],
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:11:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -680,52 +540,32 @@
                         fieldOffset = 0,
                         fieldType = TypeTypedef
                           (CName "T1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 8,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:8:6"},
                       StructField {
                         fieldName = CName "t2",
                         fieldOffset = 32,
                         fieldType = TypeTypedef
                           (CName "T2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 9,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:9:6"},
                       StructField {
                         fieldName = CName "m1",
                         fieldOffset = 64,
                         fieldType = TypeTypedef
                           (CName "M1"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 10,
-                          singleLocColumn = 6}},
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:10:6"},
                       StructField {
                         fieldName = CName "m2",
                         fieldOffset = 96,
                         fieldType = TypeTypedef
                           (CName "M2"),
-                        fieldSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typedef_vs_macro.h"],
-                          singleLocLine = 11,
-                          singleLocColumn = 6}}],
+                        fieldSourceLoc =
+                        "examples/typedef_vs_macro.h:11:6"}],
                     structFlam = Nothing,
-                    structSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "typedef_vs_macro.h"],
-                      singleLocLine = 7,
-                      singleLocColumn = 8}}}
+                    structSourceLoc =
+                    "examples/typedef_vs_macro.h:7:8"}}
               (Add 4)
               (Seq
                 [

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 4,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/typedef_vs_macro.h:4:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -21,22 +17,14 @@ WrapCHeader
                 (PrimIntegral
                   (PrimInt Signed)))},
           macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 4,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/typedef_vs_macro.h:4:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/typedef_vs_macro.h:5:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -45,34 +33,22 @@ WrapCHeader
             macroBody = MTerm
               (MType (PrimChar Nothing))},
           macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 5,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/typedef_vs_macro.h:5:9"},
       DeclTypedef
         Typedef {
           typedefName = CName "T1",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}},
+          typedefSourceLoc =
+          "examples/typedef_vs_macro.h:1:13"},
       DeclTypedef
         Typedef {
           typedefName = CName "T2",
           typedefType = TypePrim
             (PrimChar Nothing),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 2,
-            singleLocColumn = 14}},
+          typedefSourceLoc =
+          "examples/typedef_vs_macro.h:2:14"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -87,49 +63,29 @@ WrapCHeader
               fieldOffset = 0,
               fieldType = TypeTypedef
                 (CName "T1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 8,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:8:6"},
             StructField {
               fieldName = CName "t2",
               fieldOffset = 32,
               fieldType = TypeTypedef
                 (CName "T2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 9,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:9:6"},
             StructField {
               fieldName = CName "m1",
               fieldOffset = 64,
               fieldType = TypeTypedef
                 (CName "M1"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 10,
-                singleLocColumn = 6}},
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:10:6"},
             StructField {
               fieldName = CName "m2",
               fieldOffset = 96,
               fieldType = TypeTypedef
                 (CName "M2"),
-              fieldSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typedef_vs_macro.h"],
-                singleLocLine = 11,
-                singleLocColumn = 6}}],
+              fieldSourceLoc =
+              "examples/typedef_vs_macro.h:11:6"}],
           structFlam = Nothing,
-          structSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedef_vs_macro.h"],
-            singleLocLine = 7,
-            singleLocColumn = 8}}])
+          structSourceLoc =
+          "examples/typedef_vs_macro.h:7:8"}])

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -20,12 +20,8 @@
           typedefName = CName "myint",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedefs.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}}},
+          typedefSourceLoc =
+          "examples/typedefs.h:1:13"}},
   DeclNewtypeInstance
     Storable
     (HsName
@@ -54,12 +50,8 @@
             (TypePrim
               (PrimIntegral
                 (PrimInt Signed))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedefs.h"],
-            singleLocLine = 2,
-            singleLocColumn = 15}}},
+          typedefSourceLoc =
+          "examples/typedefs.h:2:15"}},
   DeclNewtypeInstance
     Storable
     (HsName

--- a/hs-bindgen/fixtures/typedefs.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedefs.tree-diff.txt
@@ -6,12 +6,8 @@ WrapCHeader
           typedefName = CName "myint",
           typedefType = TypePrim
             (PrimIntegral (PrimInt Signed)),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedefs.h"],
-            singleLocLine = 1,
-            singleLocColumn = 13}},
+          typedefSourceLoc =
+          "examples/typedefs.h:1:13"},
       DeclTypedef
         Typedef {
           typedefName = CName "intptr",
@@ -19,9 +15,5 @@ WrapCHeader
             (TypePrim
               (PrimIntegral
                 (PrimInt Signed))),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typedefs.h"],
-            singleLocLine = 2,
-            singleLocColumn = 15}}])
+          typedefSourceLoc =
+          "examples/typedefs.h:2:15"}])

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -27,27 +27,15 @@
             EnumValue {
               valueName = CName "FOO1",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typenames.h"],
-                singleLocLine = 15,
-                singleLocColumn = 2}},
+              valueSourceLoc =
+              "examples/typenames.h:15:2"},
             EnumValue {
               valueName = CName "FOO2",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typenames.h"],
-                singleLocLine = 16,
-                singleLocColumn = 2}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 14,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/typenames.h:16:2"}],
+          enumSourceLoc =
+          "examples/typenames.h:14:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -77,27 +65,15 @@
               EnumValue {
                 valueName = CName "FOO1",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typenames.h"],
-                  singleLocLine = 15,
-                  singleLocColumn = 2}},
+                valueSourceLoc =
+                "examples/typenames.h:15:2"},
               EnumValue {
                 valueName = CName "FOO2",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "typenames.h"],
-                  singleLocLine = 16,
-                  singleLocColumn = 2}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "typenames.h"],
-              singleLocLine = 14,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/typenames.h:16:2"}],
+            enumSourceLoc =
+            "examples/typenames.h:14:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -132,27 +108,15 @@
                       EnumValue {
                         valueName = CName "FOO1",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typenames.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 2}},
+                        valueSourceLoc =
+                        "examples/typenames.h:15:2"},
                       EnumValue {
                         valueName = CName "FOO2",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typenames.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 2}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "typenames.h"],
-                      singleLocLine = 14,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/typenames.h:16:2"}],
+                    enumSourceLoc =
+                    "examples/typenames.h:14:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -187,27 +151,15 @@
                       EnumValue {
                         valueName = CName "FOO1",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typenames.h"],
-                          singleLocLine = 15,
-                          singleLocColumn = 2}},
+                        valueSourceLoc =
+                        "examples/typenames.h:15:2"},
                       EnumValue {
                         valueName = CName "FOO2",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "typenames.h"],
-                          singleLocLine = 16,
-                          singleLocColumn = 2}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "typenames.h"],
-                      singleLocLine = 14,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/typenames.h:16:2"}],
+                    enumSourceLoc =
+                    "examples/typenames.h:14:6"}}
               (Add 1)
               (Seq
                 [
@@ -232,12 +184,8 @@
         EnumValue {
           valueName = CName "FOO1",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 15,
-            singleLocColumn = 2}}},
+          valueSourceLoc =
+          "examples/typenames.h:15:2"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -255,12 +203,8 @@
         EnumValue {
           valueName = CName "FOO2",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 16,
-            singleLocColumn = 2}}},
+          valueSourceLoc =
+          "examples/typenames.h:16:2"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -282,12 +226,8 @@
           typedefName = CName "foo",
           typedefType = TypePrim
             (PrimFloating PrimDouble),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 19,
-            singleLocColumn = 16}}},
+          typedefSourceLoc =
+          "examples/typenames.h:19:16"}},
   DeclNewtypeInstance
     Storable
     (HsName "@NsTypeConstr" "Foo")]

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -13,35 +13,19 @@ WrapCHeader
             EnumValue {
               valueName = CName "FOO1",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typenames.h"],
-                singleLocLine = 15,
-                singleLocColumn = 2}},
+              valueSourceLoc =
+              "examples/typenames.h:15:2"},
             EnumValue {
               valueName = CName "FOO2",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "typenames.h"],
-                singleLocLine = 16,
-                singleLocColumn = 2}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 14,
-            singleLocColumn = 6}},
+              valueSourceLoc =
+              "examples/typenames.h:16:2"}],
+          enumSourceLoc =
+          "examples/typenames.h:14:6"},
       DeclTypedef
         Typedef {
           typedefName = CName "foo",
           typedefType = TypePrim
             (PrimFloating PrimDouble),
-          typedefSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "typenames.h"],
-            singleLocLine = 19,
-            singleLocColumn = 16}}])
+          typedefSourceLoc =
+          "examples/typenames.h:19:16"}])

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -28,28 +28,16 @@
               valueName = CName
                 "Say\20320\22909",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "uses_utf8.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9}},
+              valueSourceLoc =
+              "examples/uses_utf8.h:5:9"},
             EnumValue {
               valueName = CName
                 "Say\25308\25308",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "uses_utf8.h"],
-                singleLocLine = 6,
-                singleLocColumn = 9}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "uses_utf8.h"],
-            singleLocLine = 4,
-            singleLocColumn = 6}}},
+              valueSourceLoc =
+              "examples/uses_utf8.h:6:9"}],
+          enumSourceLoc =
+          "examples/uses_utf8.h:4:6"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -80,28 +68,16 @@
                 valueName = CName
                   "Say\20320\22909",
                 valueValue = 0,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "uses_utf8.h"],
-                  singleLocLine = 5,
-                  singleLocColumn = 9}},
+                valueSourceLoc =
+                "examples/uses_utf8.h:5:9"},
               EnumValue {
                 valueName = CName
                   "Say\25308\25308",
                 valueValue = 1,
-                valueSourceLoc = SingleLoc {
-                  singleLocPath = [
-                    "examples",
-                    "uses_utf8.h"],
-                  singleLocLine = 6,
-                  singleLocColumn = 9}}],
-            enumSourceLoc = SingleLoc {
-              singleLocPath = [
-                "examples",
-                "uses_utf8.h"],
-              singleLocLine = 4,
-              singleLocColumn = 6}}}
+                valueSourceLoc =
+                "examples/uses_utf8.h:6:9"}],
+            enumSourceLoc =
+            "examples/uses_utf8.h:4:6"}}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -137,28 +113,16 @@
                         valueName = CName
                           "Say\20320\22909",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "uses_utf8.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}},
+                        valueSourceLoc =
+                        "examples/uses_utf8.h:5:9"},
                       EnumValue {
                         valueName = CName
                           "Say\25308\25308",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "uses_utf8.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 9}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "uses_utf8.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 6}}})
+                        valueSourceLoc =
+                        "examples/uses_utf8.h:6:9"}],
+                    enumSourceLoc =
+                    "examples/uses_utf8.h:4:6"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -194,28 +158,16 @@
                         valueName = CName
                           "Say\20320\22909",
                         valueValue = 0,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "uses_utf8.h"],
-                          singleLocLine = 5,
-                          singleLocColumn = 9}},
+                        valueSourceLoc =
+                        "examples/uses_utf8.h:5:9"},
                       EnumValue {
                         valueName = CName
                           "Say\25308\25308",
                         valueValue = 1,
-                        valueSourceLoc = SingleLoc {
-                          singleLocPath = [
-                            "examples",
-                            "uses_utf8.h"],
-                          singleLocLine = 6,
-                          singleLocColumn = 9}}],
-                    enumSourceLoc = SingleLoc {
-                      singleLocPath = [
-                        "examples",
-                        "uses_utf8.h"],
-                      singleLocLine = 4,
-                      singleLocColumn = 6}}}
+                        valueSourceLoc =
+                        "examples/uses_utf8.h:6:9"}],
+                    enumSourceLoc =
+                    "examples/uses_utf8.h:4:6"}}
               (Add 1)
               (Seq
                 [
@@ -241,12 +193,8 @@
           valueName = CName
             "Say\20320\22909",
           valueValue = 0,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "uses_utf8.h"],
-            singleLocLine = 5,
-            singleLocColumn = 9}}},
+          valueSourceLoc =
+          "examples/uses_utf8.h:5:9"}},
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -265,9 +213,5 @@
           valueName = CName
             "Say\25308\25308",
           valueValue = 1,
-          valueSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "uses_utf8.h"],
-            singleLocLine = 6,
-            singleLocColumn = 9}}}]
+          valueSourceLoc =
+          "examples/uses_utf8.h:6:9"}}]

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -5,12 +5,8 @@ WrapCHeader
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
-              multiLocExpansion = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "uses_utf8.h"],
-                singleLocLine = 2,
-                singleLocColumn = 9},
+              multiLocExpansion =
+              "examples/uses_utf8.h:2:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -18,12 +14,8 @@ WrapCHeader
             macroArgs = [],
             macroBody = MTerm MEmpty},
           macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "uses_utf8.h"],
-            singleLocLine = 2,
-            singleLocColumn = 9}},
+          macroDeclSourceLoc =
+          "examples/uses_utf8.h:2:9"},
       DeclEnum
         Enu {
           enumTag = CName "MyEnum",
@@ -37,25 +29,13 @@ WrapCHeader
               valueName = CName
                 "Say\20320\22909",
               valueValue = 0,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "uses_utf8.h"],
-                singleLocLine = 5,
-                singleLocColumn = 9}},
+              valueSourceLoc =
+              "examples/uses_utf8.h:5:9"},
             EnumValue {
               valueName = CName
                 "Say\25308\25308",
               valueValue = 1,
-              valueSourceLoc = SingleLoc {
-                singleLocPath = [
-                  "examples",
-                  "uses_utf8.h"],
-                singleLocLine = 6,
-                singleLocColumn = 9}}],
-          enumSourceLoc = SingleLoc {
-            singleLocPath = [
-              "examples",
-              "uses_utf8.h"],
-            singleLocLine = 4,
-            singleLocColumn = 6}}])
+              valueSourceLoc =
+              "examples/uses_utf8.h:6:9"}],
+          enumSourceLoc =
+          "examples/uses_utf8.h:4:6"}])


### PR DESCRIPTION
currently the SingleLoc records take the most of golden files, obfuscating the important parts:

2,804 additions and 8,422 deletions. i.e 5600 line difference.