### PR TITLE
Show global help information in subparser usage

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Cmdline.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cmdline.hs
@@ -21,8 +21,10 @@ import HsBindgen.Lib
 -------------------------------------------------------------------------------}
 
 getCmdline :: IO Cmdline
-getCmdline = execParser opts
+getCmdline = customExecParser p opts
   where
+    p = prefs helpShowGlobals
+
     opts :: ParserInfo Cmdline
     opts = info (parseCmdline <**> helper) $
       mconcat [


### PR DESCRIPTION
I.e. when using

```
hs-bindgen preprocess --help
```

we get

```
Usage: hs-bindgen preprocess (-i|--input PATH) [--module NAME]
                             [--render-line-length ARG] [-o|--output PATH]

  Generate Haskell module from C header

Available options:
  -i,--input PATH          Input C header, relative to an include path directory
  --module NAME            Name of the generated Haskell module
                           (default: "Generated")
  --render-line-length ARG Maximum length line (default: 80)
  -o,--output PATH         Output path for the Haskell module
  -h,--help                Show this help text

Global options:
  -v,--verbose             Verbose output
  --select-all             Process all elements
  --select-by-filename ARG Match filename against PCRE
  --select-by-element-name ARG
                           Match element name against PCRE
  --select-from-main-file  Only process elements from the main file (this is the
                           default)
  --target TRIPLE          Target (for cross-compilation); supported:
                           x86_64-pc-linux, i386-pc-linux, aarch64-pc-linux,
                           x86_64-pc-windows, x86_64-apple-macosx,
                           aarch64-apple-macosx
  --standard STANDARD      C standard (default: c17; supported: c89, c99, c11,
                           c17, c23)
  --gnu                    Enable GNU extensions
  --system-include-path DIR
                           System include search path directory
  -I,--include-path DIR    Non-system include search path directory
  --clang-option OPTION    Pass option to libclang
```

Note the Global options