### PR TITLE
Fix function argument iteration

### DIFF
--- a/hs-bindgen-libclang/clang-ast-dump/Main.hs
+++ b/hs-bindgen-libclang/clang-ast-dump/Main.hs
@@ -124,6 +124,15 @@ foldDecls opts@Options{..} cursor = do
         traceU 1 "integer value"
           =<< liftIO (clang_getEnumConstantDeclValue cursor)
         pure False -- leaf
+      Right CXCursor_FunctionDecl -> do
+        numArgs <- liftIO $ clang_getNumArgTypes cursorType
+        traceU 1 "args" numArgs
+        forM_ [0 .. numArgs - 1] $ \i -> do
+          argType <- liftIO $ clang_getArgType cursorType (fromIntegral i)
+          traceO_ 2 i =<< liftIO (clang_getTypeSpelling argType)
+        resultType <- liftIO $ clang_getResultType cursorType
+        traceU 1 "result" =<< liftIO (clang_getTypeSpelling resultType)
+        pure False
       Right CXCursor_TypedefDecl -> do
         traceU 1 "typedef name" =<< liftIO (clang_getTypedefName cursorType)
         pure True -- results in repeated information unless typedef is decl

--- a/hs-bindgen/examples/simple_func.h
+++ b/hs-bindgen/examples/simple_func.h
@@ -3,3 +3,5 @@ double erf(double arg);
 static inline double bad_fma(double x, double y, double z) {
     return (x * y) + z;
 }
+
+void no_args(void);

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -59,4 +59,26 @@
           functionHeader =
           "simple_func.h",
           functionSourceLoc =
-          "examples/simple_func.h:3:22"}}]
+          "examples/simple_func.h:3:22"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
+        "no_args",
+      foreignImportType = HsIO
+        (HsPrimType HsPrimVoid),
+      foreignImportOrigName =
+      "no_args",
+      foreignImportHeader =
+      "simple_func.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName "no_args",
+          functionType = TypeFun
+            []
+            (TypePrim PrimVoid),
+          functionHeader =
+          "simple_func.h",
+          functionSourceLoc =
+          "examples/simple_func.h:7:6"}}]

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -3,9 +3,12 @@
 
 module Example where
 
+import Data.Void (Void)
 import qualified Foreign.C as FC
 import Prelude (IO)
 
 foreign import capi safe "simple_func.h erf" erf :: FC.CDouble -> IO FC.CDouble
 
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDouble
+
+foreign import capi safe "simple_func.h no_args" no_args :: IO Void

--- a/hs-bindgen/fixtures/simple_func.rs
+++ b/hs-bindgen/fixtures/simple_func.rs
@@ -3,3 +3,6 @@
 extern "C" {
     pub fn erf(arg: f64) -> f64;
 }
+extern "C" {
+    pub fn no_args();
+}

--- a/hs-bindgen/fixtures/simple_func.th.txt
+++ b/hs-bindgen/fixtures/simple_func.th.txt
@@ -2,3 +2,4 @@ foreign import capi safe "simple_func.h erf" erf :: CDouble ->
                                                     IO CDouble
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: CDouble ->
                                                             CDouble -> CDouble -> IO CDouble
+foreign import capi safe "simple_func.h no_args" no_args :: IO Void

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -30,4 +30,14 @@ WrapCHeader
           functionHeader =
           "simple_func.h",
           functionSourceLoc =
-          "examples/simple_func.h:3:22"}])
+          "examples/simple_func.h:3:22"},
+      DeclFunction
+        Function {
+          functionName = CName "no_args",
+          functionType = TypeFun
+            []
+            (TypePrim PrimVoid),
+          functionHeader =
+          "simple_func.h",
+          functionSourceLoc =
+          "examples/simple_func.h:7:6"}])

--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -301,8 +301,8 @@ processTypeDecl' relPath path unit ty = case fromSimpleEnum $ cxtKind ty of
         res' <- processTypeDeclRec relPath path unit res
 
         nargs <- liftIO $ clang_getNumArgTypes ty
-        args' <- forM [0 .. fromIntegral nargs - 1] $ \i -> do
-            arg <- liftIO $ clang_getArgType ty i
+        args' <- forM [0 .. nargs - 1] $ \i -> do
+            arg <- liftIO $ clang_getArgType ty (fromIntegral i)
             processTypeDeclRec relPath path unit arg
 
         return $ TypeFun args' res'


### PR DESCRIPTION
Problematic code:

```haskell
nargs <- liftIO $ clang_getNumArgTypes ty
args' <- forM [0 .. fromIntegral nargs - 1] $ \i -> ...
```

Function `clang_getNumArgTypes` returns an `int` while `clang_getArgType` takes an `unsigned int`, hence the need for `fromIntegral`.  This does not work when the function has no arguments, however.  When `nargs` is zero, `fromIntegral nargs - 1` underflows to the maximum value of the unsigned type.  This results in many iterations, but it generally fails quickly when attempting to get and use a non-existent argument.

This commit fixes the issue by adding an auxiliary function that works with both signed and unsigned types.  It checks for the zero case before subtraction.

A function with no arguments is added to the `simple_func.h` example.