### PR TITLE
Always use C.Expr.BuildPlatform

### DIFF
--- a/c-expr/c-expr.cabal
+++ b/c-expr/c-expr.cabal
@@ -76,12 +76,12 @@ common common
         >= 0.5   && < 0.6
 
 -- Platform independent core library
+-- Note: the C.Operator.Classes should not be publicly visible.
+-- We should only be able to import the definitions "polluted"
+-- by instances declarations (from C.Expr.BuildPlatform).
 library c-expr-core
-
   import:
     common
-  visibility:
-    public
   hs-source-dirs:
     core
   exposed-modules:
@@ -105,11 +105,15 @@ library
     lib
   exposed-modules:
     C.Expr.BuildPlatform
+  other-modules:
     C.Expr.Posix32
     C.Expr.Posix64
     C.Expr.Win64
   build-depends:
     c-expr:c-expr-core
+  reexported-modules:
+    C.Operators,
+    C.Type
   default-language:
     Haskell2010
 

--- a/c-expr/lib/C/Expr/BuildPlatform.hs
+++ b/c-expr/lib/C/Expr/BuildPlatform.hs
@@ -2,6 +2,7 @@
 
 #include <MachDeps.h>
 
+-- | This module is incorrectly named, it's really a @HostPlatform@.
 module C.Expr.BuildPlatform
   ( module C.Operator.Classes
   ) where

--- a/hs-bindgen/fixtures/macro_functions.pp.hs
+++ b/hs-bindgen/fixtures/macro_functions.pp.hs
@@ -2,8 +2,8 @@
 
 module Example where
 
-import C.Typing ((*), (+), (/), (<), (<<))
-import qualified C.Typing as C
+import C.Expr.BuildPlatform ((*), (+), (/), (<), (<<))
+import qualified C.Expr.BuildPlatform as C
 import Data.Type.Equality ((~))
 import qualified Foreign.C as FC
 import qualified HsBindgen.Syntax as HsBindgen

--- a/hs-bindgen/fixtures/macros.pp.hs
+++ b/hs-bindgen/fixtures/macros.pp.hs
@@ -2,7 +2,7 @@
 
 module Example where
 
-import C.Typing ((*), (+))
+import C.Expr.BuildPlatform ((*), (+))
 import qualified Foreign.C as FC
 
 oBJECTLIKE1 :: FC.CInt

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -120,7 +120,7 @@ library
       -- Internal dependencies
     , hs-bindgen-libclang
     , hs-bindgen-runtime
-    , c-expr:c-expr-core
+    , c-expr
   build-depends:
       -- External dependencies
     , containers         >= 0.6.5.1 && < 0.8
@@ -177,7 +177,7 @@ test-suite golden
       -- Internal dependencies
     , hs-bindgen
     , hs-bindgen-runtime
-    , c-expr:c-expr-core
+    , c-expr
   build-depends:
       -- Inherited dependencies
     , bytestring

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
@@ -72,7 +72,7 @@ iDataBits = HsImportModule "Data.Bits" (Just "Bits")
 
 -- | @C.Typing@ import module
 iCTyping :: HsImportModule
-iCTyping = HsImportModule "C.Typing" (Just "C")
+iCTyping = HsImportModule "C.Expr.BuildPlatform" (Just "C")
 
 {-------------------------------------------------------------------------------
   NameType

--- a/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
@@ -18,7 +18,7 @@ import GHC.Float
   ( castWord64ToDouble, castDoubleToWord64
   , castWord32ToFloat , castFloatToWord32 )
 
-import C.Operator.Classes qualified as C
+import C.Expr.BuildPlatform qualified as C
 import HsBindgen.C.AST.Literal (canBeRepresentedAsRational)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name


### PR DESCRIPTION
From the perspective of the compiler, it's always compiling code for host. Thus we can use `C.Expr.BuildPlatform` (which is really a HostPlatform - compiled code shouldn't really be aware of build platform anwyay).

This is an alternative to #391. Arguably a lot simpiler one. There are a lot of further cleanups, which can be made in `c-expr`, (e.g. renaming the `C.Expr.BuildPlatform`, potentially getting rid of non-host architecture modules, simplifying library structure, making instances non-orphans etc) but these are not strictly necessary, so not done to not obscure this change.