### PR TITLE
Do not attempt to reparse builtin macros

### DIFF
--- a/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
@@ -45,25 +45,28 @@ foldDecls relPath tracer p unit = checkPredicate relPath tracer p $ \current -> 
       Right CXCursor_StructDecl  -> typeDecl current
       Right CXCursor_EnumDecl    -> typeDecl current
 
-      Right CXCursor_MacroDefinition -> do
-        mbMExpr <- mkMacro relPath unit current
-        macro <- case mbMExpr of
-          Left err -> return $ MacroReparseError err
-          Right macro@( Macro _ mVar mArgs mExpr ) -> do
-            macroTyEnv <- macroTypes <$> get
-            let tcRes = tcMacro buildPlatform macroTyEnv mVar mArgs mExpr
-              -- TODO (cross-compilation): use of 'buildPlatform'.
-            case tcRes of
-              Left err ->
-                return $ MacroTcError macro err
-              Right ty -> do
-                modify $ registerMacroType mVar ty
-                return MacroDecl {
-                    macroDeclMacro     = macro
-                  , macroDeclMacroTy   = ty
-                  , macroDeclSourceLoc = sloc
-                  }
-        return $ Continue $ Just $ DeclMacro macro
+      Right CXCursor_MacroDefinition ->
+        if isBuiltinMacro sloc
+          then return $ Continue Nothing
+          else do
+            mbMExpr <- mkMacro relPath unit current
+            macro <- case mbMExpr of
+              Left err -> return $ MacroReparseError err
+              Right macro@( Macro _ mVar mArgs mExpr ) -> do
+                macroTyEnv <- macroTypes <$> get
+                let tcRes = tcMacro buildPlatform macroTyEnv mVar mArgs mExpr
+                  -- TODO (cross-compilation): use of 'buildPlatform'.
+                case tcRes of
+                  Left err ->
+                    return $ MacroTcError macro err
+                  Right ty -> do
+                    modify $ registerMacroType mVar ty
+                    return MacroDecl {
+                        macroDeclMacro     = macro
+                      , macroDeclMacroTy   = ty
+                      , macroDeclSourceLoc = sloc
+                      }
+            return $ Continue $ Just $ DeclMacro macro
       Right CXCursor_MacroExpansion -> do
         mloc <- liftIO $ HighLevel.clang_getCursorLocation relPath current
         modify $ registerMacroExpansion mloc
@@ -106,6 +109,15 @@ foldDecls relPath tracer p unit = checkPredicate relPath tracer p $ \current -> 
 {-------------------------------------------------------------------------------
   Macros
 -------------------------------------------------------------------------------}
+
+-- | Determine if a macro definition is for a builtin macro from its source
+-- location
+--
+-- The source path for builtin macros is the empty string.
+--
+-- This hack is necessary because @clang_Cursor_isMacroBuiltin@ is not working.
+isBuiltinMacro :: SingleLoc -> Bool
+isBuiltinMacro = Text.null . getSourcePath . singleLocPath
 
 mkMacro ::
      MonadIO m


### PR DESCRIPTION
`libclang` may insert [builtin macros][] at the top of a translation unit.  In the AST, the corresponding macro definitions have a source location where the file is an empty string.  Attempting to reparse these macros results in failure.

[builtin macros]: <https://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros>

Minimal reproduction:

```
$ cabal run hs-bindgen -- \
    --select-all \
    dev parse --input hs-bindgen/examples/simple_structs.h
hs-bindgen: CallFailed "CXFile 0x0000000000000000" CallStack (from HasCallStack):
  collectBacktrace, called at src/HsBindgen/Clang/Internal/Results.hs:41:14 in hs-bindgen-libclang-0.1.0-inplace:HsBindgen.Clang.Internal.Results
  callFailed, called at src/HsBindgen/Clang/Internal/Results.hs:68:12 in hs-bindgen-libclang-0.1.0-inplace:HsBindgen.Clang.Internal.Results
  ensureOn, called at src/HsBindgen/Clang/Internal/Results.hs:54:10 in hs-bindgen-libclang-0.1.0-inplace:HsBindgen.Clang.Internal.Results
  ensure, called at src/HsBindgen/Clang/Internal/Results.hs:74:17 in hs-bindgen-libclang-0.1.0-inplace:HsBindgen.Clang.Internal.Results
  ensureNotNull, called at src/HsBindgen/Clang/LowLevel/Core.hs:1786:27 in hs-bindgen-libclang-0.1.0-inplace:HsBindgen.Clang.LowLevel.Core
```

Related to #372