### PR TITLE
Pull void out of primitive types, i.e. PrimType

### DIFF
--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -26,7 +26,7 @@
           macroName = CName "BOOL",
           macroArgs = [],
           macroBody = MTerm
-            (MType PrimBool)}},
+            (MType (TypePrim PrimBool))}},
   DeclData
     Struct {
       structName = HsName

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -13,7 +13,7 @@ WrapCHeader
             macroName = CName "BOOL",
             macroArgs = [],
             macroBody = MTerm
-              (MType PrimBool)},
+              (MType (TypePrim PrimBool))},
           macroDeclMacroTy = "PrimTy",
           macroDeclSourceLoc =
           "examples/bool.h:13:9"},

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -988,7 +988,7 @@
               fieldName = CName "field_6",
               fieldOffset = 192,
               fieldType = TypePointer
-                (TypePrim PrimVoid),
+                TypeVoid,
               fieldSourceLoc =
               "examples/distilled_lib_1.h:42:31"}},
         Field {
@@ -1130,7 +1130,7 @@
               fieldName = CName "field_6",
               fieldOffset = 192,
               fieldType = TypePointer
-                (TypePrim PrimVoid),
+                TypeVoid,
               fieldSourceLoc =
               "examples/distilled_lib_1.h:42:31"},
             StructField {
@@ -1301,7 +1301,7 @@
                 fieldName = CName "field_6",
                 fieldOffset = 192,
                 fieldType = TypePointer
-                  (TypePrim PrimVoid),
+                  TypeVoid,
                 fieldSourceLoc =
                 "examples/distilled_lib_1.h:42:31"}},
           Field {
@@ -1443,7 +1443,7 @@
                 fieldName = CName "field_6",
                 fieldOffset = 192,
                 fieldType = TypePointer
-                  (TypePrim PrimVoid),
+                  TypeVoid,
                 fieldSourceLoc =
                 "examples/distilled_lib_1.h:42:31"},
               StructField {
@@ -1619,7 +1619,7 @@
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
-                          (TypePrim PrimVoid),
+                          TypeVoid,
                         fieldSourceLoc =
                         "examples/distilled_lib_1.h:42:31"}},
                   Field {
@@ -1761,7 +1761,7 @@
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
-                          (TypePrim PrimVoid),
+                          TypeVoid,
                         fieldSourceLoc =
                         "examples/distilled_lib_1.h:42:31"},
                       StructField {
@@ -1948,7 +1948,7 @@
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
-                          (TypePrim PrimVoid),
+                          TypeVoid,
                         fieldSourceLoc =
                         "examples/distilled_lib_1.h:42:31"}},
                   Field {
@@ -2090,7 +2090,7 @@
                         fieldName = CName "field_6",
                         fieldOffset = 192,
                         fieldType = TypePointer
-                          (TypePrim PrimVoid),
+                          TypeVoid,
                         fieldSourceLoc =
                         "examples/distilled_lib_1.h:42:31"},
                       StructField {
@@ -2527,7 +2527,7 @@
           typedefType = TypePointer
             (TypeFun
               [
-                TypePointer (TypePrim PrimVoid),
+                TypePointer TypeVoid,
                 TypeTypedef (CName "uint32_t")]
               (TypeTypedef
                 (CName "uint32_t"))),

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -569,7 +569,7 @@ WrapCHeader
               fieldName = CName "field_6",
               fieldOffset = 192,
               fieldType = TypePointer
-                (TypePrim PrimVoid),
+                TypeVoid,
               fieldSourceLoc =
               "examples/distilled_lib_1.h:42:31"},
             StructField {
@@ -665,7 +665,7 @@ WrapCHeader
           typedefType = TypePointer
             (TypeFun
               [
-                TypePointer (TypePrim PrimVoid),
+                TypePointer TypeVoid,
                 TypeTypedef (CName "uint32_t")]
               (TypeTypedef
                 (CName "uint32_t"))),

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -77,7 +77,7 @@
           functionName = CName "no_args",
           functionType = TypeFun
             []
-            (TypePrim PrimVoid),
+            TypeVoid,
           functionHeader =
           "simple_func.h",
           functionSourceLoc =

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -36,7 +36,7 @@ WrapCHeader
           functionName = CName "no_args",
           functionType = TypeFun
             []
-            (TypePrim PrimVoid),
+            TypeVoid,
           functionHeader =
           "simple_func.h",
           functionSourceLoc =

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -27,9 +27,10 @@
           macroArgs = [],
           macroBody = MTerm
             (MType
-              (PrimIntegral
-                PrimInt
-                Signed))}},
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -57,7 +58,9 @@
           macroName = CName "M2",
           macroArgs = [],
           macroBody = MTerm
-            (MType (PrimChar Nothing))}},
+            (MType
+              (TypePrim
+                (PrimChar Nothing)))}},
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -14,7 +14,10 @@ WrapCHeader
             macroArgs = [],
             macroBody = MTerm
               (MType
-                (PrimIntegral PrimInt Signed))},
+                (TypePrim
+                  (PrimIntegral
+                    PrimInt
+                    Signed)))},
           macroDeclMacroTy = "PrimTy",
           macroDeclSourceLoc =
           "examples/typedef_vs_macro.h:4:9"},
@@ -30,7 +33,8 @@ WrapCHeader
             macroName = CName "M2",
             macroArgs = [],
             macroBody = MTerm
-              (MType (PrimChar Nothing))},
+              (MType
+                (TypePrim (PrimChar Nothing)))},
           macroDeclMacroTy = "PrimTy",
           macroDeclSourceLoc =
           "examples/typedef_vs_macro.h:5:9"},

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -23,7 +23,7 @@
                   (DeclPathStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop))]
-            (TypePrim PrimVoid),
+            TypeVoid,
           functionHeader = "weird01.h",
           functionSourceLoc =
           "examples/weird01.h:8:6"}},

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -11,7 +11,7 @@ WrapCHeader
                   (DeclPathStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop))]
-            (TypePrim PrimVoid),
+            TypeVoid,
           functionHeader = "weird01.h",
           functionSourceLoc =
           "examples/weird01.h:8:6"},

--- a/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
@@ -166,9 +166,7 @@ data MTerm =
   | MVar CName [MExpr]
 
     -- | Type declaration
-    --
-    -- For now we only support primitive types.
-  | MType PrimType
+  | MType Type
 
     -- | Attribute
   | MAttr Attribute MTerm

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -40,6 +40,7 @@ data Type =
   | TypePointer Type
   | TypeConstArray Natural Type
   | TypeFun [Type] Type
+  | TypeVoid
 
     -- | Arrays of unknown size
     --
@@ -100,9 +101,6 @@ data PrimType =
 
     -- | A floating-point type, such as @float@ or @long double@.
   | PrimFloating PrimFloatType
-
-    -- | @void@
-  | PrimVoid
 
     -- | @_Bool@
   | PrimBool

--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -184,7 +184,7 @@ processTypeDecl' relPath path unit ty = case fromSimpleEnum $ cxtKind ty of
         then do
             -- Anonymous top-level declaration: nothing to do but warn, as there
             -- shouldn't be one in "good" code.
-            return $ TypePrim PrimVoid
+            return TypeVoid
 
         else do
             addTypeDeclProcessing ty $ TypeStruct declPath
@@ -234,7 +234,7 @@ processTypeDecl' relPath path unit ty = case fromSimpleEnum $ cxtKind ty of
             -- anonymous declration, nothing to do
 
             -- TODO: check with struct foo { struct { ... } field; };
-            return $ TypePrim PrimVoid
+            return TypeVoid
 
         else do
             let defnName :: CName
@@ -286,7 +286,7 @@ processTypeDecl' relPath path unit ty = case fromSimpleEnum $ cxtKind ty of
         return (TypeConstArray (fromIntegral n) e')
 
     Right CXType_Void -> do
-        return $ TypePrim PrimVoid
+        return TypeVoid
 
     Right CXType_Bool -> do
         return $ TypePrim PrimBool

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Type.hs
@@ -21,7 +21,7 @@ import HsBindgen.C.Reparse.Common
 -- TODO: This parser is quite minimal at the moment.
 reparseTypeUse :: Reparse Type
 reparseTypeUse = choice [
-      TypePrim <$> reparsePrimType
+      reparsePrimType
     , TypeTypedef <$> reparseName
     ]
 
@@ -46,48 +46,48 @@ primTypeKeyword = choice [
     , keyword "bool", identifier "bool" -- newer LLVM treat "bool" as keyword, older as identifier
     ]
 
-reparsePrimType :: Reparse PrimType
+reparsePrimType :: Reparse Type
 reparsePrimType = do
     kws <- many1 primTypeKeyword
     case kws of
       -- char
-      [             "char"] -> return $ PrimChar Nothing
-      ["signed"   , "char"] -> return $ PrimChar (Just Signed)
-      ["unsigned" , "char"] -> return $ PrimChar (Just Unsigned)
+      [             "char"] -> return $ TypePrim $ PrimChar Nothing
+      ["signed"   , "char"] -> return $ TypePrim $ PrimChar (Just Signed)
+      ["unsigned" , "char"] -> return $ TypePrim $ PrimChar (Just Unsigned)
       -- short
-      [             "short"        ] -> return $ PrimIntegral PrimShort Signed
-      ["signed"   , "short"        ] -> return $ PrimIntegral PrimShort Signed
-      ["unsigned" , "short"        ] -> return $ PrimIntegral PrimShort Unsigned
-      [             "short" , "int"] -> return $ PrimIntegral PrimShort Signed
-      ["signed"   , "short" , "int"] -> return $ PrimIntegral PrimShort Signed
-      ["unsigned" , "short" , "int"] -> return $ PrimIntegral PrimShort Unsigned
+      [             "short"        ] -> return $ TypePrim $ PrimIntegral PrimShort Signed
+      ["signed"   , "short"        ] -> return $ TypePrim $ PrimIntegral PrimShort Signed
+      ["unsigned" , "short"        ] -> return $ TypePrim $ PrimIntegral PrimShort Unsigned
+      [             "short" , "int"] -> return $ TypePrim $ PrimIntegral PrimShort Signed
+      ["signed"   , "short" , "int"] -> return $ TypePrim $ PrimIntegral PrimShort Signed
+      ["unsigned" , "short" , "int"] -> return $ TypePrim $ PrimIntegral PrimShort Unsigned
       -- int
-      [             "int"] -> return $ PrimIntegral PrimInt Signed
-      ["signed"   , "int"] -> return $ PrimIntegral PrimInt Signed
-      ["unsigned" , "int"] -> return $ PrimIntegral PrimInt Unsigned
+      [             "int"] -> return $ TypePrim $ PrimIntegral PrimInt Signed
+      ["signed"   , "int"] -> return $ TypePrim $ PrimIntegral PrimInt Signed
+      ["unsigned" , "int"] -> return $ TypePrim $ PrimIntegral PrimInt Unsigned
       -- long
-      [             "long"        ] -> return $ PrimIntegral PrimLong Signed
-      ["signed"   , "long"        ] -> return $ PrimIntegral PrimLong Signed
-      ["unsigned" , "long"        ] -> return $ PrimIntegral PrimLong Unsigned
-      [             "long" , "int"] -> return $ PrimIntegral PrimLong Signed
-      ["signed"   , "long" , "int"] -> return $ PrimIntegral PrimLong Signed
-      ["unsigned" , "long" , "int"] -> return $ PrimIntegral PrimLong Unsigned
+      [             "long"        ] -> return $ TypePrim $ PrimIntegral PrimLong Signed
+      ["signed"   , "long"        ] -> return $ TypePrim $ PrimIntegral PrimLong Signed
+      ["unsigned" , "long"        ] -> return $ TypePrim $ PrimIntegral PrimLong Unsigned
+      [             "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLong Signed
+      ["signed"   , "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLong Signed
+      ["unsigned" , "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLong Unsigned
       -- long
-      [             "long" , "long"        ] -> return $ PrimIntegral PrimLongLong Signed
-      ["signed"   , "long" , "long"        ] -> return $ PrimIntegral PrimLongLong Signed
-      ["unsigned" , "long" , "long"        ] -> return $ PrimIntegral PrimLongLong Unsigned
-      [             "long" , "long" , "int"] -> return $ PrimIntegral PrimLongLong Signed
-      ["signed"   , "long" , "long" , "int"] -> return $ PrimIntegral PrimLongLong Signed
-      ["unsigned" , "long" , "long" , "int"] -> return $ PrimIntegral PrimLongLong Unsigned
+      [             "long" , "long"        ] -> return $ TypePrim $ PrimIntegral PrimLongLong Signed
+      ["signed"   , "long" , "long"        ] -> return $ TypePrim $ PrimIntegral PrimLongLong Signed
+      ["unsigned" , "long" , "long"        ] -> return $ TypePrim $ PrimIntegral PrimLongLong Unsigned
+      [             "long" , "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLongLong Signed
+      ["signed"   , "long" , "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLongLong Signed
+      ["unsigned" , "long" , "long" , "int"] -> return $ TypePrim $ PrimIntegral PrimLongLong Unsigned
       -- float, double, long double
-      [         "float" ] -> return $ PrimFloating PrimFloat
-      [         "double"] -> return $ PrimFloating PrimDouble
-      ["long" , "double"] -> return $ PrimFloating PrimLongDouble
+      [         "float" ] -> return $ TypePrim $ PrimFloating PrimFloat
+      [         "double"] -> return $ TypePrim $ PrimFloating PrimDouble
+      ["long" , "double"] -> return $ TypePrim $ PrimFloating PrimLongDouble
       -- void
-      ["void"] -> return $ PrimVoid
+      ["void"] -> return TypeVoid
       -- bool
-      ["_Bool"] -> return PrimBool
-      ["bool"]  -> return PrimBool
+      ["_Bool"] -> return $ TypePrim PrimBool
+      ["bool"]  -> return $ TypePrim PrimBool
       -- invalid
       _otherwise -> unexpected $ concat [
           "Unexpected primitive type "


### PR DESCRIPTION
These leaves PrimType for things we can actually have values of. As we treat `void` differently, this is the same argument as having e.g. constant sized and incomplete arrays separate.

As a side-product, MType has better definition now; though is still restricted by the parser to primitive types.