### PR TITLE
Avoid unnecessary qualified name in C example

### DIFF
--- a/hs-bindgen/examples/nested_types.h
+++ b/hs-bindgen/examples/nested_types.h
@@ -20,9 +20,9 @@ struct ex3 {
 // linked list where odd values are ints, and even values are doubles
 // by writing this way, we don't need forward declarations.
 struct ex4_odd {
-    int ex4_odd_value;
+    int value;
     struct ex4_even {
-        double ex4_even_value;
+        double value;
         struct ex4_odd *next;
     } *next;
 };

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -865,14 +865,13 @@
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_even_ex4_even_value",
+            "ex4_even_value",
           fieldType = HsPrimType
             HsPrimCDouble,
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName
-                "ex4_even_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
@@ -916,8 +915,7 @@
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName
-                "ex4_even_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
@@ -951,14 +949,13 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_even_ex4_even_value",
+              "ex4_even_value",
             fieldType = HsPrimType
               HsPrimCDouble,
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName
-                  "ex4_even_value",
+                fieldName = CName "value",
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
@@ -1002,8 +999,7 @@
             structAlignment = 8,
             structFields = [
               StructField {
-                fieldName = CName
-                  "ex4_even_value",
+                fieldName = CName "value",
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
@@ -1042,14 +1038,13 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_even_ex4_even_value",
+                      "ex4_even_value",
                     fieldType = HsPrimType
                       HsPrimCDouble,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName
-                          "ex4_even_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1093,8 +1088,7 @@
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName
-                          "ex4_even_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1135,14 +1129,13 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_even_ex4_even_value",
+                      "ex4_even_value",
                     fieldType = HsPrimType
                       HsPrimCDouble,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName
-                          "ex4_even_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1186,8 +1179,7 @@
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName
-                          "ex4_even_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1240,14 +1232,13 @@
         Field {
           fieldName = HsName
             "@NsVar"
-            "ex4_odd_ex4_odd_value",
+            "ex4_odd_value",
           fieldType = HsPrimType
             HsPrimCInt,
           fieldOrigin =
           FieldOriginStructField
             StructField {
-              fieldName = CName
-                "ex4_odd_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
@@ -1291,8 +1282,7 @@
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName
-                "ex4_odd_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
@@ -1331,14 +1321,13 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "ex4_odd_ex4_odd_value",
+              "ex4_odd_value",
             fieldType = HsPrimType
               HsPrimCInt,
             fieldOrigin =
             FieldOriginStructField
               StructField {
-                fieldName = CName
-                  "ex4_odd_value",
+                fieldName = CName "value",
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
@@ -1382,8 +1371,7 @@
             structAlignment = 8,
             structFields = [
               StructField {
-                fieldName = CName
-                  "ex4_odd_value",
+                fieldName = CName "value",
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
@@ -1427,14 +1415,13 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_odd_ex4_odd_value",
+                      "ex4_odd_value",
                     fieldType = HsPrimType
                       HsPrimCInt,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName
-                          "ex4_odd_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1478,8 +1465,7 @@
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName
-                          "ex4_odd_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1525,14 +1511,13 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "ex4_odd_ex4_odd_value",
+                      "ex4_odd_value",
                     fieldType = HsPrimType
                       HsPrimCInt,
                     fieldOrigin =
                     FieldOriginStructField
                       StructField {
-                        fieldName = CName
-                          "ex4_odd_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
@@ -1576,8 +1561,7 @@
                     structAlignment = 8,
                     structFields = [
                       StructField {
-                        fieldName = CName
-                          "ex4_odd_value",
+                        fieldName = CName "value",
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim

--- a/hs-bindgen/fixtures/nested_types.pp.hs
+++ b/hs-bindgen/fixtures/nested_types.pp.hs
@@ -92,7 +92,7 @@ deriving stock instance Show Ex3
 deriving stock instance Eq Ex3
 
 data Ex4_even = Ex4_even
-  { ex4_even_ex4_even_value :: FC.CDouble
+  { ex4_even_value :: FC.CDouble
   , ex4_even_next :: F.Ptr Ex4_odd
   }
 
@@ -112,8 +112,8 @@ instance F.Storable Ex4_even where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Ex4_even ex4_even_ex4_even_value2 ex4_even_next3 ->
-               F.pokeByteOff ptr0 (0 :: Int) ex4_even_ex4_even_value2
+          Ex4_even ex4_even_value2 ex4_even_next3 ->
+               F.pokeByteOff ptr0 (0 :: Int) ex4_even_value2
             >> F.pokeByteOff ptr0 (8 :: Int) ex4_even_next3
 
 deriving stock instance Show Ex4_even
@@ -121,7 +121,7 @@ deriving stock instance Show Ex4_even
 deriving stock instance Eq Ex4_even
 
 data Ex4_odd = Ex4_odd
-  { ex4_odd_ex4_odd_value :: FC.CInt
+  { ex4_odd_value :: FC.CInt
   , ex4_odd_next :: F.Ptr Ex4_even
   }
 
@@ -141,8 +141,8 @@ instance F.Storable Ex4_odd where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Ex4_odd ex4_odd_ex4_odd_value2 ex4_odd_next3 ->
-               F.pokeByteOff ptr0 (0 :: Int) ex4_odd_ex4_odd_value2
+          Ex4_odd ex4_odd_value2 ex4_odd_next3 ->
+               F.pokeByteOff ptr0 (0 :: Int) ex4_odd_value2
             >> F.pokeByteOff ptr0 (8 :: Int) ex4_odd_next3
 
 deriving stock instance Show Ex4_odd

--- a/hs-bindgen/fixtures/nested_types.rs
+++ b/hs-bindgen/fixtures/nested_types.rs
@@ -60,13 +60,13 @@ const _: () = {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ex4_odd {
-    pub ex4_odd_value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_int,
     pub next: *mut ex4_odd_ex4_even,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ex4_odd_ex4_even {
-    pub ex4_even_value: f64,
+    pub value: f64,
     pub next: *mut ex4_odd,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -76,8 +76,8 @@ const _: () = {
         "Alignment of ex4_odd_ex4_even",
     ][::std::mem::align_of::<ex4_odd_ex4_even>() - 8usize];
     [
-        "Offset of field: ex4_odd_ex4_even::ex4_even_value",
-    ][::std::mem::offset_of!(ex4_odd_ex4_even, ex4_even_value) - 0usize];
+        "Offset of field: ex4_odd_ex4_even::value",
+    ][::std::mem::offset_of!(ex4_odd_ex4_even, value) - 0usize];
     [
         "Offset of field: ex4_odd_ex4_even::next",
     ][::std::mem::offset_of!(ex4_odd_ex4_even, next) - 8usize];
@@ -86,8 +86,6 @@ const _: () = {
 const _: () = {
     ["Size of ex4_odd"][::std::mem::size_of::<ex4_odd>() - 16usize];
     ["Alignment of ex4_odd"][::std::mem::align_of::<ex4_odd>() - 8usize];
-    [
-        "Offset of field: ex4_odd::ex4_odd_value",
-    ][::std::mem::offset_of!(ex4_odd, ex4_odd_value) - 0usize];
+    ["Offset of field: ex4_odd::value"][::std::mem::offset_of!(ex4_odd, value) - 0usize];
     ["Offset of field: ex4_odd::next"][::std::mem::offset_of!(ex4_odd, next) - 8usize];
 };

--- a/hs-bindgen/fixtures/nested_types.th.txt
+++ b/hs-bindgen/fixtures/nested_types.th.txt
@@ -28,26 +28,25 @@ instance Storable Ex3
 deriving stock instance Show Ex3
 deriving stock instance Eq Ex3
 data Ex4_even
-    = Ex4_even {ex4_even_ex4_even_value :: CDouble,
+    = Ex4_even {ex4_even_value :: CDouble,
                 ex4_even_next :: (Ptr Ex4_odd)}
 instance Storable Ex4_even
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
            peek = \ptr_0 -> (pure Ex4_even <*> peekByteOff ptr_0 (0 :: Int)) <*> peekByteOff ptr_0 (8 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Ex4_even ex4_even_ex4_even_value_3
-                                              ex4_even_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_even_ex4_even_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_even_next_4}}
+                                    {Ex4_even ex4_even_value_3
+                                              ex4_even_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_even_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_even_next_4}}
 deriving stock instance Show Ex4_even
 deriving stock instance Eq Ex4_even
 data Ex4_odd
-    = Ex4_odd {ex4_odd_ex4_odd_value :: CInt,
-               ex4_odd_next :: (Ptr Ex4_even)}
+    = Ex4_odd {ex4_odd_value :: CInt, ex4_odd_next :: (Ptr Ex4_even)}
 instance Storable Ex4_odd
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
            peek = \ptr_0 -> (pure Ex4_odd <*> peekByteOff ptr_0 (0 :: Int)) <*> peekByteOff ptr_0 (8 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Ex4_odd ex4_odd_ex4_odd_value_3
-                                             ex4_odd_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_odd_ex4_odd_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_odd_next_4}}
+                                    {Ex4_odd ex4_odd_value_3
+                                             ex4_odd_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_odd_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_odd_next_4}}
 deriving stock instance Show Ex4_odd
 deriving stock instance Eq Ex4_odd

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -92,8 +92,7 @@ WrapCHeader
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName
-                "ex4_even_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
@@ -123,8 +122,7 @@ WrapCHeader
           structAlignment = 8,
           structFields = [
             StructField {
-              fieldName = CName
-                "ex4_odd_value",
+              fieldName = CName "value",
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim


### PR DESCRIPTION
This makes the generated Haskell code a bit cleaner.