### PR TITLE
Various small fixes

### DIFF
--- a/c-expr/core/C/Type.hs
+++ b/c-expr/core/C/Type.hs
@@ -19,7 +19,7 @@ module C.Type
 
   -- * Platform
   , Platform(..), WordWidth(..), OS(..)
-  , buildPlatform
+  , hostPlatform
 
   ) where
 
@@ -88,14 +88,14 @@ data Platform = Platform { platformWordWidth :: !WordWidth
                          , platformOS        :: !OS }
   deriving stock ( Eq, Show, Generic )
 
-buildPlatform :: Platform
-buildPlatform =
+hostPlatform :: Platform
+hostPlatform =
   Platform
     { platformWordWidth =
         case sizeOf @( Foreign.Ptr () ) undefined of
           4 -> WordWidth32
           8 -> WordWidth64
-          w -> error $ "buildPlatform: unsupported word width (" ++ show (8 * w) ++ " bits)"
+          w -> error $ "hostPlatform: unsupported word width (" ++ show (8 * w) ++ " bits)"
     , platformOS =
         case System.Info.os of
           "mingw32" -> Windows

--- a/c-expr/test/Main.hs
+++ b/c-expr/test/Main.hs
@@ -107,12 +107,12 @@ main = do
       ]
 
 
-  let platform = buildPlatform
+  let platform = hostPlatform
       clangArgs0 =
         Clang.defaultClangArgs
           { Clang.clangCStandard = Just Clang.C23 }
       clangArgs =
-        case platformOS buildPlatform of
+        case platformOS hostPlatform of
           Windows -> clangArgs0
           Posix ->
             clangArgs0

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -161,7 +161,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -36,8 +36,8 @@ a_DEFINE_1 = (20560 :: FC.CUInt)
 a_DEFINE_2 :: FC.CInt
 a_DEFINE_2 = (2 :: FC.CInt)
 
-tWO_ARGS :: ((,,) FC.CInt) FC.CInt
-tWO_ARGS = (,,) (13398 :: FC.CInt) (30874 :: FC.CInt)
+tWO_ARGS :: ((,) FC.CInt) FC.CInt
+tWO_ARGS = (,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 
 foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: (F.Ptr A_type_t) -> Uint32_t -> (F.Ptr Uint8_t) -> IO Int32_t
 

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -305,7 +305,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 30874})]},
           macroDeclMacroTy =
-          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
           macroDeclSourceLoc =
           "distilled_lib_1.h:55:9"},
       DeclFunction

--- a/hs-bindgen/fixtures/macro_strings.hs
+++ b/hs-bindgen/fixtures/macro_strings.hs
@@ -11,19 +11,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        97
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [97],
+          unicodeCodePoint = Just 'a'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -36,19 +30,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        34
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [34],
+          unicodeCodePoint = Just `'"'`}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -61,19 +49,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        9
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [9],
+          unicodeCodePoint = Just '\t'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -86,19 +68,14 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        0
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [0],
+          unicodeCodePoint = Just
+            '\NUL'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -111,19 +88,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        39
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [39],
+          unicodeCodePoint = Just '\''}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -136,19 +107,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        63
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [63],
+          unicodeCodePoint = Just '?'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -161,19 +126,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        83
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [83],
+          unicodeCodePoint = Nothing}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -186,19 +145,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        83
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [83],
+          unicodeCodePoint = Nothing}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -211,19 +164,13 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        511
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList [1, 255],
+          unicodeCodePoint = Nothing}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -236,19 +183,15 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        14909826
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList
+            [227, 129, 130],
+          unicodeCodePoint = Just
+            '\12354'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -261,19 +204,15 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        14909826
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList
+            [227, 129, 130],
+          unicodeCodePoint = Just
+            '\12354'}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -286,19 +225,14 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon IntLikeTyCon)))
-            [
-              TyConAppTy
-                (ATyCon
-                  (GenerativeTyCon
-                    (DataTyCon
-                      (IntLikeTyCon
-                        (CIntegralType
-                          (IntLike (Int Signed)))))))
-                []]}},
-      varDeclBody = VarDeclIntegral
-        14909826
-        HsPrimCInt},
+                (DataTyCon CharLitTyCon)))
+            []}},
+      varDeclBody = VarDeclChar
+        CharValue {
+          charValue =
+          Prim.byteArrayFromList
+            [227, 129, 130],
+          unicodeCodePoint = Nothing}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -311,7 +245,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -356,7 +290,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -401,7 +335,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -446,7 +380,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -491,7 +425,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -536,7 +470,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -581,7 +515,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -626,7 +560,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -671,7 +605,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -717,7 +651,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -763,7 +697,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -809,7 +743,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -863,7 +797,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -909,7 +843,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -955,7 +889,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon

--- a/hs-bindgen/fixtures/macro_strings.pp.hs
+++ b/hs-bindgen/fixtures/macro_strings.pp.hs
@@ -3,88 +3,89 @@
 
 module Example where
 
+import qualified C.Char
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified Foreign.C.String as FC
 import Prelude (Int)
 
-c1 :: FC.CInt
-c1 = (97 :: FC.CInt)
+c1 :: C.Char.CharValue
+c1 = C.Char.charValueFromAddr "a"# 1 (Just 'a')
 
-c2 :: FC.CInt
-c2 = (34 :: FC.CInt)
+c2 :: C.Char.CharValue
+c2 = C.Char.charValueFromAddr "\""# 1 (Just '"')
 
-c3 :: FC.CInt
-c3 = (9 :: FC.CInt)
+c3 :: C.Char.CharValue
+c3 = C.Char.charValueFromAddr "\t"# 1 (Just '\t')
 
-c4 :: FC.CInt
-c4 = (0 :: FC.CInt)
+c4 :: C.Char.CharValue
+c4 = C.Char.charValueFromAddr "\0"# 1 (Just '\NUL')
 
-c5 :: FC.CInt
-c5 = (39 :: FC.CInt)
+c5 :: C.Char.CharValue
+c5 = C.Char.charValueFromAddr "\'"# 1 (Just '\'')
 
-c6 :: FC.CInt
-c6 = (63 :: FC.CInt)
+c6 :: C.Char.CharValue
+c6 = C.Char.charValueFromAddr "?"# 1 (Just '?')
 
-c7 :: FC.CInt
-c7 = (83 :: FC.CInt)
+c7 :: C.Char.CharValue
+c7 = C.Char.charValueFromAddr "S"# 1 Nothing
 
-c8 :: FC.CInt
-c8 = (83 :: FC.CInt)
+c8 :: C.Char.CharValue
+c8 = C.Char.charValueFromAddr "S"# 1 Nothing
 
-d :: FC.CInt
-d = (511 :: FC.CInt)
+d :: C.Char.CharValue
+d = C.Char.charValueFromAddr "\x1\xFF"# 2 Nothing
 
-j1 :: FC.CInt
-j1 = (14909826 :: FC.CInt)
+j1 :: C.Char.CharValue
+j1 = C.Char.charValueFromAddr "\xE3\x81\x82"# 3 (Just '\12354')
 
-j2 :: FC.CInt
-j2 = (14909826 :: FC.CInt)
+j2 :: C.Char.CharValue
+j2 = C.Char.charValueFromAddr "\xE3\x81\x82"# 3 (Just '\12354')
 
-j3 :: FC.CInt
-j3 = (14909826 :: FC.CInt)
+j3 :: C.Char.CharValue
+j3 = C.Char.charValueFromAddr "\xE3\x81\x82"# 3 Nothing
 
-s1 :: ((,,) (F.Ptr FC.CChar)) Int
+s1 :: ((,) (F.Ptr FC.CChar)) Int
 s1 = ((F.Ptr "a"#, 1) :: FC.CStringLen)
 
-s2 :: ((,,) (F.Ptr FC.CChar)) Int
+s2 :: ((,) (F.Ptr FC.CChar)) Int
 s2 = ((F.Ptr "\'"#, 1) :: FC.CStringLen)
 
-s3 :: ((,,) (F.Ptr FC.CChar)) Int
+s3 :: ((,) (F.Ptr FC.CChar)) Int
 s3 = ((F.Ptr "\t"#, 1) :: FC.CStringLen)
 
-s4 :: ((,,) (F.Ptr FC.CChar)) Int
+s4 :: ((,) (F.Ptr FC.CChar)) Int
 s4 = ((F.Ptr "\0"#, 1) :: FC.CStringLen)
 
-s5 :: ((,,) (F.Ptr FC.CChar)) Int
+s5 :: ((,) (F.Ptr FC.CChar)) Int
 s5 = ((F.Ptr "\'"#, 1) :: FC.CStringLen)
 
-s6 :: ((,,) (F.Ptr FC.CChar)) Int
+s6 :: ((,) (F.Ptr FC.CChar)) Int
 s6 = ((F.Ptr "?"#, 1) :: FC.CStringLen)
 
-s7 :: ((,,) (F.Ptr FC.CChar)) Int
+s7 :: ((,) (F.Ptr FC.CChar)) Int
 s7 = ((F.Ptr "S"#, 1) :: FC.CStringLen)
 
-s8 :: ((,,) (F.Ptr FC.CChar)) Int
+s8 :: ((,) (F.Ptr FC.CChar)) Int
 s8 = ((F.Ptr "S"#, 1) :: FC.CStringLen)
 
-t1 :: ((,,) (F.Ptr FC.CChar)) Int
+t1 :: ((,) (F.Ptr FC.CChar)) Int
 t1 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
 
-t2 :: ((,,) (F.Ptr FC.CChar)) Int
+t2 :: ((,) (F.Ptr FC.CChar)) Int
 t2 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
 
-t3 :: ((,,) (F.Ptr FC.CChar)) Int
+t3 :: ((,) (F.Ptr FC.CChar)) Int
 t3 = ((F.Ptr "\xE3\x81\x82"#, 3) :: FC.CStringLen)
 
-u :: ((,,) (F.Ptr FC.CChar)) Int
+u :: ((,) (F.Ptr FC.CChar)) Int
 u = ((F.Ptr "\x1\xFF\x1\xFF\x1\xFF\x1\xFF"#, 8) :: FC.CStringLen)
 
-v :: ((,,) (F.Ptr FC.CChar)) Int
+v :: ((,) (F.Ptr FC.CChar)) Int
 v = ((F.Ptr "\x1\x2\x3\x4\x5\x6"#, 6) :: FC.CStringLen)
 
-w1 :: ((,,) (F.Ptr FC.CChar)) Int
+w1 :: ((,) (F.Ptr FC.CChar)) Int
 w1 = ((F.Ptr "hij\0"#, 4) :: FC.CStringLen)
 
-w2 :: ((,,) (F.Ptr FC.CChar)) Int
+w2 :: ((,) (F.Ptr FC.CChar)) Int
 w2 = ((F.Ptr "abc\0def\0g"#, 9) :: FC.CStringLen)

--- a/hs-bindgen/fixtures/macro_strings.th.txt
+++ b/hs-bindgen/fixtures/macro_strings.th.txt
@@ -1,27 +1,27 @@
-c1 :: CInt
-c1 = 97 :: CInt
-c2 :: CInt
-c2 = 34 :: CInt
-c3 :: CInt
-c3 = 9 :: CInt
-c4 :: CInt
-c4 = 0 :: CInt
-c5 :: CInt
-c5 = 39 :: CInt
-c6 :: CInt
-c6 = 63 :: CInt
-c7 :: CInt
-c7 = 83 :: CInt
-c8 :: CInt
-c8 = 83 :: CInt
-d :: CInt
-d = 511 :: CInt
-j1 :: CInt
-j1 = 14909826 :: CInt
-j2 :: CInt
-j2 = 14909826 :: CInt
-j3 :: CInt
-j3 = 14909826 :: CInt
+c1 :: CharValue
+c1 = CharValue (addrToByteArray 1 "<binary data>") (Just 'a')
+c2 :: CharValue
+c2 = CharValue (addrToByteArray 1 "<binary data>") (Just '"')
+c3 :: CharValue
+c3 = CharValue (addrToByteArray 1 "<binary data>") (Just '\t')
+c4 :: CharValue
+c4 = CharValue (addrToByteArray 1 "<binary data>") (Just '\NUL')
+c5 :: CharValue
+c5 = CharValue (addrToByteArray 1 "<binary data>") (Just '\'')
+c6 :: CharValue
+c6 = CharValue (addrToByteArray 1 "<binary data>") (Just '?')
+c7 :: CharValue
+c7 = CharValue (addrToByteArray 1 "<binary data>") Nothing
+c8 :: CharValue
+c8 = CharValue (addrToByteArray 1 "<binary data>") Nothing
+d :: CharValue
+d = CharValue (addrToByteArray 2 "<binary data>") Nothing
+j1 :: CharValue
+j1 = CharValue (addrToByteArray 3 "<binary data>") (Just '\12354')
+j2 :: CharValue
+j2 = CharValue (addrToByteArray 3 "<binary data>") (Just '\12354')
+j3 :: CharValue
+j3 = CharValue (addrToByteArray 3 "<binary data>") Nothing
 s1 :: (,) (Ptr CChar) Int
 s1 = (Ptr "a"#, 1) :: CStringLen
 s2 :: (,) (Ptr CChar) Int

--- a/hs-bindgen/fixtures/macro_strings.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_strings.tree-diff.txt
@@ -20,8 +20,7 @@ WrapCHeader
                     charValue =
                     Prim.byteArrayFromList [97],
                     unicodeCodePoint = Just 'a'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:4:9"},
       DeclMacro
@@ -44,8 +43,7 @@ WrapCHeader
                     Prim.byteArrayFromList [34],
                     unicodeCodePoint = Just
                       `'"'`}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:5:9"},
       DeclMacro
@@ -68,8 +66,7 @@ WrapCHeader
                     Prim.byteArrayFromList [9],
                     unicodeCodePoint = Just
                       '\t'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:6:9"},
       DeclMacro
@@ -92,8 +89,7 @@ WrapCHeader
                     Prim.byteArrayFromList [0],
                     unicodeCodePoint = Just
                       '\NUL'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:7:9"},
       DeclMacro
@@ -116,8 +112,7 @@ WrapCHeader
                     Prim.byteArrayFromList [39],
                     unicodeCodePoint = Just
                       '\''}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:8:9"},
       DeclMacro
@@ -139,8 +134,7 @@ WrapCHeader
                     charValue =
                     Prim.byteArrayFromList [63],
                     unicodeCodePoint = Just '?'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:9:9"},
       DeclMacro
@@ -162,8 +156,7 @@ WrapCHeader
                     charValue =
                     Prim.byteArrayFromList [83],
                     unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:10:9"},
       DeclMacro
@@ -185,8 +178,7 @@ WrapCHeader
                     charValue =
                     Prim.byteArrayFromList [83],
                     unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:11:9"},
       DeclMacro
@@ -208,8 +200,7 @@ WrapCHeader
                     charValue =
                     Prim.byteArrayFromList [1, 255],
                     unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:13:9"},
       DeclMacro
@@ -233,8 +224,7 @@ WrapCHeader
                       [227, 129, 130],
                     unicodeCodePoint = Just
                       '\12354'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:15:9"},
       DeclMacro
@@ -258,8 +248,7 @@ WrapCHeader
                       [227, 129, 130],
                     unicodeCodePoint = Just
                       '\12354'}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:16:9"},
       DeclMacro
@@ -283,8 +272,7 @@ WrapCHeader
                     Prim.byteArrayFromList
                       [227, 129, 130],
                     unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
+          macroDeclMacroTy = "CharLit",
           macroDeclSourceLoc =
           "macro_strings.h:17:9"},
       DeclMacro
@@ -309,7 +297,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         'a'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:20:9"},
       DeclMacro
@@ -334,7 +322,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\''}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:21:9"},
       DeclMacro
@@ -359,7 +347,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\t'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:22:9"},
       DeclMacro
@@ -384,7 +372,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\NUL'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:23:9"},
       DeclMacro
@@ -409,7 +397,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\''}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:24:9"},
       DeclMacro
@@ -434,7 +422,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '?'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:25:9"},
       DeclMacro
@@ -458,7 +446,7 @@ WrapCHeader
                       Prim.byteArrayFromList [83],
                       unicodeCodePoint = Nothing}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:26:9"},
       DeclMacro
@@ -482,7 +470,7 @@ WrapCHeader
                       Prim.byteArrayFromList [83],
                       unicodeCodePoint = Nothing}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:27:9"},
       DeclMacro
@@ -509,7 +497,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\12354'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:29:9"},
       DeclMacro
@@ -536,7 +524,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\12354'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:30:9"},
       DeclMacro
@@ -569,7 +557,7 @@ WrapCHeader
                       Prim.byteArrayFromList [130],
                       unicodeCodePoint = Nothing}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:31:9"},
       DeclMacro
@@ -606,7 +594,7 @@ WrapCHeader
                       Prim.byteArrayFromList [1, 255],
                       unicodeCodePoint = Nothing}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:33:9"},
       DeclMacro
@@ -651,7 +639,7 @@ WrapCHeader
                       Prim.byteArrayFromList [6],
                       unicodeCodePoint = Nothing}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:34:9"},
       DeclMacro
@@ -689,7 +677,7 @@ WrapCHeader
                       unicodeCodePoint = Just
                         '\NUL'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:36:9"},
       DeclMacro
@@ -747,6 +735,6 @@ WrapCHeader
                       unicodeCodePoint = Just
                         'g'}]})},
           macroDeclMacroTy =
-          "Tuple (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
           macroDeclSourceLoc =
           "macro_strings.h:37:9"}])

--- a/hs-bindgen/fixtures/macros.hs
+++ b/hs-bindgen/fixtures/macros.hs
@@ -344,7 +344,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -389,7 +389,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon
@@ -434,7 +434,7 @@
           quantTyBody = TyConAppTy
             (ATyCon
               (GenerativeTyCon
-                (DataTyCon TupleTyCon)))
+                (DataTyCon (TupleTyCon 2))))
             [
               TyConAppTy
                 (ATyCon

--- a/hs-bindgen/fixtures/macros.pp.hs
+++ b/hs-bindgen/fixtures/macros.pp.hs
@@ -45,14 +45,14 @@ lONG_INT_TOKEN3 = (18446744073709550592 :: FC.CULLong)
 lONG_INT_TOKEN4 :: FC.CULLong
 lONG_INT_TOKEN4 = (18446744073709550592 :: FC.CULLong)
 
-tUPLE1 :: ((,,) FC.CInt) FC.CInt
-tUPLE1 = (,,) (1 :: FC.CInt) (2 :: FC.CInt)
+tUPLE1 :: ((,) FC.CInt) FC.CInt
+tUPLE1 = (,) (1 :: FC.CInt) (2 :: FC.CInt)
 
-tUPLE2 :: ((,,) FC.CInt) FC.CInt
-tUPLE2 = (,,) (3 :: FC.CInt) (4 :: FC.CInt)
+tUPLE2 :: ((,) FC.CInt) FC.CInt
+tUPLE2 = (,) (3 :: FC.CInt) (4 :: FC.CInt)
 
-tUPLE3 :: ((,,) FC.CInt) FC.CInt
-tUPLE3 = (,,) (5 :: FC.CInt) (6 :: FC.CInt)
+tUPLE3 :: ((,) FC.CInt) FC.CInt
+tUPLE3 = (,) (5 :: FC.CInt) (6 :: FC.CInt)
 
 fLT1_1 :: FC.CDouble
 fLT1_1 = (110000.0 :: FC.CDouble)

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -353,7 +353,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 2})]},
           macroDeclMacroTy =
-          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
           macroDeclSourceLoc =
           "macros.h:17:9"},
       DeclMacro
@@ -385,7 +385,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 4})]},
           macroDeclMacroTy =
-          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
           macroDeclSourceLoc =
           "macros.h:18:9"},
       DeclMacro
@@ -417,7 +417,7 @@ WrapCHeader
                         (_×_ PrimInt Signed),
                       integerLiteralValue = 6})]},
           macroDeclMacroTy =
-          "Tuple (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
           macroDeclSourceLoc =
           "macros.h:19:9"},
       DeclMacro

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
@@ -69,10 +69,18 @@ data ResolvedName = ResolvedName {
   deriving (Eq, Ord, Show)
 
 -- | Name for tuples
-tupleResolvedName :: Word -> ResolvedName
-tupleResolvedName i = ResolvedName tup IdentifierName Nothing
+tupleResolvedName :: Bool -> Word -> ResolvedName
+tupleResolvedName wantType i = ResolvedName tup IdentifierName Nothing
   where
-    tup = "(" ++ replicate (fromIntegral i) ',' ++ ")"
+    tup
+      | i == 0
+      = "()"
+      | i == 1
+      = if wantType
+        then "Solo"
+        else "MkSolo"
+      | otherwise
+      = "(" ++ replicate (fromIntegral (i - 1)) ',' ++ ")"
 
 {-------------------------------------------------------------------------------
   Imports helpers
@@ -166,8 +174,8 @@ resolveGlobal :: Global -> ResolvedName
 resolveGlobal = \case
     -- When adding a new global that resolves to a non-qualified identifier, be
     -- sure to reserve the name in "HsBindgen.Hs.AST.Name".
-    Tuple_type i         -> tupleResolvedName i
-    Tuple_constructor i  -> tupleResolvedName i
+    Tuple_type i         -> tupleResolvedName True  i
+    Tuple_constructor i  -> tupleResolvedName False i
     Applicative_pure     -> importU 'pure
     Applicative_seq      -> importU '(<*>)
     Monad_return         -> importU 'return
@@ -272,7 +280,7 @@ resolveGlobal = \case
 
     PrimType hsPrimType  -> case hsPrimType of
       HsPrimVoid       -> importU ''Data.Void.Void
-      HsPrimUnit       -> tupleResolvedName 0
+      HsPrimUnit       -> tupleResolvedName True 0
       HsPrimCChar      -> importQ ''Foreign.C.CChar
       HsPrimCSChar     -> importQ ''Foreign.C.CSChar
       HsPrimCUChar     -> importQ ''Foreign.C.CUChar

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Names.hs
@@ -20,6 +20,7 @@ import HsBindgen.Hs.AST.Type
 
 import Language.Haskell.TH.Syntax qualified as TH
 
+import C.Char ( CharValue(..), charValueFromAddr )
 import C.Expr.HostPlatform qualified
 import Data.Bits qualified
 import Data.Ix qualified
@@ -196,6 +197,9 @@ resolveGlobal = \case
     HasFlexibleArrayMember_offset -> importQ 'HsBindgen.Runtime.FlexibleArrayMember.flexibleArrayMemberOffset
     Bitfield_peekBitOffWidth -> importQ 'HsBindgen.Runtime.Bitfield.peekBitOffWidth
     Bitfield_pokeBitOffWidth -> importQ 'HsBindgen.Runtime.Bitfield.pokeBitOffWidth
+    CharValue_tycon       -> importQ ''C.Char.CharValue
+    CharValue_constructor -> importQ 'C.Char.CharValue
+    CharValue_fromAddr    -> importQ 'C.Char.charValueFromAddr
 
     Bits_class       -> importQ ''Data.Bits.Bits
     Bounded_class    -> importU ''Bounded

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Render.hs
@@ -31,6 +31,7 @@ import HsBindgen.NameHint
 import HsBindgen.SHs.AST
 import Text.SimplePrettyPrint
 
+import C.Char (CharValue(..))
 import DeBruijn (EmptyCtx, Env (..), lookupEnv, Add (..))
 
 
@@ -222,7 +223,13 @@ prettyExpr env prec = \case
         , " :: "
         , prettyPrimType t
         ]
-
+    EChar (CharValue { charValue = ba, unicodeCodePoint = mbUnicode }) ->
+      prettyExpr env 0 (EGlobal CharValue_fromAddr)
+        <+> string str
+        <+> string (show len)
+        <+> case mbUnicode of { Nothing -> "Nothing"; Just c -> parens ("Just" <+> string (show c)) }
+      where
+        (str, len) = addrLiteral ba
     EString bs ->
       -- Use unboxed Addr# literals to turn a string literal into a
       -- value of type CStringLen.

--- a/hs-bindgen/src/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/PP/Translation.hs
@@ -168,6 +168,11 @@ resolveExprImports = \case
     EFree {} -> mempty
     ECon _n -> mempty
     EIntegral _ t -> maybe mempty resolvePrimTypeImports t
+    EChar {} -> mconcat $ map resolveGlobalImports
+                  [ CharValue_tycon
+                  , CharValue_constructor
+                  , CharValue_fromAddr
+                  ]
     EString {} -> resolvePrimTypeImports Hs.HsPrimCStringLen
                <> resolveGlobalImports Ptr_constructor
     EFloat _ t -> resolvePrimTypeImports t

--- a/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Backend/TH/Translation.hs
@@ -23,6 +23,7 @@ import GHC.Float
   ( castWord64ToDouble, castDoubleToWord64
   , castWord32ToFloat , castFloatToWord32 )
 
+import C.Char (CharValue(..), charValueFromAddr)
 import C.Expr.HostPlatform qualified as C
 import HsBindgen.C.AST.Literal (canBeRepresentedAsRational)
 import HsBindgen.Hs.AST qualified as Hs
@@ -67,6 +68,9 @@ mkGlobal = \case
       HasFlexibleArrayMember_offset -> 'HsBindgen.Runtime.FlexibleArrayMember.flexibleArrayMemberOffset
       Bitfield_peekBitOffWidth -> 'HsBindgen.Runtime.Bitfield.peekBitOffWidth
       Bitfield_pokeBitOffWidth -> 'HsBindgen.Runtime.Bitfield.pokeBitOffWidth
+      CharValue_tycon        -> ''C.Char.CharValue
+      CharValue_constructor  -> 'C.Char.CharValue
+      CharValue_fromAddr    -> 'C.Char.charValueFromAddr
 
       Bits_class       -> ''Data.Bits.Bits
       Bounded_class    -> ''Bounded
@@ -206,6 +210,7 @@ mkExpr env = \case
               else [| Foreign.C.Types.CDouble $ castWord64ToDouble $( TH.lift $ castDoubleToWord64 d ) |]
           )
           (mkPrimType t)
+      EChar c -> [| c |]
       EString ba@(ByteArray ba#) ->
         let
           len :: Integer

--- a/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Decl.hs
@@ -24,7 +24,7 @@ import HsBindgen.Clang.Paths
 import HsBindgen.Runtime.Enum.Simple
 import HsBindgen.Util.Tracer
 import HsBindgen.C.Tc.Macro (tcMacro)
-import C.Type (buildPlatform)
+import C.Type (hostPlatform)
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -54,8 +54,7 @@ foldDecls tracer p unit = checkPredicate tracer p $ \current -> do
               Left err -> return $ MacroReparseError err
               Right macro@( Macro _ mVar mArgs mExpr ) -> do
                 macroTyEnv <- macroTypes <$> get
-                let tcRes = tcMacro buildPlatform macroTyEnv mVar mArgs mExpr
-                  -- TODO (cross-compilation): use of 'buildPlatform'.
+                let tcRes = tcMacro hostPlatform macroTyEnv mVar mArgs mExpr
                 case tcRes of
                   Left err ->
                     return $ MacroTcError macro err

--- a/hs-bindgen/src/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST.hs
@@ -70,6 +70,7 @@ import HsBindgen.Util.TestEquality
 
 import DeBruijn
 
+import C.Char qualified as CExpr
 
 {-------------------------------------------------------------------------------
   Information about generated code
@@ -282,6 +283,7 @@ data VarDeclRHS ctx
   = VarDeclIntegral Integer HsPrimType
   | VarDeclFloat Float
   | VarDeclDouble Double
+  | VarDeclChar   CExpr.CharValue
   | VarDeclString ByteArray
   | VarDeclLambda (Lambda VarDeclRHS ctx)
   | VarDeclApp VarDeclRHSAppHead [VarDeclRHS ctx]

--- a/hs-bindgen/src/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/Translation.hs
@@ -584,11 +584,8 @@ macroExprHsExpr = goExpr where
       Just $ Hs.VarDeclIntegral i (maybe HsPrimCInt (uncurry integralType) mbIntTy)
 
     goChar :: C.CharLiteral -> Maybe (Hs.VarDeclRHS ctx)
-    goChar (C.CharLiteral { charLiteralValue = C.CharValue { charValue = charBytes }}) =
-      return $
-        Hs.VarDeclIntegral
-          ( C.fromBytes $ map fromIntegral $ IsList.toList charBytes )
-          HsPrimCInt
+    goChar (C.CharLiteral { charLiteralValue = c }) =
+      return $ Hs.VarDeclChar c
 
     goString :: C.StringLiteral -> Maybe (Hs.VarDeclRHS ctx)
     goString (C.StringLiteral { stringLiteralValue = s }) = do

--- a/hs-bindgen/src/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/AST.hs
@@ -1,5 +1,6 @@
 -- | Simplified HS abstract syntax tree
 module HsBindgen.SHs.AST (
+-- TODO: drop S prefix?
     Global (..),
     ClosedExpr,
     SExpr (..),
@@ -24,9 +25,7 @@ import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 
 import DeBruijn
-
-
--- TODO: drop S prefix?
+import C.Char qualified as CExpr
 
 {-------------------------------------------------------------------------------
   Backend representation
@@ -55,6 +54,9 @@ data Global =
   | HasFlexibleArrayMember_offset
   | Bitfield_peekBitOffWidth
   | Bitfield_pokeBitOffWidth
+  | CharValue_tycon
+  | CharValue_constructor
+  | CharValue_fromAddr
 
     -- Other type classes
   | Bits_class
@@ -147,6 +149,7 @@ data SExpr ctx =
   | EIntegral Integer (Maybe HsPrimType)
   | EFloat Float HsPrimType -- ^ Type annotation to distinguish Float/CFLoat
   | EDouble Double HsPrimType
+  | EChar CExpr.CharValue
   | EString ByteArray
   | EApp (SExpr ctx) (SExpr ctx)
   | EInfix Global (SExpr ctx) (SExpr ctx)

--- a/hs-bindgen/src/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/Translation.hs
@@ -184,8 +184,8 @@ tyConGlobal = \case
     case tc of
       C.DataTyCon dc ->
         case dc of
-          C.TupleTyCon @n ->
-            TGlobal $ Tuple_type $ 2 + Fin.reflectToNum @n Proxy
+          C.TupleTyCon n ->
+            TGlobal $ Tuple_type n
           C.VoidTyCon ->
             TGlobal $ PrimType HsPrimVoid
           C.IntLikeTyCon   ->

--- a/hs-bindgen/src/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/SHs/Translation.hs
@@ -201,15 +201,8 @@ tyConGlobal = \case
             TGlobal $ PrimType $ hsPrimFloatTy floaty
           C.PtrTyCon ->
             TGlobal Foreign_Ptr
-          C.StringTyCon ->
-            -- We use 'CStringLen' for C strings.
-            --
-            -- type CStringLen = (Ptr CChar, Int)
-            ( TGlobal $ Tuple_type 2 )
-              `TApp`
-            ( TApp (TGlobal Foreign_Ptr) (TGlobal $ PrimType HsPrimCChar) )
-              `TApp`
-            ( TGlobal $ PrimType HsPrimInt )
+          C.CharLitTyCon ->
+            TGlobal CharValue_tycon
           C.PrimTyTyCon ->
             error "tyConGlobal PrimTyTyCon"
           C.EmptyTyCon ->
@@ -311,6 +304,7 @@ translateBody (Hs.VarDeclVar x)                     = EBound x
 translateBody (Hs.VarDeclFloat f)                   = EFloat f HsPrimCFloat
 translateBody (Hs.VarDeclDouble d)                  = EDouble d HsPrimCDouble
 translateBody (Hs.VarDeclIntegral i ty)             = EIntegral i (Just ty)
+translateBody (Hs.VarDeclChar c)                    = EChar c
 translateBody (Hs.VarDeclString s)                  = EString s
 translateBody (Hs.VarDeclLambda (Hs.Lambda hint b)) = ELam hint (translateBody b)
 translateBody (Hs.VarDeclApp f as)                  = foldl' EApp (translateAppHead f) (map translateBody as)

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -158,7 +158,7 @@ instance ToExpr (GenerativeTyCon args resKi) where
 
 instance ToExpr (DataTyCon n) where
   toExpr = \case
-    TupleTyCon              -> Expr.App "TupleTyCon"     []
+    TupleTyCon n            -> Expr.App "TupleTyCon"     [toExpr n]
     VoidTyCon               -> Expr.App "VoidTyCon"      []
     PtrTyCon                -> Expr.App "PtrTyCon"       []
     StringTyCon             -> Expr.App "StringTyCon"    []

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -161,7 +161,7 @@ instance ToExpr (DataTyCon n) where
     TupleTyCon n            -> Expr.App "TupleTyCon"     [toExpr n]
     VoidTyCon               -> Expr.App "VoidTyCon"      []
     PtrTyCon                -> Expr.App "PtrTyCon"       []
-    StringTyCon             -> Expr.App "StringTyCon"    []
+    CharLitTyCon            -> Expr.App "CharLitTyCon"   []
     IntLikeTyCon            -> Expr.App "IntLikeTyCon"   []
     FloatLikeTyCon          -> Expr.App "FloatLikeTyCon" []
     PrimIntInfoTyCon   info -> Expr.App "IntLikeTyCon"   [toExpr info]


### PR DESCRIPTION
This PR includes various small fixes:

  - improves the desugaring of character literals in macros, now desugaring to a datatype that
    keeps track of more information about the original literal, instead of simply desugaring to `CInt`
  - fixes a buglet in the pretty-printing of tuples and simplifies the constructor a little bit,
  - renames `buildPlatform` to `hostPlatform` in the `c-expr` library