### PR TITLE
Use subparserInline

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Cmdline.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cmdline.hs
@@ -23,7 +23,7 @@ import HsBindgen.Lib
 getCmdline :: IO Cmdline
 getCmdline = customExecParser p opts
   where
-    p = prefs helpShowGlobals
+    p = prefs $ helpShowGlobals <> subparserInline
 
     opts :: ParserInfo Cmdline
     opts = info (parseCmdline <**> helper) $


### PR DESCRIPTION
This allows to write

```
hs-bindgen preprocess -I. -i foo.h
```

instead of always requiring global arguments to be before subcommand name, i.e.

```
hs-bindgen -I. preprocess -i foo.h
```