### PR TITLE
Macros: support for character and string literals

### DIFF
--- a/c-expr/c-expr.cabal
+++ b/c-expr/c-expr.cabal
@@ -41,6 +41,8 @@ common common
     -Wno-unticked-promoted-constructors
   default-extensions:
     DataKinds
+    DeriveGeneric
+    DeriveTraversable
     DerivingStrategies
     FlexibleInstances
     GADTs

--- a/c-expr/c-expr.cabal
+++ b/c-expr/c-expr.cabal
@@ -78,7 +78,7 @@ common common
 -- Platform independent core library
 -- Note: the C.Operator.Classes should not be publicly visible.
 -- We should only be able to import the definitions "polluted"
--- by instances declarations (from C.Expr.BuildPlatform).
+-- by instances declarations (from C.Expr.HostPlatform).
 library c-expr-core
   import:
     common
@@ -104,7 +104,7 @@ library
   hs-source-dirs:
     lib
   exposed-modules:
-    C.Expr.BuildPlatform
+    C.Expr.HostPlatform
   other-modules:
     C.Expr.Posix32
     C.Expr.Posix64

--- a/c-expr/c-expr.cabal
+++ b/c-expr/c-expr.cabal
@@ -77,6 +77,11 @@ common common
     , vec
         >= 0.5   && < 0.6
 
+  if impl(ghc < 9.4)
+    build-depends:
+      data-array-byte
+        >= 0.1.0.1 && < 0.2
+
 -- Platform independent core library
 -- Note: the C.Operator.Classes should not be publicly visible.
 -- We should only be able to import the definitions "polluted"
@@ -87,6 +92,7 @@ library c-expr-core
   hs-source-dirs:
     core
   exposed-modules:
+    C.Char
     C.Type
     C.Type.Internal.Universe
     C.Operators
@@ -114,6 +120,7 @@ library
   build-depends:
     c-expr:c-expr-core
   reexported-modules:
+    C.Char,
     C.Operators,
     C.Type
   default-language:

--- a/c-expr/core/C/Char.hs
+++ b/c-expr/core/C/Char.hs
@@ -1,0 +1,112 @@
+module C.Char
+  ( CharValue(..)
+  , charValueFromCodeUnit
+  , charValueFromCodePoint
+  , fromHaskellChar
+  , utf8SingleByteCodeUnit
+  ) where
+
+-- base
+import Data.Array.Byte
+  ( ByteArray )
+import Data.Bits
+  ( Bits(..) )
+import Data.Char
+  ( ord, chr )
+import Data.List
+  ( unfoldr )
+import Data.Maybe
+  ( fromMaybe )
+import Data.Word
+  ( Word8, Word64 )
+import GHC.Exts qualified as IsList
+  ( IsList(..) )
+import GHC.Generics
+  ( Generic )
+
+--------------------------------------------------------------------------------
+
+-- | A character, represented both as a Unicode code point (if applicable)
+-- and as the underlying character code units.
+data CharValue
+  = CharValue
+    { charValue :: !ByteArray
+      -- ^ The **code units** for a character: some bytes whose interpretation
+      -- depends on the text encoding chosen.
+    , unicodeCodePoint :: !( Maybe Char )
+       -- ^ The (optional) **Unicode code point** for this character. This is
+       -- an unsigned integer less than @0x10FF@ that uniquely identifies a
+       -- Unicode character. For example, @永@ has the Unicode code point
+       -- @0x6C38@ (also written @U+6C38@).
+       --
+       -- The representation of this code point as actual bits depends on the
+       -- text encoding, e.g. the UTF-8 encoding of @永@ is @0xE6B0B8@
+       -- (or @15118520@ in decimal notation).
+    }
+  deriving stock ( Eq, Ord, Show, Generic )
+
+-- | Turn a Haskell 'Char' into a @C@ 'CharValue'.
+fromHaskellChar :: Char -> CharValue
+fromHaskellChar c =
+  CharValue
+    { charValue = IsList.fromList
+                $ fromMaybe [ 0xEF, 0xBF, 0xBD ] -- Unicode replacement character
+                $ utf8ByteCodeUnits ( fromIntegral ( ord c ) )
+    , unicodeCodePoint = Just c
+      -- A Haskell 'Char' value is precisely a Unicode code point.
+    }
+
+
+-- | Does this character fit into a single byte?
+utf8SingleByteCodeUnit :: CharValue -> Maybe Word8
+utf8SingleByteCodeUnit ( CharValue { charValue = ba } ) =
+  case IsList.toList ba of
+    [ b ] -> Just b
+    _     -> Nothing
+
+-- | Convert a number to a 'CharValue' as raw bytes.
+charValueFromCodeUnit :: ( Integral i, Bits i ) => i -> CharValue
+charValueFromCodeUnit u =
+   CharValue
+    { charValue = IsList.fromList $ bytes u
+    , unicodeCodePoint = Nothing }
+  where
+    bytes = reverse . unfoldr step
+    step 0 = Nothing
+    step x = Just (fromIntegral (x .&. 0xFF), x `shiftR` 8)
+{-# INLINEABLE charValueFromCodeUnit #-}
+
+-- | Convert a numeric Unicode code point to a 'CharValue'.
+charValueFromCodePoint :: ( Integral i, Bits i ) => i -> CharValue
+charValueFromCodePoint i =
+  CharValue
+    { charValue = IsList.fromList
+                $ fromMaybe [ 0xEF, 0xBF, 0xBD ] -- Unicode replacement character
+                $ utf8ByteCodeUnits ( fromIntegral i )
+    , unicodeCodePoint = Just $ chr $ fromIntegral i
+    }
+
+utf8ByteCodeUnits :: Word64 -> Maybe [ Word8 ]
+utf8ByteCodeUnits p
+  | p <= 0x7F
+  = Just [ fromIntegral p ]
+  | p <= 0x7FF
+  = Just
+      [ 0xC0 .|. ( fromIntegral ( p `shiftR` 6 ) .&. 0x1F )
+      , 0X80 .|. ( fromIntegral   p              .&. 0X3F )
+      ]
+  | p <= 0xFFFF
+  = Just
+      [ 0xE0 .|. ( fromIntegral ( p `shiftR` 12 ) .&. 0x0F )
+      , 0x80 .|. ( fromIntegral ( p `shiftR` 6  ) .&. 0x3F )
+      , 0X80 .|. ( fromIntegral   p               .&. 0X3F )
+      ]
+  | p <= 0x10FFFF
+  = Just
+      [ 0xF0 .|. ( fromIntegral ( p `shiftR` 18 ) .&. 0x07 )
+      , 0x80 .|. ( fromIntegral ( p `shiftR` 12 ) .&. 0x3F )
+      , 0x80 .|. ( fromIntegral ( p `shiftR` 6  ) .&. 0x3F )
+      , 0X80 .|. ( fromIntegral   p               .&. 0X3F )
+      ]
+  | otherwise
+  = Nothing

--- a/c-expr/core/C/Operator/Internal.hs
+++ b/c-expr/core/C/Operator/Internal.hs
@@ -9,6 +9,8 @@ import Control.Exception
   ( assert )
 import qualified Data.Kind as Hs
 import Data.Void qualified as Absurd
+import GHC.Generics
+  ( Generic )
 
 -- fin
 import Data.Nat ( Nat(..) )
@@ -39,13 +41,13 @@ data OpImpl n
   | SubPtrAndPtr
   -- | Subtract an integral value from a pointer.
   | SubPtrAndIntegral
-  deriving stock Show
+  deriving stock ( Show, Generic )
 
 data Conversion
   = FromIntegralTo { fromIntegralTo :: !( Type Absurd.Void ) }
   | RealToFracTo   { realToFracTo   :: !( Type Absurd.Void ) }
   | PtrToInt
-  deriving stock Show
+  deriving stock ( Show, Generic )
 
 --------------------------------------------------------------------------------
 

--- a/c-expr/core/C/Type.hs
+++ b/c-expr/core/C/Type.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module C.Type
@@ -31,6 +30,8 @@ import Foreign.Ptr qualified as Foreign
   ( Ptr )
 import Foreign.Storable
   ( sizeOf )
+import GHC.Generics
+  ( Generic )
 import System.Info qualified
   ( os )
 
@@ -40,27 +41,27 @@ data Type a
   = Void
   | Arithmetic !ArithmeticType
   | Ptr        !a
-  deriving stock ( Eq, Ord, Show, Functor, Foldable, Traversable )
+  deriving stock ( Eq, Ord, Show, Functor, Foldable, Traversable, Generic )
 
 data ArithmeticType
   = Integral  !IntegralType
   | FloatLike !FloatingType
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data FloatingType = FloatType | DoubleType
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data IntegralType
   = Bool
   | CharLike !CharLikeType
   | IntLike  !IntLikeType
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data CharLikeType = Char | SChar | UChar
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data Sign = Signed | Unsigned
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data IntLikeType
   = Short    !Sign
@@ -68,12 +69,12 @@ data IntLikeType
   | Long     !Sign
   | LongLong !Sign
   | PtrDiff
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 --------------------------------------------------------------------------------
 
 data WordWidth = WordWidth32 | WordWidth64
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 wordWidthInBits :: WordWidth -> Word
 wordWidthInBits = \case
@@ -81,10 +82,11 @@ wordWidthInBits = \case
   WordWidth64 -> 64
 
 data OS = Windows | Posix
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 data Platform = Platform { platformWordWidth :: !WordWidth
                          , platformOS        :: !OS }
+  deriving stock ( Eq, Show, Generic )
 
 buildPlatform :: Platform
 buildPlatform =
@@ -101,7 +103,7 @@ buildPlatform =
     }
 
 newtype IntegerConversionRank = IntegerConversionRank Rational
-  deriving stock ( Eq, Ord, Show )
+  deriving stock ( Eq, Ord, Show, Generic )
 
 intLikeTypeSign :: IntLikeType -> Sign
 intLikeTypeSign = \case

--- a/c-expr/core/C/Type/Internal/Universe.hs
+++ b/c-expr/core/C/Type/Internal/Universe.hs
@@ -12,6 +12,8 @@ module C.Type.Internal.Universe
 -- base
 import Data.Functor
   ( (<&>) )
+import GHC.Generics
+  ( Generic )
 
 -- fin
 import qualified Data.Type.Nat as Fin
@@ -31,7 +33,7 @@ newtype F n = F { unF :: [ ( Vec n ( Type OpaqueTy ), Maybe Int ) ] }
 
 -- | An opaque named type with a unique identifier.
 newtype OpaqueTy = OpaqueTy Int
-  deriving stock Eq
+  deriving stock ( Eq, Ord, Show, Generic )
 
 -- | Enumerate all tuples of types.
 --

--- a/c-expr/lib/C/Expr/HostPlatform.hs
+++ b/c-expr/lib/C/Expr/HostPlatform.hs
@@ -2,8 +2,7 @@
 
 #include <MachDeps.h>
 
--- | This module is incorrectly named, it's really a @HostPlatform@.
-module C.Expr.BuildPlatform
+module C.Expr.HostPlatform
   ( module C.Operator.Classes
   ) where
 

--- a/hs-bindgen/examples/macro_strings.h
+++ b/hs-bindgen/examples/macro_strings.h
@@ -1,0 +1,37 @@
+// -------------------------------
+
+// Character literals
+#define C1 'a'
+#define C2 '"'
+#define C3 '\t'
+#define C4 '\0'
+#define C5 '\''
+#define C6 '\?'
+#define C7 '\123' // S
+#define C8 '\x53' // S
+
+#define D '\777'
+
+#define J1 'あ'
+#define J2 '\u3042'
+#define J3 '\xE3\x81\x82'
+
+// String literals
+#define S1 "a"
+#define S2 "'"
+#define S3 "\t"
+#define S4 "\0"
+#define S5 "\'"
+#define S6 "\?"
+#define S7 "\123" // S
+#define S8 "\x53" // S
+
+#define T1 "あ"
+#define T2 "\u3042"
+#define T3 "\xE3\x81\x82"
+
+#define U "\777\777\777\777"
+#define V "\1\2\3\4\5\6"
+
+#define W1 "hij\0"
+#define W2 "abc\0def\0g"

--- a/hs-bindgen/examples/macros.h
+++ b/hs-bindgen/examples/macros.h
@@ -14,6 +14,10 @@
 #define LONG_INT_TOKEN3 1844'6744'0737'0955'0592uLL
 #define LONG_INT_TOKEN4 184467'440737'0'95505'92LLU
 
+#define TUPLE1 ( 1 , 2 )
+#define TUPLE2 3 , 4
+#define TUPLE3 5, 6
+
 // ---
 // https://en.cppreference.com/w/cpp/language/floating_literal
 // (1)

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -18,7 +18,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Signed))))))
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         5
@@ -42,7 +43,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Signed))))))
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         3
@@ -66,7 +68,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Signed))))))
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         4
@@ -90,7 +93,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Signed))))))
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         0
@@ -114,7 +118,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Unsigned))))))
+                        (CIntegralType
+                          (IntLike (Int Unsigned)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         20560
@@ -138,7 +143,8 @@
                   (GenerativeTyCon
                     (DataTyCon
                       (IntLikeTyCon
-                        (IntLike (Int Signed))))))
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
         2
@@ -155,18 +161,43 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (IntLike (Int Signed))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        13398
-        HsPrimCInt},
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon
+                            (CIntegralType
+                              (IntLike (Int Signed)))))))
+                    []],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon
+                            (CIntegralType
+                              (IntLike (Int Signed)))))))
+                    []]]}},
+      varDeclBody = VarDeclApp
+        (InfixAppHead MTuple)
+        [
+          VarDeclIntegral
+            13398
+            HsPrimCInt,
+          VarDeclIntegral
+            30874
+            HsPrimCInt]},
   DeclForeignImport
     ForeignImportDecl {
       foreignImportName = HsName

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -34,8 +34,8 @@ a_DEFINE_1 = (20560 :: FC.CUInt)
 a_DEFINE_2 :: FC.CInt
 a_DEFINE_2 = (2 :: FC.CInt)
 
-tWO_ARGS :: FC.CInt
-tWO_ARGS = (13398 :: FC.CInt)
+tWO_ARGS :: ((,,) FC.CInt) FC.CInt
+tWO_ARGS = (,,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 
 foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: (F.Ptr A_type_t) -> Uint32_t -> (F.Ptr Uint8_t) -> IO Int32_t
 

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -10,8 +10,8 @@ a_DEFINE_1 :: CUInt
 a_DEFINE_1 = 20560 :: CUInt
 a_DEFINE_2 :: CInt
 a_DEFINE_2 = 2 :: CInt
-tWO_ARGS :: CInt
-tWO_ARGS = 13398 :: CInt
+tWO_ARGS :: (,) CInt CInt
+tWO_ARGS = (,) (13398 :: CInt) (30874 :: CInt)
 foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: Ptr A_type_t ->
                                                                   Uint32_t ->
                                                                   Ptr Uint8_t -> IO Int32_t

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -20,7 +20,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 5})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:10:9"},
       DeclMacro
@@ -42,7 +42,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 3})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:11:9"},
       DeclMacro
@@ -65,219 +65,113 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 4})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:12:9"},
       DeclMacro
-        (MacroReparseError
-          ReparseError {
-            reparseError =
-            concat
-              [
-                "\"distilled_lib_1.h\" (line 17, column 32):\n",
-                "unexpected Token {tokenKind = simpleEnum CXToken_Literal, tokenSpelling = TokenSpelling {getTokenSpelling = \"\\\"pack(1)\\\"\"}, tokenExtent = \"<distilled_lib_1.h:17:32-17:41>\", tokenCursorKind = simpleEnum CXCursor_MacroDefinition}\n",
-                "expecting expression"],
-            reparseErrorTokens = [
-              Token {
-                tokenKind = SimpleEnum 2,
-                tokenSpelling = TokenSpelling
-                  "PACK_START",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:9",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:19",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 2,
-                tokenSpelling = TokenSpelling
-                  "_Pragma",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:24",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:31",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 0,
-                tokenSpelling = TokenSpelling
-                  "(",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:31",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:32",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 3,
-                tokenSpelling = TokenSpelling
-                  "\"pack(1)\"",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:32",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:41",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 0,
-                tokenSpelling = TokenSpelling
-                  ")",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:41",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:17:42",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501}]}),
+        MacroTcError {
+          macroTcErrorMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "distilled_lib_1.h:17:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "PACK_START",
+            macroArgs = [],
+            macroBody = MTerm
+              (MVar
+                (CName "_Pragma")
+                [
+                  MTerm
+                    (MString
+                      StringLiteral {
+                        stringLiteralText =
+                        "\"pack(1)\"",
+                        stringLiteralValue = [
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [112],
+                            unicodeCodePoint = Just 'p'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [97],
+                            unicodeCodePoint = Just 'a'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [99],
+                            unicodeCodePoint = Just 'c'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [107],
+                            unicodeCodePoint = Just 'k'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [40],
+                            unicodeCodePoint = Just `'('`},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [49],
+                            unicodeCodePoint = Just '1'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [41],
+                            unicodeCodePoint = Just
+                              `')'`}]})])},
+          macroTcError = T.concat
+            [
+              "Failed to typecheck macro:\n",
+              "Unbound variable: '_Pragma'\n"]},
       DeclMacro
-        (MacroReparseError
-          ReparseError {
-            reparseError =
-            concat
-              [
-                "\"distilled_lib_1.h\" (line 18, column 32):\n",
-                "unexpected Token {tokenKind = simpleEnum CXToken_Literal, tokenSpelling = TokenSpelling {getTokenSpelling = \"\\\"pack()\\\"\"}, tokenExtent = \"<distilled_lib_1.h:18:32-18:40>\", tokenCursorKind = simpleEnum CXCursor_MacroDefinition}\n",
-                "expecting expression"],
-            reparseErrorTokens = [
-              Token {
-                tokenKind = SimpleEnum 2,
-                tokenSpelling = TokenSpelling
-                  "PACK_FINISH",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:9",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:20",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 2,
-                tokenSpelling = TokenSpelling
-                  "_Pragma",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:24",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:31",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 0,
-                tokenSpelling = TokenSpelling
-                  "(",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:31",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:32",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 3,
-                tokenSpelling = TokenSpelling
-                  "\"pack()\"",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:32",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:40",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 0,
-                tokenSpelling = TokenSpelling
-                  ")",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:40",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "distilled_lib_1.h:18:41",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501}]}),
+        MacroTcError {
+          macroTcErrorMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "distilled_lib_1.h:18:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "PACK_FINISH",
+            macroArgs = [],
+            macroBody = MTerm
+              (MVar
+                (CName "_Pragma")
+                [
+                  MTerm
+                    (MString
+                      StringLiteral {
+                        stringLiteralText =
+                        "\"pack()\"",
+                        stringLiteralValue = [
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [112],
+                            unicodeCodePoint = Just 'p'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [97],
+                            unicodeCodePoint = Just 'a'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [99],
+                            unicodeCodePoint = Just 'c'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [107],
+                            unicodeCodePoint = Just 'k'},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [40],
+                            unicodeCodePoint = Just `'('`},
+                          CharValue {
+                            charValue =
+                            Prim.byteArrayFromList [41],
+                            unicodeCodePoint = Just
+                              `')'`}]})])},
+          macroTcError = T.concat
+            [
+              "Failed to typecheck macro:\n",
+              "Unbound variable: '_Pragma'\n"]},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
@@ -335,7 +229,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 0})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:52:9"},
       DeclMacro
@@ -357,7 +251,7 @@ WrapCHeader
                     (_×_ PrimInt Unsigned),
                   integerLiteralValue = 20560})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Unsigned))",
+          "IntLike (CIntegralType (IntLike (Int Unsigned)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:53:9"},
       DeclMacro
@@ -379,7 +273,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 2})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:54:9"},
       DeclMacro
@@ -393,15 +287,25 @@ WrapCHeader
               multiLocFile = Nothing},
             macroName = CName "TWO_ARGS",
             macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0x3456",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 13398})},
+            macroBody = MApp
+              MTuple
+              [
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "0x3456",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 13398}),
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "0x789A",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 30874})]},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:55:9"},
       DeclFunction

--- a/hs-bindgen/fixtures/macro_functions.hs
+++ b/hs-bindgen/fixtures/macro_functions.hs
@@ -25,7 +25,8 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike (Int Signed))))))
+                              (CIntegralType
+                                (IntLike (Int Signed)))))))
                       []]]],
           quantTyBody = FunTy
             (TyVarTy (Idx 0))
@@ -44,7 +45,8 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike (Int Signed))))))
+                              (CIntegralType
+                                (IntLike (Int Signed)))))))
                       []]])}},
       varDeclBody = VarDeclLambda
         (Lambda
@@ -167,7 +169,8 @@
                       (GenerativeTyCon
                         (DataTyCon
                           (IntLikeTyCon
-                            (IntLike (Int Signed))))))
+                            (CIntegralType
+                              (IntLike (Int Signed)))))))
                     []]))}},
       varDeclBody = VarDeclLambda
         (Lambda
@@ -211,8 +214,9 @@
                             (GenerativeTyCon
                               (DataTyCon
                                 (IntLikeTyCon
-                                  (IntLike
-                                    (LongLong Unsigned))))))
+                                  (CIntegralType
+                                    (IntLike
+                                      (LongLong Unsigned)))))))
                           []],
                     TyVarTy (Idx 1)]],
             ClassTy
@@ -230,8 +234,9 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike
-                                (LongLong Unsigned))))))
+                              (CIntegralType
+                                (IntLike
+                                  (LongLong Unsigned)))))))
                       []],
                 TyVarTy (Idx 1)]],
           quantTyBody = FunTy
@@ -257,8 +262,9 @@
                               (GenerativeTyCon
                                 (DataTyCon
                                   (IntLikeTyCon
-                                    (IntLike
-                                      (LongLong Unsigned))))))
+                                    (CIntegralType
+                                      (IntLike
+                                        (LongLong Unsigned)))))))
                             []],
                       TyVarTy (Idx 1)]]))}},
       varDeclBody = VarDeclLambda
@@ -304,8 +310,9 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike
-                                (LongLong Unsigned))))))
+                              (CIntegralType
+                                (IntLike
+                                  (LongLong Unsigned)))))))
                       []],
                 TyVarTy (Idx 1)],
             NomEqTy
@@ -328,8 +335,9 @@
                           (GenerativeTyCon
                             (DataTyCon
                               (IntLikeTyCon
-                                (IntLike
-                                  (LongLong Unsigned))))))
+                                (CIntegralType
+                                  (IntLike
+                                    (LongLong Unsigned)))))))
                         []],
                   TyVarTy (Idx 1)])],
           quantTyBody = FunTy
@@ -391,7 +399,8 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike (Int Signed))))))
+                              (CIntegralType
+                                (IntLike (Int Signed)))))))
                       []]]],
           quantTyBody = FunTy
             (TyVarTy (Idx 0))
@@ -412,7 +421,8 @@
                           (GenerativeTyCon
                             (DataTyCon
                               (IntLikeTyCon
-                                (IntLike (Int Signed))))))
+                                (CIntegralType
+                                  (IntLike (Int Signed)))))))
                         []]]))}},
       varDeclBody = VarDeclLambda
         (Lambda
@@ -459,7 +469,8 @@
                         (GenerativeTyCon
                           (DataTyCon
                             (IntLikeTyCon
-                              (IntLike (Int Unsigned))))))
+                              (CIntegralType
+                                (IntLike (Int Unsigned)))))))
                       []]],
             ClassTy
               (AClass
@@ -482,7 +493,8 @@
                             (GenerativeTyCon
                               (DataTyCon
                                 (IntLikeTyCon
-                                  (IntLike (Int Unsigned))))))
+                                  (CIntegralType
+                                    (IntLike (Int Unsigned)))))))
                           []]]]],
           quantTyBody = FunTy
             (TyVarTy (Idx 0))
@@ -508,7 +520,8 @@
                               (GenerativeTyCon
                                 (DataTyCon
                                   (IntLikeTyCon
-                                    (IntLike (Int Unsigned))))))
+                                    (CIntegralType
+                                      (IntLike (Int Unsigned)))))))
                             []]]]))}},
       varDeclBody = VarDeclLambda
         (Lambda

--- a/hs-bindgen/fixtures/macro_functions.pp.hs
+++ b/hs-bindgen/fixtures/macro_functions.pp.hs
@@ -2,8 +2,8 @@
 
 module Example where
 
-import C.Expr.BuildPlatform ((*), (+), (/), (<), (<<))
-import qualified C.Expr.BuildPlatform as C
+import C.Expr.HostPlatform ((*), (+), (/), (<), (<<))
+import qualified C.Expr.HostPlatform as C
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.Syntax as HsBindgen
 import Prelude ((~))

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -24,7 +24,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 1})]},
           macroDeclMacroTy =
-          "(forall a. Add a (IntLike (IntLike (Int Signed))) => (a -> AddRes a (IntLike (IntLike (Int Signed)))))",
+          "(forall a. Add a (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> AddRes a (IntLike (CIntegralType (IntLike (Int Signed))))))",
           macroDeclSourceLoc =
           "macro_functions.h:1:9"},
       DeclMacro
@@ -104,7 +104,7 @@ WrapCHeader
                 MTerm (MVar (CName "X") []),
                 MTerm (MVar (CName "Y") [])]},
           macroDeclMacroTy =
-          "(forall a b. RelOrd a b => (a -> b -> IntLike (IntLike (Int Signed))))",
+          "(forall a b. RelOrd a b => (a -> b -> IntLike (CIntegralType (IntLike (Int Signed)))))",
           macroDeclSourceLoc =
           "macro_functions.h:7:9"},
       DeclMacro
@@ -136,7 +136,7 @@ WrapCHeader
                           integerLiteralValue = 12}),
                     MTerm (MVar (CName "Y") [])]]},
           macroDeclMacroTy =
-          "(forall a b. Add a (MultRes (IntLike (IntLike (LongLong Unsigned))) b) => Mult (IntLike (IntLike (LongLong Unsigned))) b => (a -> b -> AddRes a (MultRes (IntLike (IntLike (LongLong Unsigned))) b)))",
+          "(forall a b. Add a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b) => Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (a -> b -> AddRes a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b)))",
           macroDeclSourceLoc =
           "macro_functions.h:8:9"},
       DeclMacro
@@ -168,7 +168,7 @@ WrapCHeader
                           integerLiteralValue = 3}),
                     MTerm (MVar (CName "Y") [])]]},
           macroDeclMacroTy =
-          "(forall a b. Mult (IntLike (IntLike (LongLong Unsigned))) b => IntLike b_10[tau] ~ MultRes (IntLike (IntLike (LongLong Unsigned))) b => (IntLike a -> b -> ShiftRes (IntLike a)))",
+          "(forall a b. Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => IntLike b_10[tau] ~ MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (IntLike a -> b -> ShiftRes (IntLike a)))",
           macroDeclSourceLoc =
           "macro_functions.h:9:9"},
       DeclMacro
@@ -199,7 +199,7 @@ WrapCHeader
                         MTerm
                           (MVar (CName "X") [])])])},
           macroDeclMacroTy =
-          "(forall a b. Add b (IntLike (IntLike (Int Signed))) => (a -> b -> AddRes b (IntLike (IntLike (Int Signed)))))",
+          "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> b -> AddRes b (IntLike (CIntegralType (IntLike (Int Signed))))))",
           macroDeclSourceLoc =
           "macro_functions.h:11:9"},
       DeclMacro
@@ -231,7 +231,7 @@ WrapCHeader
                             (_×_ PrimInt Unsigned),
                           integerLiteralValue = 12})]]},
           macroDeclMacroTy =
-          "(forall a b. Add b (IntLike (IntLike (Int Unsigned))) => Div a (AddRes b (IntLike (IntLike (Int Unsigned)))) => (a -> b -> DivRes a (AddRes b (IntLike (IntLike (Int Unsigned))))))",
+          "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Unsigned)))) => Div a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned))))) => (a -> b -> DivRes a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned)))))))",
           macroDeclSourceLoc =
           "macro_functions.h:13:9"},
       DeclMacro

--- a/hs-bindgen/fixtures/macro_strings.hs
+++ b/hs-bindgen/fixtures/macro_strings.hs
@@ -3,7 +3,7 @@
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "oBJECTLIKE1",
+        "c1",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -22,13 +22,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        1
+        97
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "oBJECTLIKE2",
+        "c2",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -47,67 +47,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        2
+        34
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "oBJECTLIKE3",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MAdd)
-        [
-          VarDeclIntegral 3 HsPrimCInt,
-          VarDeclIntegral 3 HsPrimCInt]},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "oBJECTLIKE4",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MAdd)
-        [
-          VarDeclIntegral 4 HsPrimCInt,
-          VarDeclIntegral 4 HsPrimCInt]},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "mEANING_OF_LIFE1",
+        "c3",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -126,13 +72,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        42
+        9
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "mEANING_OF_LIFE2",
+        "c4",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -151,13 +97,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        42
+        0
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "mEANING_OF_LIFE3",
+        "c5",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -176,13 +122,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        42
+        39
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "mEANING_OF_LIFE4",
+        "c6",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -201,13 +147,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        42
+        63
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "mEANING_OF_LIFE5",
+        "c7",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -226,13 +172,13 @@
                           (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        42
+        83
         HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "lONG_INT_TOKEN1",
+        "c8",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -248,17 +194,16 @@
                     (DataTyCon
                       (IntLikeTyCon
                         (CIntegralType
-                          (IntLike
-                            (LongLong Unsigned)))))))
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        18446744073709550592
-        HsPrimCULLong},
+        83
+        HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "lONG_INT_TOKEN2",
+        "d",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -274,17 +219,16 @@
                     (DataTyCon
                       (IntLikeTyCon
                         (CIntegralType
-                          (IntLike
-                            (LongLong Unsigned)))))))
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        18446744073709550592
-        HsPrimCULLong},
+        511
+        HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "lONG_INT_TOKEN3",
+        "j1",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -300,17 +244,16 @@
                     (DataTyCon
                       (IntLikeTyCon
                         (CIntegralType
-                          (IntLike
-                            (LongLong Unsigned)))))))
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        18446744073709550592
-        HsPrimCULLong},
+        14909826
+        HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "lONG_INT_TOKEN4",
+        "j2",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -326,17 +269,41 @@
                     (DataTyCon
                       (IntLikeTyCon
                         (CIntegralType
-                          (IntLike
-                            (LongLong Unsigned)))))))
+                          (IntLike (Int Signed)))))))
                 []]}},
       varDeclBody = VarDeclIntegral
-        18446744073709550592
-        HsPrimCULLong},
+        14909826
+        HsPrimCInt},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "tUPLE1",
+        "j3",
+      varDeclType = ForallTy {
+        forallTyBinders = [],
+        forallTy = QuantTy {
+          quantTyCts = [],
+          quantTyBody = TyConAppTy
+            (ATyCon
+              (GenerativeTyCon
+                (DataTyCon IntLikeTyCon)))
+            [
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon
+                      (IntLikeTyCon
+                        (CIntegralType
+                          (IntLike (Int Signed)))))))
+                []]}},
+      varDeclBody = VarDeclIntegral
+        14909826
+        HsPrimCInt},
+  DeclVar
+    VarDecl {
+      varDeclName = HsName
+        "@NsVar"
+        "s1",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -349,16 +316,21 @@
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon IntLikeTyCon)))
+                    (DataTyCon PtrTyCon)))
                 [
                   TyConAppTy
                     (ATyCon
                       (GenerativeTyCon
-                        (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
-                    []],
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
@@ -368,20 +340,15 @@
                     (ATyCon
                       (GenerativeTyCon
                         (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
+                          (IntLikeTyCon HsIntType))))
                     []]]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MTuple)
-        [
-          VarDeclIntegral 1 HsPrimCInt,
-          VarDeclIntegral 2 HsPrimCInt]},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [97])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "tUPLE2",
+        "s2",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -394,16 +361,21 @@
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon IntLikeTyCon)))
+                    (DataTyCon PtrTyCon)))
                 [
                   TyConAppTy
                     (ATyCon
                       (GenerativeTyCon
-                        (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
-                    []],
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
@@ -413,20 +385,15 @@
                     (ATyCon
                       (GenerativeTyCon
                         (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
+                          (IntLikeTyCon HsIntType))))
                     []]]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MTuple)
-        [
-          VarDeclIntegral 3 HsPrimCInt,
-          VarDeclIntegral 4 HsPrimCInt]},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [39])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "tUPLE3",
+        "s3",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -439,16 +406,21 @@
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon IntLikeTyCon)))
+                    (DataTyCon PtrTyCon)))
                 [
                   TyConAppTy
                     (ATyCon
                       (GenerativeTyCon
-                        (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
-                    []],
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
@@ -458,20 +430,15 @@
                     (ATyCon
                       (GenerativeTyCon
                         (DataTyCon
-                          (IntLikeTyCon
-                            (CIntegralType
-                              (IntLike (Int Signed)))))))
+                          (IntLikeTyCon HsIntType))))
                     []]]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MTuple)
-        [
-          VarDeclIntegral 5 HsPrimCInt,
-          VarDeclIntegral 6 HsPrimCInt]},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [9])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT1_1",
+        "s4",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -479,21 +446,44 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        110000.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [0])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT1_2",
+        "s5",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -501,21 +491,44 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        1.2e-2},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [39])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT1_3",
+        "s6",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -523,21 +536,44 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        1.3e-2},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [63])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT2_1",
+        "s7",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -545,21 +581,44 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        21.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [83])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT2_2",
+        "s8",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -567,21 +626,44 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        2200.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList [83])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT2_3",
+        "t1",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -589,21 +671,45 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        23.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [227, 129, 130])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT3_1",
+        "t2",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -611,21 +717,45 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        31.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [227, 129, 130])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT3_2",
+        "t3",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -633,21 +763,45 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        0.32},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [227, 129, 130])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT3_3",
+        "u",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -655,21 +809,53 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        33.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [
+            1,
+            255,
+            1,
+            255,
+            1,
+            255,
+            1,
+            255])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT3_4",
+        "v",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -677,21 +863,45 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        3.4e-3},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [1, 2, 3, 4, 5, 6])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT4_1",
+        "w1",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -699,21 +909,45 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        650000.0},
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
+              TyConAppTy
+                (ATyCon
+                  (GenerativeTyCon
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [104, 105, 106, 0])},
   DeclVar
     VarDecl {
       varDeclName = HsName
         "@NsVar"
-        "fLT4_2",
+        "w2",
       varDeclType = ForallTy {
         forallTyBinders = [],
         forallTy = QuantTy {
@@ -721,199 +955,46 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
+                (DataTyCon TupleTyCon)))
             [
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        6.6e-2},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT4_3",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
+                    (DataTyCon PtrTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon IntLikeTyCon)))
+                    [
+                      TyConAppTy
+                        (ATyCon
+                          (GenerativeTyCon
+                            (DataTyCon
+                              (IntLikeTyCon
+                                (CIntegralType
+                                  (CharLike Char))))))
+                        []]],
               TyConAppTy
                 (ATyCon
                   (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        6.7e-2},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT5_1",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        81.0},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT5_2",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        82.0},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT6_1",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        15520.0},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT6_2",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclDouble
-        98.0},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "fLT6_3",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon FloatType))))
-                []]}},
-      varDeclBody = VarDeclFloat
-        9.9e-3},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "bAD1",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon FloatLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (FloatLikeTyCon DoubleType))))
-                []]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MAdd)
-        [
-          VarDeclDouble 0.1,
-          VarDeclIntegral 1 HsPrimCInt]},
-  DeclVar
-    VarDecl {
-      varDeclName = HsName
-        "@NsVar"
-        "bAD2",
-      varDeclType = ForallTy {
-        forallTyBinders = [],
-        forallTy = QuantTy {
-          quantTyCts = [],
-          quantTyBody = TyConAppTy
-            (ATyCon
-              (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Long Unsigned)))))))
-                []]}},
-      varDeclBody = VarDeclApp
-        (InfixAppHead MMult)
-        [
-          VarDeclIntegral 2 HsPrimCLong,
-          VarDeclIntegral
-            2
-            HsPrimCULong]}]
+                    (DataTyCon IntLikeTyCon)))
+                [
+                  TyConAppTy
+                    (ATyCon
+                      (GenerativeTyCon
+                        (DataTyCon
+                          (IntLikeTyCon HsIntType))))
+                    []]]}},
+      varDeclBody = VarDeclString
+        (Prim.byteArrayFromList
+          [
+            97,
+            98,
+            99,
+            0,
+            100,
+            101,
+            102,
+            0,
+            103])}]

--- a/hs-bindgen/fixtures/macro_strings.pp.hs
+++ b/hs-bindgen/fixtures/macro_strings.pp.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Example where
+
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified Foreign.C.String as FC
+import Prelude (Int)
+
+c1 :: FC.CInt
+c1 = (97 :: FC.CInt)
+
+c2 :: FC.CInt
+c2 = (34 :: FC.CInt)
+
+c3 :: FC.CInt
+c3 = (9 :: FC.CInt)
+
+c4 :: FC.CInt
+c4 = (0 :: FC.CInt)
+
+c5 :: FC.CInt
+c5 = (39 :: FC.CInt)
+
+c6 :: FC.CInt
+c6 = (63 :: FC.CInt)
+
+c7 :: FC.CInt
+c7 = (83 :: FC.CInt)
+
+c8 :: FC.CInt
+c8 = (83 :: FC.CInt)
+
+d :: FC.CInt
+d = (511 :: FC.CInt)
+
+j1 :: FC.CInt
+j1 = (14909826 :: FC.CInt)
+
+j2 :: FC.CInt
+j2 = (14909826 :: FC.CInt)
+
+j3 :: FC.CInt
+j3 = (14909826 :: FC.CInt)
+
+s1 :: ((,,) (F.Ptr FC.CChar)) Int
+s1 = ((F.Ptr "a"#, 1) :: FC.CStringLen)
+
+s2 :: ((,,) (F.Ptr FC.CChar)) Int
+s2 = ((F.Ptr "\'"#, 1) :: FC.CStringLen)
+
+s3 :: ((,,) (F.Ptr FC.CChar)) Int
+s3 = ((F.Ptr "\t"#, 1) :: FC.CStringLen)
+
+s4 :: ((,,) (F.Ptr FC.CChar)) Int
+s4 = ((F.Ptr "\0"#, 1) :: FC.CStringLen)
+
+s5 :: ((,,) (F.Ptr FC.CChar)) Int
+s5 = ((F.Ptr "\'"#, 1) :: FC.CStringLen)
+
+s6 :: ((,,) (F.Ptr FC.CChar)) Int
+s6 = ((F.Ptr "?"#, 1) :: FC.CStringLen)
+
+s7 :: ((,,) (F.Ptr FC.CChar)) Int
+s7 = ((F.Ptr "S"#, 1) :: FC.CStringLen)
+
+s8 :: ((,,) (F.Ptr FC.CChar)) Int
+s8 = ((F.Ptr "S"#, 1) :: FC.CStringLen)
+
+t1 :: ((,,) (F.Ptr FC.CChar)) Int
+t1 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
+
+t2 :: ((,,) (F.Ptr FC.CChar)) Int
+t2 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
+
+t3 :: ((,,) (F.Ptr FC.CChar)) Int
+t3 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
+
+u :: ((,,) (F.Ptr FC.CChar)) Int
+u = ((F.Ptr "\x1\xFF\x1\xFF\x1\xFF\x1\xFF"#, 8) :: FC.CStringLen)
+
+v :: ((,,) (F.Ptr FC.CChar)) Int
+v = ((F.Ptr "\x1\x2\x3\x4\x5\x6"#, 6) :: FC.CStringLen)
+
+w1 :: ((,,) (F.Ptr FC.CChar)) Int
+w1 = ((F.Ptr "hij\0"#, 4) :: FC.CStringLen)
+
+w2 :: ((,,) (F.Ptr FC.CChar)) Int
+w2 = ((F.Ptr "abc\0def\0g"#, 9) :: FC.CStringLen)

--- a/hs-bindgen/fixtures/macro_strings.th.txt
+++ b/hs-bindgen/fixtures/macro_strings.th.txt
@@ -1,0 +1,54 @@
+c1 :: CInt
+c1 = 97 :: CInt
+c2 :: CInt
+c2 = 34 :: CInt
+c3 :: CInt
+c3 = 9 :: CInt
+c4 :: CInt
+c4 = 0 :: CInt
+c5 :: CInt
+c5 = 39 :: CInt
+c6 :: CInt
+c6 = 63 :: CInt
+c7 :: CInt
+c7 = 83 :: CInt
+c8 :: CInt
+c8 = 83 :: CInt
+d :: CInt
+d = 511 :: CInt
+j1 :: CInt
+j1 = 14909826 :: CInt
+j2 :: CInt
+j2 = 14909826 :: CInt
+j3 :: CInt
+j3 = 14909826 :: CInt
+s1 :: (,) (Ptr CChar) Int
+s1 = (Ptr "a"#, 1) :: CStringLen
+s2 :: (,) (Ptr CChar) Int
+s2 = (Ptr "'"#, 1) :: CStringLen
+s3 :: (,) (Ptr CChar) Int
+s3 = (Ptr "\t"#, 1) :: CStringLen
+s4 :: (,) (Ptr CChar) Int
+s4 = (Ptr "\NUL"#, 1) :: CStringLen
+s5 :: (,) (Ptr CChar) Int
+s5 = (Ptr "'"#, 1) :: CStringLen
+s6 :: (,) (Ptr CChar) Int
+s6 = (Ptr "?"#, 1) :: CStringLen
+s7 :: (,) (Ptr CChar) Int
+s7 = (Ptr "S"#, 1) :: CStringLen
+s8 :: (,) (Ptr CChar) Int
+s8 = (Ptr "S"#, 1) :: CStringLen
+t1 :: (,) (Ptr CChar) Int
+t1 = (Ptr "\227\129\130"#, 3) :: CStringLen
+t2 :: (,) (Ptr CChar) Int
+t2 = (Ptr "\227\129\130"#, 3) :: CStringLen
+t3 :: (,) (Ptr CChar) Int
+t3 = (Ptr "\227\129\130"#, 3) :: CStringLen
+u :: (,) (Ptr CChar) Int
+u = (Ptr "\SOH\255\SOH\255\SOH\255\SOH\255"#, 8) :: CStringLen
+v :: (,) (Ptr CChar) Int
+v = (Ptr "\SOH\STX\ETX\EOT\ENQ\ACK"#, 6) :: CStringLen
+w1 :: (,) (Ptr CChar) Int
+w1 = (Ptr "hij\NUL"#, 4) :: CStringLen
+w2 :: (,) (Ptr CChar) Int
+w2 = (Ptr "abc\NULdef\NULg"#, 9) :: CStringLen

--- a/hs-bindgen/fixtures/macro_strings.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_strings.tree-diff.txt
@@ -1,0 +1,752 @@
+WrapCHeader
+  (Header
+    [
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:4:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C1",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'a'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [97],
+                    unicodeCodePoint = Just 'a'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:4:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:5:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C2",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\"'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [34],
+                    unicodeCodePoint = Just
+                      `'"'`}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:5:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:6:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C3",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\t'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [9],
+                    unicodeCodePoint = Just
+                      '\t'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:6:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:7:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C4",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\0'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [0],
+                    unicodeCodePoint = Just
+                      '\NUL'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:7:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:8:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C5",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\''",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [39],
+                    unicodeCodePoint = Just
+                      '\''}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:8:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:9:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C6",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\?'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [63],
+                    unicodeCodePoint = Just '?'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:9:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:10:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C7",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\123'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [83],
+                    unicodeCodePoint = Nothing}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:10:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:11:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "C8",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\x53'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [83],
+                    unicodeCodePoint = Nothing}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:11:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:13:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "D",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\777'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [1, 255],
+                    unicodeCodePoint = Nothing}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:13:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:15:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "J1",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\12354'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList
+                      [227, 129, 130],
+                    unicodeCodePoint = Just
+                      '\12354'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:15:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:16:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "J2",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText = "'\\u3042'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList
+                      [227, 129, 130],
+                    unicodeCodePoint = Just
+                      '\12354'}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:16:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:17:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "J3",
+            macroArgs = [],
+            macroBody = MTerm
+              (MChar
+                CharLiteral {
+                  charLiteralText =
+                  "'\\xE3\\x81\\x82'",
+                  charLiteralValue = CharValue {
+                    charValue =
+                    Prim.byteArrayFromList
+                      [227, 129, 130],
+                    unicodeCodePoint = Nothing}})},
+          macroDeclMacroTy =
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclSourceLoc =
+          "macro_strings.h:17:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:20:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S1",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"a\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [97],
+                      unicodeCodePoint = Just
+                        'a'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:20:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:21:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S2",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"'\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [39],
+                      unicodeCodePoint = Just
+                        '\''}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:21:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:22:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S3",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\t\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [9],
+                      unicodeCodePoint = Just
+                        '\t'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:22:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:23:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S4",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\0\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [0],
+                      unicodeCodePoint = Just
+                        '\NUL'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:23:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:24:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S5",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\'\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [39],
+                      unicodeCodePoint = Just
+                        '\''}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:24:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:25:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S6",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\?\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [63],
+                      unicodeCodePoint = Just
+                        '?'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:25:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:26:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S7",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\123\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [83],
+                      unicodeCodePoint = Nothing}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:26:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:27:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "S8",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText = "\"\\x53\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [83],
+                      unicodeCodePoint = Nothing}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:27:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:29:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "T1",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"\12354\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList
+                        [227, 129, 130],
+                      unicodeCodePoint = Just
+                        '\12354'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:29:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:30:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "T2",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"\\u3042\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList
+                        [227, 129, 130],
+                      unicodeCodePoint = Just
+                        '\12354'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:30:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:31:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "T3",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"\\xE3\\x81\\x82\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [227],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [129],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [130],
+                      unicodeCodePoint = Nothing}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:31:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:33:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "U",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"\\777\\777\\777\\777\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [1, 255],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [1, 255],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [1, 255],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [1, 255],
+                      unicodeCodePoint = Nothing}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:33:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:34:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "V",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"\\1\\2\\3\\4\\5\\6\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [1],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [2],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [3],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [4],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [5],
+                      unicodeCodePoint = Nothing},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [6],
+                      unicodeCodePoint = Nothing}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:34:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:36:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "W1",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"hij\\0\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [104],
+                      unicodeCodePoint = Just 'h'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [105],
+                      unicodeCodePoint = Just 'i'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [106],
+                      unicodeCodePoint = Just 'j'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [0],
+                      unicodeCodePoint = Just
+                        '\NUL'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:36:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macro_strings.h:37:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "W2",
+            macroArgs = [],
+            macroBody = MTerm
+              (MString
+                StringLiteral {
+                  stringLiteralText =
+                  "\"abc\\0def\\0g\"",
+                  stringLiteralValue = [
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [97],
+                      unicodeCodePoint = Just 'a'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [98],
+                      unicodeCodePoint = Just 'b'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [99],
+                      unicodeCodePoint = Just 'c'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [0],
+                      unicodeCodePoint = Just '\NUL'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [100],
+                      unicodeCodePoint = Just 'd'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [101],
+                      unicodeCodePoint = Just 'e'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [102],
+                      unicodeCodePoint = Just 'f'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [0],
+                      unicodeCodePoint = Just '\NUL'},
+                    CharValue {
+                      charValue =
+                      Prim.byteArrayFromList [103],
+                      unicodeCodePoint = Just
+                        'g'}]})},
+          macroDeclMacroTy =
+          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          macroDeclSourceLoc =
+          "macro_strings.h:37:9"}])

--- a/hs-bindgen/fixtures/macros.pp.hs
+++ b/hs-bindgen/fixtures/macros.pp.hs
@@ -2,7 +2,7 @@
 
 module Example where
 
-import C.Expr.BuildPlatform ((*), (+))
+import C.Expr.HostPlatform ((*), (+))
 import qualified Foreign.C as FC
 
 oBJECTLIKE1 :: FC.CInt
@@ -43,6 +43,15 @@ lONG_INT_TOKEN3 = (18446744073709550592 :: FC.CULLong)
 
 lONG_INT_TOKEN4 :: FC.CULLong
 lONG_INT_TOKEN4 = (18446744073709550592 :: FC.CULLong)
+
+tUPLE1 :: ((,,) FC.CInt) FC.CInt
+tUPLE1 = (,,) (1 :: FC.CInt) (2 :: FC.CInt)
+
+tUPLE2 :: ((,,) FC.CInt) FC.CInt
+tUPLE2 = (,,) (3 :: FC.CInt) (4 :: FC.CInt)
+
+tUPLE3 :: ((,,) FC.CInt) FC.CInt
+tUPLE3 = (,,) (5 :: FC.CInt) (6 :: FC.CInt)
 
 fLT1_1 :: FC.CDouble
 fLT1_1 = (110000.0 :: FC.CDouble)

--- a/hs-bindgen/fixtures/macros.th.txt
+++ b/hs-bindgen/fixtures/macros.th.txt
@@ -24,6 +24,12 @@ lONG_INT_TOKEN3 :: CULLong
 lONG_INT_TOKEN3 = 18446744073709550592 :: CULLong
 lONG_INT_TOKEN4 :: CULLong
 lONG_INT_TOKEN4 = 18446744073709550592 :: CULLong
+tUPLE1 :: (,) CInt CInt
+tUPLE1 = (,) (1 :: CInt) (2 :: CInt)
+tUPLE2 :: (,) CInt CInt
+tUPLE2 = (,) (3 :: CInt) (4 :: CInt)
+tUPLE3 :: (,) CInt CInt
+tUPLE3 = (,) (5 :: CInt) (6 :: CInt)
 fLT1_1 :: CDouble
 fLT1_1 = 110000.0 :: CDouble
 fLT1_2 :: CDouble

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -20,7 +20,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 1})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:1:9"},
       DeclMacro
@@ -42,7 +42,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 2})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:2:9"},
       DeclMacro
@@ -74,7 +74,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 3})]},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:3:9"},
       DeclMacro
@@ -106,7 +106,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 4})]},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:4:9"},
       DeclMacro
@@ -129,7 +129,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:6:9"},
       DeclMacro
@@ -152,7 +152,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:7:9"},
       DeclMacro
@@ -175,7 +175,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:8:9"},
       DeclMacro
@@ -198,7 +198,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:9:9"},
       DeclMacro
@@ -221,7 +221,7 @@ WrapCHeader
                     (_×_ PrimInt Signed),
                   integerLiteralValue = 42})},
           macroDeclMacroTy =
-          "IntLike (IntLike (Int Signed))",
+          "IntLike (CIntegralType (IntLike (Int Signed)))",
           macroDeclSourceLoc =
           "macros.h:10:9"},
       DeclMacro
@@ -246,7 +246,7 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy =
-          "IntLike (IntLike (LongLong Unsigned))",
+          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
           macroDeclSourceLoc =
           "macros.h:12:9"},
       DeclMacro
@@ -271,7 +271,7 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy =
-          "IntLike (IntLike (LongLong Unsigned))",
+          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
           macroDeclSourceLoc =
           "macros.h:13:9"},
       DeclMacro
@@ -296,7 +296,7 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy =
-          "IntLike (IntLike (LongLong Unsigned))",
+          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
           macroDeclSourceLoc =
           "macros.h:14:9"},
       DeclMacro
@@ -321,7 +321,7 @@ WrapCHeader
                   integerLiteralValue =
                   18446744073709550592})},
           macroDeclMacroTy =
-          "IntLike (IntLike (LongLong Unsigned))",
+          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
           macroDeclSourceLoc =
           "macros.h:15:9"},
       DeclMacro
@@ -329,7 +329,103 @@ WrapCHeader
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:20:9",
+              "macros.h:17:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "TUPLE1",
+            macroArgs = [],
+            macroBody = MApp
+              MTuple
+              [
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "1",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 1}),
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "2",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 2})]},
+          macroDeclMacroTy =
+          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          macroDeclSourceLoc =
+          "macros.h:17:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macros.h:18:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "TUPLE2",
+            macroArgs = [],
+            macroBody = MApp
+              MTuple
+              [
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "3",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 3}),
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "4",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 4})]},
+          macroDeclMacroTy =
+          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          macroDeclSourceLoc =
+          "macros.h:18:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macros.h:19:9",
+              multiLocPresumed = Nothing,
+              multiLocSpelling = Nothing,
+              multiLocFile = Nothing},
+            macroName = CName "TUPLE3",
+            macroArgs = [],
+            macroBody = MApp
+              MTuple
+              [
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "5",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 5}),
+                MTerm
+                  (MInt
+                    IntegerLiteral {
+                      integerLiteralText = "6",
+                      integerLiteralType = Just
+                        (_×_ PrimInt Signed),
+                      integerLiteralValue = 6})]},
+          macroDeclMacroTy =
+          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          macroDeclSourceLoc =
+          "macros.h:19:9"},
+      DeclMacro
+        MacroDecl {
+          macroDeclMacro = Macro {
+            macroLoc = MultiLoc {
+              multiLocExpansion =
+              "macros.h:24:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -348,13 +444,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:20:9"},
+          "macros.h:24:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:21:9",
+              "macros.h:25:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -373,13 +469,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:21:9"},
+          "macros.h:25:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:22:9",
+              "macros.h:26:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -398,13 +494,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:22:9"},
+          "macros.h:26:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:24:9",
+              "macros.h:28:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -423,13 +519,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:24:9"},
+          "macros.h:28:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:25:9",
+              "macros.h:29:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -448,13 +544,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:25:9"},
+          "macros.h:29:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:26:9",
+              "macros.h:30:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -473,13 +569,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:26:9"},
+          "macros.h:30:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:28:9",
+              "macros.h:32:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -498,13 +594,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:28:9"},
+          "macros.h:32:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:29:9",
+              "macros.h:33:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -523,13 +619,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:29:9"},
+          "macros.h:33:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:30:9",
+              "macros.h:34:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -548,13 +644,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:30:9"},
+          "macros.h:34:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:31:9",
+              "macros.h:35:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -573,13 +669,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:31:9"},
+          "macros.h:35:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:33:9",
+              "macros.h:37:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -598,13 +694,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:33:9"},
+          "macros.h:37:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:34:9",
+              "macros.h:38:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -623,13 +719,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:34:9"},
+          "macros.h:38:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:35:9",
+              "macros.h:39:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -649,13 +745,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:35:9"},
+          "macros.h:39:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:37:9",
+              "macros.h:41:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -674,13 +770,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:37:9"},
+          "macros.h:41:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:38:9",
+              "macros.h:42:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -700,13 +796,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:38:9"},
+          "macros.h:42:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:40:9",
+              "macros.h:44:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -726,13 +822,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:40:9"},
+          "macros.h:44:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:41:9",
+              "macros.h:45:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -751,13 +847,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:41:9"},
+          "macros.h:45:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:42:9",
+              "macros.h:46:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -777,13 +873,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike FloatType",
           macroDeclSourceLoc =
-          "macros.h:42:9"},
+          "macros.h:46:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:45:9",
+              "macros.h:49:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -811,13 +907,13 @@ WrapCHeader
           macroDeclMacroTy =
           "FloatLike DoubleType",
           macroDeclSourceLoc =
-          "macros.h:45:9"},
+          "macros.h:49:9"},
       DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "macros.h:46:9",
+              "macros.h:50:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -841,6 +937,6 @@ WrapCHeader
                         (_×_ PrimLong Unsigned),
                       integerLiteralValue = 2})]},
           macroDeclMacroTy =
-          "IntLike (IntLike (Long Unsigned))",
+          "IntLike (CIntegralType (IntLike (Long Unsigned)))",
           macroDeclSourceLoc =
-          "macros.h:46:9"}])
+          "macros.h:50:9"}])

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
@@ -20,7 +20,7 @@ import HsBindgen.Hs.AST.Type
 
 import Language.Haskell.TH.Syntax qualified as TH
 
-import C.Expr.BuildPlatform qualified
+import C.Expr.HostPlatform qualified
 import Data.Bits qualified
 import Data.Ix qualified
 import Data.Void qualified
@@ -110,7 +110,7 @@ nameType nm
 moduleOf :: String -> String -> HsImportModule
 moduleOf "Void" _  = HsImportModule "Data.Void" Nothing
 moduleOf _ident m0 = case parts of
-    ["C","Operator","Classes"]       -> HsImportModule "C.Expr.BuildPlatform" (Just "C")
+    ["C","Operator","Classes"]       -> HsImportModule "C.Expr.HostPlatform" (Just "C")
     ["HsBindgen","Runtime","Syntax"] -> HsImportModule "HsBindgen.Runtime.Syntax" (Just "HsBindgen")
     ["GHC", "Bits"]                  -> HsImportModule "Data.Bits" (Just "Bits")
     ["GHC", "Base"]                  -> iPrelude
@@ -206,52 +206,52 @@ resolveGlobal = \case
     -- So for now code using ~ will not work with preprocessor setup on GHC-9.2.
     NomEq_class -> ResolvedName "~" OperatorName (Just (UnqualifiedHsImport iPrelude))
 
-    Not_class             -> importQ ''C.Expr.BuildPlatform.Not
-    Not_not               -> importQ 'C.Expr.BuildPlatform.not
-    Logical_class         -> importQ ''C.Expr.BuildPlatform.Logical
-    Logical_and           -> importU '(C.Expr.BuildPlatform.&&)
-    Logical_or            -> importU '(C.Expr.BuildPlatform.||)
-    RelEq_class           -> importQ ''C.Expr.BuildPlatform.RelEq
-    RelEq_eq              -> importU '(C.Expr.BuildPlatform.==)
-    RelEq_uneq            -> importU '(C.Expr.BuildPlatform.!=)
-    RelOrd_class          -> importQ ''C.Expr.BuildPlatform.RelOrd
-    RelOrd_lt             -> importU '(C.Expr.BuildPlatform.<)
-    RelOrd_le             -> importU '(C.Expr.BuildPlatform.<=)
-    RelOrd_gt             -> importU '(C.Expr.BuildPlatform.>)
-    RelOrd_ge             -> importU '(C.Expr.BuildPlatform.>=)
-    Plus_class            -> importQ ''C.Expr.BuildPlatform.Plus
-    Plus_resTyCon         -> importQ ''C.Expr.BuildPlatform.PlusRes
-    Plus_plus             -> importQ 'C.Expr.BuildPlatform.plus
-    Minus_class           -> importQ ''C.Expr.BuildPlatform.Minus
-    Minus_resTyCon        -> importQ ''C.Expr.BuildPlatform.MinusRes
-    Minus_negate          -> importQ 'C.Expr.BuildPlatform.negate
-    Add_class             -> importQ ''C.Expr.BuildPlatform.Add
-    Add_resTyCon          -> importQ ''C.Expr.BuildPlatform.AddRes
-    Add_add               -> importU '(C.Expr.BuildPlatform.+)
-    Sub_class             -> importQ ''C.Expr.BuildPlatform.Sub
-    Sub_resTyCon          -> importQ ''C.Expr.BuildPlatform.SubRes
-    Sub_minus             -> importU '(C.Expr.BuildPlatform.-)
-    Mult_class            -> importQ ''C.Expr.BuildPlatform.Mult
-    Mult_resTyCon         -> importQ ''C.Expr.BuildPlatform.MultRes
-    Mult_mult             -> importU '(C.Expr.BuildPlatform.*)
-    Div_class             -> importQ ''C.Expr.BuildPlatform.Div
-    Div_resTyCon          -> importQ ''C.Expr.BuildPlatform.DivRes
-    Div_div               -> importU '(C.Expr.BuildPlatform./)
-    Rem_class             -> importQ ''C.Expr.BuildPlatform.Rem
-    Rem_resTyCon          -> importQ ''C.Expr.BuildPlatform.RemRes
-    Rem_rem               -> importU '(C.Expr.BuildPlatform.%)
-    Complement_class      -> importQ ''C.Expr.BuildPlatform.Complement
-    Complement_resTyCon   -> importQ ''C.Expr.BuildPlatform.ComplementRes
-    Complement_complement -> importQ '(C.Expr.BuildPlatform..~)
-    Bitwise_class         -> importQ ''C.Expr.BuildPlatform.Bitwise
-    Bitwise_resTyCon      -> importQ ''C.Expr.BuildPlatform.BitsRes
-    Bitwise_and           -> importU '(C.Expr.BuildPlatform..&.)
-    Bitwise_or            -> importU '(C.Expr.BuildPlatform..|.)
-    Bitwise_xor           -> importU '(C.Expr.BuildPlatform..^.)
-    Shift_class           -> importQ ''C.Expr.BuildPlatform.Shift
-    Shift_resTyCon        -> importQ ''C.Expr.BuildPlatform.ShiftRes
-    Shift_shiftL          -> importU '(C.Expr.BuildPlatform.<<)
-    Shift_shiftR          -> importU '(C.Expr.BuildPlatform.>>)
+    Not_class             -> importQ ''C.Expr.HostPlatform.Not
+    Not_not               -> importQ 'C.Expr.HostPlatform.not
+    Logical_class         -> importQ ''C.Expr.HostPlatform.Logical
+    Logical_and           -> importU '(C.Expr.HostPlatform.&&)
+    Logical_or            -> importU '(C.Expr.HostPlatform.||)
+    RelEq_class           -> importQ ''C.Expr.HostPlatform.RelEq
+    RelEq_eq              -> importU '(C.Expr.HostPlatform.==)
+    RelEq_uneq            -> importU '(C.Expr.HostPlatform.!=)
+    RelOrd_class          -> importQ ''C.Expr.HostPlatform.RelOrd
+    RelOrd_lt             -> importU '(C.Expr.HostPlatform.<)
+    RelOrd_le             -> importU '(C.Expr.HostPlatform.<=)
+    RelOrd_gt             -> importU '(C.Expr.HostPlatform.>)
+    RelOrd_ge             -> importU '(C.Expr.HostPlatform.>=)
+    Plus_class            -> importQ ''C.Expr.HostPlatform.Plus
+    Plus_resTyCon         -> importQ ''C.Expr.HostPlatform.PlusRes
+    Plus_plus             -> importQ 'C.Expr.HostPlatform.plus
+    Minus_class           -> importQ ''C.Expr.HostPlatform.Minus
+    Minus_resTyCon        -> importQ ''C.Expr.HostPlatform.MinusRes
+    Minus_negate          -> importQ 'C.Expr.HostPlatform.negate
+    Add_class             -> importQ ''C.Expr.HostPlatform.Add
+    Add_resTyCon          -> importQ ''C.Expr.HostPlatform.AddRes
+    Add_add               -> importU '(C.Expr.HostPlatform.+)
+    Sub_class             -> importQ ''C.Expr.HostPlatform.Sub
+    Sub_resTyCon          -> importQ ''C.Expr.HostPlatform.SubRes
+    Sub_minus             -> importU '(C.Expr.HostPlatform.-)
+    Mult_class            -> importQ ''C.Expr.HostPlatform.Mult
+    Mult_resTyCon         -> importQ ''C.Expr.HostPlatform.MultRes
+    Mult_mult             -> importU '(C.Expr.HostPlatform.*)
+    Div_class             -> importQ ''C.Expr.HostPlatform.Div
+    Div_resTyCon          -> importQ ''C.Expr.HostPlatform.DivRes
+    Div_div               -> importU '(C.Expr.HostPlatform./)
+    Rem_class             -> importQ ''C.Expr.HostPlatform.Rem
+    Rem_resTyCon          -> importQ ''C.Expr.HostPlatform.RemRes
+    Rem_rem               -> importU '(C.Expr.HostPlatform.%)
+    Complement_class      -> importQ ''C.Expr.HostPlatform.Complement
+    Complement_resTyCon   -> importQ ''C.Expr.HostPlatform.ComplementRes
+    Complement_complement -> importQ '(C.Expr.HostPlatform..~)
+    Bitwise_class         -> importQ ''C.Expr.HostPlatform.Bitwise
+    Bitwise_resTyCon      -> importQ ''C.Expr.HostPlatform.BitsRes
+    Bitwise_and           -> importU '(C.Expr.HostPlatform..&.)
+    Bitwise_or            -> importU '(C.Expr.HostPlatform..|.)
+    Bitwise_xor           -> importU '(C.Expr.HostPlatform..^.)
+    Shift_class           -> importQ ''C.Expr.HostPlatform.Shift
+    Shift_resTyCon        -> importQ ''C.Expr.HostPlatform.ShiftRes
+    Shift_shiftL          -> importU '(C.Expr.HostPlatform.<<)
+    Shift_shiftR          -> importU '(C.Expr.HostPlatform.>>)
 
     IntLike_tycon    -> importQ ''HsBindgen.Runtime.Syntax.IntLike
     FloatLike_tycon  -> importQ ''HsBindgen.Runtime.Syntax.FloatLike

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Translation.hs
@@ -176,6 +176,8 @@ resolveExprImports = \case
     EFree {} -> mempty
     ECon _n -> mempty
     EIntegral _ t -> maybe mempty resolvePrimTypeImports t
+    EString {} -> resolvePrimTypeImports Hs.HsPrimCStringLen
+               <> resolveGlobalImports Ptr_constructor
     EFloat _ t -> resolvePrimTypeImports t
     EDouble _ t -> resolvePrimTypeImports t
     EApp f x -> resolveExprImports f <> resolveExprImports x

--- a/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
@@ -18,7 +18,7 @@ import GHC.Float
   ( castWord64ToDouble, castDoubleToWord64
   , castWord32ToFloat , castFloatToWord32 )
 
-import C.Expr.BuildPlatform qualified as C
+import C.Expr.HostPlatform qualified as C
 import HsBindgen.C.AST.Literal (canBeRepresentedAsRational)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -40,6 +40,9 @@ module HsBindgen.C.AST (
   , MTerm(..)
   , IntegerLiteral(..)
   , FloatingLiteral(..)
+  , CharLiteral(..)
+  , StringLiteral(..)
+  , fromBytes
     -- ** Attributes
   , Attribute(..)
     -- ** Classification

--- a/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
@@ -22,6 +22,7 @@ import Data.String
 import Data.Text qualified as Text
 import Data.Type.Equality
   ( type (:~:)(..) )
+import Data.Type.Nat (SNatI)
 import GHC.Generics (Generic)
 import System.FilePath (takeBaseName)
 import Text.Show.Pretty (PrettyVal(..))
@@ -118,6 +119,8 @@ data MFun arity where
   MLogicalAnd :: MFun ( S ( S Z ) )
   -- | @||@
   MLogicalOr  :: MFun ( S ( S Z ) )
+  -- | Tuples
+  MTuple      :: SNatI n => MFun ( S ( S n ) )
 
 deriving stock instance Show ( MFun arity )
 deriving stock instance Eq   ( MFun arity )
@@ -159,6 +162,12 @@ data MTerm =
 
     -- | Floating-point literal
   | MFloat FloatingLiteral
+
+    -- | Character literal
+  | MChar CharLiteral
+
+    -- | String literal
+  | MString StringLiteral
 
     -- | Variable or function/macro call
     --

--- a/hs-bindgen/src/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MagicHash #-}
+
 -- | Haskell AST
 --
 -- Abstract Haskell syntax for the specific purposes of hs-bindgen: we only
@@ -54,10 +56,11 @@ module HsBindgen.Hs.AST (
   , PatSynOrigin(..)
   ) where
 
+import Data.Maybe ( isJust )
+import Data.Type.Nat as Nat
+
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as C
-import Data.Type.Nat as Nat
-import Data.Maybe ( isJust )
 
 import HsBindgen.Imports
 import HsBindgen.NameHint
@@ -67,6 +70,7 @@ import HsBindgen.Orphans ()
 import HsBindgen.Util.TestEquality
 
 import DeBruijn
+
 
 {-------------------------------------------------------------------------------
   Information about generated code
@@ -279,6 +283,7 @@ data VarDeclRHS ctx
   = VarDeclIntegral Integer HsPrimType
   | VarDeclFloat Float
   | VarDeclDouble Double
+  | VarDeclString ByteArray
   | VarDeclLambda (Lambda VarDeclRHS ctx)
   | VarDeclApp VarDeclRHSAppHead [VarDeclRHS ctx]
   | VarDeclVar (Idx ctx)

--- a/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST/Type.hs
@@ -39,6 +39,7 @@ data HsPrimType
     -- CSUSeconds
     | HsPrimCFloat
     | HsPrimCDouble
+    | HsPrimCStringLen
 
     | HsPrimInt
 

--- a/hs-bindgen/src/HsBindgen/Imports.hs
+++ b/hs-bindgen/src/HsBindgen/Imports.hs
@@ -39,6 +39,7 @@ import Data.Vec.Lazy as X (Vec (..))
 -- without needing to add/remove imports.
 import Debug.Trace as X (traceShowId, traceShow, traceM)
 import HsBindgen.Debug as X
+import Data.Array.Byte as X
 
 import Text.Show.Pretty (PrettyVal(..))
 

--- a/hs-bindgen/src/HsBindgen/Pretty/Orphans.hs
+++ b/hs-bindgen/src/HsBindgen/Pretty/Orphans.hs
@@ -3,9 +3,11 @@
 module HsBindgen.Pretty.Orphans where
 
 -- base
+import Data.Array.Byte
 import Data.Foldable
   ( toList )
 import Data.List.NonEmpty qualified as NE
+import GHC.Exts qualified as IsList ( IsList(..) )
 
 -- containers
 import Data.IntMap.Strict
@@ -22,6 +24,9 @@ import Text.Show.Pretty qualified as Pretty
 import Data.Vec.Lazy
   ( Vec(..) )
 
+-- c-expr
+import C.Char qualified as C
+
 --------------------------------------------------------------------------------
 
 deriving anyclass instance PrettyVal a => PrettyVal ( NE.NonEmpty a )
@@ -31,3 +36,8 @@ instance PrettyVal a => PrettyVal ( Vec n a ) where
 
 instance PrettyVal a => PrettyVal ( IntMap a ) where
   prettyVal v = Pretty.Con "IntMap" [ prettyVal ( IntMap.assocs v ) ]
+
+instance PrettyVal ByteArray where
+  prettyVal ba = Pretty.Con "ByteArray" [ prettyVal ( IsList.toList ba ) ]
+
+instance PrettyVal C.CharValue

--- a/hs-bindgen/src/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/AST.hs
@@ -24,6 +24,7 @@ import HsBindgen.Hs.AST.Type
 
 import DeBruijn
 
+
 -- TODO: drop S prefix?
 
 {-------------------------------------------------------------------------------
@@ -31,8 +32,8 @@ import DeBruijn
 -------------------------------------------------------------------------------}
 
 data Global =
-    Unit_type
-  | Unit_constructor
+    Tuple_type Word
+  | Tuple_constructor Word
   | Applicative_pure
   | Applicative_seq
   | Monad_return
@@ -45,6 +46,7 @@ data Global =
   | Storable_peek
   | Storable_poke
   | Foreign_Ptr
+  | Ptr_constructor
   | Foreign_FunPtr
   | ConstantArray
   | IO_type
@@ -144,6 +146,7 @@ data SExpr ctx =
   | EIntegral Integer (Maybe HsPrimType)
   | EFloat Float HsPrimType -- ^ Type annotation to distinguish Float/CFLoat
   | EDouble Double HsPrimType
+  | EString ByteArray
   | EApp (SExpr ctx) (SExpr ctx)
   | EInfix Global (SExpr ctx) (SExpr ctx)
   | ELam NameHint (SExpr (S ctx))

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -23,6 +23,7 @@ import HsBindgen.NameHint
 import HsBindgen.Runtime.Enum.Simple
 
 import C.Type qualified as CExpr
+import C.Char qualified as CExpr
 
 import DeBruijn
 
@@ -64,8 +65,12 @@ instance ToExpr C.TokenSpelling
 instance ToExpr C.Type
 instance ToExpr C.Typedef
 
+instance ToExpr CExpr.CharValue
+
 instance ToExpr C.IntegerLiteral
 instance ToExpr C.FloatingLiteral
+instance ToExpr C.CharLiteral
+instance ToExpr C.StringLiteral
 instance ToExpr a => ToExpr (C.Range a)
 instance ToExpr a => ToExpr (C.Token a)
 
@@ -153,6 +158,7 @@ instance ToExpr (GenerativeTyCon args resKi) where
 
 instance ToExpr (DataTyCon n) where
   toExpr = \case
+    TupleTyCon              -> Expr.App "TupleTyCon"     []
     VoidTyCon               -> Expr.App "VoidTyCon"      []
     PtrTyCon                -> Expr.App "PtrTyCon"       []
     StringTyCon             -> Expr.App "StringTyCon"    []

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -164,31 +164,11 @@ instance ToExpr (DataTyCon n) where
     EmptyTyCon              -> Expr.App "EmptyTyCon"     []
 
 instance ToExpr CExpr.IntegralType where
-  toExpr = \case
-    CExpr.Bool       -> Expr.App "Bool"     []
-    CExpr.CharLike s -> Expr.App "CharLike" [toExpr s]
-    CExpr.IntLike  i -> Expr.App "IntLike"  [toExpr i]
 instance ToExpr CExpr.CharLikeType where
-  toExpr = \case
-    CExpr.Char  -> Expr.App "Char" []
-    CExpr.SChar -> Expr.App "SChar" []
-    CExpr.UChar -> Expr.App "UChar" []
 instance ToExpr CExpr.IntLikeType where
-  toExpr = \case
-    CExpr.Short    s -> Expr.App "Short"    [toExpr s]
-    CExpr.Int      s -> Expr.App "Int"      [toExpr s]
-    CExpr.Long     s -> Expr.App "Long"     [toExpr s]
-    CExpr.LongLong s -> Expr.App "LongLong" [toExpr s]
-    CExpr.PtrDiff    -> Expr.App "PtrDiff"  []
 instance ToExpr CExpr.Sign where
-  toExpr = \case
-    CExpr.Signed   -> Expr.App "Signed"   []
-    CExpr.Unsigned -> Expr.App "Unsigned" []
-
 instance ToExpr CExpr.FloatingType where
-  toExpr = \case
-    CExpr.FloatType  -> Expr.App "FloatType"  []
-    CExpr.DoubleType -> Expr.App "DoubleType" []
+instance ToExpr IntegralType
 
 instance ToExpr (FamilyTyCon n) where
   toExpr = \case

--- a/hs-bindgen/tests/golden.hs
+++ b/hs-bindgen/tests/golden.hs
@@ -47,6 +47,7 @@ main' packageRoot bg = testGroup "golden"
     , golden "primitive_types"
     , golden "typedefs"
     , golden "macros"
+    , testGroup "macro_strings" $ goldenNoRust "macro_strings" -- rs-bindgen panics on this
     , golden "macro_functions"
     , golden "uses_utf8"
     , golden "typedef_vs_macro"
@@ -66,7 +67,10 @@ main' packageRoot bg = testGroup "golden"
     , golden "bitfields"
     ]
   where
-    golden name = testGroup name
+    golden name =
+      testGroup name $ goldenNoRust name ++ [ goldenRust bg name ]
+
+    goldenNoRust name =
         [ goldenTreeDiff name
         , goldenHs name
 -- Pretty-printing of TH differs between GHC versions; for example, @()@ becomes
@@ -76,7 +80,6 @@ main' packageRoot bg = testGroup "golden"
         , goldenTh packageRoot name
 #endif
         , goldenPP name
-        , goldenRust bg name
         ]
 
     goldenTreeDiff name = ediffGolden1 goldenTestSteps "treediff" ("fixtures" </> (name ++ ".tree-diff.txt")) $ \report -> do


### PR DESCRIPTION
This commit adds support for C character literals and string literals in macros.

Some remarks:

  - The implementation assumes that the source file is encoded in UTF-8. I believe that's the only encoding that the Clang library supports anyway.
  - The implementation doesn't support wide character types, such as `char16_t`.
  - C character literals are of type `int`, not `char`. We distinguish two types of such literals, as per the C standard:
      * code unit: a specific `int` value, whose interpretation as a linguistic or symbolic character depends on the choice of a text encoding,
      * Unicode code point: a unique numeric identifier for a specific character, whose value (e.g. in a `char *` array) depends on the text encoding chosen.
  - We translate character literals to `CInt`, and use unboxed `Addr#` literals to translate string literals to `CStringLen` (allowing for the possibility of inner null bytes).