### PR TITLE
Use absolute paths in library, relative paths in text fixtures

### DIFF
--- a/c-expr/test/CallClang.hs
+++ b/c-expr/test/CallClang.hs
@@ -321,7 +321,7 @@ clangVisitChildren args f srcContents = do
 
   unit <- clangGetTranslationUnit args srcContents
 
-  diags  <- Clang.clang_getDiagnostics Nothing unit Nothing
+  diags  <- Clang.clang_getDiagnostics unit Nothing
   let (errors, _warnings) = partition diagnosticIsSevere diags
 
 {-

--- a/hs-bindgen-libclang/hs-bindgen-libclang.cabal
+++ b/hs-bindgen-libclang/hs-bindgen-libclang.cabal
@@ -87,7 +87,6 @@ library
     , hs-bindgen-runtime
   build-depends:
       -- External dependencies
-    , filepath      >= 1.4.2.2 && < 1.6
     , mtl           >= 2.2     && < 2.4
     , pretty-show   >= 1.10    && < 1.11
     , text          >= 1.2     && < 2.2

--- a/hs-bindgen-libclang/src/HsBindgen/Clang/HighLevel/SourceLoc.hs
+++ b/hs-bindgen-libclang/src/HsBindgen/Clang/HighLevel/SourceLoc.hs
@@ -37,7 +37,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Foreign.C
 import GHC.Generics (Generic)
-import System.FilePath qualified as FilePath
 import Text.Show.Pretty (PrettyVal(..))
 
 import HsBindgen.Clang.LowLevel.Core qualified as Core
@@ -263,12 +262,9 @@ instance Show a => PrettyVal (Range a) where
   Conversion
 -------------------------------------------------------------------------------}
 
-toMulti ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceLocation
-  -> IO MultiLoc
-toMulti relPath location = do
-    expansion <- clang_getExpansionLocation relPath location
+toMulti :: Core.CXSourceLocation -> IO MultiLoc
+toMulti location = do
+    expansion <- clang_getExpansionLocation location
 
     let unlessIsExpanion :: SingleLoc -> Maybe SingleLoc
         unlessIsExpanion loc = do
@@ -276,15 +272,12 @@ toMulti relPath location = do
             return loc
 
     MultiLoc expansion
-      <$> (unlessIsExpanion <$> clang_getPresumedLocation relPath location)
-      <*> (unlessIsExpanion <$> clang_getSpellingLocation relPath location)
-      <*> (unlessIsExpanion <$> clang_getFileLocation     relPath location)
+      <$> (unlessIsExpanion <$> clang_getPresumedLocation location)
+      <*> (unlessIsExpanion <$> clang_getSpellingLocation location)
+      <*> (unlessIsExpanion <$> clang_getFileLocation     location)
 
-toRange ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceRange
-  -> IO (Range MultiLoc)
-toRange = toRangeWith . toMulti
+toRange :: Core.CXSourceRange -> IO (Range MultiLoc)
+toRange = toRangeWith toMulti
 
 fromSingle :: Core.CXTranslationUnit -> SingleLoc -> IO Core.CXSourceLocation
 fromSingle unit SingleLoc{singleLocPath, singleLocLine, singleLocColumn} = do
@@ -305,86 +298,59 @@ fromRange unit Range{rangeStart, rangeEnd} = do
   Get single location
 -------------------------------------------------------------------------------}
 
-clang_getExpansionLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceLocation
-  -> IO SingleLoc
-clang_getExpansionLocation relPath location =
-    toSingle' relPath =<< Core.clang_getExpansionLocation location
+clang_getExpansionLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getExpansionLocation location =
+    toSingle' =<< Core.clang_getExpansionLocation location
 
-clang_getPresumedLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceLocation
-  -> IO SingleLoc
-clang_getPresumedLocation relPath location =
-    toSingle relPath <$> Core.clang_getPresumedLocation location
+clang_getPresumedLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getPresumedLocation location =
+    toSingle <$> Core.clang_getPresumedLocation location
 
-clang_getSpellingLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceLocation
-  -> IO SingleLoc
-clang_getSpellingLocation relPath location =
-    toSingle' relPath =<< Core.clang_getSpellingLocation location
+clang_getSpellingLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getSpellingLocation location =
+    toSingle' =<< Core.clang_getSpellingLocation location
 
-clang_getFileLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXSourceLocation
-  -> IO SingleLoc
-clang_getFileLocation relPath location =
-    toSingle' relPath =<< Core.clang_getFileLocation location
+clang_getFileLocation :: Core.CXSourceLocation -> IO SingleLoc
+clang_getFileLocation location =
+    toSingle' =<< Core.clang_getFileLocation location
 
 {-------------------------------------------------------------------------------
   Convenience wrappers for @CXSourceLocation@
 -------------------------------------------------------------------------------}
 
 -- | Retrieve the source location of the given diagnostic.
-clang_getDiagnosticLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXDiagnostic
-  -> IO MultiLoc
-clang_getDiagnosticLocation relPath diagnostic =
-    toMulti relPath =<< Core.clang_getDiagnosticLocation diagnostic
+clang_getDiagnosticLocation :: Core.CXDiagnostic -> IO MultiLoc
+clang_getDiagnosticLocation diagnostic =
+    toMulti =<< Core.clang_getDiagnosticLocation diagnostic
 
 -- | Retrieve the physical location of the source constructor referenced by the
 -- given cursor.
-clang_getCursorLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXCursor
-  -> IO MultiLoc
-clang_getCursorLocation relPath cursor =
-    toMulti relPath =<< Core.clang_getCursorLocation cursor
+clang_getCursorLocation :: Core.CXCursor -> IO MultiLoc
+clang_getCursorLocation cursor =
+    toMulti =<< Core.clang_getCursorLocation cursor
 
 -- | Retrieve the source location of the given token.
-clang_getTokenLocation ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXTranslationUnit
-  -> Core.CXToken
-  -> IO MultiLoc
-clang_getTokenLocation relPath unit token =
-    toMulti relPath =<< Core.clang_getTokenLocation unit token
+clang_getTokenLocation :: Core.CXTranslationUnit -> Core.CXToken -> IO MultiLoc
+clang_getTokenLocation unit token =
+    toMulti =<< Core.clang_getTokenLocation unit token
 
 {-------------------------------------------------------------------------------
   Convenience wrappers for @CXSourceRange@
 -------------------------------------------------------------------------------}
 
 -- | Retrieve a source range associated with the diagnostic.
-clang_getDiagnosticRange ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXDiagnostic
-  -> CUInt
-  -> IO (Range MultiLoc)
-clang_getDiagnosticRange relPath diagnostic range =
-    toRange relPath =<< Core.clang_getDiagnosticRange diagnostic range
+clang_getDiagnosticRange :: Core.CXDiagnostic -> CUInt -> IO (Range MultiLoc)
+clang_getDiagnosticRange diagnostic range =
+    toRange =<< Core.clang_getDiagnosticRange diagnostic range
 
 -- | Retrieve the replacement information for a given fix-it.
 clang_getDiagnosticFixIt ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXDiagnostic
+     Core.CXDiagnostic
   -> CUInt
   -> IO (Range MultiLoc, Text)
-clang_getDiagnosticFixIt relPath diagnostic fixit = do
+clang_getDiagnosticFixIt diagnostic fixit = do
     (range, replacement) <- Core.clang_getDiagnosticFixIt diagnostic fixit
-    (, replacement) <$> toRange relPath range
+    (, replacement) <$> toRange range
 
 -- | Retrieve a range for a piece that forms the cursors spelling name.
 --
@@ -392,57 +358,43 @@ clang_getDiagnosticFixIt relPath diagnostic fixit = do
 -- relevant part of the returned range is the /spelling/ location. That
 -- assumption may be false.
 clang_Cursor_getSpellingNameRange ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXCursor
+     Core.CXCursor
   -> CUInt
   -> CUInt
   -> IO (Range SingleLoc)
-clang_Cursor_getSpellingNameRange relPath cursor pieceIndex options = do
+clang_Cursor_getSpellingNameRange cursor pieceIndex options = do
     range <- Core.clang_Cursor_getSpellingNameRange cursor pieceIndex options
-    toRangeWith (clang_getSpellingLocation relPath) range
+    toRangeWith clang_getSpellingLocation range
 
 -- | Retrieve the physical extent of the source construct referenced by the
 -- given cursor.
-clang_getCursorExtent ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXCursor
-  -> IO (Range MultiLoc)
-clang_getCursorExtent relPath cursor =
-    toRange relPath =<< Core.clang_getCursorExtent cursor
+clang_getCursorExtent :: Core.CXCursor -> IO (Range MultiLoc)
+clang_getCursorExtent cursor =
+    toRange =<< Core.clang_getCursorExtent cursor
 
 -- | Retrieve a source range that covers the given token.
 clang_getTokenExtent ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Core.CXTranslationUnit
+     Core.CXTranslationUnit
   -> Core.CXToken
   -> IO (Range MultiLoc)
-clang_getTokenExtent relPath unit token =
-    toRange relPath =<< Core.clang_getTokenExtent unit token
+clang_getTokenExtent unit token =
+    toRange =<< Core.clang_getTokenExtent unit token
 
 {-------------------------------------------------------------------------------
   Auxiliary
 -------------------------------------------------------------------------------}
 
-toSingle ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> (Text, CUInt, CUInt)
-  -> SingleLoc
-toSingle relPath (singleLocPath, singleLocLine, singleLocColumn) = SingleLoc{
-      singleLocPath   = SourcePath $ maybe id makeRelative relPath singleLocPath
+toSingle :: (Text, CUInt, CUInt) -> SingleLoc
+toSingle (singleLocPath, singleLocLine, singleLocColumn) = SingleLoc{
+      singleLocPath   = SourcePath   singleLocPath
     , singleLocLine   = fromIntegral singleLocLine
     , singleLocColumn = fromIntegral singleLocColumn
     }
-  where
-    makeRelative :: FilePath -> Text -> Text
-    makeRelative path = Text.pack . FilePath.makeRelative path . Text.unpack
 
-toSingle' ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> (Core.CXFile, CUInt, CUInt, CUInt)
-  -> IO SingleLoc
-toSingle' relPath (file, singleLocLine, singleLocColumn, _offset) = do
+toSingle' :: (Core.CXFile, CUInt, CUInt, CUInt) -> IO SingleLoc
+toSingle' (file, singleLocLine, singleLocColumn, _offset) = do
     singleLocPath <- Core.clang_getFileName file
-    return $ toSingle relPath (singleLocPath, singleLocLine, singleLocColumn)
+    return $ toSingle (singleLocPath, singleLocLine, singleLocColumn)
 
 toRangeWith ::
     (Core.CXSourceLocation -> IO a)

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -162,7 +162,6 @@ executable hs-bindgen
   build-depends:
       -- Inherited dependencies
     , data-default
-    , directory
     , filepath
   build-depends:
     , optparse-applicative >= 0.18 && < 0.19

--- a/hs-bindgen/src/HsBindgen/C/Fold/Common.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Common.hs
@@ -47,18 +47,17 @@ instance PrettyLogMsg Skipped where
 
 checkPredicate ::
      MonadIO m
-  => Maybe FilePath -- ^ Directory to make paths relative to
-  -> Tracer IO Skipped
+  => Tracer IO Skipped
   -> Predicate
   -> Fold m a
   -> Fold m a
-checkPredicate relPath tracer p k current = do
+checkPredicate tracer p k current = do
     isMatch <- liftIO $ Predicate.match current p
     case isMatch of
       Right ()     -> k current
       Left  reason -> liftIO $ do
         name <- clang_getCursorSpelling current
-        loc  <- HighLevel.clang_getCursorLocation relPath current
+        loc  <- HighLevel.clang_getCursorLocation current
         traceWith tracer Info $ Skipped name loc reason
         return $ Continue Nothing
 
@@ -83,12 +82,11 @@ data UnrecognizedType = UnrecognizedType {
 
 unrecognizedCursor ::
      (MonadIO m, HasCallStack)
-  => Maybe FilePath -- ^ Directory to make paths relative to
-  -> CXCursor
+  => CXCursor
   -> m a
-unrecognizedCursor relPath cursor = liftIO $ do
+unrecognizedCursor cursor = liftIO $ do
     unrecognizedCursorKind  <- clang_getCursorKind cursor
-    unrecognizedCursorLoc   <- HighLevel.clang_getCursorLocation relPath cursor
+    unrecognizedCursorLoc   <- HighLevel.clang_getCursorLocation cursor
     unrecognizedCursorTrace <- collectBacktrace
     throwIO UnrecognizedCursor{
         unrecognizedCursorKind

--- a/hs-bindgen/src/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src/HsBindgen/C/Parser.hs
@@ -55,13 +55,12 @@ data TranslationUnitException =
 --
 -- Maybe throw 'TranslationUnitException'.
 withTranslationUnit ::
-     Maybe FilePath        -- ^ Directory to make paths relative to
-  -> Tracer IO Diagnostic  -- ^ Tracer for warnings
+     Tracer IO Diagnostic  -- ^ Tracer for warnings
   -> ClangArgs
   -> FilePath
   -> (CXTranslationUnit -> IO r)
   -> IO r
-withTranslationUnit relPath tracer args fp k = do
+withTranslationUnit tracer args fp k = do
     -- checkFileExists fp
 
     index  <- clang_createIndex DontDisplayDiagnostics
@@ -69,7 +68,7 @@ withTranslationUnit relPath tracer args fp k = do
 
     case mUnit of
       Right unit -> do
-        diags  <- HighLevel.clang_getDiagnostics relPath unit Nothing
+        diags  <- HighLevel.clang_getDiagnostics unit Nothing
 
         let errors, warnings :: [Diagnostic]
             (errors, warnings) = partition diagnosticIsError diags

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -14,12 +14,11 @@ import HsBindgen.Lib
 -- TODO: add TranslationOpts argument
 --
 generateBindingsFor ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> FilePath       -- ^ C header
+     FilePath -- ^ C header
   -> Q [Dec]
-generateBindingsFor relPath fp = do
-    cHeader <- liftIO $ withTranslationUnit relPath traceWarnings args fp $
-                          parseCHeader relPath traceSkipped p
+generateBindingsFor fp = do
+    cHeader <- liftIO $ withTranslationUnit traceWarnings args fp $
+                          parseCHeader traceSkipped p
     genTH defaultTranslationOpts cHeader
   where
     traceWarnings :: Tracer IO Diagnostic

--- a/hs-bindgen/test-th/HsBindgen/TestTH/Spliced.hs
+++ b/hs-bindgen/test-th/HsBindgen/TestTH/Spliced.hs
@@ -10,7 +10,7 @@ import System.FilePath ((</>))
 import Foreign
 import Foreign.C.Types
 
-$(runIO (findPackageDirectory "hs-bindgen") >>= \dir -> templateHaskell (Just dir) (dir </> "examples" </> "test-th-01.h"))
+$(runIO (findPackageDirectory "hs-bindgen") >>= \dir -> templateHaskell (dir </> "examples" </> "test-th-01.h"))
 
 -- usage
 

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -10,10 +10,8 @@ import Data.TreeDiff.OMap qualified as OMap
 import Data.Vec.Lazy (Vec)
 import Data.Vec.Lazy qualified as Vec
 import Foreign.C
-import System.Directory qualified as Dir
-import System.FilePath (makeRelative, splitDirectories)
+import System.FilePath (isRelative, splitDirectories)
 import System.FilePath.Posix qualified as Posix
-import System.IO.Unsafe (unsafePerformIO)
 
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro as CMacro
@@ -74,10 +72,18 @@ instance ToExpr a => ToExpr (C.Token a)
 -- do not use record syntax, as it's very verbose
 instance ToExpr C.SingleLoc where
   toExpr (C.SingleLoc p l c) = toExpr $
-    -- use posix directory separators even on windows
-    Posix.joinPath (splitDirectories (makeRelative cwd (Text.unpack (C.getSourcePath p)))) ++ ":" ++
-    show l ++ ":" ++
-    show c
+    let nativePath = Text.unpack $ C.getSourcePath p
+        dirs = splitDirectories nativePath
+        -- use posix directory separators even on windows
+        normalizedPath = Posix.joinPath $
+          if isRelative nativePath
+            then dirs
+            else
+              -- make relative to musl-include when applicable
+              case dropWhile (/= "musl-include") dirs of
+                []    -> dirs
+                dirs' -> dirs'
+    in  normalizedPath ++ ":" ++ show l ++ ":" ++ show c
 
 instance ToExpr C.ReparseError where
   toExpr C.ReparseError {..} = Expr.Rec "ReparseError" $ OMap.fromList
@@ -309,16 +315,3 @@ instance ToExpr (Idx j) where
 
 instance ToExpr (Size ctx) where
   toExpr size = Expr.App "Size" [toExpr (sizeToInt size)]
-
-{-------------------------------------------------------------------------------
-  Dirty Hacks
--------------------------------------------------------------------------------}
-
--- | Unsafely get the current working directory
---
--- We need to use relative paths in test fixtures since absolute paths differ
--- across different systems.  Paths are only compared via 'ToExpr C.SingleLoc`,
--- and a minimal hack allows us to transform absolute paths to relative paths
--- there.
-cwd :: FilePath
-cwd = unsafePerformIO Dir.getCurrentDirectory

--- a/hs-bindgen/tests/TH.hs
+++ b/hs-bindgen/tests/TH.hs
@@ -10,7 +10,6 @@ import Control.Monad.State.Strict (State, get, put, evalState)
 import Data.Generics qualified as SYB
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
-import System.Directory qualified as Dir
 import System.FilePath ((</>))
 import Test.Tasty (TestTree, TestName)
 
@@ -26,9 +25,7 @@ goldenTh packageRoot name = goldenVsStringDiff_ "th" ("fixtures" </> (name ++ ".
 
     let tracer = mkTracer report report report False
 
-    relPath <- Just <$> Dir.getCurrentDirectory
-
-    header <- parseC relPath tracer args fp
+    header <- parseC tracer args fp
     let decls :: Qu [TH.Dec]
         decls = genTH defaultTranslationOpts header
 
@@ -58,14 +55,13 @@ runQu :: Qu a -> a
 runQu (Qu m) = evalState m 0
 
 parseC ::
-     Maybe FilePath -- ^ Directory to make paths relative to
-  -> Tracer IO String
+     Tracer IO String
   -> ClangArgs
   -> FilePath
   -> IO CHeader
-parseC relPath tracer args fp =
-    withTranslationUnit relPath tracerD args fp $
-      parseCHeader relPath tracerP SelectFromMainFile
+parseC tracer args fp =
+    withTranslationUnit tracerD args fp $
+      parseCHeader tracerP SelectFromMainFile
   where
     tracerD = contramap show tracer
     tracerP = contramap prettyLogMsg tracer


### PR DESCRIPTION
I added source location information to the C AST in December.  One issue that came up was use of absolute paths in test fixtures, which we cannot do because tests running on different systems have different absolute paths ([`0de1f2e9`][]).  My initial goal was to just change absolute paths to relative paths in tests, but the opaque `CHeader` type was problematic.  I implemented a fix using a type class and demonstrated how it could be used in a minimal fix for the errors we were seeing ([`ca045aed`][]).  For consistency, I ended up reverting that commit ([`477379de`][]) and implementing the change in the source location constructors themselves (which involved propagating `relPath` through many parts of the source) ([`f9799326`][]).

We now need to compare source paths, to determine which paths to import from as well as in the implementation of external bindings.  `libclang` always uses absolute paths, and we should only compare absolute paths.  We therefore need to use absolute paths in the library and translate to relative paths only in the tests.

I reverted the previous implementation.  The opaque `CHeader` still makes it difficult to implement a solution in just tests.  I considered restoring those type classes and implementing a `CHeader` instance, but I remembered hearing that dirty hacks are not so frowned upon in test the code, so I implemented a small fix that uses `unsafePerformIO` to get the current working directory for the `ToExpr SingleLoc` instance.

Is this hack acceptable, or should we go ahead and add to the `CHeader` API?

[`0de1f2e9`]: <https://github.com/well-typed/hs-bindgen/commit/0de1f2e9e008451abe2e432ecda01c1b985ba3ca>
[`ca045aed`]: <https://github.com/well-typed/hs-bindgen/commit/ca045aedc106e2139df919f425208f4cbdc98265>
[`477379de`]: <https://github.com/well-typed/hs-bindgen/commit/477379dec817f8105900c15278039f8cc9e5dfcc>
[`f9799326`]: <https://github.com/well-typed/hs-bindgen/commit/f9799326afe6e2d7d281de4a7704bfa899614354>