### PR TITLE
Set target in `c-expr` test on Windows

### DIFF
--- a/c-expr/test/Main.hs
+++ b/c-expr/test/Main.hs
@@ -113,7 +113,12 @@ main = do
           { Clang.clangCStandard = Just Clang.C23 }
       clangArgs =
         case platformOS hostPlatform of
-          Windows -> clangArgs0
+          Windows ->
+            clangArgs0
+              { Clang.clangTarget =
+                  Just (Clang.Target_Windows_X86_64, Clang.TargetEnvDefault)
+              , Clang.clangStdInc = True
+              }
           Posix ->
             clangArgs0
               { Clang.clangTarget =


### PR DESCRIPTION
@sheaf asked:

> does it work if you also add `Just (Clang.Target_Linux_X86_64, Clang.TargetEnvDefault)` to the Windows path in the c-expr test-suite?

This PR includes just that change.  A PR is required to test it in CI.