### PR TITLE
More careful translation of `PrimVoid`

### DIFF
--- a/hs-bindgen/fixtures/bitfields.pp.hs
+++ b/hs-bindgen/fixtures/bitfields.pp.hs
@@ -46,7 +46,7 @@ instance F.Storable Overflow32 where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Overflow32 -> return (())
+          Overflow32 -> return ()
 
 data Overflow32b = Overflow32b
   {}
@@ -63,7 +63,7 @@ instance F.Storable Overflow32b where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Overflow32b -> return (())
+          Overflow32b -> return ()
 
 data Overflow32c = Overflow32c
   {}
@@ -80,7 +80,7 @@ instance F.Storable Overflow32c where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Overflow32c -> return (())
+          Overflow32c -> return ()
 
 data Overflow64 = Overflow64
   {}
@@ -97,7 +97,7 @@ instance F.Storable Overflow64 where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Overflow64 -> return (())
+          Overflow64 -> return ()
 
 data AlignA = AlignA
   {}
@@ -114,7 +114,7 @@ instance F.Storable AlignA where
     \ptr0 ->
       \s1 ->
         case s1 of
-          AlignA -> return (())
+          AlignA -> return ()
 
 data AlignB = AlignB
   {}
@@ -131,4 +131,4 @@ instance F.Storable AlignB where
     \ptr0 ->
       \s1 ->
         case s1 of
-          AlignB -> return (())
+          AlignB -> return ()

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -184,7 +184,11 @@
               "@NsTypeConstr"
               "Uint32_t"))
           (HsFun
-            (HsPrimType HsPrimVoid)
+            (HsPtr
+              (HsTypRef
+                (HsName
+                  "@NsTypeConstr"
+                  "Uint8_t")))
             (HsIO
               (HsTypRef
                 (HsName
@@ -204,7 +208,8 @@
                 (TypeTypedef
                   (CName "a_type_t")),
               TypeTypedef (CName "uint32_t"),
-              TypePrim PrimVoid]
+              TypeIncompleteArray
+                (TypeTypedef (CName "uint8_t"))]
             (TypeTypedef (CName "int32_t")),
           functionHeader =
           "distilled_lib_1.h",

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -34,7 +34,7 @@ a_DEFINE_2 = 2
 tWO_ARGS :: FC.CInt
 tWO_ARGS = 13398
 
-foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: (F.Ptr A_type_t) -> Uint32_t -> Void -> IO Int32_t
+foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: (F.Ptr A_type_t) -> Uint32_t -> (F.Ptr Uint8_t) -> IO Int32_t
 
 data Another_typedef_struct_t = Another_typedef_struct_t
   { another_typedef_struct_t_foo :: FC.CInt

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -13,7 +13,8 @@ a_DEFINE_2 = 2
 tWO_ARGS :: CInt
 tWO_ARGS = 13398
 foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: Ptr A_type_t ->
-                                                                  Uint32_t -> Void -> IO Int32_t
+                                                                  Uint32_t ->
+                                                                  Ptr Uint8_t -> IO Int32_t
 data Another_typedef_struct_t
     = Another_typedef_struct_t {another_typedef_struct_t_foo :: CInt,
                                 another_typedef_struct_t_bar :: CChar}

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -413,7 +413,8 @@ WrapCHeader
                 (TypeTypedef
                   (CName "a_type_t")),
               TypeTypedef (CName "uint32_t"),
-              TypePrim PrimVoid]
+              TypeIncompleteArray
+                (TypeTypedef (CName "uint8_t"))]
             (TypeTypedef (CName "int32_t")),
           functionHeader =
           "distilled_lib_1.h",

--- a/hs-bindgen/fixtures/opaque_declaration.pp.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.pp.hs
@@ -47,6 +47,6 @@ instance F.Storable Baz where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Baz -> return (())
+          Baz -> return ()
 
 data Quu

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -66,7 +66,7 @@
         "@NsVar"
         "no_args",
       foreignImportType = HsIO
-        (HsPrimType HsPrimVoid),
+        (HsPrimType HsPrimUnit),
       foreignImportOrigName =
       "no_args",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -10,4 +10,4 @@ foreign import capi safe "simple_func.h erf" erf :: FC.CDouble -> IO FC.CDouble
 
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDouble
 
-foreign import capi safe "simple_func.h no_args" no_args :: IO (())
+foreign import capi safe "simple_func.h no_args" no_args :: IO ()

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -3,7 +3,6 @@
 
 module Example where
 
-import Data.Void (Void)
 import qualified Foreign.C as FC
 import Prelude (IO)
 
@@ -11,4 +10,4 @@ foreign import capi safe "simple_func.h erf" erf :: FC.CDouble -> IO FC.CDouble
 
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDouble
 
-foreign import capi safe "simple_func.h no_args" no_args :: IO Void
+foreign import capi safe "simple_func.h no_args" no_args :: IO (())

--- a/hs-bindgen/fixtures/simple_func.th.txt
+++ b/hs-bindgen/fixtures/simple_func.th.txt
@@ -2,4 +2,4 @@ foreign import capi safe "simple_func.h erf" erf :: CDouble ->
                                                     IO CDouble
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: CDouble ->
                                                             CDouble -> CDouble -> IO CDouble
-foreign import capi safe "simple_func.h no_args" no_args :: IO Void
+foreign import capi safe "simple_func.h no_args" no_args :: IO Unit

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -8,7 +8,7 @@
         (HsPtr
           (HsTypRef
             (HsName "@NsTypeConstr" "Bar")))
-        (HsIO (HsPrimType HsPrimVoid)),
+        (HsIO (HsPrimType HsPrimUnit)),
       foreignImportOrigName = "func",
       foreignImportHeader =
       "weird01.h",

--- a/hs-bindgen/fixtures/weird01.pp.hs
+++ b/hs-bindgen/fixtures/weird01.pp.hs
@@ -7,7 +7,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import Prelude ((<*>), IO, pure)
 
-foreign import capi safe "weird01.h func" func :: (F.Ptr Bar) -> IO (())
+foreign import capi safe "weird01.h func" func :: (F.Ptr Bar) -> IO ()
 
 data Foo = Foo
   { foo_z :: FC.CInt

--- a/hs-bindgen/fixtures/weird01.pp.hs
+++ b/hs-bindgen/fixtures/weird01.pp.hs
@@ -3,12 +3,11 @@
 
 module Example where
 
-import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import Prelude ((<*>), IO, pure)
 
-foreign import capi safe "weird01.h func" func :: (F.Ptr Bar) -> IO Void
+foreign import capi safe "weird01.h func" func :: (F.Ptr Bar) -> IO (())
 
 data Foo = Foo
   { foo_z :: FC.CInt

--- a/hs-bindgen/fixtures/weird01.th.txt
+++ b/hs-bindgen/fixtures/weird01.th.txt
@@ -1,5 +1,5 @@
 foreign import capi safe "weird01.h func" func :: Ptr Bar ->
-                                                  IO Void
+                                                  IO Unit
 data Foo = Foo {foo_z :: CInt}
 instance Storable Foo
     where {sizeOf = \_ -> 4;

--- a/hs-bindgen/src/HsBindgen/Backend/PP.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP.hs
@@ -88,7 +88,7 @@ data ResolvedName = ResolvedName {
     }
   deriving (Eq, Ord, Show)
 
--- | Construct a `ResvoledName` with no import
+-- | Construct a `ResolvedName` with no import
 noImport :: String -> ResolvedName
 noImport s = ResolvedName {
       resolvedNameString = s

--- a/hs-bindgen/src/HsBindgen/Backend/PP.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP.hs
@@ -211,6 +211,7 @@ resolveGlobal = \case
 
     PrimType hsPrimType  -> case hsPrimType of
       HsPrimVoid     -> importU iDataVoid "Void"
+      HsPrimUnit     -> noImport "()"
       HsPrimCChar    -> importQ iForeignC "CChar"
       HsPrimCSChar   -> importQ iForeignC "CSChar"
       HsPrimCUChar   -> importQ iForeignC "CUChar"

--- a/hs-bindgen/src/HsBindgen/Backend/PP.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP.hs
@@ -117,6 +117,7 @@ data NameType = IdentifierName | OperatorName
 
 nameType :: String -> NameType
 nameType nm
+  | nm == "()"         = IdentifierName
   | all isIdentChar nm = IdentifierName
   | otherwise          = OperatorName
   where

--- a/hs-bindgen/src/HsBindgen/Backend/TH.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH.hs
@@ -115,6 +115,7 @@ mkGlobal =  \case
       PrimType t           -> mkGlobalP t
     where
       mkGlobalP HsPrimVoid     = ''Data.Void.Void
+      mkGlobalP HsPrimUnit     = ''()
       mkGlobalP HsPrimCChar    = ''Foreign.C.Types.CChar
       mkGlobalP HsPrimCUChar   = ''Foreign.C.Types.CUChar
       mkGlobalP HsPrimCSChar   = ''Foreign.C.Types.CSChar

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -40,6 +40,22 @@ data Type =
   | TypePointer Type
   | TypeConstArray Natural Type
   | TypeFun [Type] Type
+
+    -- | Arrays of unknown size
+    --
+    -- Arrays normally have a known size, but not always:
+    --
+    -- * Arrays of unknown size are allowed as function arguments; such arrays
+    --   are interpreted as pointers.
+    -- * Arrays of unknown size may be declared for externs; this is considered
+    --   an incomplete type.
+    -- * Structs may contain an array of undefined size as their last field,
+    --   known as a "flexible array member" (FLAM).
+    --
+    -- We treat the FLAM case separately.
+    --
+    -- See <https://en.cppreference.com/w/c/language/array#Arrays_of_unknown_size>
+  | TypeIncompleteArray Type
   deriving stock (Show, Eq, Generic)
   deriving anyclass (PrettyVal)
 

--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -305,14 +305,9 @@ processTypeDecl' relPath path unit ty = case fromSimpleEnum $ cxtKind ty of
         return $ TypeFun args' res'
 
     Right CXType_IncompleteArray -> do
-        -- in distilled_lib_1.h we have:
-        --
-        -- int32_t some_fun(a_type_t *i, uint32_t j, uint8_t k[]);
-        --
-        -- I'm not sure what's an intention here. Should the k, have uint8_t *,
-        -- i.e. a pointer type instead?
-        --
-        return $ TypePrim PrimVoid -- TODO
+        e <- liftIO $ clang_getArrayElementType ty
+        e' <- processTypeDeclRec relPath path unit e
+        return (TypeIncompleteArray e')
 
     _ -> do
       name <- CName <$> liftIO (clang_getTypeSpelling ty)

--- a/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
@@ -12,6 +12,7 @@ import HsBindgen.Hs.AST.Name
 
 data HsPrimType
     = HsPrimVoid
+    | HsPrimUnit
     | HsPrimCChar
     | HsPrimCSChar
     | HsPrimCUChar

--- a/hs-bindgen/src/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/Translation.hs
@@ -312,7 +312,9 @@ typ nm = go CTop
     goPrim _ C.PrimPtrDiff                  = HsPrimCPtrDiff
 
     goVoid :: TypeContext -> HsPrimType
-    goVoid _ = HsPrimVoid
+    goVoid CFunRes = HsPrimUnit
+    goVoid CPtrArg = HsPrimVoid
+    goVoid c       = error $ "typ: unexpected void in context " ++ show c
 
     goArrayUnknownSize :: TypeContext -> C.Type -> HsType
     goArrayUnknownSize CFunArg t =

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -13,7 +13,7 @@ import Orphans ()
 import Rust
 import Misc
 
-#if __GLASGOW_HASKELL__ >=904
+#if __GLASGOW_HASKELL__ ==908
 import TH
 #endif
 
@@ -66,8 +66,10 @@ main' packageRoot bg = testGroup "golden"
     golden name = testGroup name
         [ goldenTreeDiff name
         , goldenHs name
--- Since GHC-9.4 the Template Haskell ppr function has changed slightly
-#if __GLASGOW_HASKELL__ >=904
+-- Pretty-printing of TH differs between GHC versions; for example, @()@ becomes
+-- @Unit@ in 9.8 <https://github.com/ghc-proposals/ghc-proposals/pull/475>.
+-- We therefore test TH only with one specific GHC version.
+#if __GLASGOW_HASKELL__ ==908
         , goldenTh packageRoot name
 #endif
         , goldenPP name


### PR DESCRIPTION
This also fixes the treatment of arrays of unknown size as function arguments, as the `PrimVoid` placeholder we were using there was getting in the way of a correct translation of `void`.