### PR TITLE
Configure Windows test using `C_INCLUDE_PATH`

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -69,6 +69,12 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: echo "LLVM_CONFIG=$LLVM_PATH/bin/llvm-config" >> "$GITHUB_ENV"
 
+      - name: Windows C_INCLUDE_PATH
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          chcp 65001 # set code page to utf-8
+          echo "C_INCLUDE_PATH=C:\tools\ghc-${{ matrix.ghc }}\mingw\lib\clang\14.0.6\include" >> $env:GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/c-expr/test/Main.hs
+++ b/c-expr/test/Main.hs
@@ -114,11 +114,6 @@ main = do
       clangArgs =
         case platformOS buildPlatform of
           Windows -> clangArgs0
-              -- TODO query default system include path
-              { Clang.clangSystemIncludePathDirs =
-                  [ fromString "C:/tools/ghc-9.4.8/mingw/lib/clang/14.0.6/include"
-                  ]
-              }
           Posix ->
             clangArgs0
               { Clang.clangTarget =


### PR DESCRIPTION
As discussed in #420, `libclang` automatically includes directories specified in environment variables `C_INCLUDE_PATH` and `CPATH` in the system include search path.  This PR removes the temporarily hard-coded include path for the `c-expr` test on Windows and sets `C_INCLUDE_PATH` instead.

I am unable to test this locally, so it may take a few CI failures before I get it working.  Apologies for the noise.