### PR TITLE
Refactor `c-expr` dependencies

### DIFF
--- a/c-expr/c-expr.cabal
+++ b/c-expr/c-expr.cabal
@@ -37,107 +37,100 @@ description:
 
 common common
   ghc-options:
-    -Wall
-    -Wno-unticked-promoted-constructors
+      -Wall
+      -Wunused-packages
+      -Wno-unticked-promoted-constructors
   default-extensions:
-    DataKinds
-    DeriveGeneric
-    DeriveTraversable
-    DerivingStrategies
-    FlexibleInstances
-    GADTs
-    ImportQualifiedPost
-    LambdaCase
-    MagicHash
-    MultiParamTypeClasses
-    ParallelListComp
-    StandaloneKindSignatures
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeOperators
-
+      DataKinds
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleInstances
+      GADTs
+      ImportQualifiedPost
+      LambdaCase
+      MagicHash
+      MultiParamTypeClasses
+      ParallelListComp
+      StandaloneKindSignatures
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
   build-depends:
-      base
-        >= 4.16  && < 4.21
-    , template-haskell
-        >= 2.18  && < 2.23
-    , containers
-        >= 0.6   && < 0.8
-    , directory
-        >= 1.3   && < 1.4
-    , filepath
-        >= 1.4   && < 1.6
-    , fin
-        >= 0.3.2 && < 0.4
-    , text
-        >= 1.2   && < 2.2
-    , vec
-        >= 0.5   && < 0.6
-
-  if impl(ghc < 9.4)
-    build-depends:
-      data-array-byte
-        >= 0.1.0.1 && < 0.2
+      base >= 4.16 && < 4.21
+  default-language:
+      Haskell2010
 
 -- Platform independent core library
 -- Note: the C.Operator.Classes should not be publicly visible.
 -- We should only be able to import the definitions "polluted"
 -- by instances declarations (from C.Expr.HostPlatform).
 library c-expr-core
-  import:
-    common
-  hs-source-dirs:
-    core
-  exposed-modules:
-    C.Char
-    C.Type
-    C.Type.Internal.Universe
-    C.Operators
-    C.Operator.Classes
-    C.Operator.GenInstances
-  other-modules:
-    C.Operator.Internal
-    C.Operator.TH
-  default-language:
-    Haskell2010
+  import:         common
+  hs-source-dirs: core
 
+  exposed-modules:
+      C.Char
+      C.Type
+      C.Type.Internal.Universe
+      C.Operators
+      C.Operator.Classes
+      C.Operator.GenInstances
+  other-modules:
+      C.Operator.Internal
+      C.Operator.TH
+
+  build-depends:
+      -- External dependencies
+      fin              >= 0.3.2 && < 0.4
+    , template-haskell >= 2.18  && < 2.23
+    , vec              >= 0.5   && < 0.6
+  if impl(ghc < 9.4)
+    build-depends:
+      data-array-byte >= 0.1.0.1 && < 0.2
 
 -- C arithmetic DSL, in the form of platform-dependent modules
 library
-  import:
-    common
-  hs-source-dirs:
-    lib
+  import:         common
+  hs-source-dirs: lib
+
   exposed-modules:
-    C.Expr.HostPlatform
+      C.Expr.HostPlatform
   other-modules:
-    C.Expr.Posix32
-    C.Expr.Posix64
-    C.Expr.Win64
-  build-depends:
-    c-expr:c-expr-core
+      C.Expr.Posix32
+      C.Expr.Posix64
+      C.Expr.Win64
   reexported-modules:
-    C.Char,
-    C.Operators,
-    C.Type
-  default-language:
-    Haskell2010
+      C.Char
+    , C.Operators
+    , C.Type
+
+  build-depends:
+      -- Internal dependencies
+      c-expr:c-expr-core
 
 test-suite tests
-  import:
-    common
-  hs-source-dirs:
-    test
-  main-is:
-    Main.hs
+  import:         common
+  hs-source-dirs: test
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
+
   other-modules:
-    CallClang
-  type:
-    exitcode-stdio-1.0
+      CallClang
+
   build-depends:
+      -- Internal dependencies
       c-expr:c-expr-core
     , hs-bindgen-libclang
     , hs-bindgen-runtime
-  default-language:
-    Haskell2010
+  build-depends:
+      -- Inherited dependencies
+      fin
+    , vec
+  build-depends:
+      -- External dependencies
+      containers >= 0.6 && < 0.8
+    , directory  >= 1.3 && < 1.4
+    , filepath   >= 1.4 && < 1.6
+    , text       >= 1.2 && < 2.2


### PR DESCRIPTION
This refactors the `c-expr.cabal` file as requested in https://github.com/well-typed/hs-bindgen/pull/450#issuecomment-2687128121.

I moved dependencies from the `common` section to each `library` and `test-suite`.  As in the other packages in the project, I split them into "internal dependencies," "inherited dependencies," and "external dependencies." Note that I only used "inherited dependencies" for dependencies with versions specified in the same file.  Bounds for packages `filepath` and `text` are set by internal dependency `hs-bindgen-libclang`, so the bounds for these "external dependencies" are not necessary, but perhaps it would be dangerous to leave them off if the dependencies for `hs-bindgen-libclang` were to change.

I did not check/change any of the bounds.

I added the `-Wunused-packages` GHC option to alert of unused packages as the code changes.

I reformatted the sections to match the style of the other packages in the project.  I did not touch the top settings.