### PR TITLE
Separate out construction for Haskell _variables_

### DIFF
--- a/hs-bindgen/src/HsBindgen/Hs/AST/Name.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/AST/Name.hs
@@ -43,14 +43,9 @@ namespaceOf = \case
 class SingNamespace ns where
   singNamespace :: SNamespace ns
 
-instance SingNamespace 'NsTypeConstr where
-  singNamespace = SNsTypeConstr
-
-instance SingNamespace 'NsConstr where
-  singNamespace = SNsConstr
-
-instance SingNamespace 'NsVar where
-  singNamespace = SNsVar
+instance SingNamespace 'NsTypeConstr where singNamespace = SNsTypeConstr
+instance SingNamespace 'NsConstr     where singNamespace = SNsConstr
+instance SingNamespace 'NsVar        where singNamespace = SNsVar
 
 -- | Haskell name in namespace @ns@
 newtype HsName (ns :: Namespace) = HsName { getHsName :: Text }


### PR DESCRIPTION
For variables there is no need to worry about invalid first characters, so the distinction between drop/prefix is irrelevant. This clarifies the code.