### PR TITLE
Introduce `GlobalCExpr`

### DIFF
--- a/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
@@ -13,8 +13,9 @@ module HsBindgen.Backend.PP.Names (
 
 import Data.Char qualified as Char
 
-import HsBindgen.SHs.AST
+import HsBindgen.Clang.Args (Target(..))
 import HsBindgen.Hs.AST.Type
+import HsBindgen.SHs.AST
 
 {-------------------------------------------------------------------------------
   Imports
@@ -70,9 +71,15 @@ iDataIx = HsImportModule "Data.Ix" (Just "Ix")
 iDataBits :: HsImportModule
 iDataBits = HsImportModule "Data.Bits" (Just "Bits")
 
--- | @C.Typing@ import module
-iCTyping :: HsImportModule
-iCTyping = HsImportModule "C.Typing" (Just "C")
+-- | @C.Expr.*@ platform specific import module
+iCExprFor :: Target -> HsImportModule
+iCExprFor = \case
+    Target_Linux_X86_64   -> HsImportModule "C.Expr.Posix64" (Just "CExpr")
+    Target_Linux_AArch64  -> HsImportModule "C.Expr.Posix64" (Just "CExpr")
+    Target_Linux_X86      -> HsImportModule "C.Expr.Posix32" (Just "CExpr")
+    Target_MacOS_X86_64   -> HsImportModule "C.Expr.Posix64" (Just "CExpr")
+    Target_MacOS_AArch64  -> HsImportModule "C.Expr.Posix64" (Just "CExpr")
+    Target_Windows_X86_64 -> HsImportModule "C.Expr.Win64"   (Just "CExpr")
 
 {-------------------------------------------------------------------------------
   NameType
@@ -180,52 +187,7 @@ resolveGlobal = \case
 
     NomEq_class -> importU iDataTypeEquality  "~"
 
-    Not_class             -> importQ iCTyping "Not"
-    Not_not               -> importQ iCTyping "not"
-    Logical_class         -> importQ iCTyping "Logical"
-    Logical_and           -> importU iCTyping "&&"
-    Logical_or            -> importU iCTyping "||"
-    RelEq_class           -> importQ iCTyping "RelEq"
-    RelEq_eq              -> importU iCTyping "=="
-    RelEq_uneq            -> importU iCTyping "!="
-    RelOrd_class          -> importQ iCTyping "RelOrd"
-    RelOrd_lt             -> importU iCTyping "<"
-    RelOrd_le             -> importU iCTyping "<="
-    RelOrd_gt             -> importU iCTyping ">"
-    RelOrd_ge             -> importU iCTyping ">="
-    Plus_class            -> importQ iCTyping "Plus"
-    Plus_resTyCon         -> importQ iCTyping "PlusRes"
-    Plus_plus             -> importQ iCTyping "plus"
-    Minus_class           -> importQ iCTyping "Minus"
-    Minus_resTyCon        -> importQ iCTyping "MinusRes"
-    Minus_negate          -> importQ iCTyping "negate"
-    Add_class             -> importQ iCTyping "Add"
-    Add_resTyCon          -> importQ iCTyping "AddRes"
-    Add_add               -> importU iCTyping "+"
-    Sub_class             -> importQ iCTyping "Sub"
-    Sub_resTyCon          -> importQ iCTyping "SubRes"
-    Sub_minus             -> importU iCTyping "-"
-    Mult_class            -> importQ iCTyping "Mult"
-    Mult_resTyCon         -> importQ iCTyping "MultRes"
-    Mult_mult             -> importU iCTyping "*"
-    Div_class             -> importQ iCTyping "Div"
-    Div_resTyCon          -> importQ iCTyping "DivRes"
-    Div_div               -> importU iCTyping "/"
-    Rem_class             -> importQ iCTyping "Rem"
-    Rem_resTyCon          -> importQ iCTyping "RemRes"
-    Rem_rem               -> importU iCTyping "%"
-    Complement_class      -> importQ iCTyping "Complement"
-    Complement_resTyCon   -> importQ iCTyping "ComplementRes"
-    Complement_complement -> importQ iCTyping ".~"
-    Bitwise_class         -> importQ iCTyping "Bitwise"
-    Bitwise_resTyCon      -> importQ iCTyping "BitsRes"
-    Bitwise_and           -> importU iCTyping ".&."
-    Bitwise_or            -> importU iCTyping ".|."
-    Bitwise_xor           -> importU iCTyping ".^."
-    Shift_class           -> importQ iCTyping "Shift"
-    Shift_resTyCon        -> importQ iCTyping "ShiftRes"
-    Shift_shiftL          -> importU iCTyping "<<"
-    Shift_shiftR          -> importU iCTyping ">>"
+    CExpr target name -> resolveGlobalCExpr target name
 
     IntLike_tycon    -> importQ iHsBindgenSyntax "IntLike"
     FloatLike_tycon  -> importQ iHsBindgenSyntax "FloatLike"
@@ -253,6 +215,58 @@ resolveGlobal = \case
       HsPrimCFloat   -> importQ iForeignC "CFloat"
       HsPrimCDouble  -> importQ iForeignC "CDouble"
       HsPrimCPtrDiff -> importQ iForeignC "CPtrdiff"
+
+resolveGlobalCExpr :: Target -> GlobalCExpr -> ResolvedName
+resolveGlobalCExpr target = \case
+    Not_class             -> importQ iCExpr "Not"
+    Not_not               -> importQ iCExpr "not"
+    Logical_class         -> importQ iCExpr "Logical"
+    Logical_and           -> importU iCExpr "&&"
+    Logical_or            -> importU iCExpr "||"
+    RelEq_class           -> importQ iCExpr "RelEq"
+    RelEq_eq              -> importU iCExpr "=="
+    RelEq_uneq            -> importU iCExpr "!="
+    RelOrd_class          -> importQ iCExpr "RelOrd"
+    RelOrd_lt             -> importU iCExpr "<"
+    RelOrd_le             -> importU iCExpr "<="
+    RelOrd_gt             -> importU iCExpr ">"
+    RelOrd_ge             -> importU iCExpr ">="
+    Plus_class            -> importQ iCExpr "Plus"
+    Plus_resTyCon         -> importQ iCExpr "PlusRes"
+    Plus_plus             -> importQ iCExpr "plus"
+    Minus_class           -> importQ iCExpr "Minus"
+    Minus_resTyCon        -> importQ iCExpr "MinusRes"
+    Minus_negate          -> importQ iCExpr "negate"
+    Add_class             -> importQ iCExpr "Add"
+    Add_resTyCon          -> importQ iCExpr "AddRes"
+    Add_add               -> importU iCExpr "+"
+    Sub_class             -> importQ iCExpr "Sub"
+    Sub_resTyCon          -> importQ iCExpr "SubRes"
+    Sub_minus             -> importU iCExpr "-"
+    Mult_class            -> importQ iCExpr "Mult"
+    Mult_resTyCon         -> importQ iCExpr "MultRes"
+    Mult_mult             -> importU iCExpr "*"
+    Div_class             -> importQ iCExpr "Div"
+    Div_resTyCon          -> importQ iCExpr "DivRes"
+    Div_div               -> importU iCExpr "/"
+    Rem_class             -> importQ iCExpr "Rem"
+    Rem_resTyCon          -> importQ iCExpr "RemRes"
+    Rem_rem               -> importU iCExpr "%"
+    Complement_class      -> importQ iCExpr "Complement"
+    Complement_resTyCon   -> importQ iCExpr "ComplementRes"
+    Complement_complement -> importQ iCExpr ".~"
+    Bitwise_class         -> importQ iCExpr "Bitwise"
+    Bitwise_resTyCon      -> importQ iCExpr "BitsRes"
+    Bitwise_and           -> importU iCExpr ".&."
+    Bitwise_or            -> importU iCExpr ".|."
+    Bitwise_xor           -> importU iCExpr ".^."
+    Shift_class           -> importQ iCExpr "Shift"
+    Shift_resTyCon        -> importQ iCExpr "ShiftRes"
+    Shift_shiftL          -> importU iCExpr "<<"
+    Shift_shiftR          -> importU iCExpr ">>"
+  where
+    iCExpr :: HsImportModule
+    iCExpr = iCExprFor target
 
 {-------------------------------------------------------------------------------
   BackendName

--- a/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
@@ -20,6 +20,7 @@ import GHC.Float
 
 import C.Operator.Classes qualified as C
 import HsBindgen.C.AST.Literal (canBeRepresentedAsRational)
+import HsBindgen.Clang.Args (Target)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
@@ -77,52 +78,7 @@ mkGlobal =  \case
 
       NomEq_class -> ''(~)
 
-      Not_class             -> ''C.Not
-      Not_not               ->  'C.not
-      Logical_class         -> ''C.Logical
-      Logical_and           -> '(C.&&)
-      Logical_or            -> '(C.||)
-      RelEq_class           -> ''C.RelEq
-      RelEq_eq              -> '(C.==)
-      RelEq_uneq            -> '(C.!=)
-      RelOrd_class          -> ''C.RelOrd
-      RelOrd_lt             -> '(C.<)
-      RelOrd_le             -> '(C.<=)
-      RelOrd_gt             -> '(C.>)
-      RelOrd_ge             -> '(C.>=)
-      Plus_class            -> ''C.Plus
-      Plus_resTyCon         -> ''C.PlusRes
-      Plus_plus             ->  'C.plus
-      Minus_class           -> ''C.Minus
-      Minus_resTyCon        -> ''C.MinusRes
-      Minus_negate          ->  'C.negate
-      Add_class             -> ''C.Add
-      Add_resTyCon          -> ''C.AddRes
-      Add_add               -> '(C.+)
-      Sub_class             -> ''C.Sub
-      Sub_resTyCon          -> ''C.SubRes
-      Sub_minus             -> '(C.-)
-      Mult_class            -> ''C.Mult
-      Mult_resTyCon         -> ''C.MultRes
-      Mult_mult             -> '(C.*)
-      Div_class             -> ''C.Div
-      Div_resTyCon          -> ''C.DivRes
-      Div_div               -> '(C./)
-      Rem_class             -> ''C.Rem
-      Rem_resTyCon          -> ''C.RemRes
-      Rem_rem               -> '(C.%)
-      Complement_class      -> ''C.Complement
-      Complement_resTyCon   -> ''C.ComplementRes
-      Complement_complement -> '(C..~)
-      Bitwise_class         -> ''C.Bitwise
-      Bitwise_resTyCon      -> ''C.BitsRes
-      Bitwise_and           -> '(C..&.)
-      Bitwise_or            -> '(C..|.)
-      Bitwise_xor           -> '(C..^.)
-      Shift_class           -> ''C.Shift
-      Shift_resTyCon        -> ''C.ShiftRes
-      Shift_shiftL          -> '(C.<<)
-      Shift_shiftR          -> '(C.>>)
+      CExpr target name -> mkGlobalCExpr target name
 
       IntLike_tycon        -> ''HsBindgen.Runtime.Syntax.IntLike
       FloatLike_tycon      -> ''HsBindgen.Runtime.Syntax.FloatLike
@@ -175,6 +131,57 @@ mkGlobal =  \case
         -> [| Foreign.C.Types.CDouble $ castWord64ToDouble $( TH.lift $ castDoubleToWord64 d ) |]
       EApp f x      -> TH.appE (mkExpr be f) (mkExpr be x)
 -}
+
+-- | TODO: Target @target@ into account
+mkGlobalCExpr :: Target -> GlobalCExpr -> TH.Name
+mkGlobalCExpr _target = \case
+      Not_class             -> ''C.Not
+      Not_not               ->  'C.not
+      Logical_class         -> ''C.Logical
+      Logical_and           -> '(C.&&)
+      Logical_or            -> '(C.||)
+      RelEq_class           -> ''C.RelEq
+      RelEq_eq              -> '(C.==)
+      RelEq_uneq            -> '(C.!=)
+      RelOrd_class          -> ''C.RelOrd
+      RelOrd_lt             -> '(C.<)
+      RelOrd_le             -> '(C.<=)
+      RelOrd_gt             -> '(C.>)
+      RelOrd_ge             -> '(C.>=)
+      Plus_class            -> ''C.Plus
+      Plus_resTyCon         -> ''C.PlusRes
+      Plus_plus             ->  'C.plus
+      Minus_class           -> ''C.Minus
+      Minus_resTyCon        -> ''C.MinusRes
+      Minus_negate          ->  'C.negate
+      Add_class             -> ''C.Add
+      Add_resTyCon          -> ''C.AddRes
+      Add_add               -> '(C.+)
+      Sub_class             -> ''C.Sub
+      Sub_resTyCon          -> ''C.SubRes
+      Sub_minus             -> '(C.-)
+      Mult_class            -> ''C.Mult
+      Mult_resTyCon         -> ''C.MultRes
+      Mult_mult             -> '(C.*)
+      Div_class             -> ''C.Div
+      Div_resTyCon          -> ''C.DivRes
+      Div_div               -> '(C./)
+      Rem_class             -> ''C.Rem
+      Rem_resTyCon          -> ''C.RemRes
+      Rem_rem               -> '(C.%)
+      Complement_class      -> ''C.Complement
+      Complement_resTyCon   -> ''C.ComplementRes
+      Complement_complement -> '(C..~)
+      Bitwise_class         -> ''C.Bitwise
+      Bitwise_resTyCon      -> ''C.BitsRes
+      Bitwise_and           -> '(C..&.)
+      Bitwise_or            -> '(C..|.)
+      Bitwise_xor           -> '(C..^.)
+      Shift_class           -> ''C.Shift
+      Shift_resTyCon        -> ''C.ShiftRes
+      Shift_shiftL          -> '(C.<<)
+      Shift_shiftR          -> '(C.>>)
+
 
 mkExpr :: Quote q => Env ctx TH.Name -> SExpr ctx -> q TH.Exp
 mkExpr env = \case

--- a/hs-bindgen/src/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/AST.hs
@@ -1,6 +1,7 @@
 -- | Simplified HS abstract syntax tree
 module HsBindgen.SHs.AST (
     Global (..),
+    GlobalCExpr (..),
     ClosedExpr,
     SExpr (..),
     pattern EInt,
@@ -16,11 +17,12 @@ module HsBindgen.SHs.AST (
     PatternSynonym (..),
 ) where
 
-import HsBindgen.Imports
-import HsBindgen.NameHint
+import HsBindgen.Clang.Args (Target)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
+import HsBindgen.Imports
+import HsBindgen.NameHint
 
 import DeBruijn
 
@@ -72,7 +74,22 @@ data Global =
     -- | Primitive (unboxed) type equality
   | NomEq_class
 
-  | Not_class
+    -- | Names from @c-expr@ must be imported from a platform-specific module
+  | CExpr Target GlobalCExpr
+
+  | IntLike_tycon
+  | FloatLike_tycon
+
+  | CFloat_constructor
+  | CDouble_constructor
+  | GHC_Float_castWord32ToFloat
+  | GHC_Float_castWord64ToDouble
+
+  | PrimType HsPrimType
+  deriving stock (Eq, Show)
+
+data GlobalCExpr =
+    Not_class
   | Not_not
   | Logical_class
   | Logical_and
@@ -118,16 +135,6 @@ data Global =
   | Shift_resTyCon
   | Shift_shiftL
   | Shift_shiftR
-
-  | IntLike_tycon
-  | FloatLike_tycon
-
-  | CFloat_constructor
-  | CDouble_constructor
-  | GHC_Float_castWord32ToFloat
-  | GHC_Float_castWord64ToDouble
-
-  | PrimType HsPrimType
   deriving stock (Eq, Show)
 
 type ClosedExpr = SExpr EmptyCtx

--- a/hs-bindgen/src/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/Translation.hs
@@ -9,6 +9,7 @@ import Data.Text qualified as T
 
 import HsBindgen.C.AST qualified as C (MFun(..))
 import HsBindgen.C.Tc.Macro qualified as C
+import HsBindgen.Clang.Args (Target)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
@@ -173,8 +174,8 @@ simpleTyConApp
     = Just $ TGlobal $ PrimType $ hsPrimFloatTy floaty
 simpleTyConApp _ _ = Nothing
 
-tyConGlobal :: C.TyCon args res -> SType ctx
-tyConGlobal = \case
+tyConGlobal :: Target -> C.TyCon args res -> SType ctx
+tyConGlobal target = \case
   C.GenerativeTyCon tc ->
     case tc of
       C.DataTyCon dc ->
@@ -199,57 +200,57 @@ tyConGlobal = \case
             error "tyConGlobal EmptyTyCon"
       C.ClassTyCon cls -> TGlobal $
         case cls of
-          C.NotTyCon        -> Not_class
-          C.LogicalTyCon    -> Logical_class
-          C.RelEqTyCon      -> RelEq_class
-          C.RelOrdTyCon     -> RelOrd_class
-          C.PlusTyCon       -> Plus_class
-          C.MinusTyCon      -> Minus_class
-          C.AddTyCon        -> Add_class
-          C.SubTyCon        -> Sub_class
-          C.MultTyCon       -> Mult_class
-          C.DivTyCon        -> Div_class
-          C.RemTyCon        -> Rem_class
-          C.ComplementTyCon -> Complement_class
-          C.BitwiseTyCon    -> Bitwise_class
-          C.ShiftTyCon      -> Shift_class
+          C.NotTyCon        -> CExpr target Not_class
+          C.LogicalTyCon    -> CExpr target Logical_class
+          C.RelEqTyCon      -> CExpr target RelEq_class
+          C.RelOrdTyCon     -> CExpr target RelOrd_class
+          C.PlusTyCon       -> CExpr target Plus_class
+          C.MinusTyCon      -> CExpr target Minus_class
+          C.AddTyCon        -> CExpr target Add_class
+          C.SubTyCon        -> CExpr target Sub_class
+          C.MultTyCon       -> CExpr target Mult_class
+          C.DivTyCon        -> CExpr target Div_class
+          C.RemTyCon        -> CExpr target Rem_class
+          C.ComplementTyCon -> CExpr target Complement_class
+          C.BitwiseTyCon    -> CExpr target Bitwise_class
+          C.ShiftTyCon      -> CExpr target Shift_class
   C.FamilyTyCon tc -> TGlobal $
     case tc of
-      C.PlusResTyCon       -> Plus_resTyCon
-      C.MinusResTyCon      -> Minus_resTyCon
-      C.AddResTyCon        -> Add_resTyCon
-      C.SubResTyCon        -> Sub_resTyCon
-      C.MultResTyCon       -> Mult_resTyCon
-      C.DivResTyCon        -> Div_resTyCon
-      C.RemResTyCon        -> Rem_resTyCon
-      C.ComplementResTyCon -> Complement_resTyCon
-      C.BitsResTyCon       -> Bitwise_resTyCon
-      C.ShiftResTyCon      -> Shift_resTyCon
+      C.PlusResTyCon       -> CExpr target Plus_resTyCon
+      C.MinusResTyCon      -> CExpr target Minus_resTyCon
+      C.AddResTyCon        -> CExpr target Add_resTyCon
+      C.SubResTyCon        -> CExpr target Sub_resTyCon
+      C.MultResTyCon       -> CExpr target Mult_resTyCon
+      C.DivResTyCon        -> CExpr target Div_resTyCon
+      C.RemResTyCon        -> CExpr target Rem_resTyCon
+      C.ComplementResTyCon -> CExpr target Complement_resTyCon
+      C.BitsResTyCon       -> CExpr target Bitwise_resTyCon
+      C.ShiftResTyCon      -> CExpr target Shift_resTyCon
 
-mfunGlobal :: C.MFun arity -> Global
-mfunGlobal = \case
-  C.MUnaryPlus  -> Plus_plus
-  C.MUnaryMinus -> Minus_negate
-  C.MLogicalNot -> Not_not
-  C.MBitwiseNot -> Complement_complement
-  C.MMult       -> Mult_mult
-  C.MDiv        -> Div_div
-  C.MRem        -> Rem_rem
-  C.MAdd        -> Add_add
-  C.MSub        -> Sub_minus
-  C.MShiftLeft  -> Shift_shiftL
-  C.MShiftRight -> Shift_shiftR
-  C.MRelLT      -> RelOrd_lt
-  C.MRelLE      -> RelOrd_le
-  C.MRelGT      -> RelOrd_gt
-  C.MRelGE      -> RelOrd_ge
-  C.MRelEQ      -> RelEq_eq
-  C.MRelNE      -> RelEq_uneq
-  C.MBitwiseAnd -> Bitwise_and
-  C.MBitwiseXor -> Bitwise_xor
-  C.MBitwiseOr  -> Bitwise_or
-  C.MLogicalAnd -> Logical_and
-  C.MLogicalOr  -> Logical_or
+mfunGlobal :: Target -> C.MFun arity -> Global
+mfunGlobal target = \case
+  C.MUnaryPlus  -> CExpr target Plus_plus
+  C.MUnaryMinus -> CExpr target Minus_negate
+  C.MLogicalNot -> CExpr target Not_not
+  C.MBitwiseNot -> CExpr target Complement_complement
+  C.MMult       -> CExpr target Mult_mult
+  C.MDiv        -> CExpr target Div_div
+  C.MRem        -> CExpr target Rem_rem
+  C.MAdd        -> CExpr target Add_add
+  C.MSub        -> CExpr target Sub_minus
+  C.MShiftLeft  -> CExpr target Shift_shiftL
+  C.MShiftRight -> CExpr target Shift_shiftR
+  C.MRelLT      -> CExpr target RelOrd_lt
+  C.MRelLE      -> CExpr target RelOrd_le
+  C.MRelGT      -> CExpr target RelOrd_gt
+  C.MRelGE      -> CExpr target RelOrd_ge
+  C.MRelEQ      -> CExpr target RelEq_eq
+  C.MRelNE      -> CExpr target RelEq_uneq
+  C.MBitwiseAnd -> CExpr target Bitwise_and
+  C.MBitwiseXor -> CExpr target Bitwise_xor
+  C.MBitwiseOr  -> CExpr target Bitwise_or
+  C.MLogicalAnd -> CExpr target Logical_and
+  C.MLogicalOr  -> CExpr target Logical_or
 
 
 hsPrimIntTy :: C.IntegralType -> HsPrimType


### PR DESCRIPTION
This introduces

```haskell
data Global =
     .. -- all the other names
  | CExpr Target GlobalCExpr

data GlobalCExpr =
    Not_class
  | .. -- etc
```

The reason is that names from `c-expr` must be imported from a platform specific module. By adding the target to the name itself, the translation from C to our internal Haskell representations can be target platform specific, at which point further processing (such as rendering of the Haskell code) is context free.

However, it seems we might need to further improve separation of concerns in the pipeline. In particular, it seems to make sense to change a function such as

```haskell
tyConGlobal :: C.TyCon args res -> SType ctx
```

to

```haskell
tyConGlobal :: Target -> C.TyCon args res -> SType ctx
```

However, it seems less reasonable to add a `Target` argument to a function such as 

```haskell
translatePredTy :: Hs.PredType ctx -> SType ctx
```

After all, the idea was that the translation from C to Haskell would embed target specific decisions; we should not need to make further such decisions in the translation from `Hs` to `SHs`. The core of the problem seems to be that we have definitions such as this in `Hs.AST`:

```haskell
data PredType ctx
  = DictTy AClass [TauType ctx]
  | ..

data AClass where
  AClass :: C.TyCon args C.Ct -> AClass
```

Note that this is a _Haskell_ type wrapping a _C_ type. Not entirely sure how to best address this; @sheaf let's discuss this next week.






