### PR TITLE
Make clang_visitChildren rethrow the exception thrown by visitor

### DIFF
--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -45,6 +45,7 @@ library
       DeriveAnyClass
       DerivingStrategies
       DerivingVia
+      LambdaCase
       MagicHash
       TypeFamilies
       UnboxedTuples

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Core.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/LowLevel/Core.hs
@@ -190,6 +190,7 @@ module HsBindgen.Clang.LowLevel.Core (
 
 import Control.Exception
 import Control.Monad
+import Data.IORef
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Foreign
@@ -823,14 +824,24 @@ clang_visitChildren ::
      -- ^ 'True' if the traversal was terminated prematurely by the visitor
      -- returning 'CXChildVisit_Break'.
 clang_visitChildren root visitor = do
+    -- reference cell for a possible exception thrown by 'visitor'.
+    eRef <- newIORef Nothing
+
     visitor' <- mkCursorVisitor $ \current parent -> do
       current' <- CXCursor <$> copyToHaskellHeap current
       parent'  <- CXCursor <$> copyToHaskellHeap parent
-      try (visitor current' parent') >>= \e -> case e of
-        Left err -> print (err :: SomeException) >> return (simpleEnum CXChildVisit_Break)
+      try (visitor current' parent') >>= \case
+        Left exc -> do
+          writeIORef eRef (Just (exc :: SomeException))
+          return (simpleEnum CXChildVisit_Break)
         Right x -> return x
-    onHaskellHeap root $ \parent' ->
+
+    res <- onHaskellHeap root $ \parent' ->
       (/= 0) <$> wrap_visitChildren parent' visitor'
+
+    readIORef eRef >>= \case
+      Nothing  -> return res
+      Just exc -> throwIO exc
 
 {-------------------------------------------------------------------------------
   Cross-referencing in the AST


### PR DESCRIPTION
As exception don't propagate through C-call stack frames (how could they! there are no Haskell exceptions in C!), we need to propagate them manually