### PR TITLE
Generate macro newtype instances

### DIFF
--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -27,6 +27,58 @@
           macroArgs = [],
           macroBody = MTerm
             (MType (TypePrim PrimBool))}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Ix
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bounded
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bits
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    FiniteBits
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Integral
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName "@NsTypeConstr" "BOOL"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
+    (HsName "@NsTypeConstr" "BOOL"),
   DeclData
     Struct {
       structName = HsName

--- a/hs-bindgen/fixtures/bool.pp.hs
+++ b/hs-bindgen/fixtures/bool.pp.hs
@@ -5,13 +5,42 @@
 
 module Example where
 
+import Data.Bits (FiniteBits)
+import qualified Data.Bits as Bits
+import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
-import Prelude ((<*>), (>>), Eq, Int, Show, pure)
+import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 newtype BOOL = BOOL
   { unBOOL :: FC.CBool
   }
+
+deriving newtype instance F.Storable BOOL
+
+deriving stock instance Eq BOOL
+
+deriving stock instance Ord BOOL
+
+deriving stock instance Read BOOL
+
+deriving stock instance Show BOOL
+
+deriving newtype instance Enum BOOL
+
+deriving newtype instance Ix.Ix BOOL
+
+deriving newtype instance Bounded BOOL
+
+deriving newtype instance Bits.Bits BOOL
+
+deriving newtype instance FiniteBits BOOL
+
+deriving newtype instance Integral BOOL
+
+deriving newtype instance Num BOOL
+
+deriving newtype instance Real BOOL
 
 data Bools1 = Bools1
   { bools1_x :: FC.CBool

--- a/hs-bindgen/fixtures/bool.th.txt
+++ b/hs-bindgen/fixtures/bool.th.txt
@@ -1,4 +1,17 @@
 newtype BOOL = BOOL {unBOOL :: CBool}
+deriving newtype instance Storable BOOL
+deriving stock instance Eq BOOL
+deriving stock instance Ord BOOL
+deriving stock instance Read BOOL
+deriving stock instance Show BOOL
+deriving newtype instance Enum BOOL
+deriving newtype instance Ix BOOL
+deriving newtype instance Bounded BOOL
+deriving newtype instance Bits BOOL
+deriving newtype instance FiniteBits BOOL
+deriving newtype instance Integral BOOL
+deriving newtype instance Num BOOL
+deriving newtype instance Real BOOL
 data Bools1 = Bools1 {bools1_x :: CBool, bools1_y :: CBool}
 instance Storable Bools1
     where {sizeOf = \_ -> 2 :: Int;

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -31,6 +31,58 @@
                 (PrimIntegral
                   PrimInt
                   Signed)))}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Ix
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bounded
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bits
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    FiniteBits
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Integral
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName "@NsTypeConstr" "M1"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
+    (HsName "@NsTypeConstr" "M1"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -61,6 +113,58 @@
             (MType
               (TypePrim
                 (PrimChar Nothing)))}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Ix
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bounded
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bits
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    FiniteBits
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Integral
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName "@NsTypeConstr" "M2"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
+    (HsName "@NsTypeConstr" "M2"),
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
@@ -16,9 +16,61 @@ newtype M1 = M1
   { unM1 :: FC.CInt
   }
 
+deriving newtype instance F.Storable M1
+
+deriving stock instance Eq M1
+
+deriving stock instance Ord M1
+
+deriving stock instance Read M1
+
+deriving stock instance Show M1
+
+deriving newtype instance Enum M1
+
+deriving newtype instance Ix.Ix M1
+
+deriving newtype instance Bounded M1
+
+deriving newtype instance Bits.Bits M1
+
+deriving newtype instance FiniteBits M1
+
+deriving newtype instance Integral M1
+
+deriving newtype instance Num M1
+
+deriving newtype instance Real M1
+
 newtype M2 = M2
   { unM2 :: FC.CChar
   }
+
+deriving newtype instance F.Storable M2
+
+deriving stock instance Eq M2
+
+deriving stock instance Ord M2
+
+deriving stock instance Read M2
+
+deriving stock instance Show M2
+
+deriving newtype instance Enum M2
+
+deriving newtype instance Ix.Ix M2
+
+deriving newtype instance Bounded M2
+
+deriving newtype instance Bits.Bits M2
+
+deriving newtype instance FiniteBits M2
+
+deriving newtype instance Integral M2
+
+deriving newtype instance Num M2
+
+deriving newtype instance Real M2
 
 newtype T1 = T1
   { unT1 :: FC.CInt

--- a/hs-bindgen/fixtures/typedef_vs_macro.th.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.th.txt
@@ -1,5 +1,31 @@
 newtype M1 = M1 {unM1 :: CInt}
+deriving newtype instance Storable M1
+deriving stock instance Eq M1
+deriving stock instance Ord M1
+deriving stock instance Read M1
+deriving stock instance Show M1
+deriving newtype instance Enum M1
+deriving newtype instance Ix M1
+deriving newtype instance Bounded M1
+deriving newtype instance Bits M1
+deriving newtype instance FiniteBits M1
+deriving newtype instance Integral M1
+deriving newtype instance Num M1
+deriving newtype instance Real M1
 newtype M2 = M2 {unM2 :: CChar}
+deriving newtype instance Storable M2
+deriving stock instance Eq M2
+deriving stock instance Ord M2
+deriving stock instance Read M2
+deriving stock instance Show M2
+deriving newtype instance Enum M2
+deriving newtype instance Ix M2
+deriving newtype instance Bounded M2
+deriving newtype instance Bits M2
+deriving newtype instance FiniteBits M2
+deriving newtype instance Integral M2
+deriving newtype instance Num M2
+deriving newtype instance Real M2
 newtype T1 = T1 {unT1 :: CInt}
 deriving newtype instance Storable T1
 deriving stock instance Eq T1


### PR DESCRIPTION
We generate the same instances as for `typedef`s.