### PR TITLE
Macro parsing: only allow MEmpty at the top level

### DIFF
--- a/hs-bindgen/examples/typedef_vs_macro.h
+++ b/hs-bindgen/examples/typedef_vs_macro.h
@@ -4,6 +4,7 @@ typedef char T2;
 #define M1 int
 #define M2 char
 #define M3 int[3]
+#define M4 int*
 
 struct ExampleStruct {
   T1 t1;

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -206,7 +206,7 @@ WrapCHeader
                           multiLocFile = Nothing}},
                       tokenCursorKind = SimpleEnum
                         501}])
-                MEmpty)},
+                Nothing)},
           macroDeclMacroTy = "Empty",
           macroDeclSourceLoc =
           "distilled_lib_1.h:25:9"},

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -12,7 +12,7 @@ WrapCHeader
               multiLocFile = Nothing},
             macroName = CName "ENUMS_H",
             macroArgs = [],
-            macroBody = MTerm MEmpty},
+            macroBody = MEmpty},
           macroDeclMacroTy = "Empty",
           macroDeclSourceLoc =
           "enums.h:2:9"},

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -224,7 +224,7 @@
         Macro {
           macroLoc = MultiLoc {
             multiLocExpansion =
-            "typedef_vs_macro.h:15:9",
+            "typedef_vs_macro.h:16:9",
             multiLocPresumed = Nothing,
             multiLocSpelling = Nothing,
             multiLocFile = Nothing},
@@ -488,7 +488,7 @@
               fieldType = TypeTypedef
                 (CName "T1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:9:6"}},
+              "typedef_vs_macro.h:10:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -504,7 +504,7 @@
               fieldType = TypeTypedef
                 (CName "T2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:10:6"}},
+              "typedef_vs_macro.h:11:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -520,7 +520,7 @@
               fieldType = TypeTypedef
                 (CName "M1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:11:6"}},
+              "typedef_vs_macro.h:12:6"}},
         Field {
           fieldName = HsName
             "@NsVar"
@@ -536,7 +536,7 @@
               fieldType = TypeTypedef
                 (CName "M2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:12:6"}}],
+              "typedef_vs_macro.h:13:6"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -554,7 +554,7 @@
               fieldType = TypeTypedef
                 (CName "T1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:9:6"},
+              "typedef_vs_macro.h:10:6"},
             StructField {
               fieldName = CName "t2",
               fieldOffset = 32,
@@ -562,7 +562,7 @@
               fieldType = TypeTypedef
                 (CName "T2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:10:6"},
+              "typedef_vs_macro.h:11:6"},
             StructField {
               fieldName = CName "m1",
               fieldOffset = 64,
@@ -570,7 +570,7 @@
               fieldType = TypeTypedef
                 (CName "M1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:11:6"},
+              "typedef_vs_macro.h:12:6"},
             StructField {
               fieldName = CName "m2",
               fieldOffset = 96,
@@ -578,10 +578,10 @@
               fieldType = TypeTypedef
                 (CName "M2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:12:6"}],
+              "typedef_vs_macro.h:13:6"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:8:8"}},
+          "typedef_vs_macro.h:9:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -607,7 +607,7 @@
                 fieldType = TypeTypedef
                   (CName "T1"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:9:6"}},
+                "typedef_vs_macro.h:10:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -623,7 +623,7 @@
                 fieldType = TypeTypedef
                   (CName "T2"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:10:6"}},
+                "typedef_vs_macro.h:11:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -639,7 +639,7 @@
                 fieldType = TypeTypedef
                   (CName "M1"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:11:6"}},
+                "typedef_vs_macro.h:12:6"}},
           Field {
             fieldName = HsName
               "@NsVar"
@@ -655,7 +655,7 @@
                 fieldType = TypeTypedef
                   (CName "M2"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:12:6"}}],
+                "typedef_vs_macro.h:13:6"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -673,7 +673,7 @@
                 fieldType = TypeTypedef
                   (CName "T1"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:9:6"},
+                "typedef_vs_macro.h:10:6"},
               StructField {
                 fieldName = CName "t2",
                 fieldOffset = 32,
@@ -681,7 +681,7 @@
                 fieldType = TypeTypedef
                   (CName "T2"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:10:6"},
+                "typedef_vs_macro.h:11:6"},
               StructField {
                 fieldName = CName "m1",
                 fieldOffset = 64,
@@ -689,7 +689,7 @@
                 fieldType = TypeTypedef
                   (CName "M1"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:11:6"},
+                "typedef_vs_macro.h:12:6"},
               StructField {
                 fieldName = CName "m2",
                 fieldOffset = 96,
@@ -697,10 +697,10 @@
                 fieldType = TypeTypedef
                   (CName "M2"),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:12:6"}],
+                "typedef_vs_macro.h:13:6"}],
             structFlam = Nothing,
             structSourceLoc =
-            "typedef_vs_macro.h:8:8"}}
+            "typedef_vs_macro.h:9:8"}}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -731,7 +731,7 @@
                         fieldType = TypeTypedef
                           (CName "T1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:9:6"}},
+                        "typedef_vs_macro.h:10:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -747,7 +747,7 @@
                         fieldType = TypeTypedef
                           (CName "T2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:10:6"}},
+                        "typedef_vs_macro.h:11:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -763,7 +763,7 @@
                         fieldType = TypeTypedef
                           (CName "M1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:11:6"}},
+                        "typedef_vs_macro.h:12:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -779,7 +779,7 @@
                         fieldType = TypeTypedef
                           (CName "M2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:12:6"}}],
+                        "typedef_vs_macro.h:13:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -797,7 +797,7 @@
                         fieldType = TypeTypedef
                           (CName "T1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:9:6"},
+                        "typedef_vs_macro.h:10:6"},
                       StructField {
                         fieldName = CName "t2",
                         fieldOffset = 32,
@@ -805,7 +805,7 @@
                         fieldType = TypeTypedef
                           (CName "T2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:10:6"},
+                        "typedef_vs_macro.h:11:6"},
                       StructField {
                         fieldName = CName "m1",
                         fieldOffset = 64,
@@ -813,7 +813,7 @@
                         fieldType = TypeTypedef
                           (CName "M1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:11:6"},
+                        "typedef_vs_macro.h:12:6"},
                       StructField {
                         fieldName = CName "m2",
                         fieldOffset = 96,
@@ -821,10 +821,10 @@
                         fieldType = TypeTypedef
                           (CName "M2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:12:6"}],
+                        "typedef_vs_macro.h:13:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:8:8"}})
+                    "typedef_vs_macro.h:9:8"}})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -859,7 +859,7 @@
                         fieldType = TypeTypedef
                           (CName "T1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:9:6"}},
+                        "typedef_vs_macro.h:10:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -875,7 +875,7 @@
                         fieldType = TypeTypedef
                           (CName "T2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:10:6"}},
+                        "typedef_vs_macro.h:11:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -891,7 +891,7 @@
                         fieldType = TypeTypedef
                           (CName "M1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:11:6"}},
+                        "typedef_vs_macro.h:12:6"}},
                   Field {
                     fieldName = HsName
                       "@NsVar"
@@ -907,7 +907,7 @@
                         fieldType = TypeTypedef
                           (CName "M2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:12:6"}}],
+                        "typedef_vs_macro.h:13:6"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -925,7 +925,7 @@
                         fieldType = TypeTypedef
                           (CName "T1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:9:6"},
+                        "typedef_vs_macro.h:10:6"},
                       StructField {
                         fieldName = CName "t2",
                         fieldOffset = 32,
@@ -933,7 +933,7 @@
                         fieldType = TypeTypedef
                           (CName "T2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:10:6"},
+                        "typedef_vs_macro.h:11:6"},
                       StructField {
                         fieldName = CName "m1",
                         fieldOffset = 64,
@@ -941,7 +941,7 @@
                         fieldType = TypeTypedef
                           (CName "M1"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:11:6"},
+                        "typedef_vs_macro.h:12:6"},
                       StructField {
                         fieldName = CName "m2",
                         fieldOffset = 96,
@@ -949,10 +949,10 @@
                         fieldType = TypeTypedef
                           (CName "M2"),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:12:6"}],
+                        "typedef_vs_macro.h:13:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:8:8"}}
+                    "typedef_vs_macro.h:9:8"}}
               (Add 4)
               (Seq
                 [
@@ -1003,7 +1003,7 @@
                 (TypeTypedef
                   (CName "uint64_t")),
               fieldSourceLoc =
-              "typedef_vs_macro.h:18:13"}}],
+              "typedef_vs_macro.h:19:13"}}],
       structOrigin =
       StructOriginStruct
         Struct {
@@ -1021,10 +1021,10 @@
                 (TypeTypedef
                   (CName "uint64_t")),
               fieldSourceLoc =
-              "typedef_vs_macro.h:18:13"}],
+              "typedef_vs_macro.h:19:13"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:17:8"}},
+          "typedef_vs_macro.h:18:8"}},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1054,7 +1054,7 @@
                   (TypeTypedef
                     (CName "uint64_t")),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:18:13"}}],
+                "typedef_vs_macro.h:19:13"}}],
         structOrigin =
         StructOriginStruct
           Struct {
@@ -1072,10 +1072,10 @@
                   (TypeTypedef
                     (CName "uint64_t")),
                 fieldSourceLoc =
-                "typedef_vs_macro.h:18:13"}],
+                "typedef_vs_macro.h:19:13"}],
             structFlam = Nothing,
             structSourceLoc =
-            "typedef_vs_macro.h:17:8"}}
+            "typedef_vs_macro.h:18:8"}}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 8,
@@ -1110,7 +1110,7 @@
                           (TypeTypedef
                             (CName "uint64_t")),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:18:13"}}],
+                        "typedef_vs_macro.h:19:13"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1128,10 +1128,10 @@
                           (TypeTypedef
                             (CName "uint64_t")),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:18:13"}],
+                        "typedef_vs_macro.h:19:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:17:8"}})
+                    "typedef_vs_macro.h:18:8"}})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1166,7 +1166,7 @@
                           (TypeTypedef
                             (CName "uint64_t")),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:18:13"}}],
+                        "typedef_vs_macro.h:19:13"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
@@ -1184,10 +1184,10 @@
                           (TypeTypedef
                             (CName "uint64_t")),
                         fieldSourceLoc =
-                        "typedef_vs_macro.h:18:13"}],
+                        "typedef_vs_macro.h:19:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:17:8"}}
+                    "typedef_vs_macro.h:18:8"}}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -61,11 +61,77 @@ WrapCHeader
           macroDeclSourceLoc =
           "typedef_vs_macro.h:6:9"},
       DeclMacro
+        (MacroReparseError
+          ReparseError {
+            reparseError = concat
+              [
+                "\"typedef_vs_macro.h\" (line 7, column 15):\n",
+                "unexpected end of input\n",
+                "expecting simple expression"],
+            reparseErrorTokens = [
+              Token {
+                tokenKind = SimpleEnum 2,
+                tokenSpelling = TokenSpelling
+                  "M4",
+                tokenExtent = Range {
+                  rangeStart = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:9",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing},
+                  rangeEnd = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:11",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing}},
+                tokenCursorKind = SimpleEnum
+                  501},
+              Token {
+                tokenKind = SimpleEnum 1,
+                tokenSpelling = TokenSpelling
+                  "int",
+                tokenExtent = Range {
+                  rangeStart = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:12",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing},
+                  rangeEnd = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:15",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing}},
+                tokenCursorKind = SimpleEnum
+                  501},
+              Token {
+                tokenKind = SimpleEnum 0,
+                tokenSpelling = TokenSpelling
+                  "*",
+                tokenExtent = Range {
+                  rangeStart = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:15",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing},
+                  rangeEnd = MultiLoc {
+                    multiLocExpansion =
+                    "typedef_vs_macro.h:7:16",
+                    multiLocPresumed = Nothing,
+                    multiLocSpelling = Nothing,
+                    multiLocFile = Nothing}},
+                tokenCursorKind = SimpleEnum
+                  501}]}),
+      DeclMacro
         MacroDecl {
           macroDeclMacro = Macro {
             macroLoc = MultiLoc {
               multiLocExpansion =
-              "typedef_vs_macro.h:15:9",
+              "typedef_vs_macro.h:16:9",
               multiLocPresumed = Nothing,
               multiLocSpelling = Nothing,
               multiLocFile = Nothing},
@@ -79,7 +145,7 @@ WrapCHeader
                     Signed)))},
           macroDeclMacroTy = "PrimTy",
           macroDeclSourceLoc =
-          "typedef_vs_macro.h:15:9"},
+          "typedef_vs_macro.h:16:9"},
       DeclTypedef
         Typedef {
           typedefName = CName "T1",
@@ -110,7 +176,7 @@ WrapCHeader
               fieldType = TypeTypedef
                 (CName "T1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:9:6"},
+              "typedef_vs_macro.h:10:6"},
             StructField {
               fieldName = CName "t2",
               fieldOffset = 32,
@@ -118,7 +184,7 @@ WrapCHeader
               fieldType = TypeTypedef
                 (CName "T2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:10:6"},
+              "typedef_vs_macro.h:11:6"},
             StructField {
               fieldName = CName "m1",
               fieldOffset = 64,
@@ -126,7 +192,7 @@ WrapCHeader
               fieldType = TypeTypedef
                 (CName "M1"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:11:6"},
+              "typedef_vs_macro.h:12:6"},
             StructField {
               fieldName = CName "m2",
               fieldOffset = 96,
@@ -134,10 +200,10 @@ WrapCHeader
               fieldType = TypeTypedef
                 (CName "M2"),
               fieldSourceLoc =
-              "typedef_vs_macro.h:12:6"}],
+              "typedef_vs_macro.h:13:6"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:8:8"},
+          "typedef_vs_macro.h:9:8"},
       DeclStruct
         Struct {
           structDeclPath = DeclPathStruct
@@ -154,7 +220,7 @@ WrapCHeader
                 (TypeTypedef
                   (CName "uint64_t")),
               fieldSourceLoc =
-              "typedef_vs_macro.h:18:13"}],
+              "typedef_vs_macro.h:19:13"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:17:8"}])
+          "typedef_vs_macro.h:18:8"}])

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -12,7 +12,7 @@ WrapCHeader
               multiLocFile = Nothing},
             macroName = CName "USES_UTF8_H",
             macroArgs = [],
-            macroBody = MTerm MEmpty},
+            macroBody = MEmpty},
           macroDeclMacroTy = "Empty",
           macroDeclSourceLoc =
           "uses_utf8.h:2:9"},

--- a/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Macro.hs
@@ -57,13 +57,16 @@ data Macro = Macro {
 -- | Body of a function-like macro
 data MExpr =
     MTerm MTerm
+  | -- | Empty
+    MEmpty
   -- | Exactly saturated non-nullary function application.
   | forall n. MApp ( MFun ( S n ) ) ( Vec ( S n ) MExpr )
 deriving stock instance Show MExpr
 instance PrettyVal MExpr where
   prettyVal = \case
-    MTerm tm    -> Pretty.Con "MTerm" [prettyVal tm]
-    MApp f args -> Pretty.Con "MApp" [prettyVal f, prettyVal args]
+    MTerm tm    -> Pretty.Con "MTerm"  [prettyVal tm]
+    MEmpty      -> Pretty.Con "MEmpty" []
+    MApp f args -> Pretty.Con "MApp"   [prettyVal f, prettyVal args]
 
 instance Eq MExpr where
   MTerm m1 == MTerm m2 = m1 == m2
@@ -154,11 +157,9 @@ instance PrettyVal ( MFun arity ) where
   prettyVal f = Pretty.Con (show f) []
 
 data MTerm =
-    -- | Empty
-    MEmpty
 
     -- | Integer literal
-  | MInt IntegerLiteral
+    MInt IntegerLiteral
 
     -- | Floating-point literal
   | MFloat FloatingLiteral
@@ -178,7 +179,7 @@ data MTerm =
   | MType Type
 
     -- | Attribute
-  | MAttr Attribute MTerm
+  | MAttr Attribute (Maybe MTerm)
 
     -- | Stringizing
     --
@@ -222,7 +223,7 @@ isIncludeGuard Macro{macroLoc, macroName, macroArgs, macroBody} =
         macroName `elem` includeGuards
       , null macroArgs
       , case macroBody of
-          MTerm MEmpty
+          MEmpty
             -> True
           MTerm ( MInt IntegerLiteral { integerLiteralValue = 1 } )
             -> True

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Decl.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Decl.hs
@@ -286,6 +286,7 @@ literalSizeMaybe ( SizeExpression sz ) =
           -- macro-defined constants, e.g.:
           --
           --   int arr[SOME_CONSTANT];
+    MEmpty -> Nothing
     MApp {} -> Nothing
 
 --------------------------------------------------------------------------------

--- a/hs-bindgen/src/HsBindgen/C/Reparse/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/Reparse/Macro.hs
@@ -68,14 +68,14 @@ mTerm =
   where
     term :: Reparse MTerm
     term = choice [
-        MEmpty       <$  eof
-      , MInt         <$> literalInteger
+        MInt         <$> literalInteger
       , MFloat       <$> literalFloat
       , MChar        <$> literalChar
       , MString      <$> literalString
       , MVar         <$> var <*> option [] actualArgs
       , MType        <$> reparsePrimTypeWithArrs
-      , MAttr        <$> reparseAttribute <*> mTerm
+      , MAttr        <$> reparseAttribute
+                     <*> ( choice [ Just <$> mTerm, Nothing <$ eof ] )
       , MStringize   <$  punctuation "#" <*> var
       ]
 
@@ -141,7 +141,7 @@ actualArgs = parens $ mExpr `sepBy` comma
 -------------------------------------------------------------------------------}
 
 mExprTuple :: Reparse MExpr
-mExprTuple = try tuple <|> mExpr
+mExprTuple = try tuple <|> mExpr <|> ( MEmpty <$ eof )
   where
     tuple = do
       openParen <- optionMaybe $ punctuation "("

--- a/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/C/Tc/Macro.hs
@@ -1212,12 +1212,12 @@ inferTop funNm argsList body =
 
 inferExpr :: MExpr -> TcGenM ( Type Ty )
 inferExpr = \case
+  MEmpty -> return Empty
   MTerm tm -> inferTerm tm
   MApp fun args -> inferApp ( FunName $ Right fun ) ( Vec.toList args )
 
 inferTerm :: MTerm -> TcGenM ( Type Ty )
 inferTerm = \case
-  MEmpty -> return Empty
   MInt i@( IntegerLiteral { integerLiteralType = mbIntyTy } ) ->
     IntLike <$>
       case mbIntyTy of
@@ -1238,7 +1238,10 @@ inferTerm = \case
     return String
   MVar fun args -> inferApp ( FunName $ Left fun ) args
   MType {} -> return PrimTy
-  MAttr _attr tm -> inferTerm tm
+  MAttr _attr mbTerm ->
+    case mbTerm of
+      Nothing -> return Empty
+      Just tm -> inferTerm tm
   MStringize {} -> return String
   MConcat a1 a2 -> do
     ty1 <- inferTerm a1

--- a/hs-bindgen/src/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/Translation.hs
@@ -554,12 +554,12 @@ macroExprHsExpr = goExpr where
     goExpr :: Map C.CName (Idx ctx) -> C.MExpr -> Maybe (Hs.VarDeclRHS ctx)
     goExpr env = \case
       C.MTerm tm -> goTerm env tm
+      C.MEmpty -> Nothing
       C.MApp fun args ->
         goApp env (Hs.InfixAppHead fun) (toList args)
 
     goTerm :: Map C.CName (Idx ctx) -> C.MTerm -> Maybe (Hs.VarDeclRHS ctx)
     goTerm env = \case
-      C.MEmpty -> Nothing
       C.MInt i -> goInt i
       C.MFloat f -> goFloat f
       C.MChar c -> goChar c
@@ -573,7 +573,7 @@ macroExprHsExpr = goExpr where
             in  goApp env (Hs.VarAppHead hsVar) args
 
       C.MType {} -> Nothing
-      C.MAttr _attr tm' -> goTerm env tm'
+      C.MAttr _attr tm' -> goTerm env =<< tm'
       C.MStringize {} -> Nothing
       C.MConcat {} -> Nothing
 

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -124,6 +124,8 @@ instance ToExpr C.MExpr where
   toExpr = \case
     C.MTerm tm ->
       Expr.App "MTerm" [toExpr tm]
+    C.MEmpty ->
+      Expr.App "MEmpty" []
     C.MApp fun args ->
       Expr.App "MApp" [toExpr fun, toExpr (toList args)]
 


### PR DESCRIPTION
This ensures we don't try to parse something like:

```c
#define M1 int*
#define M2 3+
```

as "int times empty" or "3 plus empty".