### PR TITLE
Add throw_TODO and basic hs-bindgen exception machinery

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -74,6 +74,7 @@ library
       HsBindgen.Hs.AST.Name
       HsBindgen.Hs.AST.Type
       HsBindgen.NameHint
+      HsBindgen.Errors
   other-modules:
       Data.DynGraph
       HsBindgen.Backend.Extensions

--- a/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
@@ -103,6 +103,7 @@ import C.Operators qualified as C.Op
 
 -- hs-bindgen
 import HsBindgen.Imports
+import HsBindgen.Errors
 import HsBindgen.C.AST.Literal
   ( IntegerLiteral(..), FloatingLiteral(..) )
 import HsBindgen.C.AST.Macro
@@ -1262,7 +1263,7 @@ fromPrimFloatTy :: PrimFloatType -> C.FloatingType
 fromPrimFloatTy = \case
   PrimFloat      -> C.FloatType
   PrimDouble     -> C.DoubleType
-  PrimLongDouble -> error "tcMacro: long double not supported"
+  PrimLongDouble -> throw_TODO 349 "tcMacro: long double not supported"
 
 inferApp :: FunName -> [ MExpr ] -> TcGenM ( Type Ty )
 inferApp fun mbArgs = do

--- a/hs-bindgen/src/HsBindgen/Errors.hs
+++ b/hs-bindgen/src/HsBindgen/Errors.hs
@@ -1,0 +1,53 @@
+module HsBindgen.Errors (
+    HsBindgenException (..),
+    TODOException (..),
+    throw_TODO,
+) where
+
+import GHC.Stack (CallStack, callStack, prettyCallStack)
+import Control.Exception (SomeException (..), Exception (..), throw)
+import Data.Typeable (cast)
+
+import HsBindgen.Imports
+
+-------------------------------------------------------------------------------
+-- HsBindgenException
+-------------------------------------------------------------------------------
+
+-- | Superclass for @hs-bindgen@ exceptions
+data HsBindgenException where
+    HsBindgenException :: Exception e => e -> HsBindgenException
+
+instance Show HsBindgenException where
+    showsPrec d (HsBindgenException e) = showsPrec d e
+
+hsBindgenExceptionToException :: Exception e => e -> SomeException
+hsBindgenExceptionToException = toException . HsBindgenException
+
+hsBindgenExceptionFromException :: Exception e => SomeException -> Maybe e
+hsBindgenExceptionFromException x = do
+    HsBindgenException a <- fromException x
+    cast a
+
+instance Exception HsBindgenException where
+    displayException (HsBindgenException e) = displayException e
+
+-------------------------------------------------------------------------------
+-- TODOs
+-------------------------------------------------------------------------------
+
+data TODOException = TODOException !CallStack !Int !String
+  deriving Show
+
+instance Exception TODOException where
+    toException = hsBindgenExceptionToException
+    fromException = hsBindgenExceptionFromException
+    displayException (TODOException cs issue msg) = unlines
+        [ "hs-bindgen known issue: https://github.com/well-typed/hs-bindgen/issues/" ++ show issue
+        , msg
+        , prettyCallStack cs
+        ]
+
+-- | Throw a pure, known TODO exception.
+throw_TODO :: HasCallStack => Int -> String -> a
+throw_TODO issue msg = throw (TODOException callStack issue msg)


### PR DESCRIPTION
Example:

Given `foo.h`

```c
#define FOO 12.3Lh
```

we will now error with

```
% cabal run hs-bindgen -- -I. preprocess  -i foo.h
hs-bindgen known issue: https://github.com/well-typed/hs-bindgen/issues/349
tcMacro: long double not supported
CallStack (from HasCallStack):
  throw_TODO, called at src/HsBindgen/C/Tc/Macro.hs:1266:21 in hs-bindgen-0.1.0-inplace:HsBindgen.C.Tc.Macro
```

---

Another HsBindgenException would be `PanicException` for unexpected, should not happen cases, which we cannot have issue numbers for. I'll add that in follow up PR.

---

Regarding this particular case of long double not supported, arguably macro checker should handle that, and then we could fail later in the translation phase. At the moment we don't, there we have

```
floatingType :: C.PrimFloatType -> HsPrimType
floatingType = \case
  C.PrimFloat      -> HsPrimCFloat
  C.PrimDouble     -> HsPrimCDouble
  C.PrimLongDouble -> HsPrimCDouble -- wrong (see #247)
```

---

This is another step towards resolving #340.