### PR TITLE
Rewrite nested struct self-referring example

### DIFF
--- a/hs-bindgen/examples/nested_types.h
+++ b/hs-bindgen/examples/nested_types.h
@@ -16,11 +16,13 @@ struct ex3 {
     float ex3_c;
 };
 
-struct ex4 {
-    struct ex4_b {
-        int ex3_a;
-        char ex3_b;
-        struct ex4_b *recur;
-    } linkedlist;
-    float ex3_c;
+// struct with inline struct which reference itself.
+// linked list where odd values are ints, and even values are doubles
+// by writing this way, we don't need forward declarations.
+struct ex4_odd {
+    int ex4_odd_value;
+    struct ex4_even {
+        double ex4_even_value;
+        struct ex4_odd *next;
+    } *next;
 };

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -793,219 +793,163 @@
     Struct {
       structName = HsName
         "@NsTypeConstr"
-        "Ex4_b",
+        "Ex4_even",
       structConstr = HsName
         "@NsConstr"
-        "Ex4_b",
+        "Ex4_even",
       structFields = [
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_b_ex3_a",
+            "ex4_even_ex4_even_value",
           fieldType = HsPrimType
-            HsPrimCInt,
+            HsPrimCDouble,
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName "ex3_a",
+              fieldName = CName
+                "ex4_even_value",
               fieldOffset = 0,
               fieldType = TypePrim
-                (PrimIntegral (PrimInt Signed)),
+                (PrimFloating PrimDouble),
               fieldSourceLoc =
-              "examples/nested_types.h:21:13"}},
+              "examples/nested_types.h:25:16"}},
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_b_ex3_b",
-          fieldType = HsPrimType
-            HsPrimCChar,
-          fieldOrigin =
-          FieldOriginStructField
-            StructField {
-              fieldName = CName "ex3_b",
-              fieldOffset = 32,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "examples/nested_types.h:22:14"}},
-        Field {
-          fieldName = HsName
-            "@NsVar"
-            "ex4_b_recur",
+            "ex4_even_next",
           fieldType = HsPtr
             (HsTypRef
               (HsName
                 "@NsTypeConstr"
-                "Ex4_b")),
+                "Ex4_odd")),
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName "recur",
+              fieldName = CName "next",
               fieldOffset = 64,
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathStruct
-                    (DeclNameTag (CName "ex4_b"))
-                    (DeclPathField
-                      (CName "linkedlist")
-                      (DeclPathStruct
-                        (DeclNameTag (CName "ex4"))
-                        DeclPathTop)))),
+                    (DeclNameTag (CName "ex4_odd"))
+                    DeclPathTop)),
               fieldSourceLoc =
-              "examples/nested_types.h:23:23"}}],
+              "examples/nested_types.h:26:25"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4_b"))
+            (DeclNameTag (CName "ex4_even"))
             (DeclPathField
-              (CName "linkedlist")
+              (CName "next")
               (DeclPathStruct
-                (DeclNameTag (CName "ex4"))
+                (DeclNameTag (CName "ex4_odd"))
                 DeclPathTop)),
           structSizeof = 16,
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName "ex3_a",
+              fieldName = CName
+                "ex4_even_value",
               fieldOffset = 0,
               fieldType = TypePrim
-                (PrimIntegral (PrimInt Signed)),
+                (PrimFloating PrimDouble),
               fieldSourceLoc =
-              "examples/nested_types.h:21:13"},
+              "examples/nested_types.h:25:16"},
             StructField {
-              fieldName = CName "ex3_b",
-              fieldOffset = 32,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "examples/nested_types.h:22:14"},
-            StructField {
-              fieldName = CName "recur",
+              fieldName = CName "next",
               fieldOffset = 64,
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathStruct
-                    (DeclNameTag (CName "ex4_b"))
-                    (DeclPathField
-                      (CName "linkedlist")
-                      (DeclPathStruct
-                        (DeclNameTag (CName "ex4"))
-                        DeclPathTop)))),
+                    (DeclNameTag (CName "ex4_odd"))
+                    DeclPathTop)),
               fieldSourceLoc =
-              "examples/nested_types.h:23:23"}],
+              "examples/nested_types.h:26:25"}],
           structFlam = Nothing,
           structSourceLoc =
-          "examples/nested_types.h:20:12"}},
+          "examples/nested_types.h:24:12"}},
   DeclInstance
     (InstanceStorable
       Struct {
         structName = HsName
           "@NsTypeConstr"
-          "Ex4_b",
+          "Ex4_even",
         structConstr = HsName
           "@NsConstr"
-          "Ex4_b",
+          "Ex4_even",
         structFields = [
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_b_ex3_a",
+              "ex4_even_ex4_even_value",
             fieldType = HsPrimType
-              HsPrimCInt,
+              HsPrimCDouble,
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName "ex3_a",
+                fieldName = CName
+                  "ex4_even_value",
                 fieldOffset = 0,
                 fieldType = TypePrim
-                  (PrimIntegral (PrimInt Signed)),
+                  (PrimFloating PrimDouble),
                 fieldSourceLoc =
-                "examples/nested_types.h:21:13"}},
+                "examples/nested_types.h:25:16"}},
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_b_ex3_b",
-            fieldType = HsPrimType
-              HsPrimCChar,
-            fieldOrigin =
-            FieldOriginStructField
-              StructField {
-                fieldName = CName "ex3_b",
-                fieldOffset = 32,
-                fieldType = TypePrim
-                  (PrimChar Nothing),
-                fieldSourceLoc =
-                "examples/nested_types.h:22:14"}},
-          Field {
-            fieldName = HsName
-              "@NsVar"
-              "ex4_b_recur",
+              "ex4_even_next",
             fieldType = HsPtr
               (HsTypRef
                 (HsName
                   "@NsTypeConstr"
-                  "Ex4_b")),
+                  "Ex4_odd")),
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName "recur",
+                fieldName = CName "next",
                 fieldOffset = 64,
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathStruct
-                      (DeclNameTag (CName "ex4_b"))
-                      (DeclPathField
-                        (CName "linkedlist")
-                        (DeclPathStruct
-                          (DeclNameTag (CName "ex4"))
-                          DeclPathTop)))),
+                      (DeclNameTag (CName "ex4_odd"))
+                      DeclPathTop)),
                 fieldSourceLoc =
-                "examples/nested_types.h:23:23"}}],
+                "examples/nested_types.h:26:25"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathStruct
-              (DeclNameTag (CName "ex4_b"))
+              (DeclNameTag (CName "ex4_even"))
               (DeclPathField
-                (CName "linkedlist")
+                (CName "next")
                 (DeclPathStruct
-                  (DeclNameTag (CName "ex4"))
+                  (DeclNameTag (CName "ex4_odd"))
                   DeclPathTop)),
             structSizeof = 16,
             structAlignment = 8,
             structFields = [
               StructField {
-                fieldName = CName "ex3_a",
+                fieldName = CName
+                  "ex4_even_value",
                 fieldOffset = 0,
                 fieldType = TypePrim
-                  (PrimIntegral (PrimInt Signed)),
+                  (PrimFloating PrimDouble),
                 fieldSourceLoc =
-                "examples/nested_types.h:21:13"},
+                "examples/nested_types.h:25:16"},
               StructField {
-                fieldName = CName "ex3_b",
-                fieldOffset = 32,
-                fieldType = TypePrim
-                  (PrimChar Nothing),
-                fieldSourceLoc =
-                "examples/nested_types.h:22:14"},
-              StructField {
-                fieldName = CName "recur",
+                fieldName = CName "next",
                 fieldOffset = 64,
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathStruct
-                      (DeclNameTag (CName "ex4_b"))
-                      (DeclPathField
-                        (CName "linkedlist")
-                        (DeclPathStruct
-                          (DeclNameTag (CName "ex4"))
-                          DeclPathTop)))),
+                      (DeclNameTag (CName "ex4_odd"))
+                      DeclPathTop)),
                 fieldSourceLoc =
-                "examples/nested_types.h:23:23"}],
+                "examples/nested_types.h:26:25"}],
             structFlam = Nothing,
             structSourceLoc =
-            "examples/nested_types.h:20:12"}}
+            "examples/nested_types.h:24:12"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1016,113 +960,84 @@
               Struct {
                 structName = HsName
                   "@NsTypeConstr"
-                  "Ex4_b",
+                  "Ex4_even",
                 structConstr = HsName
                   "@NsConstr"
-                  "Ex4_b",
+                  "Ex4_even",
                 structFields = [
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_b_ex3_a",
+                      "ex4_even_ex4_even_value",
                     fieldType = HsPrimType
-                      HsPrimCInt,
+                      HsPrimCDouble,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "ex3_a",
+                        fieldName = CName
+                          "ex4_even_value",
                         fieldOffset = 0,
                         fieldType = TypePrim
-                          (PrimIntegral (PrimInt Signed)),
+                          (PrimFloating PrimDouble),
                         fieldSourceLoc =
-                        "examples/nested_types.h:21:13"}},
+                        "examples/nested_types.h:25:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_b_ex3_b",
-                    fieldType = HsPrimType
-                      HsPrimCChar,
-                    fieldOrigin =
-                    FieldOriginStructField
-                      StructField {
-                        fieldName = CName "ex3_b",
-                        fieldOffset = 32,
-                        fieldType = TypePrim
-                          (PrimChar Nothing),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:22:14"}},
-                  Field {
-                    fieldName = HsName
-                      "@NsVar"
-                      "ex4_b_recur",
+                      "ex4_even_next",
                     fieldType = HsPtr
                       (HsTypRef
                         (HsName
                           "@NsTypeConstr"
-                          "Ex4_b")),
+                          "Ex4_odd")),
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "recur",
+                        fieldName = CName "next",
                         fieldOffset = 64,
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathStruct
-                              (DeclNameTag (CName "ex4_b"))
-                              (DeclPathField
-                                (CName "linkedlist")
-                                (DeclPathStruct
-                                  (DeclNameTag (CName "ex4"))
-                                  DeclPathTop)))),
+                              (DeclNameTag (CName "ex4_odd"))
+                              DeclPathTop)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:23:23"}}],
+                        "examples/nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathStruct
-                      (DeclNameTag (CName "ex4_b"))
+                      (DeclNameTag (CName "ex4_even"))
                       (DeclPathField
-                        (CName "linkedlist")
+                        (CName "next")
                         (DeclPathStruct
-                          (DeclNameTag (CName "ex4"))
+                          (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop)),
                     structSizeof = 16,
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName "ex3_a",
+                        fieldName = CName
+                          "ex4_even_value",
                         fieldOffset = 0,
                         fieldType = TypePrim
-                          (PrimIntegral (PrimInt Signed)),
+                          (PrimFloating PrimDouble),
                         fieldSourceLoc =
-                        "examples/nested_types.h:21:13"},
+                        "examples/nested_types.h:25:16"},
                       StructField {
-                        fieldName = CName "ex3_b",
-                        fieldOffset = 32,
-                        fieldType = TypePrim
-                          (PrimChar Nothing),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:22:14"},
-                      StructField {
-                        fieldName = CName "recur",
+                        fieldName = CName "next",
                         fieldOffset = 64,
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathStruct
-                              (DeclNameTag (CName "ex4_b"))
-                              (DeclPathField
-                                (CName "linkedlist")
-                                (DeclPathStruct
-                                  (DeclNameTag (CName "ex4"))
-                                  DeclPathTop)))),
+                              (DeclNameTag (CName "ex4_odd"))
+                              DeclPathTop)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:23:23"}],
+                        "examples/nested_types.h:26:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "examples/nested_types.h:20:12"}})
+                    "examples/nested_types.h:24:12"}})
             [
               PeekByteOff (Idx 0) 0,
-              PeekByteOff (Idx 0) 4,
               PeekByteOff (Idx 0) 8]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1133,280 +1048,261 @@
               Struct {
                 structName = HsName
                   "@NsTypeConstr"
-                  "Ex4_b",
+                  "Ex4_even",
                 structConstr = HsName
                   "@NsConstr"
-                  "Ex4_b",
+                  "Ex4_even",
                 structFields = [
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_b_ex3_a",
+                      "ex4_even_ex4_even_value",
                     fieldType = HsPrimType
-                      HsPrimCInt,
+                      HsPrimCDouble,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "ex3_a",
+                        fieldName = CName
+                          "ex4_even_value",
                         fieldOffset = 0,
                         fieldType = TypePrim
-                          (PrimIntegral (PrimInt Signed)),
+                          (PrimFloating PrimDouble),
                         fieldSourceLoc =
-                        "examples/nested_types.h:21:13"}},
+                        "examples/nested_types.h:25:16"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_b_ex3_b",
-                    fieldType = HsPrimType
-                      HsPrimCChar,
-                    fieldOrigin =
-                    FieldOriginStructField
-                      StructField {
-                        fieldName = CName "ex3_b",
-                        fieldOffset = 32,
-                        fieldType = TypePrim
-                          (PrimChar Nothing),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:22:14"}},
-                  Field {
-                    fieldName = HsName
-                      "@NsVar"
-                      "ex4_b_recur",
+                      "ex4_even_next",
                     fieldType = HsPtr
                       (HsTypRef
                         (HsName
                           "@NsTypeConstr"
-                          "Ex4_b")),
+                          "Ex4_odd")),
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "recur",
+                        fieldName = CName "next",
                         fieldOffset = 64,
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathStruct
-                              (DeclNameTag (CName "ex4_b"))
-                              (DeclPathField
-                                (CName "linkedlist")
-                                (DeclPathStruct
-                                  (DeclNameTag (CName "ex4"))
-                                  DeclPathTop)))),
+                              (DeclNameTag (CName "ex4_odd"))
+                              DeclPathTop)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:23:23"}}],
+                        "examples/nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathStruct
-                      (DeclNameTag (CName "ex4_b"))
+                      (DeclNameTag (CName "ex4_even"))
                       (DeclPathField
-                        (CName "linkedlist")
+                        (CName "next")
                         (DeclPathStruct
-                          (DeclNameTag (CName "ex4"))
+                          (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop)),
                     structSizeof = 16,
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName "ex3_a",
+                        fieldName = CName
+                          "ex4_even_value",
                         fieldOffset = 0,
                         fieldType = TypePrim
-                          (PrimIntegral (PrimInt Signed)),
+                          (PrimFloating PrimDouble),
                         fieldSourceLoc =
-                        "examples/nested_types.h:21:13"},
+                        "examples/nested_types.h:25:16"},
                       StructField {
-                        fieldName = CName "ex3_b",
-                        fieldOffset = 32,
-                        fieldType = TypePrim
-                          (PrimChar Nothing),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:22:14"},
-                      StructField {
-                        fieldName = CName "recur",
+                        fieldName = CName "next",
                         fieldOffset = 64,
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathStruct
-                              (DeclNameTag (CName "ex4_b"))
-                              (DeclPathField
-                                (CName "linkedlist")
-                                (DeclPathStruct
-                                  (DeclNameTag (CName "ex4"))
-                                  DeclPathTop)))),
+                              (DeclNameTag (CName "ex4_odd"))
+                              DeclPathTop)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:23:23"}],
+                        "examples/nested_types.h:26:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "examples/nested_types.h:20:12"}}
-              (Add 3)
+                    "examples/nested_types.h:24:12"}}
+              (Add 2)
               (Seq
                 [
-                  PokeByteOff (Idx 4) 0 (Idx 0),
-                  PokeByteOff (Idx 4) 4 (Idx 1),
+                  PokeByteOff (Idx 3) 0 (Idx 0),
                   PokeByteOff
-                    (Idx 4)
+                    (Idx 3)
                     8
-                    (Idx 2)])))}),
+                    (Idx 1)])))}),
   DeclData
     Struct {
       structName = HsName
         "@NsTypeConstr"
-        "Ex4",
+        "Ex4_odd",
       structConstr = HsName
         "@NsConstr"
-        "Ex4",
+        "Ex4_odd",
       structFields = [
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_linkedlist",
-          fieldType = HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Ex4_b"),
+            "ex4_odd_ex4_odd_value",
+          fieldType = HsPrimType
+            HsPrimCInt,
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName "linkedlist",
+              fieldName = CName
+                "ex4_odd_value",
               fieldOffset = 0,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  (DeclNameTag (CName "ex4_b"))
-                  (DeclPathField
-                    (CName "linkedlist")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "ex4"))
-                      DeclPathTop))),
+              fieldType = TypePrim
+                (PrimIntegral (PrimInt Signed)),
               fieldSourceLoc =
-              "examples/nested_types.h:24:7"}},
+              "examples/nested_types.h:23:9"}},
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_ex3_c",
-          fieldType = HsPrimType
-            HsPrimCFloat,
+            "ex4_odd_next",
+          fieldType = HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Ex4_even")),
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName "ex3_c",
-              fieldOffset = 128,
-              fieldType = TypePrim
-                (PrimFloating PrimFloat),
+              fieldName = CName "next",
+              fieldOffset = 64,
+              fieldType = TypePointer
+                (TypeStruct
+                  (DeclPathStruct
+                    (DeclNameTag (CName "ex4_even"))
+                    (DeclPathField
+                      (CName "next")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "ex4_odd"))
+                        DeclPathTop)))),
               fieldSourceLoc =
-              "examples/nested_types.h:25:11"}}],
+              "examples/nested_types.h:27:8"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4"))
+            (DeclNameTag (CName "ex4_odd"))
             DeclPathTop,
-          structSizeof = 24,
+          structSizeof = 16,
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName "linkedlist",
+              fieldName = CName
+                "ex4_odd_value",
               fieldOffset = 0,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  (DeclNameTag (CName "ex4_b"))
-                  (DeclPathField
-                    (CName "linkedlist")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "ex4"))
-                      DeclPathTop))),
-              fieldSourceLoc =
-              "examples/nested_types.h:24:7"},
-            StructField {
-              fieldName = CName "ex3_c",
-              fieldOffset = 128,
               fieldType = TypePrim
-                (PrimFloating PrimFloat),
+                (PrimIntegral (PrimInt Signed)),
               fieldSourceLoc =
-              "examples/nested_types.h:25:11"}],
+              "examples/nested_types.h:23:9"},
+            StructField {
+              fieldName = CName "next",
+              fieldOffset = 64,
+              fieldType = TypePointer
+                (TypeStruct
+                  (DeclPathStruct
+                    (DeclNameTag (CName "ex4_even"))
+                    (DeclPathField
+                      (CName "next")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "ex4_odd"))
+                        DeclPathTop)))),
+              fieldSourceLoc =
+              "examples/nested_types.h:27:8"}],
           structFlam = Nothing,
           structSourceLoc =
-          "examples/nested_types.h:19:8"}},
+          "examples/nested_types.h:22:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
         structName = HsName
           "@NsTypeConstr"
-          "Ex4",
+          "Ex4_odd",
         structConstr = HsName
           "@NsConstr"
-          "Ex4",
+          "Ex4_odd",
         structFields = [
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_linkedlist",
-            fieldType = HsTypRef
-              (HsName
-                "@NsTypeConstr"
-                "Ex4_b"),
+              "ex4_odd_ex4_odd_value",
+            fieldType = HsPrimType
+              HsPrimCInt,
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName "linkedlist",
+                fieldName = CName
+                  "ex4_odd_value",
                 fieldOffset = 0,
-                fieldType = TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "ex4_b"))
-                    (DeclPathField
-                      (CName "linkedlist")
-                      (DeclPathStruct
-                        (DeclNameTag (CName "ex4"))
-                        DeclPathTop))),
+                fieldType = TypePrim
+                  (PrimIntegral (PrimInt Signed)),
                 fieldSourceLoc =
-                "examples/nested_types.h:24:7"}},
+                "examples/nested_types.h:23:9"}},
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_ex3_c",
-            fieldType = HsPrimType
-              HsPrimCFloat,
+              "ex4_odd_next",
+            fieldType = HsPtr
+              (HsTypRef
+                (HsName
+                  "@NsTypeConstr"
+                  "Ex4_even")),
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName "ex3_c",
-                fieldOffset = 128,
-                fieldType = TypePrim
-                  (PrimFloating PrimFloat),
+                fieldName = CName "next",
+                fieldOffset = 64,
+                fieldType = TypePointer
+                  (TypeStruct
+                    (DeclPathStruct
+                      (DeclNameTag (CName "ex4_even"))
+                      (DeclPathField
+                        (CName "next")
+                        (DeclPathStruct
+                          (DeclNameTag (CName "ex4_odd"))
+                          DeclPathTop)))),
                 fieldSourceLoc =
-                "examples/nested_types.h:25:11"}}],
+                "examples/nested_types.h:27:8"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathStruct
-              (DeclNameTag (CName "ex4"))
+              (DeclNameTag (CName "ex4_odd"))
               DeclPathTop,
-            structSizeof = 24,
+            structSizeof = 16,
             structAlignment = 8,
             structFields = [
               StructField {
-                fieldName = CName "linkedlist",
+                fieldName = CName
+                  "ex4_odd_value",
                 fieldOffset = 0,
-                fieldType = TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "ex4_b"))
-                    (DeclPathField
-                      (CName "linkedlist")
-                      (DeclPathStruct
-                        (DeclNameTag (CName "ex4"))
-                        DeclPathTop))),
-                fieldSourceLoc =
-                "examples/nested_types.h:24:7"},
-              StructField {
-                fieldName = CName "ex3_c",
-                fieldOffset = 128,
                 fieldType = TypePrim
-                  (PrimFloating PrimFloat),
+                  (PrimIntegral (PrimInt Signed)),
                 fieldSourceLoc =
-                "examples/nested_types.h:25:11"}],
+                "examples/nested_types.h:23:9"},
+              StructField {
+                fieldName = CName "next",
+                fieldOffset = 64,
+                fieldType = TypePointer
+                  (TypeStruct
+                    (DeclPathStruct
+                      (DeclNameTag (CName "ex4_even"))
+                      (DeclPathField
+                        (CName "next")
+                        (DeclPathStruct
+                          (DeclNameTag (CName "ex4_odd"))
+                          DeclPathTop)))),
+                fieldSourceLoc =
+                "examples/nested_types.h:27:8"}],
             structFlam = Nothing,
             structSourceLoc =
-            "examples/nested_types.h:19:8"}}
+            "examples/nested_types.h:22:8"}}
       StorableInstance {
-        storableSizeOf = 24,
+        storableSizeOf = 16,
         storableAlignment = 8,
         storablePeek = Lambda
           (NameHint "ptr")
@@ -1415,84 +1311,89 @@
               Struct {
                 structName = HsName
                   "@NsTypeConstr"
-                  "Ex4",
+                  "Ex4_odd",
                 structConstr = HsName
                   "@NsConstr"
-                  "Ex4",
+                  "Ex4_odd",
                 structFields = [
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_linkedlist",
-                    fieldType = HsTypRef
-                      (HsName
-                        "@NsTypeConstr"
-                        "Ex4_b"),
+                      "ex4_odd_ex4_odd_value",
+                    fieldType = HsPrimType
+                      HsPrimCInt,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "linkedlist",
+                        fieldName = CName
+                          "ex4_odd_value",
                         fieldOffset = 0,
-                        fieldType = TypeStruct
-                          (DeclPathStruct
-                            (DeclNameTag (CName "ex4_b"))
-                            (DeclPathField
-                              (CName "linkedlist")
-                              (DeclPathStruct
-                                (DeclNameTag (CName "ex4"))
-                                DeclPathTop))),
+                        fieldType = TypePrim
+                          (PrimIntegral (PrimInt Signed)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:24:7"}},
+                        "examples/nested_types.h:23:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_ex3_c",
-                    fieldType = HsPrimType
-                      HsPrimCFloat,
+                      "ex4_odd_next",
+                    fieldType = HsPtr
+                      (HsTypRef
+                        (HsName
+                          "@NsTypeConstr"
+                          "Ex4_even")),
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "ex3_c",
-                        fieldOffset = 128,
-                        fieldType = TypePrim
-                          (PrimFloating PrimFloat),
+                        fieldName = CName "next",
+                        fieldOffset = 64,
+                        fieldType = TypePointer
+                          (TypeStruct
+                            (DeclPathStruct
+                              (DeclNameTag (CName "ex4_even"))
+                              (DeclPathField
+                                (CName "next")
+                                (DeclPathStruct
+                                  (DeclNameTag (CName "ex4_odd"))
+                                  DeclPathTop)))),
                         fieldSourceLoc =
-                        "examples/nested_types.h:25:11"}}],
+                        "examples/nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathStruct
-                      (DeclNameTag (CName "ex4"))
+                      (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
-                    structSizeof = 24,
+                    structSizeof = 16,
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName "linkedlist",
+                        fieldName = CName
+                          "ex4_odd_value",
                         fieldOffset = 0,
-                        fieldType = TypeStruct
-                          (DeclPathStruct
-                            (DeclNameTag (CName "ex4_b"))
-                            (DeclPathField
-                              (CName "linkedlist")
-                              (DeclPathStruct
-                                (DeclNameTag (CName "ex4"))
-                                DeclPathTop))),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:24:7"},
-                      StructField {
-                        fieldName = CName "ex3_c",
-                        fieldOffset = 128,
                         fieldType = TypePrim
-                          (PrimFloating PrimFloat),
+                          (PrimIntegral (PrimInt Signed)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:25:11"}],
+                        "examples/nested_types.h:23:9"},
+                      StructField {
+                        fieldName = CName "next",
+                        fieldOffset = 64,
+                        fieldType = TypePointer
+                          (TypeStruct
+                            (DeclPathStruct
+                              (DeclNameTag (CName "ex4_even"))
+                              (DeclPathField
+                                (CName "next")
+                                (DeclPathStruct
+                                  (DeclNameTag (CName "ex4_odd"))
+                                  DeclPathTop)))),
+                        fieldSourceLoc =
+                        "examples/nested_types.h:27:8"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "examples/nested_types.h:19:8"}})
+                    "examples/nested_types.h:22:8"}})
             [
               PeekByteOff (Idx 0) 0,
-              PeekByteOff (Idx 0) 16]),
+              PeekByteOff (Idx 0) 8]),
         storablePoke = Lambda
           (NameHint "ptr")
           (Lambda
@@ -1502,86 +1403,91 @@
               Struct {
                 structName = HsName
                   "@NsTypeConstr"
-                  "Ex4",
+                  "Ex4_odd",
                 structConstr = HsName
                   "@NsConstr"
-                  "Ex4",
+                  "Ex4_odd",
                 structFields = [
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_linkedlist",
-                    fieldType = HsTypRef
-                      (HsName
-                        "@NsTypeConstr"
-                        "Ex4_b"),
+                      "ex4_odd_ex4_odd_value",
+                    fieldType = HsPrimType
+                      HsPrimCInt,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "linkedlist",
+                        fieldName = CName
+                          "ex4_odd_value",
                         fieldOffset = 0,
-                        fieldType = TypeStruct
-                          (DeclPathStruct
-                            (DeclNameTag (CName "ex4_b"))
-                            (DeclPathField
-                              (CName "linkedlist")
-                              (DeclPathStruct
-                                (DeclNameTag (CName "ex4"))
-                                DeclPathTop))),
+                        fieldType = TypePrim
+                          (PrimIntegral (PrimInt Signed)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:24:7"}},
+                        "examples/nested_types.h:23:9"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_ex3_c",
-                    fieldType = HsPrimType
-                      HsPrimCFloat,
+                      "ex4_odd_next",
+                    fieldType = HsPtr
+                      (HsTypRef
+                        (HsName
+                          "@NsTypeConstr"
+                          "Ex4_even")),
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName "ex3_c",
-                        fieldOffset = 128,
-                        fieldType = TypePrim
-                          (PrimFloating PrimFloat),
+                        fieldName = CName "next",
+                        fieldOffset = 64,
+                        fieldType = TypePointer
+                          (TypeStruct
+                            (DeclPathStruct
+                              (DeclNameTag (CName "ex4_even"))
+                              (DeclPathField
+                                (CName "next")
+                                (DeclPathStruct
+                                  (DeclNameTag (CName "ex4_odd"))
+                                  DeclPathTop)))),
                         fieldSourceLoc =
-                        "examples/nested_types.h:25:11"}}],
+                        "examples/nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathStruct
-                      (DeclNameTag (CName "ex4"))
+                      (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
-                    structSizeof = 24,
+                    structSizeof = 16,
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName "linkedlist",
+                        fieldName = CName
+                          "ex4_odd_value",
                         fieldOffset = 0,
-                        fieldType = TypeStruct
-                          (DeclPathStruct
-                            (DeclNameTag (CName "ex4_b"))
-                            (DeclPathField
-                              (CName "linkedlist")
-                              (DeclPathStruct
-                                (DeclNameTag (CName "ex4"))
-                                DeclPathTop))),
-                        fieldSourceLoc =
-                        "examples/nested_types.h:24:7"},
-                      StructField {
-                        fieldName = CName "ex3_c",
-                        fieldOffset = 128,
                         fieldType = TypePrim
-                          (PrimFloating PrimFloat),
+                          (PrimIntegral (PrimInt Signed)),
                         fieldSourceLoc =
-                        "examples/nested_types.h:25:11"}],
+                        "examples/nested_types.h:23:9"},
+                      StructField {
+                        fieldName = CName "next",
+                        fieldOffset = 64,
+                        fieldType = TypePointer
+                          (TypeStruct
+                            (DeclPathStruct
+                              (DeclNameTag (CName "ex4_even"))
+                              (DeclPathField
+                                (CName "next")
+                                (DeclPathStruct
+                                  (DeclNameTag (CName "ex4_odd"))
+                                  DeclPathTop)))),
+                        fieldSourceLoc =
+                        "examples/nested_types.h:27:8"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "examples/nested_types.h:19:8"}}
+                    "examples/nested_types.h:22:8"}}
               (Add 2)
               (Seq
                 [
                   PokeByteOff (Idx 3) 0 (Idx 0),
                   PokeByteOff
                     (Idx 3)
-                    16
+                    8
                     (Idx 1)])))})]

--- a/hs-bindgen/fixtures/nested_types.pp.hs
+++ b/hs-bindgen/fixtures/nested_types.pp.hs
@@ -77,13 +77,12 @@ instance F.Storable Ex3 where
         case s1 of
           Ex3 ex3_ex3_c2 -> F.pokeByteOff ptr0 8 ex3_ex3_c2
 
-data Ex4_b = Ex4_b
-  { ex4_b_ex3_a :: FC.CInt
-  , ex4_b_ex3_b :: FC.CChar
-  , ex4_b_recur :: F.Ptr Ex4_b
+data Ex4_even = Ex4_even
+  { ex4_even_ex4_even_value :: FC.CDouble
+  , ex4_even_next :: F.Ptr Ex4_odd
   }
 
-instance F.Storable Ex4_b where
+instance F.Storable Ex4_even where
 
   sizeOf = \_ -> 16
 
@@ -91,41 +90,39 @@ instance F.Storable Ex4_b where
 
   peek =
     \ptr0 ->
-          pure Ex4_b
+          pure Ex4_even
       <*> F.peekByteOff ptr0 0
-      <*> F.peekByteOff ptr0 4
       <*> F.peekByteOff ptr0 8
 
   poke =
     \ptr0 ->
       \s1 ->
         case s1 of
-          Ex4_b ex4_b_ex3_a2 ex4_b_ex3_b3 ex4_b_recur4 ->
-               F.pokeByteOff ptr0 0 ex4_b_ex3_a2
-            >> F.pokeByteOff ptr0 4 ex4_b_ex3_b3
-            >> F.pokeByteOff ptr0 8 ex4_b_recur4
+          Ex4_even ex4_even_ex4_even_value2 ex4_even_next3 ->
+               F.pokeByteOff ptr0 0 ex4_even_ex4_even_value2
+            >> F.pokeByteOff ptr0 8 ex4_even_next3
 
-data Ex4 = Ex4
-  { ex4_linkedlist :: Ex4_b
-  , ex4_ex3_c :: FC.CFloat
+data Ex4_odd = Ex4_odd
+  { ex4_odd_ex4_odd_value :: FC.CInt
+  , ex4_odd_next :: F.Ptr Ex4_even
   }
 
-instance F.Storable Ex4 where
+instance F.Storable Ex4_odd where
 
-  sizeOf = \_ -> 24
+  sizeOf = \_ -> 16
 
   alignment = \_ -> 8
 
   peek =
     \ptr0 ->
-          pure Ex4
+          pure Ex4_odd
       <*> F.peekByteOff ptr0 0
-      <*> F.peekByteOff ptr0 16
+      <*> F.peekByteOff ptr0 8
 
   poke =
     \ptr0 ->
       \s1 ->
         case s1 of
-          Ex4 ex4_linkedlist2 ex4_ex3_c3 ->
-               F.pokeByteOff ptr0 0 ex4_linkedlist2
-            >> F.pokeByteOff ptr0 16 ex4_ex3_c3
+          Ex4_odd ex4_odd_ex4_odd_value2 ex4_odd_next3 ->
+               F.pokeByteOff ptr0 0 ex4_odd_ex4_odd_value2
+            >> F.pokeByteOff ptr0 8 ex4_odd_next3

--- a/hs-bindgen/fixtures/nested_types.rs
+++ b/hs-bindgen/fixtures/nested_types.rs
@@ -59,37 +59,35 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct ex4 {
-    pub linkedlist: ex4_ex4_b,
-    pub ex3_c: f32,
+pub struct ex4_odd {
+    pub ex4_odd_value: ::std::os::raw::c_int,
+    pub next: *mut ex4_odd_ex4_even,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct ex4_ex4_b {
-    pub ex3_a: ::std::os::raw::c_int,
-    pub ex3_b: ::std::os::raw::c_char,
-    pub recur: *mut ex4_ex4_b,
+pub struct ex4_odd_ex4_even {
+    pub ex4_even_value: f64,
+    pub next: *mut ex4_odd,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of ex4_ex4_b"][::std::mem::size_of::<ex4_ex4_b>() - 16usize];
-    ["Alignment of ex4_ex4_b"][::std::mem::align_of::<ex4_ex4_b>() - 8usize];
+    ["Size of ex4_odd_ex4_even"][::std::mem::size_of::<ex4_odd_ex4_even>() - 16usize];
     [
-        "Offset of field: ex4_ex4_b::ex3_a",
-    ][::std::mem::offset_of!(ex4_ex4_b, ex3_a) - 0usize];
+        "Alignment of ex4_odd_ex4_even",
+    ][::std::mem::align_of::<ex4_odd_ex4_even>() - 8usize];
     [
-        "Offset of field: ex4_ex4_b::ex3_b",
-    ][::std::mem::offset_of!(ex4_ex4_b, ex3_b) - 4usize];
+        "Offset of field: ex4_odd_ex4_even::ex4_even_value",
+    ][::std::mem::offset_of!(ex4_odd_ex4_even, ex4_even_value) - 0usize];
     [
-        "Offset of field: ex4_ex4_b::recur",
-    ][::std::mem::offset_of!(ex4_ex4_b, recur) - 8usize];
+        "Offset of field: ex4_odd_ex4_even::next",
+    ][::std::mem::offset_of!(ex4_odd_ex4_even, next) - 8usize];
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of ex4"][::std::mem::size_of::<ex4>() - 24usize];
-    ["Alignment of ex4"][::std::mem::align_of::<ex4>() - 8usize];
+    ["Size of ex4_odd"][::std::mem::size_of::<ex4_odd>() - 16usize];
+    ["Alignment of ex4_odd"][::std::mem::align_of::<ex4_odd>() - 8usize];
     [
-        "Offset of field: ex4::linkedlist",
-    ][::std::mem::offset_of!(ex4, linkedlist) - 0usize];
-    ["Offset of field: ex4::ex3_c"][::std::mem::offset_of!(ex4, ex3_c) - 16usize];
+        "Offset of field: ex4_odd::ex4_odd_value",
+    ][::std::mem::offset_of!(ex4_odd, ex4_odd_value) - 0usize];
+    ["Offset of field: ex4_odd::next"][::std::mem::offset_of!(ex4_odd, next) - 8usize];
 };

--- a/hs-bindgen/fixtures/nested_types.th.txt
+++ b/hs-bindgen/fixtures/nested_types.th.txt
@@ -21,23 +21,23 @@ instance Storable Ex3
            peek = \ptr_0 -> pure Ex3 <*> peekByteOff ptr_0 8;
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Ex3 ex3_ex3_c_3 -> pokeByteOff ptr_1 8 ex3_ex3_c_3}}
-data Ex4_b
-    = Ex4_b {ex4_b_ex3_a :: CInt,
-             ex4_b_ex3_b :: CChar,
-             ex4_b_recur :: (Ptr Ex4_b)}
-instance Storable Ex4_b
+data Ex4_even
+    = Ex4_even {ex4_even_ex4_even_value :: CDouble,
+                ex4_even_next :: (Ptr Ex4_odd)}
+instance Storable Ex4_even
     where {sizeOf = \_ -> 16;
            alignment = \_ -> 8;
-           peek = \ptr_0 -> ((pure Ex4_b <*> peekByteOff ptr_0 0) <*> peekByteOff ptr_0 4) <*> peekByteOff ptr_0 8;
+           peek = \ptr_0 -> (pure Ex4_even <*> peekByteOff ptr_0 0) <*> peekByteOff ptr_0 8;
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Ex4_b ex4_b_ex3_a_3
-                                           ex4_b_ex3_b_4
-                                           ex4_b_recur_5 -> pokeByteOff ptr_1 0 ex4_b_ex3_a_3 >> (pokeByteOff ptr_1 4 ex4_b_ex3_b_4 >> pokeByteOff ptr_1 8 ex4_b_recur_5)}}
-data Ex4 = Ex4 {ex4_linkedlist :: Ex4_b, ex4_ex3_c :: CFloat}
-instance Storable Ex4
-    where {sizeOf = \_ -> 24;
+                                    {Ex4_even ex4_even_ex4_even_value_3
+                                              ex4_even_next_4 -> pokeByteOff ptr_1 0 ex4_even_ex4_even_value_3 >> pokeByteOff ptr_1 8 ex4_even_next_4}}
+data Ex4_odd
+    = Ex4_odd {ex4_odd_ex4_odd_value :: CInt,
+               ex4_odd_next :: (Ptr Ex4_even)}
+instance Storable Ex4_odd
+    where {sizeOf = \_ -> 16;
            alignment = \_ -> 8;
-           peek = \ptr_0 -> (pure Ex4 <*> peekByteOff ptr_0 0) <*> peekByteOff ptr_0 16;
+           peek = \ptr_0 -> (pure Ex4_odd <*> peekByteOff ptr_0 0) <*> peekByteOff ptr_0 8;
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Ex4 ex4_linkedlist_3
-                                         ex4_ex3_c_4 -> pokeByteOff ptr_1 0 ex4_linkedlist_3 >> pokeByteOff ptr_1 16 ex4_ex3_c_4}}
+                                    {Ex4_odd ex4_odd_ex4_odd_value_3
+                                             ex4_odd_next_4 -> pokeByteOff ptr_1 0 ex4_odd_ex4_odd_value_3 >> pokeByteOff ptr_1 8 ex4_odd_next_4}}

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -76,74 +76,66 @@ WrapCHeader
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4_b"))
+            (DeclNameTag (CName "ex4_even"))
             (DeclPathField
-              (CName "linkedlist")
+              (CName "next")
               (DeclPathStruct
-                (DeclNameTag (CName "ex4"))
+                (DeclNameTag (CName "ex4_odd"))
                 DeclPathTop)),
           structSizeof = 16,
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName "ex3_a",
+              fieldName = CName
+                "ex4_even_value",
               fieldOffset = 0,
               fieldType = TypePrim
-                (PrimIntegral (PrimInt Signed)),
+                (PrimFloating PrimDouble),
               fieldSourceLoc =
-              "examples/nested_types.h:21:13"},
+              "examples/nested_types.h:25:16"},
             StructField {
-              fieldName = CName "ex3_b",
-              fieldOffset = 32,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "examples/nested_types.h:22:14"},
-            StructField {
-              fieldName = CName "recur",
+              fieldName = CName "next",
               fieldOffset = 64,
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathStruct
-                    (DeclNameTag (CName "ex4_b"))
-                    (DeclPathField
-                      (CName "linkedlist")
-                      (DeclPathStruct
-                        (DeclNameTag (CName "ex4"))
-                        DeclPathTop)))),
+                    (DeclNameTag (CName "ex4_odd"))
+                    DeclPathTop)),
               fieldSourceLoc =
-              "examples/nested_types.h:23:23"}],
+              "examples/nested_types.h:26:25"}],
           structFlam = Nothing,
           structSourceLoc =
-          "examples/nested_types.h:20:12"},
+          "examples/nested_types.h:24:12"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4"))
+            (DeclNameTag (CName "ex4_odd"))
             DeclPathTop,
-          structSizeof = 24,
+          structSizeof = 16,
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName "linkedlist",
+              fieldName = CName
+                "ex4_odd_value",
               fieldOffset = 0,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  (DeclNameTag (CName "ex4_b"))
-                  (DeclPathField
-                    (CName "linkedlist")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "ex4"))
-                      DeclPathTop))),
-              fieldSourceLoc =
-              "examples/nested_types.h:24:7"},
-            StructField {
-              fieldName = CName "ex3_c",
-              fieldOffset = 128,
               fieldType = TypePrim
-                (PrimFloating PrimFloat),
+                (PrimIntegral (PrimInt Signed)),
               fieldSourceLoc =
-              "examples/nested_types.h:25:11"}],
+              "examples/nested_types.h:23:9"},
+            StructField {
+              fieldName = CName "next",
+              fieldOffset = 64,
+              fieldType = TypePointer
+                (TypeStruct
+                  (DeclPathStruct
+                    (DeclNameTag (CName "ex4_even"))
+                    (DeclPathField
+                      (CName "next")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "ex4_odd"))
+                        DeclPathTop)))),
+              fieldSourceLoc =
+              "examples/nested_types.h:27:8"}],
           structFlam = Nothing,
           structSourceLoc =
-          "examples/nested_types.h:19:8"}])
+          "examples/nested_types.h:22:8"}])


### PR DESCRIPTION
This is more "realistic", kind of highlights why someone may want to do it this way. Maybe they very very very much don't like forward declarations.