### PR TITLE
Add `Pipeline` module, update public API

### DIFF
--- a/clang-ast-dump/Main.hs
+++ b/clang-ast-dump/Main.hs
@@ -436,11 +436,13 @@ main = clangAstDump . uncurry applyAll =<< OA.execParser pinfo
       ]
 
     fileArgument :: OA.Parser CHeaderIncludePath
-    fileArgument = OA.argument (OA.eitherReader parseCHeaderIncludePath) $
-      mconcat
-        [ OA.metavar "FILE"
-        , OA.help "C (header) file to parse"
-        ]
+    fileArgument =
+      OA.argument
+        (OA.eitherReader $ first displayException . parseCHeaderIncludePath)
+        $ mconcat [
+              OA.metavar "FILE"
+            , OA.help "C (header) file to parse"
+            ]
 
     mkFlag :: String -> String -> OA.Parser Bool
     mkFlag flag doc = OA.switch $ OA.long flag <> OA.help doc

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -1,168 +1,167 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
-            (DeclPathField
-              (CName "c")
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathField
+            (CName "c")
+            (DeclPathStruct
+              (DeclNameTag (CName "S1"))
+              DeclPathTop)),
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:4:9"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:5:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "anonymous.h:3:3"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S1"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "c",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
               (DeclPathStruct
-                (DeclNameTag (CName "S1"))
-                DeclPathTop)),
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:4:9"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:5:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "anonymous.h:3:3"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S1"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "c",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
+                DeclNameNone
+                (DeclPathField
+                  (CName "c")
+                  (DeclPathStruct
+                    (DeclNameTag (CName "S1"))
+                    DeclPathTop))),
+            fieldSourceLoc =
+            "anonymous.h:6:5"},
+          StructField {
+            fieldName = CName "d",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:8:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "anonymous.h:2:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathField
+            (CName "deep")
+            (DeclPathStruct
+              DeclNameNone
+              (DeclPathField
+                (CName "inner")
                 (DeclPathStruct
-                  DeclNameNone
-                  (DeclPathField
-                    (CName "c")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop))),
-              fieldSourceLoc =
-              "anonymous.h:6:5"},
-            StructField {
-              fieldName = CName "d",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:8:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "anonymous.h:2:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
-            (DeclPathField
-              (CName "deep")
+                  (DeclNameTag (CName "S2"))
+                  DeclPathTop)))),
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:16:11"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "anonymous.h:15:5"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathField
+            (CName "inner")
+            (DeclPathStruct
+              (DeclNameTag (CName "S2"))
+              DeclPathTop)),
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:14:9"},
+          StructField {
+            fieldName = CName "deep",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
+              (DeclPathStruct
+                DeclNameNone
+                (DeclPathField
+                  (CName "deep")
+                  (DeclPathStruct
+                    DeclNameNone
+                    (DeclPathField
+                      (CName "inner")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "S2"))
+                        DeclPathTop))))),
+            fieldSourceLoc =
+            "anonymous.h:17:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "anonymous.h:13:3"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S2"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "inner",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
               (DeclPathStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "inner")
                   (DeclPathStruct
                     (DeclNameTag (CName "S2"))
-                    DeclPathTop)))),
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:16:11"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "anonymous.h:15:5"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
-            (DeclPathField
-              (CName "inner")
-              (DeclPathStruct
-                (DeclNameTag (CName "S2"))
-                DeclPathTop)),
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:14:9"},
-            StructField {
-              fieldName = CName "deep",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  DeclNameNone
-                  (DeclPathField
-                    (CName "deep")
-                    (DeclPathStruct
-                      DeclNameNone
-                      (DeclPathField
-                        (CName "inner")
-                        (DeclPathStruct
-                          (DeclNameTag (CName "S2"))
-                          DeclPathTop))))),
-              fieldSourceLoc =
-              "anonymous.h:17:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "anonymous.h:13:3"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S2"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "inner",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  DeclNameNone
-                  (DeclPathField
-                    (CName "inner")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop))),
-              fieldSourceLoc =
-              "anonymous.h:18:5"},
-            StructField {
-              fieldName = CName "d",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "anonymous.h:20:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "anonymous.h:12:8"}])
+                    DeclPathTop))),
+            fieldSourceLoc =
+            "anonymous.h:18:5"},
+          StructField {
+            fieldName = CName "d",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "anonymous.h:20:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "anonymous.h:12:8"}]

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -1,252 +1,251 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "flags"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "fieldX",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "bitfields.h:2:10"},
-            StructField {
-              fieldName = CName "flagA",
-              fieldOffset = 8,
-              fieldWidth = Just 1,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:3:9"},
-            StructField {
-              fieldName = CName "flagB",
-              fieldOffset = 9,
-              fieldWidth = Just 1,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:4:9"},
-            StructField {
-              fieldName = CName "flagC",
-              fieldOffset = 10,
-              fieldWidth = Just 1,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:5:9"},
-            StructField {
-              fieldName = CName "fieldY",
-              fieldOffset = 16,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "bitfields.h:6:10"},
-            StructField {
-              fieldName = CName "bits",
-              fieldOffset = 24,
-              fieldWidth = Just 2,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:7:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "overflow32"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:13:9"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:14:9"},
-            StructField {
-              fieldName = CName "z",
-              fieldOffset = 64,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:15:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:12:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "overflow32b"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:19:10"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 17,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:20:10"},
-            StructField {
-              fieldName = CName "z",
-              fieldOffset = 34,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:21:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:18:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "overflow32c"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:25:10"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:26:10"},
-            StructField {
-              fieldName = CName "z",
-              fieldOffset = 64,
-              fieldWidth = Just 17,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:27:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:24:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "overflow64"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 33,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:31:10"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 64,
-              fieldWidth = Just 33,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "bitfields.h:32:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:30:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "alignA"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 1,
-              fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
-              fieldSourceLoc =
-              "bitfields.h:37:16"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 1,
-              fieldWidth = Just 10,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:38:6"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:36:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "alignB"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Just 7,
-              fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
-              fieldSourceLoc =
-              "bitfields.h:42:16"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Just 31,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "bitfields.h:43:6"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bitfields.h:41:8"}])
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "flags"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "fieldX",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "bitfields.h:2:10"},
+          StructField {
+            fieldName = CName "flagA",
+            fieldOffset = 8,
+            fieldWidth = Just 1,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:3:9"},
+          StructField {
+            fieldName = CName "flagB",
+            fieldOffset = 9,
+            fieldWidth = Just 1,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:4:9"},
+          StructField {
+            fieldName = CName "flagC",
+            fieldOffset = 10,
+            fieldWidth = Just 1,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:5:9"},
+          StructField {
+            fieldName = CName "fieldY",
+            fieldOffset = 16,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "bitfields.h:6:10"},
+          StructField {
+            fieldName = CName "bits",
+            fieldOffset = 24,
+            fieldWidth = Just 2,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:7:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "overflow32"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:13:9"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:14:9"},
+          StructField {
+            fieldName = CName "z",
+            fieldOffset = 64,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:15:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:12:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "overflow32b"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:19:10"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 17,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:20:10"},
+          StructField {
+            fieldName = CName "z",
+            fieldOffset = 34,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:21:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:18:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "overflow32c"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:25:10"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:26:10"},
+          StructField {
+            fieldName = CName "z",
+            fieldOffset = 64,
+            fieldWidth = Just 17,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:27:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:24:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "overflow64"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 33,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:31:10"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 64,
+            fieldWidth = Just 33,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "bitfields.h:32:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:30:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "alignA"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 1,
+            fieldType = TypePrim
+              (PrimChar (Just Unsigned)),
+            fieldSourceLoc =
+            "bitfields.h:37:16"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 1,
+            fieldWidth = Just 10,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:38:6"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:36:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "alignB"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Just 7,
+            fieldType = TypePrim
+              (PrimChar (Just Unsigned)),
+            fieldSourceLoc =
+            "bitfields.h:42:16"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Just 31,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "bitfields.h:43:6"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bitfields.h:41:8"}]

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -1,92 +1,91 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "bool.h:13:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "BOOL",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType (TypePrim PrimBool))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "bool.h:13:9"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bools1"))
-            DeclPathTop,
-          structSizeof = 2,
-          structAlignment = 1,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim PrimBool,
-              fieldSourceLoc = "bool.h:2:11"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 8,
-              fieldWidth = Nothing,
-              fieldType = TypePrim PrimBool,
-              fieldSourceLoc =
-              "bool.h:3:11"}],
-          structFlam = Nothing,
-          structSourceLoc = "bool.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bools2"))
-            DeclPathTop,
-          structSizeof = 2,
-          structAlignment = 1,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim PrimBool,
-              fieldSourceLoc = "bool.h:9:10"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 8,
-              fieldWidth = Nothing,
-              fieldType = TypePrim PrimBool,
-              fieldSourceLoc =
-              "bool.h:10:10"}],
-          structFlam = Nothing,
-          structSourceLoc = "bool.h:8:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bools3"))
-            DeclPathTop,
-          structSizeof = 2,
-          structAlignment = 1,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "BOOL"),
-              fieldSourceLoc =
-              "bool.h:16:10"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 8,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "BOOL"),
-              fieldSourceLoc =
-              "bool.h:17:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "bool.h:15:8"}])
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "bool.h:13:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "BOOL",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType (TypePrim PrimBool))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "bool.h:13:9"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bools1"))
+          DeclPathTop,
+        structSizeof = 2,
+        structAlignment = 1,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim PrimBool,
+            fieldSourceLoc = "bool.h:2:11"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 8,
+            fieldWidth = Nothing,
+            fieldType = TypePrim PrimBool,
+            fieldSourceLoc =
+            "bool.h:3:11"}],
+        structFlam = Nothing,
+        structSourceLoc = "bool.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bools2"))
+          DeclPathTop,
+        structSizeof = 2,
+        structAlignment = 1,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim PrimBool,
+            fieldSourceLoc = "bool.h:9:10"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 8,
+            fieldWidth = Nothing,
+            fieldType = TypePrim PrimBool,
+            fieldSourceLoc =
+            "bool.h:10:10"}],
+        structFlam = Nothing,
+        structSourceLoc = "bool.h:8:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bools3"))
+          DeclPathTop,
+        structSizeof = 2,
+        structAlignment = 1,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "BOOL"),
+            fieldSourceLoc =
+            "bool.h:16:10"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 8,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "BOOL"),
+            fieldSourceLoc =
+            "bool.h:17:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "bool.h:15:8"}]

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -1,594 +1,593 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:10:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "A",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "5",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 5})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:10:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:11:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "B",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "3",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 3})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:11:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:12:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "SOME_DEFINED_CONSTANT",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "4",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 4})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:12:9"},
-      DeclMacro
-        MacroTcError {
-          macroTcErrorMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:17:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "PACK_START",
-            macroArgs = [],
-            macroBody = MTerm
-              (MVar
-                (CName "_Pragma")
-                [
-                  MTerm
-                    (MString
-                      StringLiteral {
-                        stringLiteralText =
-                        "\"pack(1)\"",
-                        stringLiteralValue = [
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [112],
-                            unicodeCodePoint = Just 'p'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [97],
-                            unicodeCodePoint = Just 'a'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [99],
-                            unicodeCodePoint = Just 'c'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [107],
-                            unicodeCodePoint = Just 'k'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [40],
-                            unicodeCodePoint = Just `'('`},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [49],
-                            unicodeCodePoint = Just '1'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [41],
-                            unicodeCodePoint = Just
-                              `')'`}]})])},
-          macroTcError = T.concat
-            [
-              "Failed to typecheck macro:\n",
-              "Unbound variable: '_Pragma'\n"]},
-      DeclMacro
-        MacroTcError {
-          macroTcErrorMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:18:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "PACK_FINISH",
-            macroArgs = [],
-            macroBody = MTerm
-              (MVar
-                (CName "_Pragma")
-                [
-                  MTerm
-                    (MString
-                      StringLiteral {
-                        stringLiteralText =
-                        "\"pack()\"",
-                        stringLiteralValue = [
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [112],
-                            unicodeCodePoint = Just 'p'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [97],
-                            unicodeCodePoint = Just 'a'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [99],
-                            unicodeCodePoint = Just 'c'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [107],
-                            unicodeCodePoint = Just 'k'},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [40],
-                            unicodeCodePoint = Just `'('`},
-                          CharValue {
-                            charValue =
-                            Prim.byteArrayFromList [41],
-                            unicodeCodePoint = Just
-                              `')'`}]})])},
-          macroTcError = T.concat
-            [
-              "Failed to typecheck macro:\n",
-              "Unbound variable: '_Pragma'\n"]},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:25:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "PACK_ENUM",
-            macroArgs = [],
-            macroBody = MTerm
-              (MAttr
-                (Attribute
-                  [
-                    Token {
-                      tokenKind = SimpleEnum 2,
-                      tokenSpelling = TokenSpelling
-                        "packed",
-                      tokenExtent = Range {
-                        rangeStart = MultiLoc {
-                          multiLocExpansion =
-                          "distilled_lib_1.h:25:34",
-                          multiLocPresumed = Nothing,
-                          multiLocSpelling = Nothing,
-                          multiLocFile = Nothing},
-                        rangeEnd = MultiLoc {
-                          multiLocExpansion =
-                          "distilled_lib_1.h:25:40",
-                          multiLocPresumed = Nothing,
-                          multiLocSpelling = Nothing,
-                          multiLocFile = Nothing}},
-                      tokenCursorKind = SimpleEnum
-                        501}])
-                Nothing)},
-          macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:25:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:52:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "A_DEFINE_0",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0x00",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 0})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:52:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:53:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "A_DEFINE_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0x5050U",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Unsigned),
-                  integerLiteralValue = 20560})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Unsigned)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:53:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:54:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "A_DEFINE_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "2",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 2})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:54:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "distilled_lib_1.h:55:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "TWO_ARGS",
-            macroArgs = [],
-            macroBody = MApp
-              MTuple
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:10:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "A",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "5",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 5})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:10:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:11:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "B",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "3",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 3})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:11:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:12:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "SOME_DEFINED_CONSTANT",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "4",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 4})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:12:9"},
+    DeclMacro
+      MacroTcError {
+        macroTcErrorMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:17:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "PACK_START",
+          macroArgs = [],
+          macroBody = MTerm
+            (MVar
+              (CName "_Pragma")
               [
                 MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "0x3456",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 13398}),
+                  (MString
+                    StringLiteral {
+                      stringLiteralText =
+                      "\"pack(1)\"",
+                      stringLiteralValue = [
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [112],
+                          unicodeCodePoint = Just 'p'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [97],
+                          unicodeCodePoint = Just 'a'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [99],
+                          unicodeCodePoint = Just 'c'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [107],
+                          unicodeCodePoint = Just 'k'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [40],
+                          unicodeCodePoint = Just `'('`},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [49],
+                          unicodeCodePoint = Just '1'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [41],
+                          unicodeCodePoint = Just
+                            `')'`}]})])},
+        macroTcError = T.concat
+          [
+            "Failed to typecheck macro:\n",
+            "Unbound variable: '_Pragma'\n"]},
+    DeclMacro
+      MacroTcError {
+        macroTcErrorMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:18:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "PACK_FINISH",
+          macroArgs = [],
+          macroBody = MTerm
+            (MVar
+              (CName "_Pragma")
+              [
                 MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "0x789A",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 30874})]},
-          macroDeclMacroTy =
-          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
-          macroDeclSourceLoc =
-          "distilled_lib_1.h:55:9"},
-      DeclFunction
-        Function {
-          functionName = CName "some_fun",
-          functionType = TypeFun
+                  (MString
+                    StringLiteral {
+                      stringLiteralText =
+                      "\"pack()\"",
+                      stringLiteralValue = [
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [112],
+                          unicodeCodePoint = Just 'p'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [97],
+                          unicodeCodePoint = Just 'a'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [99],
+                          unicodeCodePoint = Just 'c'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [107],
+                          unicodeCodePoint = Just 'k'},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [40],
+                          unicodeCodePoint = Just `'('`},
+                        CharValue {
+                          charValue =
+                          Prim.byteArrayFromList [41],
+                          unicodeCodePoint = Just
+                            `')'`}]})])},
+        macroTcError = T.concat
+          [
+            "Failed to typecheck macro:\n",
+            "Unbound variable: '_Pragma'\n"]},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:25:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "PACK_ENUM",
+          macroArgs = [],
+          macroBody = MTerm
+            (MAttr
+              (Attribute
+                [
+                  Token {
+                    tokenKind = SimpleEnum 2,
+                    tokenSpelling = TokenSpelling
+                      "packed",
+                    tokenExtent = Range {
+                      rangeStart = MultiLoc {
+                        multiLocExpansion =
+                        "distilled_lib_1.h:25:34",
+                        multiLocPresumed = Nothing,
+                        multiLocSpelling = Nothing,
+                        multiLocFile = Nothing},
+                      rangeEnd = MultiLoc {
+                        multiLocExpansion =
+                        "distilled_lib_1.h:25:40",
+                        multiLocPresumed = Nothing,
+                        multiLocSpelling = Nothing,
+                        multiLocFile = Nothing}},
+                    tokenCursorKind = SimpleEnum
+                      501}])
+              Nothing)},
+        macroDeclMacroTy = "Empty",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:25:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:52:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "A_DEFINE_0",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "0x00",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 0})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:52:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:53:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "A_DEFINE_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "0x5050U",
+                integerLiteralType = Just
+                  (_×_ PrimInt Unsigned),
+                integerLiteralValue = 20560})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Unsigned)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:53:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:54:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "A_DEFINE_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "2",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 2})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:54:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "distilled_lib_1.h:55:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "TWO_ARGS",
+          macroArgs = [],
+          macroBody = MApp
+            MTuple
             [
-              TypePointer
-                (TypeTypedef
-                  (CName "a_type_t")),
-              TypeTypedef (CName "uint32_t"),
-              TypeIncompleteArray
-                (TypeTypedef (CName "uint8_t"))]
-            (TypeTypedef (CName "int32_t")),
-          functionHeader =
-          "distilled_lib_1.h",
-          functionSourceLoc =
-          "distilled_lib_1.h:71:9"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTypedef
-              (CName
-                "another_typedef_struct_t"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "foo",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "distilled_lib_1.h:8:22"},
-            StructField {
-              fieldName = CName "bar",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "distilled_lib_1.h:8:32"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "distilled_lib_1.h:8:9"},
-      DeclEnum
-        Enu {
-          enumTag = CName
-            "another_typedef_enum_e",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "FOO",
-              valueValue = 0,
-              valueSourceLoc =
-              "distilled_lib_1.h:9:16"},
-            EnumValue {
-              valueName = CName "BAR",
-              valueValue = 1,
-              valueSourceLoc =
-              "distilled_lib_1.h:9:21"}],
-          enumSourceLoc =
-          "distilled_lib_1.h:9:9"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "a_type_t",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          typedefSourceLoc =
-          "distilled_lib_1.h:13:13"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "var_t",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          typedefSourceLoc =
-          "distilled_lib_1.h:14:13"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "uint8_t",
-          typedefType = TypePrim
-            (PrimChar (Just Unsigned)),
-          typedefSourceLoc =
-          "alltypes.h:121:25"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "uint16_t",
-          typedefType = TypePrim
-            (PrimIntegral
-              PrimShort
-              Unsigned),
-          typedefSourceLoc =
-          "alltypes.h:126:25"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "uint32_t",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          typedefSourceLoc =
-          "alltypes.h:131:25"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "a_typedef_struct"))
-            DeclPathTop,
-          structSizeof = 140,
-          structAlignment = 1,
-          structFields = [
-            StructField {
-              fieldName = CName "field_0",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim PrimBool,
-              fieldSourceLoc =
-              "distilled_lib_1.h:36:31"},
-            StructField {
-              fieldName = CName "field_1",
-              fieldOffset = 8,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "uint8_t"),
-              fieldSourceLoc =
-              "distilled_lib_1.h:37:31"},
-            StructField {
-              fieldName = CName "field_2",
-              fieldOffset = 16,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "uint16_t"),
-              fieldSourceLoc =
-              "distilled_lib_1.h:38:31"},
-            StructField {
-              fieldName = CName "field_3",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "uint32_t"),
-              fieldSourceLoc =
-              "distilled_lib_1.h:39:31"},
-            StructField {
-              fieldName = CName "field_4",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "0x3456",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 13398}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "0x789A",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 30874})]},
+        macroDeclMacroTy =
+        "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+        macroDeclSourceLoc =
+        "distilled_lib_1.h:55:9"},
+    DeclFunction
+      Function {
+        functionName = CName "some_fun",
+        functionType = TypeFun
+          [
+            TypePointer
+              (TypeTypedef
+                (CName "a_type_t")),
+            TypeTypedef (CName "uint32_t"),
+            TypeIncompleteArray
+              (TypeTypedef (CName "uint8_t"))]
+          (TypeTypedef (CName "int32_t")),
+        functionHeader =
+        "distilled_lib_1.h",
+        functionSourceLoc =
+        "distilled_lib_1.h:71:9"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTypedef
+            (CName
+              "another_typedef_struct_t"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "foo",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "distilled_lib_1.h:8:22"},
+          StructField {
+            fieldName = CName "bar",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "distilled_lib_1.h:8:32"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "distilled_lib_1.h:8:9"},
+    DeclEnum
+      Enu {
+        enumTag = CName
+          "another_typedef_enum_e",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "FOO",
+            valueValue = 0,
+            valueSourceLoc =
+            "distilled_lib_1.h:9:16"},
+          EnumValue {
+            valueName = CName "BAR",
+            valueValue = 1,
+            valueSourceLoc =
+            "distilled_lib_1.h:9:21"}],
+        enumSourceLoc =
+        "distilled_lib_1.h:9:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "a_type_t",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        typedefSourceLoc =
+        "distilled_lib_1.h:13:13"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "var_t",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        typedefSourceLoc =
+        "distilled_lib_1.h:14:13"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "uint8_t",
+        typedefType = TypePrim
+          (PrimChar (Just Unsigned)),
+        typedefSourceLoc =
+        "alltypes.h:121:25"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "uint16_t",
+        typedefType = TypePrim
+          (PrimIntegral
+            PrimShort
+            Unsigned),
+        typedefSourceLoc =
+        "alltypes.h:126:25"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "uint32_t",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        typedefSourceLoc =
+        "alltypes.h:131:25"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "a_typedef_struct"))
+          DeclPathTop,
+        structSizeof = 140,
+        structAlignment = 1,
+        structFields = [
+          StructField {
+            fieldName = CName "field_0",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim PrimBool,
+            fieldSourceLoc =
+            "distilled_lib_1.h:36:31"},
+          StructField {
+            fieldName = CName "field_1",
+            fieldOffset = 8,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "uint8_t"),
+            fieldSourceLoc =
+            "distilled_lib_1.h:37:31"},
+          StructField {
+            fieldName = CName "field_2",
+            fieldOffset = 16,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "uint16_t"),
+            fieldSourceLoc =
+            "distilled_lib_1.h:38:31"},
+          StructField {
+            fieldName = CName "field_3",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "uint32_t"),
+            fieldSourceLoc =
+            "distilled_lib_1.h:39:31"},
+          StructField {
+            fieldName = CName "field_4",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
+              (DeclPathStruct
+                (DeclNameTypedef
+                  (CName
+                    "another_typedef_struct_t"))
+                DeclPathTop),
+            fieldSourceLoc =
+            "distilled_lib_1.h:40:31"},
+          StructField {
+            fieldName = CName "field_5",
+            fieldOffset = 128,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
                 (DeclPathStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
-                  DeclPathTop),
-              fieldSourceLoc =
-              "distilled_lib_1.h:40:31"},
-            StructField {
-              fieldName = CName "field_5",
-              fieldOffset = 128,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_struct_t"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "distilled_lib_1.h:41:31"},
-            StructField {
-              fieldName = CName "field_6",
-              fieldOffset = 192,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                TypeVoid,
-              fieldSourceLoc =
-              "distilled_lib_1.h:42:31"},
-            StructField {
-              fieldName = CName "field_7",
-              fieldOffset = 256,
-              fieldWidth = Nothing,
-              fieldType = TypeConstArray
-                7
-                (TypeTypedef
-                  (CName "uint32_t")),
-              fieldSourceLoc =
-              "distilled_lib_1.h:43:31"},
-            StructField {
-              fieldName = CName "field_8",
-              fieldOffset = 480,
-              fieldWidth = Nothing,
-              fieldType = TypeEnum
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "distilled_lib_1.h:41:31"},
+          StructField {
+            fieldName = CName "field_6",
+            fieldOffset = 192,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              TypeVoid,
+            fieldSourceLoc =
+            "distilled_lib_1.h:42:31"},
+          StructField {
+            fieldName = CName "field_7",
+            fieldOffset = 256,
+            fieldWidth = Nothing,
+            fieldType = TypeConstArray
+              7
+              (TypeTypedef
+                (CName "uint32_t")),
+            fieldSourceLoc =
+            "distilled_lib_1.h:43:31"},
+          StructField {
+            fieldName = CName "field_8",
+            fieldOffset = 480,
+            fieldWidth = Nothing,
+            fieldType = TypeEnum
+              (CName
+                "another_typedef_enum_e"),
+            fieldSourceLoc =
+            "distilled_lib_1.h:44:31"},
+          StructField {
+            fieldName = CName "field_9",
+            fieldOffset = 512,
+            fieldWidth = Nothing,
+            fieldType = TypeConstArray
+              4
+              (TypeEnum
                 (CName
-                  "another_typedef_enum_e"),
-              fieldSourceLoc =
-              "distilled_lib_1.h:44:31"},
-            StructField {
-              fieldName = CName "field_9",
-              fieldOffset = 512,
-              fieldWidth = Nothing,
-              fieldType = TypeConstArray
-                4
+                  "another_typedef_enum_e")),
+            fieldSourceLoc =
+            "distilled_lib_1.h:45:31"},
+          StructField {
+            fieldName = CName "field_10",
+            fieldOffset = 640,
+            fieldWidth = Nothing,
+            fieldType = TypeConstArray
+              5
+              (TypeConstArray
+                3
                 (TypeEnum
                   (CName
-                    "another_typedef_enum_e")),
-              fieldSourceLoc =
-              "distilled_lib_1.h:45:31"},
-            StructField {
-              fieldName = CName "field_10",
-              fieldOffset = 640,
-              fieldWidth = Nothing,
-              fieldType = TypeConstArray
-                5
-                (TypeConstArray
-                  3
-                  (TypeEnum
-                    (CName
-                      "another_typedef_enum_e"))),
-              fieldSourceLoc =
-              "distilled_lib_1.h:46:31"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "distilled_lib_1.h:34:16"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName
-            "a_typedef_struct_t",
-          typedefType = TypeStruct
-            (DeclPathStruct
-              (DeclNameTag
-                (CName "a_typedef_struct"))
-              DeclPathTop),
-          typedefSourceLoc =
-          "distilled_lib_1.h:47:3"},
-      DeclEnum
-        Enu {
-          enumTag = CName
-            "a_typedef_enum_e",
-          enumType = TypePrim
-            (PrimChar (Just Unsigned)),
-          enumSizeof = 1,
-          enumAlignment = 1,
-          enumValues = [
-            EnumValue {
-              valueName = CName "ENUM_CASE_0",
-              valueValue = 0,
-              valueSourceLoc =
-              "distilled_lib_1.h:62:3"},
-            EnumValue {
-              valueName = CName "ENUM_CASE_1",
-              valueValue = 1,
-              valueSourceLoc =
-              "distilled_lib_1.h:63:3"},
-            EnumValue {
-              valueName = CName "ENUM_CASE_2",
-              valueValue = 2,
-              valueSourceLoc =
-              "distilled_lib_1.h:64:3"},
-            EnumValue {
-              valueName = CName "ENUM_CASE_3",
-              valueValue = 3,
-              valueSourceLoc =
-              "distilled_lib_1.h:65:3"}],
-          enumSourceLoc =
-          "distilled_lib_1.h:60:9"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "int32_t",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          typedefSourceLoc =
-          "alltypes.h:106:25"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName
-            "callback_t",
-          typedefType = TypePointer
-            (TypeFun
-              [
-                TypePointer TypeVoid,
-                TypeTypedef (CName "uint32_t")]
-              (TypeTypedef
-                (CName "uint32_t"))),
-          typedefSourceLoc =
-          "distilled_lib_1.h:76:19"}])
+                    "another_typedef_enum_e"))),
+            fieldSourceLoc =
+            "distilled_lib_1.h:46:31"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "distilled_lib_1.h:34:16"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "a_typedef_struct_t",
+        typedefType = TypeStruct
+          (DeclPathStruct
+            (DeclNameTag
+              (CName "a_typedef_struct"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "distilled_lib_1.h:47:3"},
+    DeclEnum
+      Enu {
+        enumTag = CName
+          "a_typedef_enum_e",
+        enumType = TypePrim
+          (PrimChar (Just Unsigned)),
+        enumSizeof = 1,
+        enumAlignment = 1,
+        enumValues = [
+          EnumValue {
+            valueName = CName "ENUM_CASE_0",
+            valueValue = 0,
+            valueSourceLoc =
+            "distilled_lib_1.h:62:3"},
+          EnumValue {
+            valueName = CName "ENUM_CASE_1",
+            valueValue = 1,
+            valueSourceLoc =
+            "distilled_lib_1.h:63:3"},
+          EnumValue {
+            valueName = CName "ENUM_CASE_2",
+            valueValue = 2,
+            valueSourceLoc =
+            "distilled_lib_1.h:64:3"},
+          EnumValue {
+            valueName = CName "ENUM_CASE_3",
+            valueValue = 3,
+            valueSourceLoc =
+            "distilled_lib_1.h:65:3"}],
+        enumSourceLoc =
+        "distilled_lib_1.h:60:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "int32_t",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        typedefSourceLoc =
+        "alltypes.h:106:25"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "callback_t",
+        typedefType = TypePointer
+          (TypeFun
+            [
+              TypePointer TypeVoid,
+              TypeTypedef (CName "uint32_t")]
+            (TypeTypedef
+              (CName "uint32_t"))),
+        typedefSourceLoc =
+        "distilled_lib_1.h:76:19"}]

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -1,187 +1,186 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "enums.h:2:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "ENUMS_H",
-            macroArgs = [],
-            macroBody = MEmpty},
-          macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc =
-          "enums.h:2:9"},
-      DeclEnum
-        Enu {
-          enumTag = CName "first",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "FIRST1",
-              valueValue = 0,
-              valueSourceLoc = "enums.h:5:5"},
-            EnumValue {
-              valueName = CName "FIRST2",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:6:5"}],
-          enumSourceLoc = "enums.h:4:6"},
-      DeclEnum
-        Enu {
-          enumTag = CName "second",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "SECOND_A",
-              valueValue = `-1`,
-              valueSourceLoc =
-              "enums.h:10:5"},
-            EnumValue {
-              valueName = CName "SECOND_B",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:11:5"},
-            EnumValue {
-              valueName = CName "SECOND_C",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:12:5"}],
-          enumSourceLoc = "enums.h:9:6"},
-      DeclEnum
-        Enu {
-          enumTag = CName "same",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "SAME_A",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:16:5"},
-            EnumValue {
-              valueName = CName "SAME_B",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:17:5"}],
-          enumSourceLoc = "enums.h:15:6"},
-      DeclEnum
-        Enu {
-          enumTag = CName "packad",
-          enumType = TypePrim
-            (PrimChar (Just Unsigned)),
-          enumSizeof = 1,
-          enumAlignment = 1,
-          enumValues = [
-            EnumValue {
-              valueName = CName "PACKED_A",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:21:5"},
-            EnumValue {
-              valueName = CName "PACKED_B",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:21:15"},
-            EnumValue {
-              valueName = CName "PACKED_C",
-              valueValue = 2,
-              valueSourceLoc =
-              "enums.h:21:25"}],
-          enumSourceLoc = "enums.h:20:6"},
-      DeclEnum
-        Enu {
-          enumTag = CName "enumA",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "A_FOO",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:24:16"},
-            EnumValue {
-              valueName = CName "A_BAR",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:24:23"}],
-          enumSourceLoc = "enums.h:24:9"},
-      DeclEnum
-        Enu {
-          enumTag = CName "enumB",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "B_FOO",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:26:22"},
-            EnumValue {
-              valueName = CName "B_BAR",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:26:29"}],
-          enumSourceLoc =
-          "enums.h:26:14"},
-      DeclEnum
-        Enu {
-          enumTag = CName "enumC",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "C_FOO",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:28:14"},
-            EnumValue {
-              valueName = CName "C_BAR",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:28:21"}],
-          enumSourceLoc = "enums.h:28:6"},
-      DeclEnum
-        Enu {
-          enumTag = CName "enumD",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "D_FOO",
-              valueValue = 0,
-              valueSourceLoc =
-              "enums.h:31:14"},
-            EnumValue {
-              valueName = CName "D_BAR",
-              valueValue = 1,
-              valueSourceLoc =
-              "enums.h:31:21"}],
-          enumSourceLoc = "enums.h:31:6"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "enumD_t",
-          typedefType = TypeEnum
-            (CName "enumD"),
-          typedefSourceLoc =
-          "enums.h:32:20"}])
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "enums.h:2:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "ENUMS_H",
+          macroArgs = [],
+          macroBody = MEmpty},
+        macroDeclMacroTy = "Empty",
+        macroDeclSourceLoc =
+        "enums.h:2:9"},
+    DeclEnum
+      Enu {
+        enumTag = CName "first",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "FIRST1",
+            valueValue = 0,
+            valueSourceLoc = "enums.h:5:5"},
+          EnumValue {
+            valueName = CName "FIRST2",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:6:5"}],
+        enumSourceLoc = "enums.h:4:6"},
+    DeclEnum
+      Enu {
+        enumTag = CName "second",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "SECOND_A",
+            valueValue = `-1`,
+            valueSourceLoc =
+            "enums.h:10:5"},
+          EnumValue {
+            valueName = CName "SECOND_B",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:11:5"},
+          EnumValue {
+            valueName = CName "SECOND_C",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:12:5"}],
+        enumSourceLoc = "enums.h:9:6"},
+    DeclEnum
+      Enu {
+        enumTag = CName "same",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "SAME_A",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:16:5"},
+          EnumValue {
+            valueName = CName "SAME_B",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:17:5"}],
+        enumSourceLoc = "enums.h:15:6"},
+    DeclEnum
+      Enu {
+        enumTag = CName "packad",
+        enumType = TypePrim
+          (PrimChar (Just Unsigned)),
+        enumSizeof = 1,
+        enumAlignment = 1,
+        enumValues = [
+          EnumValue {
+            valueName = CName "PACKED_A",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:21:5"},
+          EnumValue {
+            valueName = CName "PACKED_B",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:21:15"},
+          EnumValue {
+            valueName = CName "PACKED_C",
+            valueValue = 2,
+            valueSourceLoc =
+            "enums.h:21:25"}],
+        enumSourceLoc = "enums.h:20:6"},
+    DeclEnum
+      Enu {
+        enumTag = CName "enumA",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "A_FOO",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:24:16"},
+          EnumValue {
+            valueName = CName "A_BAR",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:24:23"}],
+        enumSourceLoc = "enums.h:24:9"},
+    DeclEnum
+      Enu {
+        enumTag = CName "enumB",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "B_FOO",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:26:22"},
+          EnumValue {
+            valueName = CName "B_BAR",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:26:29"}],
+        enumSourceLoc =
+        "enums.h:26:14"},
+    DeclEnum
+      Enu {
+        enumTag = CName "enumC",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "C_FOO",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:28:14"},
+          EnumValue {
+            valueName = CName "C_BAR",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:28:21"}],
+        enumSourceLoc = "enums.h:28:6"},
+    DeclEnum
+      Enu {
+        enumTag = CName "enumD",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "D_FOO",
+            valueValue = 0,
+            valueSourceLoc =
+            "enums.h:31:14"},
+          EnumValue {
+            valueName = CName "D_BAR",
+            valueValue = 1,
+            valueSourceLoc =
+            "enums.h:31:21"}],
+        enumSourceLoc = "enums.h:31:6"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "enumD_t",
+        typedefType = TypeEnum
+          (CName "enumD"),
+        typedefSourceLoc =
+        "enums.h:32:20"}]

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -1,45 +1,44 @@
-WrapCHeader
-  (Header
-    [
-      DeclTypedef
-        Typedef {
-          typedefName = CName "triple",
-          typedefType = TypeConstArray
-            3
-            (TypePrim
-              (PrimIntegral PrimInt Signed)),
-          typedefSourceLoc =
-          "fixedarray.h:1:13"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "Example"))
-            DeclPathTop,
-          structSizeof = 48,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "triple",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeConstArray
+Header
+  [
+    DeclTypedef
+      Typedef {
+        typedefName = CName "triple",
+        typedefType = TypeConstArray
+          3
+          (TypePrim
+            (PrimIntegral PrimInt Signed)),
+        typedefSourceLoc =
+        "fixedarray.h:1:13"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "Example"))
+          DeclPathTop,
+        structSizeof = 48,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "triple",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeConstArray
+              3
+              (TypePrim
+                (PrimIntegral PrimInt Signed)),
+            fieldSourceLoc =
+            "fixedarray.h:4:9"},
+          StructField {
+            fieldName = CName "sudoku",
+            fieldOffset = 96,
+            fieldWidth = Nothing,
+            fieldType = TypeConstArray
+              3
+              (TypeConstArray
                 3
                 (TypePrim
-                  (PrimIntegral PrimInt Signed)),
-              fieldSourceLoc =
-              "fixedarray.h:4:9"},
-            StructField {
-              fieldName = CName "sudoku",
-              fieldOffset = 96,
-              fieldWidth = Nothing,
-              fieldType = TypeConstArray
-                3
-                (TypeConstArray
-                  3
-                  (TypePrim
-                    (PrimIntegral PrimInt Signed))),
-              fieldSourceLoc =
-              "fixedarray.h:5:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "fixedarray.h:3:8"}])
+                  (PrimIntegral PrimInt Signed))),
+            fieldSourceLoc =
+            "fixedarray.h:5:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "fixedarray.h:3:8"}]

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -1,46 +1,45 @@
-WrapCHeader
-  (Header
-    [
-      DeclTypedef
-        Typedef {
-          typedefName = CName "uint64_t",
-          typedefType = TypePrim
-            (PrimIntegral
-              PrimLong
-              Unsigned),
-          typedefSourceLoc =
-          "alltypes.h:136:25"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "uint32_t",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          typedefSourceLoc =
-          "alltypes.h:131:25"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "sixty_four",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "uint64_t"),
-              fieldSourceLoc =
-              "fixedwidth.h:4:11"},
-            StructField {
-              fieldName = CName "thirty_two",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "uint32_t"),
-              fieldSourceLoc =
-              "fixedwidth.h:5:11"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "fixedwidth.h:3:8"}])
+Header
+  [
+    DeclTypedef
+      Typedef {
+        typedefName = CName "uint64_t",
+        typedefType = TypePrim
+          (PrimIntegral
+            PrimLong
+            Unsigned),
+        typedefSourceLoc =
+        "alltypes.h:136:25"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "uint32_t",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        typedefSourceLoc =
+        "alltypes.h:131:25"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "sixty_four",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "uint64_t"),
+            fieldSourceLoc =
+            "fixedwidth.h:4:11"},
+          StructField {
+            fieldName = CName "thirty_two",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "uint32_t"),
+            fieldSourceLoc =
+            "fixedwidth.h:5:11"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "fixedwidth.h:3:8"}]

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -1,120 +1,119 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "pascal"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "len",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc = "flam.h:3:9"}],
-          structFlam = Just
-            StructField {
-              fieldName = CName "data",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc = "flam.h:4:10"},
-          structSourceLoc = "flam.h:2:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
-            (DeclPathField
-              (CName "bar")
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "pascal"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "len",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc = "flam.h:3:9"}],
+        structFlam = Just
+          StructField {
+            fieldName = CName "data",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc = "flam.h:4:10"},
+        structSourceLoc = "flam.h:2:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathField
+            (CName "bar")
+            (DeclPathStruct
+              (DeclNameTag (CName "foo"))
+              DeclPathTop)),
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc = "flam.h:11:7"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "flam.h:12:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "flam.h:10:2"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "len",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc = "flam.h:9:6"}],
+        structFlam = Just
+          StructField {
+            fieldName = CName "bar",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
               (DeclPathStruct
-                (DeclNameTag (CName "foo"))
-                DeclPathTop)),
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc = "flam.h:11:7"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "flam.h:12:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "flam.h:10:2"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "len",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc = "flam.h:9:6"}],
-          structFlam = Just
-            StructField {
-              fieldName = CName "bar",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  DeclNameNone
-                  (DeclPathField
-                    (CName "bar")
-                    (DeclPathStruct
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop))),
-              fieldSourceLoc = "flam.h:13:4"},
-          structSourceLoc = "flam.h:8:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "diff"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "first",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc = "flam.h:18:7"},
-            StructField {
-              fieldName = CName "second",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "flam.h:19:7"}],
-          structFlam = Just
-            StructField {
-              fieldName = CName "flam",
-              fieldOffset = 72,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc = "flam.h:20:7"},
-          structSourceLoc =
-          "flam.h:17:8"}])
+                DeclNameNone
+                (DeclPathField
+                  (CName "bar")
+                  (DeclPathStruct
+                    (DeclNameTag (CName "foo"))
+                    DeclPathTop))),
+            fieldSourceLoc = "flam.h:13:4"},
+        structSourceLoc = "flam.h:8:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "diff"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "first",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc = "flam.h:18:7"},
+          StructField {
+            fieldName = CName "second",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "flam.h:19:7"}],
+        structFlam = Just
+          StructField {
+            fieldName = CName "flam",
+            fieldOffset = 72,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc = "flam.h:20:7"},
+        structSourceLoc =
+        "flam.h:17:8"}]

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -1,50 +1,49 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S1"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "forward_declaration.h:4:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "forward_declaration.h:3:8"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "S1_t",
+        typedefType = TypeStruct
+          (DeclPathStruct
             (DeclNameTag (CName "S1"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "forward_declaration.h:4:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "forward_declaration.h:3:8"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "S1_t",
-          typedefType = TypeStruct
-            (DeclPathStruct
-              (DeclNameTag (CName "S1"))
-              DeclPathTop),
-          typedefSourceLoc =
-          "forward_declaration.h:1:19"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S2"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "forward_declaration.h:10:7"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "forward_declaration.h:9:8"}])
+            DeclPathTop),
+        typedefSourceLoc =
+        "forward_declaration.h:1:19"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S2"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "forward_declaration.h:10:7"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "forward_declaration.h:9:8"}]

--- a/hs-bindgen/fixtures/headers.tree-diff.txt
+++ b/hs-bindgen/fixtures/headers.tree-diff.txt
@@ -1,1 +1,1 @@
-WrapCHeader (Header [])
+Header []

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -1,271 +1,270 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:1:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "INCR",
-            macroArgs = [CName "x"],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm (MVar (CName "x") []),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "1",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 1})]},
-          macroDeclMacroTy =
-          "(forall a. Add a (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> AddRes a (IntLike (CIntegralType (IntLike (Int Signed))))))",
-          macroDeclSourceLoc =
-          "macro_functions.h:1:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:2:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "ADD",
-            macroArgs = [
-              CName "x",
-              CName "y"],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm (MVar (CName "x") []),
-                MTerm (MVar (CName "y") [])]},
-          macroDeclMacroTy =
-          "(forall a b. Add a b => (a -> b -> AddRes a b))",
-          macroDeclSourceLoc =
-          "macro_functions.h:2:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:4:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "ID",
-            macroArgs = [CName "X"],
-            macroBody = MTerm
-              (MVar (CName "X") [])},
-          macroDeclMacroTy =
-          "(forall a. (a -> a))",
-          macroDeclSourceLoc =
-          "macro_functions.h:4:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:5:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "CONST",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MTerm
-              (MVar (CName "X") [])},
-          macroDeclMacroTy =
-          "(forall a b. (a -> b -> a))",
-          macroDeclSourceLoc =
-          "macro_functions.h:5:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:7:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "CMP",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MApp
-              MRelLT
-              [
-                MTerm (MVar (CName "X") []),
-                MTerm (MVar (CName "Y") [])]},
-          macroDeclMacroTy =
-          "(forall a b. RelOrd a b => (a -> b -> IntLike (CIntegralType (IntLike (Int Signed)))))",
-          macroDeclSourceLoc =
-          "macro_functions.h:7:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:8:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FUN1",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm (MVar (CName "X") []),
-                MApp
-                  MMult
-                  [
-                    MTerm
-                      (MInt
-                        IntegerLiteral {
-                          integerLiteralText = "12ull",
-                          integerLiteralType = Just
-                            (_×_ PrimLongLong Unsigned),
-                          integerLiteralValue = 12}),
-                    MTerm (MVar (CName "Y") [])]]},
-          macroDeclMacroTy =
-          "(forall a b. Add a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b) => Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (a -> b -> AddRes a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b)))",
-          macroDeclSourceLoc =
-          "macro_functions.h:8:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:9:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FUN2",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MApp
-              MShiftLeft
-              [
-                MTerm (MVar (CName "X") []),
-                MApp
-                  MMult
-                  [
-                    MTerm
-                      (MInt
-                        IntegerLiteral {
-                          integerLiteralText = "3ull",
-                          integerLiteralType = Just
-                            (_×_ PrimLongLong Unsigned),
-                          integerLiteralValue = 3}),
-                    MTerm (MVar (CName "Y") [])]]},
-          macroDeclMacroTy =
-          "(forall a b. Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => IntLike b_10[tau] ~ MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (IntLike a -> b -> ShiftRes (IntLike a)))",
-          macroDeclSourceLoc =
-          "macro_functions.h:9:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:11:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "G",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MTerm
-              (MVar
-                (CName "CONST")
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:1:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "INCR",
+          macroArgs = [CName "x"],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm (MVar (CName "x") []),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "1",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 1})]},
+        macroDeclMacroTy =
+        "(forall a. Add a (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> AddRes a (IntLike (CIntegralType (IntLike (Int Signed))))))",
+        macroDeclSourceLoc =
+        "macro_functions.h:1:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:2:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "ADD",
+          macroArgs = [
+            CName "x",
+            CName "y"],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm (MVar (CName "x") []),
+              MTerm (MVar (CName "y") [])]},
+        macroDeclMacroTy =
+        "(forall a b. Add a b => (a -> b -> AddRes a b))",
+        macroDeclSourceLoc =
+        "macro_functions.h:2:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:4:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "ID",
+          macroArgs = [CName "X"],
+          macroBody = MTerm
+            (MVar (CName "X") [])},
+        macroDeclMacroTy =
+        "(forall a. (a -> a))",
+        macroDeclSourceLoc =
+        "macro_functions.h:4:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:5:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "CONST",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MTerm
+            (MVar (CName "X") [])},
+        macroDeclMacroTy =
+        "(forall a b. (a -> b -> a))",
+        macroDeclSourceLoc =
+        "macro_functions.h:5:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:7:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "CMP",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MApp
+            MRelLT
+            [
+              MTerm (MVar (CName "X") []),
+              MTerm (MVar (CName "Y") [])]},
+        macroDeclMacroTy =
+        "(forall a b. RelOrd a b => (a -> b -> IntLike (CIntegralType (IntLike (Int Signed)))))",
+        macroDeclSourceLoc =
+        "macro_functions.h:7:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:8:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FUN1",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm (MVar (CName "X") []),
+              MApp
+                MMult
                 [
                   MTerm
-                    (MVar
-                      (CName "INCR")
-                      [MTerm (MVar (CName "Y") [])]),
+                    (MInt
+                      IntegerLiteral {
+                        integerLiteralText = "12ull",
+                        integerLiteralType = Just
+                          (_×_ PrimLongLong Unsigned),
+                        integerLiteralValue = 12}),
+                  MTerm (MVar (CName "Y") [])]]},
+        macroDeclMacroTy =
+        "(forall a b. Add a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b) => Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (a -> b -> AddRes a (MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b)))",
+        macroDeclSourceLoc =
+        "macro_functions.h:8:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:9:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FUN2",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MApp
+            MShiftLeft
+            [
+              MTerm (MVar (CName "X") []),
+              MApp
+                MMult
+                [
                   MTerm
-                    (MVar
-                      (CName "ID")
-                      [
-                        MTerm
-                          (MVar (CName "X") [])])])},
-          macroDeclMacroTy =
-          "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> b -> AddRes b (IntLike (CIntegralType (IntLike (Int Signed))))))",
-          macroDeclSourceLoc =
-          "macro_functions.h:11:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:13:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "DIV1",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MApp
-              MDiv
+                    (MInt
+                      IntegerLiteral {
+                        integerLiteralText = "3ull",
+                        integerLiteralType = Just
+                          (_×_ PrimLongLong Unsigned),
+                        integerLiteralValue = 3}),
+                  MTerm (MVar (CName "Y") [])]]},
+        macroDeclMacroTy =
+        "(forall a b. Mult (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => IntLike b_10[tau] ~ MultRes (IntLike (CIntegralType (IntLike (LongLong Unsigned)))) b => (IntLike a -> b -> ShiftRes (IntLike a)))",
+        macroDeclSourceLoc =
+        "macro_functions.h:9:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:11:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "G",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MTerm
+            (MVar
+              (CName "CONST")
               [
-                MTerm (MVar (CName "X") []),
-                MApp
-                  MAdd
-                  [
-                    MTerm (MVar (CName "Y") []),
-                    MTerm
-                      (MInt
-                        IntegerLiteral {
-                          integerLiteralText = "12u",
-                          integerLiteralType = Just
-                            (_×_ PrimInt Unsigned),
-                          integerLiteralValue = 12})]]},
-          macroDeclMacroTy =
-          "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Unsigned)))) => Div a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned))))) => (a -> b -> DivRes a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned)))))))",
-          macroDeclSourceLoc =
-          "macro_functions.h:13:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_functions.h:14:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "DIV2",
-            macroArgs = [
-              CName "X",
-              CName "Y"],
-            macroBody = MApp
-              MDiv
-              [
-                MApp
-                  MMult
-                  [
-                    MTerm
-                      (MFloat
-                        FloatingLiteral {
-                          floatingLiteralText = "10.0f",
-                          floatingLiteralType = Just
-                            PrimFloat,
-                          floatingLiteralFloatValue =
-                          10.0,
-                          floatingLiteralDoubleValue =
-                          10.0}),
-                    MTerm (MVar (CName "X") [])],
-                MTerm (MVar (CName "Y") [])]},
-          macroDeclMacroTy =
-          "(forall a b. Mult (FloatLike FloatType) a => Div (MultRes (FloatLike FloatType) a) b => (a -> b -> DivRes (MultRes (FloatLike FloatType) a) b))",
-          macroDeclSourceLoc =
-          "macro_functions.h:14:9"}])
+                MTerm
+                  (MVar
+                    (CName "INCR")
+                    [MTerm (MVar (CName "Y") [])]),
+                MTerm
+                  (MVar
+                    (CName "ID")
+                    [
+                      MTerm
+                        (MVar (CName "X") [])])])},
+        macroDeclMacroTy =
+        "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Signed)))) => (a -> b -> AddRes b (IntLike (CIntegralType (IntLike (Int Signed))))))",
+        macroDeclSourceLoc =
+        "macro_functions.h:11:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:13:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "DIV1",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MApp
+            MDiv
+            [
+              MTerm (MVar (CName "X") []),
+              MApp
+                MAdd
+                [
+                  MTerm (MVar (CName "Y") []),
+                  MTerm
+                    (MInt
+                      IntegerLiteral {
+                        integerLiteralText = "12u",
+                        integerLiteralType = Just
+                          (_×_ PrimInt Unsigned),
+                        integerLiteralValue = 12})]]},
+        macroDeclMacroTy =
+        "(forall a b. Add b (IntLike (CIntegralType (IntLike (Int Unsigned)))) => Div a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned))))) => (a -> b -> DivRes a (AddRes b (IntLike (CIntegralType (IntLike (Int Unsigned)))))))",
+        macroDeclSourceLoc =
+        "macro_functions.h:13:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_functions.h:14:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "DIV2",
+          macroArgs = [
+            CName "X",
+            CName "Y"],
+          macroBody = MApp
+            MDiv
+            [
+              MApp
+                MMult
+                [
+                  MTerm
+                    (MFloat
+                      FloatingLiteral {
+                        floatingLiteralText = "10.0f",
+                        floatingLiteralType = Just
+                          PrimFloat,
+                        floatingLiteralFloatValue =
+                        10.0,
+                        floatingLiteralDoubleValue =
+                        10.0}),
+                  MTerm (MVar (CName "X") [])],
+              MTerm (MVar (CName "Y") [])]},
+        macroDeclMacroTy =
+        "(forall a b. Mult (FloatLike FloatType) a => Div (MultRes (FloatLike FloatType) a) b => (a -> b -> DivRes (MultRes (FloatLike FloatType) a) b))",
+        macroDeclSourceLoc =
+        "macro_functions.h:14:9"}]

--- a/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
@@ -1,312 +1,311 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_in_fundecl.h:5:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "I",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim
-                  (PrimIntegral
-                    PrimInt
-                    Signed)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "macro_in_fundecl.h:5:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_in_fundecl.h:6:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim (PrimChar Nothing)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "macro_in_fundecl.h:6:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_in_fundecl.h:7:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "F",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim
-                  (PrimFloating PrimFloat)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "macro_in_fundecl.h:7:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_in_fundecl.h:8:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "L",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim
-                  (PrimIntegral
-                    PrimLong
-                    Signed)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "macro_in_fundecl.h:8:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_in_fundecl.h:9:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim
-                  (PrimIntegral
-                    PrimShort
-                    Signed)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "macro_in_fundecl.h:9:9"},
-      DeclFunction
-        Function {
-          functionName = CName "quux",
-          functionType = TypeFun
-            [
-              TypeTypedef (CName "F"),
-              TypePrim (PrimChar Nothing)]
-            (TypePrim (PrimChar Nothing)),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:12:6"},
-      DeclFunction
-        Function {
-          functionName = CName "wam",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimFloating PrimFloat),
-              TypePointer
-                (TypeTypedef (CName "C"))]
-            (TypePointer
-              (TypeTypedef (CName "C"))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:13:4"},
-      DeclFunction
-        Function {
-          functionName = CName "foo1",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimFloating PrimFloat),
-              TypePointer
-                (TypeFun
-                  [
-                    TypePrim
-                      (PrimIntegral PrimInt Signed)]
-                  (TypePrim
-                    (PrimIntegral PrimInt Signed)))]
-            (TypePointer
-              (TypePrim (PrimChar Nothing))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:16:7"},
-      DeclFunction
-        Function {
-          functionName = CName "foo2",
-          functionType = TypeFun
-            [
-              TypeTypedef (CName "F"),
-              TypePointer
-                (TypeFun
-                  [
-                    TypePrim
-                      (PrimIntegral PrimInt Signed)]
-                  (TypePrim
-                    (PrimIntegral PrimInt Signed)))]
-            (TypePointer
-              (TypePrim (PrimChar Nothing))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:17:7"},
-      DeclFunction
-        Function {
-          functionName = CName "foo3",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimFloating PrimFloat),
-              TypePointer
-                (TypeFun
-                  [
-                    TypePrim
-                      (PrimIntegral PrimInt Signed)]
-                  (TypePrim
-                    (PrimIntegral PrimInt Signed)))]
-            (TypePointer
-              (TypeTypedef (CName "C"))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:18:4"},
-      DeclFunction
-        Function {
-          functionName = CName "bar1",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimLong Signed)]
-            (TypePointer
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_in_fundecl.h:5:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "I",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "macro_in_fundecl.h:5:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_in_fundecl.h:6:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim (PrimChar Nothing)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "macro_in_fundecl.h:6:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_in_fundecl.h:7:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "F",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimFloating PrimFloat)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "macro_in_fundecl.h:7:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_in_fundecl.h:8:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "L",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimIntegral
+                  PrimLong
+                  Signed)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "macro_in_fundecl.h:8:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_in_fundecl.h:9:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimIntegral
+                  PrimShort
+                  Signed)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "macro_in_fundecl.h:9:9"},
+    DeclFunction
+      Function {
+        functionName = CName "quux",
+        functionType = TypeFun
+          [
+            TypeTypedef (CName "F"),
+            TypePrim (PrimChar Nothing)]
+          (TypePrim (PrimChar Nothing)),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:12:6"},
+    DeclFunction
+      Function {
+        functionName = CName "wam",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimFloating PrimFloat),
+            TypePointer
+              (TypeTypedef (CName "C"))]
+          (TypePointer
+            (TypeTypedef (CName "C"))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:13:4"},
+    DeclFunction
+      Function {
+        functionName = CName "foo1",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimFloating PrimFloat),
+            TypePointer
               (TypeFun
                 [
                   TypePrim
-                    (PrimIntegral PrimShort Signed)]
+                    (PrimIntegral PrimInt Signed)]
                 (TypePrim
-                  (PrimIntegral
-                    PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:21:7"},
-      DeclFunction
-        Function {
-          functionName = CName "bar2",
-          functionType = TypeFun
-            [TypeTypedef (CName "L")]
-            (TypePointer
+                  (PrimIntegral PrimInt Signed)))]
+          (TypePointer
+            (TypePrim (PrimChar Nothing))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:16:7"},
+    DeclFunction
+      Function {
+        functionName = CName "foo2",
+        functionType = TypeFun
+          [
+            TypeTypedef (CName "F"),
+            TypePointer
               (TypeFun
                 [
                   TypePrim
-                    (PrimIntegral PrimShort Signed)]
+                    (PrimIntegral PrimInt Signed)]
                 (TypePrim
-                  (PrimIntegral
-                    PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:22:7"},
-      DeclFunction
-        Function {
-          functionName = CName "bar3",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimLong Signed)]
-            (TypePointer
-              (TypeFun
-                [TypeTypedef (CName "S")]
-                (TypePrim
-                  (PrimIntegral
-                    PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:23:7"},
-      DeclFunction
-        Function {
-          functionName = CName "bar4",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimLong Signed)]
-            (TypePointer
+                  (PrimIntegral PrimInt Signed)))]
+          (TypePointer
+            (TypePrim (PrimChar Nothing))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:17:7"},
+    DeclFunction
+      Function {
+        functionName = CName "foo3",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimFloating PrimFloat),
+            TypePointer
               (TypeFun
                 [
                   TypePrim
-                    (PrimIntegral PrimShort Signed)]
-                (TypeTypedef (CName "I")))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:24:5"},
-      DeclFunction
-        Function {
-          functionName = CName "baz1",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimInt Signed)]
-            (TypePointer
+                    (PrimIntegral PrimInt Signed)]
+                (TypePrim
+                  (PrimIntegral PrimInt Signed)))]
+          (TypePointer
+            (TypeTypedef (CName "C"))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:18:4"},
+    DeclFunction
+      Function {
+        functionName = CName "bar1",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimLong Signed)]
+          (TypePointer
+            (TypeFun
+              [
+                TypePrim
+                  (PrimIntegral PrimShort Signed)]
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:21:7"},
+    DeclFunction
+      Function {
+        functionName = CName "bar2",
+        functionType = TypeFun
+          [TypeTypedef (CName "L")]
+          (TypePointer
+            (TypeFun
+              [
+                TypePrim
+                  (PrimIntegral PrimShort Signed)]
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:22:7"},
+    DeclFunction
+      Function {
+        functionName = CName "bar3",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimLong Signed)]
+          (TypePointer
+            (TypeFun
+              [TypeTypedef (CName "S")]
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:23:7"},
+    DeclFunction
+      Function {
+        functionName = CName "bar4",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimLong Signed)]
+          (TypePointer
+            (TypeFun
+              [
+                TypePrim
+                  (PrimIntegral PrimShort Signed)]
+              (TypeTypedef (CName "I")))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:24:5"},
+    DeclFunction
+      Function {
+        functionName = CName "baz1",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimInt Signed)]
+          (TypePointer
+            (TypeConstArray
+              2
               (TypeConstArray
-                2
-                (TypeConstArray
-                  3
-                  (TypePrim
-                    (PrimIntegral
-                      PrimInt
-                      Signed))))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:27:7"},
-      DeclFunction
-        Function {
-          functionName = CName "baz2",
-          functionType = TypeFun
-            [TypeTypedef (CName "I")]
-            (TypePointer
+                3
+                (TypePrim
+                  (PrimIntegral
+                    PrimInt
+                    Signed))))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:27:7"},
+    DeclFunction
+      Function {
+        functionName = CName "baz2",
+        functionType = TypeFun
+          [TypeTypedef (CName "I")]
+          (TypePointer
+            (TypeConstArray
+              2
               (TypeConstArray
-                2
-                (TypeConstArray
-                  3
-                  (TypePrim
-                    (PrimIntegral
-                      PrimInt
-                      Signed))))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:35:7"},
-      DeclFunction
-        Function {
-          functionName = CName "baz3",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimInt Signed)]
-            (TypePointer
+                3
+                (TypePrim
+                  (PrimIntegral
+                    PrimInt
+                    Signed))))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:35:7"},
+    DeclFunction
+      Function {
+        functionName = CName "baz3",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimInt Signed)]
+          (TypePointer
+            (TypeConstArray
+              2
               (TypeConstArray
-                2
-                (TypeConstArray
-                  3
-                  (TypeTypedef (CName "I"))))),
-          functionHeader =
-          "macro_in_fundecl.h",
-          functionSourceLoc =
-          "macro_in_fundecl.h:43:5"}])
+                3
+                (TypeTypedef (CName "I"))))),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:43:5"}]

--- a/hs-bindgen/fixtures/macro_strings.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_strings.tree-diff.txt
@@ -1,740 +1,739 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:4:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'a'",
-                  charLiteralValue = CharValue {
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:4:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'a'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [97],
+                  unicodeCodePoint = Just 'a'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:4:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:5:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\"'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [34],
+                  unicodeCodePoint = Just
+                    `'"'`}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:5:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:6:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\t'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [9],
+                  unicodeCodePoint = Just
+                    '\t'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:6:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:7:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C4",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\0'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [0],
+                  unicodeCodePoint = Just
+                    '\NUL'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:7:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:8:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C5",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\''",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [39],
+                  unicodeCodePoint = Just
+                    '\''}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:8:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:9:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C6",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\?'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [63],
+                  unicodeCodePoint = Just '?'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:9:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:10:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C7",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\123'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [83],
+                  unicodeCodePoint = Nothing}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:10:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:11:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "C8",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\x53'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [83],
+                  unicodeCodePoint = Nothing}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:11:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:13:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "D",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\777'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList [1, 255],
+                  unicodeCodePoint = Nothing}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:13:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:15:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "J1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\12354'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList
+                    [227, 129, 130],
+                  unicodeCodePoint = Just
+                    '\12354'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:15:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:16:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "J2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText = "'\\u3042'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList
+                    [227, 129, 130],
+                  unicodeCodePoint = Just
+                    '\12354'}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:16:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:17:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "J3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MChar
+              CharLiteral {
+                charLiteralText =
+                "'\\xE3\\x81\\x82'",
+                charLiteralValue = CharValue {
+                  charValue =
+                  Prim.byteArrayFromList
+                    [227, 129, 130],
+                  unicodeCodePoint = Nothing}})},
+        macroDeclMacroTy = "CharLit",
+        macroDeclSourceLoc =
+        "macro_strings.h:17:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:20:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"a\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [97],
-                    unicodeCodePoint = Just 'a'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:4:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:5:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\"'",
-                  charLiteralValue = CharValue {
-                    charValue =
-                    Prim.byteArrayFromList [34],
                     unicodeCodePoint = Just
-                      `'"'`}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:5:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:6:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\t'",
-                  charLiteralValue = CharValue {
-                    charValue =
-                    Prim.byteArrayFromList [9],
-                    unicodeCodePoint = Just
-                      '\t'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:6:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:7:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C4",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\0'",
-                  charLiteralValue = CharValue {
-                    charValue =
-                    Prim.byteArrayFromList [0],
-                    unicodeCodePoint = Just
-                      '\NUL'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:7:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:8:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C5",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\''",
-                  charLiteralValue = CharValue {
+                      'a'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:20:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:21:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"'\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [39],
                     unicodeCodePoint = Just
-                      '\''}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:8:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:9:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C6",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\?'",
-                  charLiteralValue = CharValue {
+                      '\''}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:21:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:22:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\t\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [9],
+                    unicodeCodePoint = Just
+                      '\t'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:22:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:23:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S4",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\0\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [0],
+                    unicodeCodePoint = Just
+                      '\NUL'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:23:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:24:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S5",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\'\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [39],
+                    unicodeCodePoint = Just
+                      '\''}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:24:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:25:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S6",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\?\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [63],
-                    unicodeCodePoint = Just '?'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:9:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:10:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C7",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\123'",
-                  charLiteralValue = CharValue {
+                    unicodeCodePoint = Just
+                      '?'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:25:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:26:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S7",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\123\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [83],
-                    unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:10:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:11:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "C8",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\x53'",
-                  charLiteralValue = CharValue {
+                    unicodeCodePoint = Nothing}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:26:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:27:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "S8",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText = "\"\\x53\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [83],
-                    unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:11:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:13:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "D",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\777'",
-                  charLiteralValue = CharValue {
+                    unicodeCodePoint = Nothing}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:27:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:29:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "T1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"\12354\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList
+                      [227, 129, 130],
+                    unicodeCodePoint = Just
+                      '\12354'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:29:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:30:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "T2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"\\u3042\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList
+                      [227, 129, 130],
+                    unicodeCodePoint = Just
+                      '\12354'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:30:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:31:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "T3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"\\xE3\\x81\\x82\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [227],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [129],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [130],
+                    unicodeCodePoint = Nothing}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:31:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:33:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "U",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"\\777\\777\\777\\777\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
                     Prim.byteArrayFromList [1, 255],
-                    unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:13:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:15:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "J1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\12354'",
-                  charLiteralValue = CharValue {
+                    unicodeCodePoint = Nothing},
+                  CharValue {
                     charValue =
-                    Prim.byteArrayFromList
-                      [227, 129, 130],
+                    Prim.byteArrayFromList [1, 255],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [1, 255],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [1, 255],
+                    unicodeCodePoint = Nothing}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:33:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:34:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "V",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"\\1\\2\\3\\4\\5\\6\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [1],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [2],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [3],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [4],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [5],
+                    unicodeCodePoint = Nothing},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [6],
+                    unicodeCodePoint = Nothing}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:34:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:36:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "W1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"hij\\0\"",
+                stringLiteralValue = [
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [104],
+                    unicodeCodePoint = Just 'h'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [105],
+                    unicodeCodePoint = Just 'i'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [106],
+                    unicodeCodePoint = Just 'j'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [0],
                     unicodeCodePoint = Just
-                      '\12354'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:15:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:16:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "J2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText = "'\\u3042'",
-                  charLiteralValue = CharValue {
+                      '\NUL'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:36:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macro_strings.h:37:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "W2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MString
+              StringLiteral {
+                stringLiteralText =
+                "\"abc\\0def\\0g\"",
+                stringLiteralValue = [
+                  CharValue {
                     charValue =
-                    Prim.byteArrayFromList
-                      [227, 129, 130],
+                    Prim.byteArrayFromList [97],
+                    unicodeCodePoint = Just 'a'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [98],
+                    unicodeCodePoint = Just 'b'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [99],
+                    unicodeCodePoint = Just 'c'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [0],
+                    unicodeCodePoint = Just '\NUL'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [100],
+                    unicodeCodePoint = Just 'd'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [101],
+                    unicodeCodePoint = Just 'e'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [102],
+                    unicodeCodePoint = Just 'f'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [0],
+                    unicodeCodePoint = Just '\NUL'},
+                  CharValue {
+                    charValue =
+                    Prim.byteArrayFromList [103],
                     unicodeCodePoint = Just
-                      '\12354'}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:16:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:17:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "J3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MChar
-                CharLiteral {
-                  charLiteralText =
-                  "'\\xE3\\x81\\x82'",
-                  charLiteralValue = CharValue {
-                    charValue =
-                    Prim.byteArrayFromList
-                      [227, 129, 130],
-                    unicodeCodePoint = Nothing}})},
-          macroDeclMacroTy = "CharLit",
-          macroDeclSourceLoc =
-          "macro_strings.h:17:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:20:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"a\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [97],
-                      unicodeCodePoint = Just
-                        'a'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:20:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:21:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"'\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [39],
-                      unicodeCodePoint = Just
-                        '\''}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:21:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:22:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\t\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [9],
-                      unicodeCodePoint = Just
-                        '\t'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:22:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:23:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S4",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\0\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [0],
-                      unicodeCodePoint = Just
-                        '\NUL'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:23:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:24:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S5",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\'\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [39],
-                      unicodeCodePoint = Just
-                        '\''}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:24:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:25:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S6",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\?\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [63],
-                      unicodeCodePoint = Just
-                        '?'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:25:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:26:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S7",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\123\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [83],
-                      unicodeCodePoint = Nothing}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:26:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:27:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "S8",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText = "\"\\x53\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [83],
-                      unicodeCodePoint = Nothing}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:27:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:29:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "T1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"\12354\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList
-                        [227, 129, 130],
-                      unicodeCodePoint = Just
-                        '\12354'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:29:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:30:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "T2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"\\u3042\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList
-                        [227, 129, 130],
-                      unicodeCodePoint = Just
-                        '\12354'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:30:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:31:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "T3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"\\xE3\\x81\\x82\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [227],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [129],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [130],
-                      unicodeCodePoint = Nothing}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:31:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:33:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "U",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"\\777\\777\\777\\777\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [1, 255],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [1, 255],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [1, 255],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [1, 255],
-                      unicodeCodePoint = Nothing}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:33:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:34:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "V",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"\\1\\2\\3\\4\\5\\6\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [1],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [2],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [3],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [4],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [5],
-                      unicodeCodePoint = Nothing},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [6],
-                      unicodeCodePoint = Nothing}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:34:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:36:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "W1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"hij\\0\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [104],
-                      unicodeCodePoint = Just 'h'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [105],
-                      unicodeCodePoint = Just 'i'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [106],
-                      unicodeCodePoint = Just 'j'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [0],
-                      unicodeCodePoint = Just
-                        '\NUL'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:36:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macro_strings.h:37:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "W2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MString
-                StringLiteral {
-                  stringLiteralText =
-                  "\"abc\\0def\\0g\"",
-                  stringLiteralValue = [
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [97],
-                      unicodeCodePoint = Just 'a'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [98],
-                      unicodeCodePoint = Just 'b'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [99],
-                      unicodeCodePoint = Just 'c'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [0],
-                      unicodeCodePoint = Just '\NUL'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [100],
-                      unicodeCodePoint = Just 'd'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [101],
-                      unicodeCodePoint = Just 'e'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [102],
-                      unicodeCodePoint = Just 'f'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [0],
-                      unicodeCodePoint = Just '\NUL'},
-                    CharValue {
-                      charValue =
-                      Prim.byteArrayFromList [103],
-                      unicodeCodePoint = Just
-                        'g'}]})},
-          macroDeclMacroTy =
-          "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
-          macroDeclSourceLoc =
-          "macro_strings.h:37:9"}])
+                      'g'}]})},
+        macroDeclMacroTy =
+        "Tuple2 (Ptr (IntLike (CIntegralType (CharLike Char)))) (IntLike HsIntType)",
+        macroDeclSourceLoc =
+        "macro_strings.h:37:9"}]

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -1,942 +1,941 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:1:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "OBJECTLIKE1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "1",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 1})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:1:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:2:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "OBJECTLIKE2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "2",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 2})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:2:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:3:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "OBJECTLIKE3",
-            macroArgs = [],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "3",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 3}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "3",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 3})]},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:3:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:4:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "OBJECTLIKE4",
-            macroArgs = [],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "4",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 4}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "4",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 4})]},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:4:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:6:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "MEANING_OF_LIFE1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "42",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 42})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:6:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:7:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "MEANING_OF_LIFE2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "052",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 42})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:7:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:8:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "MEANING_OF_LIFE3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0x2a",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 42})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:8:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:9:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "MEANING_OF_LIFE4",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0X2A",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 42})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:9:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:10:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "MEANING_OF_LIFE5",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "0b101010",
-                  integerLiteralType = Just
-                    (_×_ PrimInt Signed),
-                  integerLiteralValue = 42})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Int Signed)))",
-          macroDeclSourceLoc =
-          "macros.h:10:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:12:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "LONG_INT_TOKEN1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText =
-                  "18446744073709550592ull",
-                  integerLiteralType = Just
-                    (_×_ PrimLongLong Unsigned),
-                  integerLiteralValue =
-                  18446744073709550592})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
-          macroDeclSourceLoc =
-          "macros.h:12:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:13:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "LONG_INT_TOKEN2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText =
-                  "18'446'744'073'709'550'592llu",
-                  integerLiteralType = Just
-                    (_×_ PrimLongLong Unsigned),
-                  integerLiteralValue =
-                  18446744073709550592})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
-          macroDeclSourceLoc =
-          "macros.h:13:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:14:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "LONG_INT_TOKEN3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText =
-                  "1844'6744'0737'0955'0592uLL",
-                  integerLiteralType = Just
-                    (_×_ PrimLongLong Unsigned),
-                  integerLiteralValue =
-                  18446744073709550592})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
-          macroDeclSourceLoc =
-          "macros.h:14:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:15:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName
-              "LONG_INT_TOKEN4",
-            macroArgs = [],
-            macroBody = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText =
-                  "184467'440737'0'95505'92LLU",
-                  integerLiteralType = Just
-                    (_×_ PrimLongLong Unsigned),
-                  integerLiteralValue =
-                  18446744073709550592})},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
-          macroDeclSourceLoc =
-          "macros.h:15:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:17:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "TUPLE1",
-            macroArgs = [],
-            macroBody = MApp
-              MTuple
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "1",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 1}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "2",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 2})]},
-          macroDeclMacroTy =
-          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
-          macroDeclSourceLoc =
-          "macros.h:17:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:18:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "TUPLE2",
-            macroArgs = [],
-            macroBody = MApp
-              MTuple
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "3",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 3}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "4",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 4})]},
-          macroDeclMacroTy =
-          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
-          macroDeclSourceLoc =
-          "macros.h:18:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:19:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "TUPLE3",
-            macroArgs = [],
-            macroBody = MApp
-              MTuple
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "5",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 5}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "6",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 6})]},
-          macroDeclMacroTy =
-          "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
-          macroDeclSourceLoc =
-          "macros.h:19:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:24:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT1_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "11e4",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  110000.0,
-                  floatingLiteralDoubleValue =
-                  110000.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:24:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:25:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT1_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "12E-3",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  1.2e-2,
-                  floatingLiteralDoubleValue =
-                  1.2e-2})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:25:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:26:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT1_3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "13e-03f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  1.3e-2,
-                  floatingLiteralDoubleValue =
-                  1.3e-2})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:26:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:28:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT2_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "21.",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  21.0,
-                  floatingLiteralDoubleValue =
-                  21.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:28:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:29:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT2_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "22.e2",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  2200.0,
-                  floatingLiteralDoubleValue =
-                  2200.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:29:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:30:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT2_3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "23.f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  23.0,
-                  floatingLiteralDoubleValue =
-                  23.0})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:30:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:32:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT3_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "31.0",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  31.0,
-                  floatingLiteralDoubleValue =
-                  31.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:32:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:33:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT3_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = ".32",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  0.32,
-                  floatingLiteralDoubleValue =
-                  0.32})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:33:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:34:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT3_3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = ".33e2",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  33.0,
-                  floatingLiteralDoubleValue =
-                  33.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:34:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:35:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT3_4",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = ".34e-2f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  3.4e-3,
-                  floatingLiteralDoubleValue =
-                  3.4e-3})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:35:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:37:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT4_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "0x41p4",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  650000.0,
-                  floatingLiteralDoubleValue =
-                  650000.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:37:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:38:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT4_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "0x42P-3",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  6.6e-2,
-                  floatingLiteralDoubleValue =
-                  6.6e-2})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:38:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:39:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT4_3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText =
-                  "0x43p-03f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  6.7e-2,
-                  floatingLiteralDoubleValue =
-                  6.7e-2})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:39:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:41:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT5_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "0x51.p0",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  81.0,
-                  floatingLiteralDoubleValue =
-                  81.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:41:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:42:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT5_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText =
-                  "0x52.P0f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  82.0,
-                  floatingLiteralDoubleValue =
-                  82.0})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:42:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:44:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT6_1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText =
-                  "0x61.0P2",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  15520.0,
-                  floatingLiteralDoubleValue =
-                  15520.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:44:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:45:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT6_2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText = "0x.62p2",
-                  floatingLiteralType = Just
-                    PrimDouble,
-                  floatingLiteralFloatValue =
-                  98.0,
-                  floatingLiteralDoubleValue =
-                  98.0})},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:45:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:46:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "FLT6_3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MFloat
-                FloatingLiteral {
-                  floatingLiteralText =
-                  "0x.63p-2f",
-                  floatingLiteralType = Just
-                    PrimFloat,
-                  floatingLiteralFloatValue =
-                  9.9e-3,
-                  floatingLiteralDoubleValue =
-                  9.9e-3})},
-          macroDeclMacroTy =
-          "FloatLike FloatType",
-          macroDeclSourceLoc =
-          "macros.h:46:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:49:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "BAD1",
-            macroArgs = [],
-            macroBody = MApp
-              MAdd
-              [
-                MTerm
-                  (MFloat
-                    FloatingLiteral {
-                      floatingLiteralText = "0.1",
-                      floatingLiteralType = Just
-                        PrimDouble,
-                      floatingLiteralFloatValue = 0.1,
-                      floatingLiteralDoubleValue =
-                      0.1}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "1",
-                      integerLiteralType = Just
-                        (_×_ PrimInt Signed),
-                      integerLiteralValue = 1})]},
-          macroDeclMacroTy =
-          "FloatLike DoubleType",
-          macroDeclSourceLoc =
-          "macros.h:49:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "macros.h:50:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "BAD2",
-            macroArgs = [],
-            macroBody = MApp
-              MMult
-              [
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "2l",
-                      integerLiteralType = Just
-                        (_×_ PrimLong Signed),
-                      integerLiteralValue = 2}),
-                MTerm
-                  (MInt
-                    IntegerLiteral {
-                      integerLiteralText = "2ul",
-                      integerLiteralType = Just
-                        (_×_ PrimLong Unsigned),
-                      integerLiteralValue = 2})]},
-          macroDeclMacroTy =
-          "IntLike (CIntegralType (IntLike (Long Unsigned)))",
-          macroDeclSourceLoc =
-          "macros.h:50:9"}])
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:1:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "OBJECTLIKE1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "1",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 1})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:1:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:2:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "OBJECTLIKE2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "2",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 2})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:2:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:3:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "OBJECTLIKE3",
+          macroArgs = [],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "3",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 3}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "3",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 3})]},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:3:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:4:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "OBJECTLIKE4",
+          macroArgs = [],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "4",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 4}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "4",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 4})]},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:4:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:6:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "MEANING_OF_LIFE1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "42",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 42})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:6:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:7:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "MEANING_OF_LIFE2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "052",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 42})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:7:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:8:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "MEANING_OF_LIFE3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "0x2a",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 42})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:8:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:9:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "MEANING_OF_LIFE4",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "0X2A",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 42})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:9:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:10:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "MEANING_OF_LIFE5",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText = "0b101010",
+                integerLiteralType = Just
+                  (_×_ PrimInt Signed),
+                integerLiteralValue = 42})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Int Signed)))",
+        macroDeclSourceLoc =
+        "macros.h:10:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:12:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "LONG_INT_TOKEN1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText =
+                "18446744073709550592ull",
+                integerLiteralType = Just
+                  (_×_ PrimLongLong Unsigned),
+                integerLiteralValue =
+                18446744073709550592})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
+        macroDeclSourceLoc =
+        "macros.h:12:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:13:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "LONG_INT_TOKEN2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText =
+                "18'446'744'073'709'550'592llu",
+                integerLiteralType = Just
+                  (_×_ PrimLongLong Unsigned),
+                integerLiteralValue =
+                18446744073709550592})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
+        macroDeclSourceLoc =
+        "macros.h:13:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:14:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "LONG_INT_TOKEN3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText =
+                "1844'6744'0737'0955'0592uLL",
+                integerLiteralType = Just
+                  (_×_ PrimLongLong Unsigned),
+                integerLiteralValue =
+                18446744073709550592})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
+        macroDeclSourceLoc =
+        "macros.h:14:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:15:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName
+            "LONG_INT_TOKEN4",
+          macroArgs = [],
+          macroBody = MTerm
+            (MInt
+              IntegerLiteral {
+                integerLiteralText =
+                "184467'440737'0'95505'92LLU",
+                integerLiteralType = Just
+                  (_×_ PrimLongLong Unsigned),
+                integerLiteralValue =
+                18446744073709550592})},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (LongLong Unsigned)))",
+        macroDeclSourceLoc =
+        "macros.h:15:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:17:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "TUPLE1",
+          macroArgs = [],
+          macroBody = MApp
+            MTuple
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "1",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 1}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "2",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 2})]},
+        macroDeclMacroTy =
+        "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+        macroDeclSourceLoc =
+        "macros.h:17:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:18:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "TUPLE2",
+          macroArgs = [],
+          macroBody = MApp
+            MTuple
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "3",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 3}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "4",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 4})]},
+        macroDeclMacroTy =
+        "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+        macroDeclSourceLoc =
+        "macros.h:18:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:19:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "TUPLE3",
+          macroArgs = [],
+          macroBody = MApp
+            MTuple
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "5",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 5}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "6",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 6})]},
+        macroDeclMacroTy =
+        "Tuple2 (IntLike (CIntegralType (IntLike (Int Signed)))) (IntLike (CIntegralType (IntLike (Int Signed))))",
+        macroDeclSourceLoc =
+        "macros.h:19:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:24:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT1_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "11e4",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                110000.0,
+                floatingLiteralDoubleValue =
+                110000.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:24:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:25:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT1_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "12E-3",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                1.2e-2,
+                floatingLiteralDoubleValue =
+                1.2e-2})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:25:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:26:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT1_3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "13e-03f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                1.3e-2,
+                floatingLiteralDoubleValue =
+                1.3e-2})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:26:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:28:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT2_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "21.",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                21.0,
+                floatingLiteralDoubleValue =
+                21.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:28:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:29:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT2_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "22.e2",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                2200.0,
+                floatingLiteralDoubleValue =
+                2200.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:29:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:30:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT2_3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "23.f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                23.0,
+                floatingLiteralDoubleValue =
+                23.0})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:30:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:32:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT3_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "31.0",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                31.0,
+                floatingLiteralDoubleValue =
+                31.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:32:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:33:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT3_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = ".32",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                0.32,
+                floatingLiteralDoubleValue =
+                0.32})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:33:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:34:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT3_3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = ".33e2",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                33.0,
+                floatingLiteralDoubleValue =
+                33.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:34:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:35:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT3_4",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = ".34e-2f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                3.4e-3,
+                floatingLiteralDoubleValue =
+                3.4e-3})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:35:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:37:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT4_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "0x41p4",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                650000.0,
+                floatingLiteralDoubleValue =
+                650000.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:37:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:38:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT4_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "0x42P-3",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                6.6e-2,
+                floatingLiteralDoubleValue =
+                6.6e-2})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:38:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:39:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT4_3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText =
+                "0x43p-03f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                6.7e-2,
+                floatingLiteralDoubleValue =
+                6.7e-2})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:39:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:41:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT5_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "0x51.p0",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                81.0,
+                floatingLiteralDoubleValue =
+                81.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:41:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:42:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT5_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText =
+                "0x52.P0f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                82.0,
+                floatingLiteralDoubleValue =
+                82.0})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:42:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:44:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT6_1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText =
+                "0x61.0P2",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                15520.0,
+                floatingLiteralDoubleValue =
+                15520.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:44:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:45:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT6_2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText = "0x.62p2",
+                floatingLiteralType = Just
+                  PrimDouble,
+                floatingLiteralFloatValue =
+                98.0,
+                floatingLiteralDoubleValue =
+                98.0})},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:45:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:46:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "FLT6_3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MFloat
+              FloatingLiteral {
+                floatingLiteralText =
+                "0x.63p-2f",
+                floatingLiteralType = Just
+                  PrimFloat,
+                floatingLiteralFloatValue =
+                9.9e-3,
+                floatingLiteralDoubleValue =
+                9.9e-3})},
+        macroDeclMacroTy =
+        "FloatLike FloatType",
+        macroDeclSourceLoc =
+        "macros.h:46:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:49:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "BAD1",
+          macroArgs = [],
+          macroBody = MApp
+            MAdd
+            [
+              MTerm
+                (MFloat
+                  FloatingLiteral {
+                    floatingLiteralText = "0.1",
+                    floatingLiteralType = Just
+                      PrimDouble,
+                    floatingLiteralFloatValue = 0.1,
+                    floatingLiteralDoubleValue =
+                    0.1}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "1",
+                    integerLiteralType = Just
+                      (_×_ PrimInt Signed),
+                    integerLiteralValue = 1})]},
+        macroDeclMacroTy =
+        "FloatLike DoubleType",
+        macroDeclSourceLoc =
+        "macros.h:49:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "macros.h:50:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "BAD2",
+          macroArgs = [],
+          macroBody = MApp
+            MMult
+            [
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "2l",
+                    integerLiteralType = Just
+                      (_×_ PrimLong Signed),
+                    integerLiteralValue = 2}),
+              MTerm
+                (MInt
+                  IntegerLiteral {
+                    integerLiteralText = "2ul",
+                    integerLiteralType = Just
+                      (_×_ PrimLong Unsigned),
+                    integerLiteralValue = 2})]},
+        macroDeclMacroTy =
+        "IntLike (CIntegralType (IntLike (Long Unsigned)))",
+        macroDeclSourceLoc =
+        "macros.h:50:9"}]

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -1,150 +1,149 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "i",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "nested_types.h:2:9"},
-            StructField {
-              fieldName = CName "c",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "nested_types.h:3:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "nested_types.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bar"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "foo1",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
-              fieldSourceLoc =
-              "nested_types.h:7:16"},
-            StructField {
-              fieldName = CName "foo2",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypeStruct
-                (DeclPathStruct
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
-              fieldSourceLoc =
-              "nested_types.h:8:16"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "nested_types.h:6:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex3"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "ex3_c",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimFloat),
-              fieldSourceLoc =
-              "nested_types.h:16:11"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "nested_types.h:11:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4_even"))
-            (DeclPathPtr
-              (DeclPathField
-                (CName "next")
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "i",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "nested_types.h:2:9"},
+          StructField {
+            fieldName = CName "c",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "nested_types.h:3:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "nested_types.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bar"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "foo1",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
+              (DeclPathStruct
+                (DeclNameTag (CName "foo"))
+                DeclPathTop),
+            fieldSourceLoc =
+            "nested_types.h:7:16"},
+          StructField {
+            fieldName = CName "foo2",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypeStruct
+              (DeclPathStruct
+                (DeclNameTag (CName "foo"))
+                DeclPathTop),
+            fieldSourceLoc =
+            "nested_types.h:8:16"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "nested_types.h:6:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "ex3"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "ex3_c",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimFloat),
+            fieldSourceLoc =
+            "nested_types.h:16:11"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "nested_types.h:11:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "ex4_even"))
+          (DeclPathPtr
+            (DeclPathField
+              (CName "next")
+              (DeclPathStruct
+                (DeclNameTag (CName "ex4_odd"))
+                DeclPathTop))),
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "value",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "nested_types.h:25:16"},
+          StructField {
+            fieldName = CName "next",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
                 (DeclPathStruct
                   (DeclNameTag (CName "ex4_odd"))
-                  DeclPathTop))),
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "value",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimDouble),
-              fieldSourceLoc =
-              "nested_types.h:25:16"},
-            StructField {
-              fieldName = CName "next",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "ex4_odd"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "nested_types.h:26:25"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "nested_types.h:24:12"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "ex4_odd"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "value",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "nested_types.h:23:9"},
-            StructField {
-              fieldName = CName "next",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "ex4_even"))
-                    (DeclPathPtr
-                      (DeclPathField
-                        (CName "next")
-                        (DeclPathStruct
-                          (DeclNameTag (CName "ex4_odd"))
-                          DeclPathTop))))),
-              fieldSourceLoc =
-              "nested_types.h:27:8"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "nested_types.h:22:8"}])
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "nested_types.h:26:25"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "nested_types.h:24:12"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "ex4_odd"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "value",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "nested_types.h:23:9"},
+          StructField {
+            fieldName = CName "next",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag (CName "ex4_even"))
+                  (DeclPathPtr
+                    (DeclPathField
+                      (CName "next")
+                      (DeclPathStruct
+                        (DeclNameTag (CName "ex4_odd"))
+                        DeclPathTop))))),
+            fieldSourceLoc =
+            "nested_types.h:27:8"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "nested_types.h:22:8"}]

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -1,63 +1,62 @@
-WrapCHeader
-  (Header
-    [
-      DeclOpaqueStruct
-        OpaqueStruct {
-          opaqueStructTag = CName "foo",
-          opaqueStructSourceLoc =
-          "opaque_declaration.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bar"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "ptrA",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "opaque_declaration.h:5:17"},
-            StructField {
-              fieldName = CName "ptrB",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "bar"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "opaque_declaration.h:6:17"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "opaque_declaration.h:4:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "baz"))
-            DeclPathTop,
-          structSizeof = 0,
-          structAlignment = 1,
-          structFields = [],
-          structFlam = Nothing,
-          structSourceLoc =
-          "opaque_declaration.h:9:8"},
-      DeclOpaqueEnum
-        OpaqueEnum {
-          opaqueEnumTag = CName "quu",
-          opaqueEnumSourceLoc =
-          "opaque_declaration.h:11:6"},
-      DeclOpaqueStruct
-        OpaqueStruct {
-          opaqueStructTag = CName
-            "opaque_union",
-          opaqueStructSourceLoc =
-          "opaque_declaration.h:13:7"}])
+Header
+  [
+    DeclOpaqueStruct
+      OpaqueStruct {
+        opaqueStructTag = CName "foo",
+        opaqueStructSourceLoc =
+        "opaque_declaration.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bar"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "ptrA",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag (CName "foo"))
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "opaque_declaration.h:5:17"},
+          StructField {
+            fieldName = CName "ptrB",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag (CName "bar"))
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "opaque_declaration.h:6:17"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "opaque_declaration.h:4:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "baz"))
+          DeclPathTop,
+        structSizeof = 0,
+        structAlignment = 1,
+        structFields = [],
+        structFlam = Nothing,
+        structSourceLoc =
+        "opaque_declaration.h:9:8"},
+    DeclOpaqueEnum
+      OpaqueEnum {
+        opaqueEnumTag = CName "quu",
+        opaqueEnumSourceLoc =
+        "opaque_declaration.h:11:6"},
+    DeclOpaqueStruct
+      OpaqueStruct {
+        opaqueStructTag = CName
+          "opaque_union",
+        opaqueStructSourceLoc =
+        "opaque_declaration.h:13:7"}]

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -1,267 +1,266 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "primitive"))
-            DeclPathTop,
-          structSizeof = 176,
-          structAlignment = 16,
-          structFields = [
-            StructField {
-              fieldName = CName "c",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "primitive_types.h:2:10"},
-            StructField {
-              fieldName = CName "sc",
-              fieldOffset = 8,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar (Just Signed)),
-              fieldSourceLoc =
-              "primitive_types.h:3:17"},
-            StructField {
-              fieldName = CName "uc",
-              fieldOffset = 16,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
-              fieldSourceLoc =
-              "primitive_types.h:4:19"},
-            StructField {
-              fieldName = CName "s",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimShort Signed),
-              fieldSourceLoc =
-              "primitive_types.h:6:11"},
-            StructField {
-              fieldName = CName "si",
-              fieldOffset = 48,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimShort Signed),
-              fieldSourceLoc =
-              "primitive_types.h:7:15"},
-            StructField {
-              fieldName = CName "ss",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimShort Signed),
-              fieldSourceLoc =
-              "primitive_types.h:8:18"},
-            StructField {
-              fieldName = CName "ssi",
-              fieldOffset = 80,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimShort Signed),
-              fieldSourceLoc =
-              "primitive_types.h:9:22"},
-            StructField {
-              fieldName = CName "us",
-              fieldOffset = 96,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimShort
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:11:20"},
-            StructField {
-              fieldName = CName "usi",
-              fieldOffset = 112,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimShort
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:12:24"},
-            StructField {
-              fieldName = CName "i",
-              fieldOffset = 128,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "primitive_types.h:14:9"},
-            StructField {
-              fieldName = CName "s2",
-              fieldOffset = 160,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "primitive_types.h:15:12"},
-            StructField {
-              fieldName = CName "si2",
-              fieldOffset = 192,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "primitive_types.h:16:16"},
-            StructField {
-              fieldName = CName "u",
-              fieldOffset = 224,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:18:14"},
-            StructField {
-              fieldName = CName "ui",
-              fieldOffset = 256,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:19:18"},
-            StructField {
-              fieldName = CName "l",
-              fieldOffset = 320,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "primitive_types.h:21:10"},
-            StructField {
-              fieldName = CName "li",
-              fieldOffset = 384,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "primitive_types.h:22:14"},
-            StructField {
-              fieldName = CName "sl",
-              fieldOffset = 448,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "primitive_types.h:23:17"},
-            StructField {
-              fieldName = CName "sli",
-              fieldOffset = 512,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimLong Signed),
-              fieldSourceLoc =
-              "primitive_types.h:24:21"},
-            StructField {
-              fieldName = CName "ul",
-              fieldOffset = 576,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLong
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:26:19"},
-            StructField {
-              fieldName = CName "uli",
-              fieldOffset = 640,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLong
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:27:23"},
-            StructField {
-              fieldName = CName "ll",
-              fieldOffset = 704,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Signed),
-              fieldSourceLoc =
-              "primitive_types.h:29:15"},
-            StructField {
-              fieldName = CName "lli",
-              fieldOffset = 768,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Signed),
-              fieldSourceLoc =
-              "primitive_types.h:30:19"},
-            StructField {
-              fieldName = CName "sll",
-              fieldOffset = 832,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Signed),
-              fieldSourceLoc =
-              "primitive_types.h:31:22"},
-            StructField {
-              fieldName = CName "slli",
-              fieldOffset = 896,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Signed),
-              fieldSourceLoc =
-              "primitive_types.h:32:26"},
-            StructField {
-              fieldName = CName "ull",
-              fieldOffset = 960,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:34:24"},
-            StructField {
-              fieldName = CName "ulli",
-              fieldOffset = 1024,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral
-                  PrimLongLong
-                  Unsigned),
-              fieldSourceLoc =
-              "primitive_types.h:35:28"},
-            StructField {
-              fieldName = CName "f",
-              fieldOffset = 1088,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimFloat),
-              fieldSourceLoc =
-              "primitive_types.h:37:11"},
-            StructField {
-              fieldName = CName "d",
-              fieldOffset = 1152,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimDouble),
-              fieldSourceLoc =
-              "primitive_types.h:38:12"},
-            StructField {
-              fieldName = CName "ld",
-              fieldOffset = 1280,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimLongDouble),
-              fieldSourceLoc =
-              "primitive_types.h:39:17"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "primitive_types.h:1:8"}])
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "primitive"))
+          DeclPathTop,
+        structSizeof = 176,
+        structAlignment = 16,
+        structFields = [
+          StructField {
+            fieldName = CName "c",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "primitive_types.h:2:10"},
+          StructField {
+            fieldName = CName "sc",
+            fieldOffset = 8,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar (Just Signed)),
+            fieldSourceLoc =
+            "primitive_types.h:3:17"},
+          StructField {
+            fieldName = CName "uc",
+            fieldOffset = 16,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar (Just Unsigned)),
+            fieldSourceLoc =
+            "primitive_types.h:4:19"},
+          StructField {
+            fieldName = CName "s",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimShort Signed),
+            fieldSourceLoc =
+            "primitive_types.h:6:11"},
+          StructField {
+            fieldName = CName "si",
+            fieldOffset = 48,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimShort Signed),
+            fieldSourceLoc =
+            "primitive_types.h:7:15"},
+          StructField {
+            fieldName = CName "ss",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimShort Signed),
+            fieldSourceLoc =
+            "primitive_types.h:8:18"},
+          StructField {
+            fieldName = CName "ssi",
+            fieldOffset = 80,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimShort Signed),
+            fieldSourceLoc =
+            "primitive_types.h:9:22"},
+          StructField {
+            fieldName = CName "us",
+            fieldOffset = 96,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimShort
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:11:20"},
+          StructField {
+            fieldName = CName "usi",
+            fieldOffset = 112,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimShort
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:12:24"},
+          StructField {
+            fieldName = CName "i",
+            fieldOffset = 128,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "primitive_types.h:14:9"},
+          StructField {
+            fieldName = CName "s2",
+            fieldOffset = 160,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "primitive_types.h:15:12"},
+          StructField {
+            fieldName = CName "si2",
+            fieldOffset = 192,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "primitive_types.h:16:16"},
+          StructField {
+            fieldName = CName "u",
+            fieldOffset = 224,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:18:14"},
+          StructField {
+            fieldName = CName "ui",
+            fieldOffset = 256,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:19:18"},
+          StructField {
+            fieldName = CName "l",
+            fieldOffset = 320,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "primitive_types.h:21:10"},
+          StructField {
+            fieldName = CName "li",
+            fieldOffset = 384,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "primitive_types.h:22:14"},
+          StructField {
+            fieldName = CName "sl",
+            fieldOffset = 448,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "primitive_types.h:23:17"},
+          StructField {
+            fieldName = CName "sli",
+            fieldOffset = 512,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimLong Signed),
+            fieldSourceLoc =
+            "primitive_types.h:24:21"},
+          StructField {
+            fieldName = CName "ul",
+            fieldOffset = 576,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLong
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:26:19"},
+          StructField {
+            fieldName = CName "uli",
+            fieldOffset = 640,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLong
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:27:23"},
+          StructField {
+            fieldName = CName "ll",
+            fieldOffset = 704,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Signed),
+            fieldSourceLoc =
+            "primitive_types.h:29:15"},
+          StructField {
+            fieldName = CName "lli",
+            fieldOffset = 768,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Signed),
+            fieldSourceLoc =
+            "primitive_types.h:30:19"},
+          StructField {
+            fieldName = CName "sll",
+            fieldOffset = 832,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Signed),
+            fieldSourceLoc =
+            "primitive_types.h:31:22"},
+          StructField {
+            fieldName = CName "slli",
+            fieldOffset = 896,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Signed),
+            fieldSourceLoc =
+            "primitive_types.h:32:26"},
+          StructField {
+            fieldName = CName "ull",
+            fieldOffset = 960,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:34:24"},
+          StructField {
+            fieldName = CName "ulli",
+            fieldOffset = 1024,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral
+                PrimLongLong
+                Unsigned),
+            fieldSourceLoc =
+            "primitive_types.h:35:28"},
+          StructField {
+            fieldName = CName "f",
+            fieldOffset = 1088,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimFloat),
+            fieldSourceLoc =
+            "primitive_types.h:37:11"},
+          StructField {
+            fieldName = CName "d",
+            fieldOffset = 1152,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "primitive_types.h:38:12"},
+          StructField {
+            fieldName = CName "ld",
+            fieldOffset = 1280,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimLongDouble),
+            fieldSourceLoc =
+            "primitive_types.h:39:17"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "primitive_types.h:1:8"}]

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -1,78 +1,77 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "linked_list_A_s"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "recursive_struct.h:2:7"},
+          StructField {
+            fieldName = CName "next",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag
+                    (CName "linked_list_A_s"))
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "recursive_struct.h:3:27"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "recursive_struct.h:1:16"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "linked_list_A_t",
+        typedefType = TypeStruct
+          (DeclPathStruct
             (DeclNameTag
               (CName "linked_list_A_s"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "recursive_struct.h:2:7"},
-            StructField {
-              fieldName = CName "next",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag
-                      (CName "linked_list_A_s"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "recursive_struct.h:3:27"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "recursive_struct.h:1:16"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName
-            "linked_list_A_t",
-          typedefType = TypeStruct
-            (DeclPathStruct
-              (DeclNameTag
-                (CName "linked_list_A_s"))
-              DeclPathTop),
-          typedefSourceLoc =
-          "recursive_struct.h:4:3"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "linked_list_B_t"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "recursive_struct.h:10:7"},
-            StructField {
-              fieldName = CName "next",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag
-                      (CName "linked_list_B_t"))
-                    DeclPathTop)),
-              fieldSourceLoc =
-              "recursive_struct.h:11:20"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "recursive_struct.h:9:8"}])
+            DeclPathTop),
+        typedefSourceLoc =
+        "recursive_struct.h:4:3"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "linked_list_B_t"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "recursive_struct.h:10:7"},
+          StructField {
+            fieldName = CName "next",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag
+                    (CName "linked_list_B_t"))
+                  DeclPathTop)),
+            fieldSourceLoc =
+            "recursive_struct.h:11:20"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "recursive_struct.h:9:8"}]

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -1,43 +1,42 @@
-WrapCHeader
-  (Header
-    [
-      DeclFunction
-        Function {
-          functionName = CName "erf",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimFloating PrimDouble)]
-            (TypePrim
-              (PrimFloating PrimDouble)),
-          functionHeader =
-          "simple_func.h",
-          functionSourceLoc =
-          "simple_func.h:1:8"},
-      DeclFunction
-        Function {
-          functionName = CName "bad_fma",
-          functionType = TypeFun
-            [
-              TypePrim
-                (PrimFloating PrimDouble),
-              TypePrim
-                (PrimFloating PrimDouble),
-              TypePrim
-                (PrimFloating PrimDouble)]
-            (TypePrim
-              (PrimFloating PrimDouble)),
-          functionHeader =
-          "simple_func.h",
-          functionSourceLoc =
-          "simple_func.h:3:22"},
-      DeclFunction
-        Function {
-          functionName = CName "no_args",
-          functionType = TypeFun
-            []
-            TypeVoid,
-          functionHeader =
-          "simple_func.h",
-          functionSourceLoc =
-          "simple_func.h:7:6"}])
+Header
+  [
+    DeclFunction
+      Function {
+        functionName = CName "erf",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimFloating PrimDouble)]
+          (TypePrim
+            (PrimFloating PrimDouble)),
+        functionHeader =
+        "simple_func.h",
+        functionSourceLoc =
+        "simple_func.h:1:8"},
+    DeclFunction
+      Function {
+        functionName = CName "bad_fma",
+        functionType = TypeFun
+          [
+            TypePrim
+              (PrimFloating PrimDouble),
+            TypePrim
+              (PrimFloating PrimDouble),
+            TypePrim
+              (PrimFloating PrimDouble)]
+          (TypePrim
+            (PrimFloating PrimDouble)),
+        functionHeader =
+        "simple_func.h",
+        functionSourceLoc =
+        "simple_func.h:3:22"},
+    DeclFunction
+      Function {
+        functionName = CName "no_args",
+        functionType = TypeFun
+          []
+          TypeVoid,
+        functionHeader =
+        "simple_func.h",
+        functionSourceLoc =
+        "simple_func.h:7:6"}]

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -1,275 +1,274 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S1"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:3:9"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:4:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:2:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S1"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:3:9"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:4:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:2:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S2"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:9:10"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:10:9"},
+          StructField {
+            fieldName = CName "c",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimFloat),
+            fieldSourceLoc =
+            "simple_structs.h:11:11"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:8:16"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "S2_t",
+        typedefType = TypeStruct
+          (DeclPathStruct
             (DeclNameTag (CName "S2"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:9:10"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:10:9"},
-            StructField {
-              fieldName = CName "c",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimFloating PrimFloat),
-              fieldSourceLoc =
-              "simple_structs.h:11:11"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:8:16"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "S2_t",
-          typedefType = TypeStruct
+            DeclPathTop),
+        typedefSourceLoc =
+        "simple_structs.h:12:3"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTypedef (CName "S3_t"))
+          DeclPathTop,
+        structSizeof = 1,
+        structAlignment = 1,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:16:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:15:9"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S4"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:20:10"},
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:21:9"},
+          StructField {
+            fieldName = CName "c",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypePrim
+                (PrimIntegral PrimInt Signed)),
+            fieldSourceLoc =
+            "simple_structs.h:22:10"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:19:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S5"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:27:10"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:28:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:26:16"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "S6"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:31:18"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:31:25"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:31:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathPtr
             (DeclPathStruct
-              (DeclNameTag (CName "S2"))
-              DeclPathTop),
-          typedefSourceLoc =
-          "simple_structs.h:12:3"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTypedef (CName "S3_t"))
-            DeclPathTop,
-          structSizeof = 1,
-          structAlignment = 1,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:16:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:15:9"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S4"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:20:10"},
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:21:9"},
-            StructField {
-              fieldName = CName "c",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypePrim
-                  (PrimIntegral PrimInt Signed)),
-              fieldSourceLoc =
-              "simple_structs.h:22:10"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:19:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S5"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:27:10"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:28:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:26:16"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "S6"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:31:18"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:31:25"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:31:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
-            (DeclPathPtr
-              (DeclPathStruct
-                (DeclNameTypedef (CName "S7a"))
-                DeclPathTop)),
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:34:23"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:34:30"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:34:9"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "S7a",
-          typedefType = TypePointer
-            (TypeStruct
-              (DeclPathStruct
-                DeclNameNone
-                (DeclPathPtr
-                  (DeclPathStruct
-                    (DeclNameTypedef (CName "S7a"))
-                    DeclPathTop)))),
-          typedefSourceLoc =
-          "simple_structs.h:34:36"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            DeclNameNone
+              (DeclNameTypedef (CName "S7a"))
+              DeclPathTop)),
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:34:23"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:34:30"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:34:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "S7a",
+        typedefType = TypePointer
+          (TypeStruct
+            (DeclPathStruct
+              DeclNameNone
+              (DeclPathPtr
+                (DeclPathStruct
+                  (DeclNameTypedef (CName "S7a"))
+                  DeclPathTop)))),
+        typedefSourceLoc =
+        "simple_structs.h:34:36"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          DeclNameNone
+          (DeclPathPtr
             (DeclPathPtr
               (DeclPathPtr
-                (DeclPathPtr
-                  (DeclPathStruct
-                    (DeclNameTypedef (CName "S7b"))
-                    DeclPathTop)))),
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimChar Nothing),
-              fieldSourceLoc =
-              "simple_structs.h:35:23"},
-            StructField {
-              fieldName = CName "b",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "simple_structs.h:35:30"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "simple_structs.h:35:9"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "S7b",
-          typedefType = TypePointer
+                (DeclPathStruct
+                  (DeclNameTypedef (CName "S7b"))
+                  DeclPathTop)))),
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimChar Nothing),
+            fieldSourceLoc =
+            "simple_structs.h:35:23"},
+          StructField {
+            fieldName = CName "b",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "simple_structs.h:35:30"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "simple_structs.h:35:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "S7b",
+        typedefType = TypePointer
+          (TypePointer
             (TypePointer
-              (TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    DeclNameNone
+              (TypeStruct
+                (DeclPathStruct
+                  DeclNameNone
+                  (DeclPathPtr
                     (DeclPathPtr
                       (DeclPathPtr
-                        (DeclPathPtr
-                          (DeclPathStruct
-                            (DeclNameTypedef (CName "S7b"))
-                            DeclPathTop)))))))),
-          typedefSourceLoc =
-          "simple_structs.h:35:38"}])
+                        (DeclPathStruct
+                          (DeclNameTypedef (CName "S7b"))
+                          DeclPathTop)))))))),
+        typedefSourceLoc =
+        "simple_structs.h:35:38"}]

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -1,226 +1,225 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "typedef_vs_macro.h:4:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "M1",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "typedef_vs_macro.h:4:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "M1",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "typedef_vs_macro.h:4:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "typedef_vs_macro.h:5:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "M2",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim (PrimChar Nothing)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "typedef_vs_macro.h:5:9"},
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "typedef_vs_macro.h:6:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "M3",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypeConstArray
+                3
                 (TypePrim
                   (PrimIntegral
                     PrimInt
-                    Signed)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "typedef_vs_macro.h:4:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "typedef_vs_macro.h:5:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "M2",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim (PrimChar Nothing)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "typedef_vs_macro.h:5:9"},
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "typedef_vs_macro.h:6:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "M3",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypeConstArray
-                  3
-                  (TypePrim
-                    (PrimIntegral
-                      PrimInt
-                      Signed))))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "typedef_vs_macro.h:6:9"},
-      DeclMacro
-        (MacroReparseError
-          ReparseError {
-            reparseError = concat
-              [
-                "\"typedef_vs_macro.h\" (line 7, column 15):\n",
-                "unexpected end of input\n",
-                "expecting simple expression"],
-            reparseErrorTokens = [
-              Token {
-                tokenKind = SimpleEnum 2,
-                tokenSpelling = TokenSpelling
-                  "M4",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:9",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:11",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 1,
-                tokenSpelling = TokenSpelling
-                  "int",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:12",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:15",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501},
-              Token {
-                tokenKind = SimpleEnum 0,
-                tokenSpelling = TokenSpelling
-                  "*",
-                tokenExtent = Range {
-                  rangeStart = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:15",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing},
-                  rangeEnd = MultiLoc {
-                    multiLocExpansion =
-                    "typedef_vs_macro.h:7:16",
-                    multiLocPresumed = Nothing,
-                    multiLocSpelling = Nothing,
-                    multiLocFile = Nothing}},
-                tokenCursorKind = SimpleEnum
-                  501}]}),
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "typedef_vs_macro.h:16:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "uint64_t",
-            macroArgs = [],
-            macroBody = MTerm
-              (MType
-                (TypePrim
-                  (PrimIntegral
-                    PrimInt
-                    Signed)))},
-          macroDeclMacroTy = "PrimTy",
-          macroDeclSourceLoc =
-          "typedef_vs_macro.h:16:9"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "T1",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          typedefSourceLoc =
-          "typedef_vs_macro.h:1:13"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "T2",
-          typedefType = TypePrim
-            (PrimChar Nothing),
-          typedefSourceLoc =
-          "typedef_vs_macro.h:2:14"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag
-              (CName "ExampleStruct"))
-            DeclPathTop,
-          structSizeof = 16,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "t1",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "T1"),
-              fieldSourceLoc =
-              "typedef_vs_macro.h:10:6"},
-            StructField {
-              fieldName = CName "t2",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "T2"),
-              fieldSourceLoc =
-              "typedef_vs_macro.h:11:6"},
-            StructField {
-              fieldName = CName "m1",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "M1"),
-              fieldSourceLoc =
-              "typedef_vs_macro.h:12:6"},
-            StructField {
-              fieldName = CName "m2",
-              fieldOffset = 96,
-              fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "M2"),
-              fieldSourceLoc =
-              "typedef_vs_macro.h:13:6"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "typedef_vs_macro.h:9:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 8,
-          structFields = [
-            StructField {
-              fieldName = CName "a",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePointer
-                (TypeTypedef
-                  (CName "uint64_t")),
-              fieldSourceLoc =
-              "typedef_vs_macro.h:19:13"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "typedef_vs_macro.h:18:8"}])
+                    Signed))))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "typedef_vs_macro.h:6:9"},
+    DeclMacro
+      (MacroReparseError
+        ReparseError {
+          reparseError = concat
+            [
+              "\"typedef_vs_macro.h\" (line 7, column 15):\n",
+              "unexpected end of input\n",
+              "expecting simple expression"],
+          reparseErrorTokens = [
+            Token {
+              tokenKind = SimpleEnum 2,
+              tokenSpelling = TokenSpelling
+                "M4",
+              tokenExtent = Range {
+                rangeStart = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:9",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing},
+                rangeEnd = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:11",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing}},
+              tokenCursorKind = SimpleEnum
+                501},
+            Token {
+              tokenKind = SimpleEnum 1,
+              tokenSpelling = TokenSpelling
+                "int",
+              tokenExtent = Range {
+                rangeStart = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:12",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing},
+                rangeEnd = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:15",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing}},
+              tokenCursorKind = SimpleEnum
+                501},
+            Token {
+              tokenKind = SimpleEnum 0,
+              tokenSpelling = TokenSpelling
+                "*",
+              tokenExtent = Range {
+                rangeStart = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:15",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing},
+                rangeEnd = MultiLoc {
+                  multiLocExpansion =
+                  "typedef_vs_macro.h:7:16",
+                  multiLocPresumed = Nothing,
+                  multiLocSpelling = Nothing,
+                  multiLocFile = Nothing}},
+              tokenCursorKind = SimpleEnum
+                501}]}),
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "typedef_vs_macro.h:16:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "uint64_t",
+          macroArgs = [],
+          macroBody = MTerm
+            (MType
+              (TypePrim
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
+        macroDeclMacroTy = "PrimTy",
+        macroDeclSourceLoc =
+        "typedef_vs_macro.h:16:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "T1",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        typedefSourceLoc =
+        "typedef_vs_macro.h:1:13"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "T2",
+        typedefType = TypePrim
+          (PrimChar Nothing),
+        typedefSourceLoc =
+        "typedef_vs_macro.h:2:14"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag
+            (CName "ExampleStruct"))
+          DeclPathTop,
+        structSizeof = 16,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "t1",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "T1"),
+            fieldSourceLoc =
+            "typedef_vs_macro.h:10:6"},
+          StructField {
+            fieldName = CName "t2",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "T2"),
+            fieldSourceLoc =
+            "typedef_vs_macro.h:11:6"},
+          StructField {
+            fieldName = CName "m1",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "M1"),
+            fieldSourceLoc =
+            "typedef_vs_macro.h:12:6"},
+          StructField {
+            fieldName = CName "m2",
+            fieldOffset = 96,
+            fieldWidth = Nothing,
+            fieldType = TypeTypedef
+              (CName "M2"),
+            fieldSourceLoc =
+            "typedef_vs_macro.h:13:6"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "typedef_vs_macro.h:9:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "a",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePointer
+              (TypeTypedef
+                (CName "uint64_t")),
+            fieldSourceLoc =
+            "typedef_vs_macro.h:19:13"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "typedef_vs_macro.h:18:8"}]

--- a/hs-bindgen/fixtures/typedefs.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedefs.tree-diff.txt
@@ -1,18 +1,17 @@
-WrapCHeader
-  (Header
-    [
-      DeclTypedef
-        Typedef {
-          typedefName = CName "myint",
-          typedefType = TypePrim
-            (PrimIntegral PrimInt Signed),
-          typedefSourceLoc =
-          "typedefs.h:1:13"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "intptr",
-          typedefType = TypePointer
-            (TypePrim
-              (PrimIntegral PrimInt Signed)),
-          typedefSourceLoc =
-          "typedefs.h:2:15"}])
+Header
+  [
+    DeclTypedef
+      Typedef {
+        typedefName = CName "myint",
+        typedefType = TypePrim
+          (PrimIntegral PrimInt Signed),
+        typedefSourceLoc =
+        "typedefs.h:1:13"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "intptr",
+        typedefType = TypePointer
+          (TypePrim
+            (PrimIntegral PrimInt Signed)),
+        typedefSourceLoc =
+        "typedefs.h:2:15"}]

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -1,30 +1,29 @@
-WrapCHeader
-  (Header
-    [
-      DeclEnum
-        Enu {
-          enumTag = CName "foo",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName "FOO1",
-              valueValue = 0,
-              valueSourceLoc =
-              "typenames.h:15:2"},
-            EnumValue {
-              valueName = CName "FOO2",
-              valueValue = 1,
-              valueSourceLoc =
-              "typenames.h:16:2"}],
-          enumSourceLoc =
-          "typenames.h:14:6"},
-      DeclTypedef
-        Typedef {
-          typedefName = CName "foo",
-          typedefType = TypePrim
-            (PrimFloating PrimDouble),
-          typedefSourceLoc =
-          "typenames.h:19:16"}])
+Header
+  [
+    DeclEnum
+      Enu {
+        enumTag = CName "foo",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName "FOO1",
+            valueValue = 0,
+            valueSourceLoc =
+            "typenames.h:15:2"},
+          EnumValue {
+            valueName = CName "FOO2",
+            valueValue = 1,
+            valueSourceLoc =
+            "typenames.h:16:2"}],
+        enumSourceLoc =
+        "typenames.h:14:6"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "foo",
+        typedefType = TypePrim
+          (PrimFloating PrimDouble),
+        typedefSourceLoc =
+        "typenames.h:19:16"}]

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -1,95 +1,94 @@
-WrapCHeader
-  (Header
-    [
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "Dim2"))
-            DeclPathTop,
-          structSizeof = 8,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:2:9"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:3:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "unions.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "Dim3"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:7:9"},
-            StructField {
-              fieldName = CName "y",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:8:9"},
-            StructField {
-              fieldName = CName "z",
-              fieldOffset = 64,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:9:9"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "unions.h:6:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "Dim"))
-            DeclPathTop,
-          structSizeof = 12,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "tag",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "unions.h:18:9"},
-            StructField {
-              fieldName = CName "payload",
-              fieldOffset = 32,
-              fieldWidth = Nothing,
-              fieldType = TypeUnion
-                (DeclPathUnion
-                  (DeclNameTag
-                    (CName "DimPayload"))
-                  DeclPathTop),
-              fieldSourceLoc =
-              "unions.h:19:22"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "unions.h:17:8"}])
+Header
+  [
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "Dim2"))
+          DeclPathTop,
+        structSizeof = 8,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:2:9"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:3:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "unions.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "Dim3"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:7:9"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:8:9"},
+          StructField {
+            fieldName = CName "z",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:9:9"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "unions.h:6:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "Dim"))
+          DeclPathTop,
+        structSizeof = 12,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "tag",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "unions.h:18:9"},
+          StructField {
+            fieldName = CName "payload",
+            fieldOffset = 32,
+            fieldWidth = Nothing,
+            fieldType = TypeUnion
+              (DeclPathUnion
+                (DeclNameTag
+                  (CName "DimPayload"))
+                DeclPathTop),
+            fieldSourceLoc =
+            "unions.h:19:22"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "unions.h:17:8"}]

--- a/hs-bindgen/fixtures/unnamed-struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/unnamed-struct.tree-diff.txt
@@ -1,1 +1,1 @@
-WrapCHeader (Header [])
+Header []

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -1,40 +1,39 @@
-WrapCHeader
-  (Header
-    [
-      DeclMacro
-        MacroDecl {
-          macroDeclMacro = Macro {
-            macroLoc = MultiLoc {
-              multiLocExpansion =
-              "uses_utf8.h:2:9",
-              multiLocPresumed = Nothing,
-              multiLocSpelling = Nothing,
-              multiLocFile = Nothing},
-            macroName = CName "USES_UTF8_H",
-            macroArgs = [],
-            macroBody = MEmpty},
-          macroDeclMacroTy = "Empty",
-          macroDeclSourceLoc =
-          "uses_utf8.h:2:9"},
-      DeclEnum
-        Enu {
-          enumTag = CName "MyEnum",
-          enumType = TypePrim
-            (PrimIntegral PrimInt Unsigned),
-          enumSizeof = 4,
-          enumAlignment = 4,
-          enumValues = [
-            EnumValue {
-              valueName = CName
-                "Say\20320\22909",
-              valueValue = 0,
-              valueSourceLoc =
-              "uses_utf8.h:5:9"},
-            EnumValue {
-              valueName = CName
-                "Say\25308\25308",
-              valueValue = 1,
-              valueSourceLoc =
-              "uses_utf8.h:6:9"}],
-          enumSourceLoc =
-          "uses_utf8.h:4:6"}])
+Header
+  [
+    DeclMacro
+      MacroDecl {
+        macroDeclMacro = Macro {
+          macroLoc = MultiLoc {
+            multiLocExpansion =
+            "uses_utf8.h:2:9",
+            multiLocPresumed = Nothing,
+            multiLocSpelling = Nothing,
+            multiLocFile = Nothing},
+          macroName = CName "USES_UTF8_H",
+          macroArgs = [],
+          macroBody = MEmpty},
+        macroDeclMacroTy = "Empty",
+        macroDeclSourceLoc =
+        "uses_utf8.h:2:9"},
+    DeclEnum
+      Enu {
+        enumTag = CName "MyEnum",
+        enumType = TypePrim
+          (PrimIntegral PrimInt Unsigned),
+        enumSizeof = 4,
+        enumAlignment = 4,
+        enumValues = [
+          EnumValue {
+            valueName = CName
+              "Say\20320\22909",
+            valueValue = 0,
+            valueSourceLoc =
+            "uses_utf8.h:5:9"},
+          EnumValue {
+            valueName = CName
+              "Say\25308\25308",
+            valueValue = 1,
+            valueSourceLoc =
+            "uses_utf8.h:6:9"}],
+        enumSourceLoc =
+        "uses_utf8.h:4:6"}]

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -1,55 +1,54 @@
-WrapCHeader
-  (Header
-    [
-      DeclFunction
-        Function {
-          functionName = CName "func",
-          functionType = TypeFun
-            [
-              TypePointer
-                (TypeStruct
-                  (DeclPathStruct
-                    (DeclNameTag (CName "bar"))
-                    (DeclPathPtr DeclPathTop)))]
-            TypeVoid,
-          functionHeader = "weird01.h",
-          functionSourceLoc =
-          "weird01.h:8:6"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "z",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "weird01.h:2:13"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "weird01.h:1:8"},
-      DeclStruct
-        Struct {
-          structDeclPath = DeclPathStruct
-            (DeclNameTag (CName "bar"))
-            (DeclPathPtr DeclPathTop),
-          structSizeof = 4,
-          structAlignment = 4,
-          structFields = [
-            StructField {
-              fieldName = CName "x",
-              fieldOffset = 0,
-              fieldWidth = Nothing,
-              fieldType = TypePrim
-                (PrimIntegral PrimInt Signed),
-              fieldSourceLoc =
-              "weird01.h:4:21"}],
-          structFlam = Nothing,
-          structSourceLoc =
-          "weird01.h:3:16"}])
+Header
+  [
+    DeclFunction
+      Function {
+        functionName = CName "func",
+        functionType = TypeFun
+          [
+            TypePointer
+              (TypeStruct
+                (DeclPathStruct
+                  (DeclNameTag (CName "bar"))
+                  (DeclPathPtr DeclPathTop)))]
+          TypeVoid,
+        functionHeader = "weird01.h",
+        functionSourceLoc =
+        "weird01.h:8:6"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "z",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "weird01.h:2:13"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "weird01.h:1:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathStruct
+          (DeclNameTag (CName "bar"))
+          (DeclPathPtr DeclPathTop),
+        structSizeof = 4,
+        structAlignment = 4,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            fieldSourceLoc =
+            "weird01.h:4:21"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "weird01.h:3:16"}]

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -61,6 +61,7 @@ library
   hs-source-dirs: src
 
   exposed-modules:
+      HsBindgen.Hs.NameMangler
       HsBindgen.Lib
       HsBindgen.TH
   exposed-modules:
@@ -69,12 +70,15 @@ library
       HsBindgen.Backend.PP.Render
       HsBindgen.Backend.TH.Translation
       HsBindgen.C.AST
+      HsBindgen.C.Parser
       HsBindgen.C.Tc.Macro
       HsBindgen.Eff
+      HsBindgen.ExtBindings
       HsBindgen.Hs.AST
       HsBindgen.Hs.AST.Name
       HsBindgen.Hs.AST.Type
       HsBindgen.NameHint
+      HsBindgen.Pipeline
       HsBindgen.Errors
   other-modules:
       Data.DynGraph
@@ -87,7 +91,6 @@ library
       HsBindgen.C.Fold.DeclState
       HsBindgen.C.Fold.Prelude
       HsBindgen.C.Fold.Type
-      HsBindgen.C.Parser
       HsBindgen.C.Predicate
       HsBindgen.C.Reparse
       HsBindgen.C.Reparse.Common
@@ -97,13 +100,11 @@ library
       HsBindgen.C.Reparse.Macro
       HsBindgen.C.Reparse.Type
       HsBindgen.Debug
-      HsBindgen.ExtBindings
       HsBindgen.GenTests
       HsBindgen.GenTests.C
       HsBindgen.GenTests.Hs
       HsBindgen.GenTests.Internal
       HsBindgen.GenTests.Readme
-      HsBindgen.Hs.NameMangler
       HsBindgen.Hs.Translation
       HsBindgen.Imports
       HsBindgen.Orphans
@@ -154,6 +155,10 @@ library
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >=0.1.0.1 && <0.2
+
+  -- for getPackageRoot
+  if !impl(ghc >=9.4)
+    build-depends: th-compat ^>=0.1.6
 
 executable hs-bindgen
   import:         lang
@@ -219,8 +224,6 @@ test-suite test-th
       Test02
 
   default-language: Haskell2010
-  other-extensions:
-      TemplateHaskell
   build-depends:
       -- Internal dependencies
     , hs-bindgen
@@ -228,17 +231,11 @@ test-suite test-th
   build-depends:
       -- Inherited dependencies
     , base <5
-    , filepath
-    , template-haskell
   build-depends:
       -- External dependencies
     , tasty ^>= 1.5
     , tasty-hunit ^>=0.10.2
     , vector ^>=0.13.2.0
-
-  -- for getPackageRoot
-  if !impl(ghc >=9.4)
-    build-depends: th-compat ^>=0.1.6
 
 test-suite test-pp
   type:           exitcode-stdio-1.0
@@ -266,7 +263,6 @@ test-suite test-pp
   build-depends:
       -- Inherited dependencies
     , base <5
-    , template-haskell
   build-depends:
       -- External dependencies
     , tasty ^>= 1.5

--- a/hs-bindgen/src/HsBindgen/GenTests.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests.hs
@@ -13,6 +13,7 @@ import HsBindgen.GenTests.C (genTestsC)
 import HsBindgen.GenTests.Hs (genTestsHs)
 import HsBindgen.GenTests.Readme (genTestsReadme)
 import HsBindgen.Hs.AST (Decl)
+import HsBindgen.Hs.NameMangler (defaultNameMangler)
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports
 
@@ -75,6 +76,7 @@ genTests headerIncludePath cHeader moduleName lineLength testSuitePath = do
       Hs.generateDeclarations
         headerIncludePath
         Hs.defaultTranslationOpts
+        defaultNameMangler
         cHeader
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
@@ -3,6 +3,9 @@
 module HsBindgen.Hs.NameMangler (
     -- * Definition
     NameMangler(..)
+  , CName(..)
+  , HsName(..)
+  , Namespace(..)
     -- ** Contexts
   , TypeConstrContext(..)
   , ConstrContext(..)

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -83,7 +83,6 @@ import HsBindgen.Clang.Args qualified as Args
 import HsBindgen.Clang.Paths qualified as Paths
 import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
-import HsBindgen.Imports (Generic)
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Pipeline qualified as Pipeline
@@ -99,7 +98,6 @@ import HsBindgen.Util.Tracer qualified as Tracer
 newtype CHeader = WrapCHeader {
       unwrapCHeader :: C.Header
     }
-  deriving Generic
 
 -- | Parse a C header
 parseCHeader :: Pipeline.Opts -> Paths.CHeaderIncludePath -> IO CHeader

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -1,324 +1,151 @@
 -- | Main entry point for using @hs-bindgen@-as-a-library
 --
--- This is split into three phases:
---
--- * Input preparation (e.g. parsing of C headers)
--- * Translation from C to Haskell
--- * Output processing (e.g. writing Haskell files)
---
--- The bulk of the work happens in translation (which is a pure function).
---
 -- Intended for unqualified import.
 --
 -- NOTE: Client code should /NOT/ have to import from @hs-bindgen-libclang@;
 -- that library should be considered internal to @hs-bindgen@.
 module HsBindgen.Lib (
-    -- * Prepare input
-    CXTranslationUnit -- opaque
-  , Diagnostic(..)
-  , FixIt(..)
-  , withTranslationUnit
-
     -- * Header resolution
-  , resolveHeader
+    Paths.CHeaderIncludePath -- opaque
+  , Paths.parseCHeaderIncludePath
+  , Resolve.resolveHeader
 
-    -- ** Clang arguments
-  , ClangArgs(..)
-  , CStandard(..)
-  , defaultClangArgs
-
-    -- ** External bindings
-  , HsPackageName(..)
-  , HsModuleName(..)
-  , HsIdentifier(..)
-  , ExtIdentifier(..)
-  , ExtBindings
-  , ExtBindingsExceptions
-  , emptyExtBindings
-  , loadExtBindings
-
-    -- *** Cross-compilation
-  , Target(..)
-  , TargetEnv(..)
-  , targetTriple
-
-    -- ** Select parts of the AST
-  , Predicate(..)
-  , C.Skipped -- opaque
-
-    -- ** Process the C input
+    -- * Parsing
   , CHeader -- opaque
   , parseCHeader
 
-    -- ** Development/debugging
-  , getTargetTriple
-  , bootstrapPrelude
-
-    -- * Translation
-  , LowLevel.TranslationOpts(..)
-  , LowLevel.defaultTranslationOpts
-  , HsModuleOpts(..)
-  , HsModule(..) -- opaque, TODO: but needed to be unwrapped by rendering functions
-  , genModule
-  , genTH
-  , genExtensions
-
-    -- ** Development/debugging
-  , genHsDecls
-
-    -- * Process output
-  , HsRenderOpts(..)
-  , prettyHs
-  , prettyC
+    -- * Preprocessor
+  , preprocessPure
+  , preprocessIO
 
     -- * Test generation
   , genTests
 
-    -- * Logging
-  , Tracer
+    -- * Development/debugging
+  , dumpCHeader
 
-    -- ** Construction
-  , nullTracer
-  , mkTracerIO
-  , mkTracerQ
-  , mkTracer
+    -- * Options
+  , Pipeline.Opts(..)
+  , Pipeline.defaultOpts
 
-    -- ** Usage
-  , contramap
-  , PrettyLogMsg(..)
+    -- ** Clang arguments
+  , Args.ClangArgs(..)
+  , Args.defaultClangArgs
+  , Args.Target(..)
+  , Args.TargetEnv(..)
+  , Args.targetTriple
+  , Args.CStandard(..)
 
-  -- * Preprocessor API
-  , preprocessor
+    -- ** External bindings
+  , ExtBindings.ExtBindings
+  , ExtBindings.emptyExtBindings
+  , ExtBindings.loadExtBindings
 
-  -- * Template Haskell API
-  , genBindings
-  , genBindings'
+    -- ** Translation options
+  , Hs.TranslationOpts(..)
+  , Hs.defaultTranslationOpts
+  , Hs.Strategy(..)
+  , Hs.TypeClass(..)
+
+    -- ** Predicates
+  , Predicate.Predicate(..)
+  , Predicate.Regex -- opaque
+
+    -- ** Logging
+  , Tracer.Tracer
+  , Tracer.nullTracer
+  , Tracer.mkTracerIO
+  , Tracer.mkTracerQ
+  , Tracer.mkTracer
+  , Tracer.contramap
+
+    -- ** Preprocessor
+  , Pipeline.PPOpts(..)
+  , Pipeline.defaultPPOpts
+  , Backend.PP.HsModuleOpts(..)
+  , Backend.PP.HsRenderOpts(..)
+
+    -- * Paths
+  , Paths.SourcePath(..)
+  , Paths.CIncludePathDir(..)
+  , (FilePath.</>)
+  , FilePath.joinPath
   ) where
 
-import Language.Haskell.TH qualified as TH
+import System.FilePath qualified as FilePath
 import Text.Show.Pretty qualified as Pretty
 
-import HsBindgen.Backend.Extensions
-import HsBindgen.Backend.PP.Render (HsRenderOpts(..))
 import HsBindgen.Backend.PP.Render qualified as Backend.PP
-import HsBindgen.Backend.PP.Translation (HsModuleOpts(..))
 import HsBindgen.Backend.PP.Translation qualified as Backend.PP
-import HsBindgen.Backend.TH.Translation qualified as Backend.TH
 import HsBindgen.C.AST qualified as C
-import HsBindgen.C.Fold qualified as C
-import HsBindgen.C.Fold.DeclState qualified as C
-import HsBindgen.C.Parser qualified as C
-import HsBindgen.C.Predicate (Predicate(..))
-import HsBindgen.Clang.Args
-import HsBindgen.Clang.HighLevel qualified as HighLevel
-import HsBindgen.Clang.HighLevel.Types
-import HsBindgen.Clang.LowLevel.Core
-import HsBindgen.Clang.Paths
-import HsBindgen.ExtBindings
-import HsBindgen.GenTests qualified as GenTests
+import HsBindgen.C.Predicate qualified as Predicate
+import HsBindgen.Clang.Args qualified as Args
+import HsBindgen.Clang.Paths qualified as Paths
+import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
-import HsBindgen.Hs.Translation qualified as LowLevel
-import HsBindgen.Resolve
-import HsBindgen.SHs.Translation qualified as SHs
-import HsBindgen.TH
-import HsBindgen.Imports
-import HsBindgen.Util.Tracer
+import HsBindgen.Imports (Generic)
+import HsBindgen.Resolve qualified as Resolve
+import HsBindgen.Hs.Translation qualified as Hs
+import HsBindgen.Pipeline qualified as Pipeline
+import HsBindgen.Util.Tracer qualified as Tracer
 
 {-------------------------------------------------------------------------------
-  Type aliases
+  Parsing
 
-  These newtypes ensure that these types are opaque in client code. The precise
-  nature of the C AST and Haskell AST is not part of the public API.
+  An opaque newtype is used because the C and Haskell ASTs are /not/ part of the
+  public API.
 -------------------------------------------------------------------------------}
 
 newtype CHeader = WrapCHeader {
       unwrapCHeader :: C.Header
     }
-  deriving (Generic)
+  deriving Generic
 
-newtype HsModule = WrapHsModule {
-      unwrapHsModule :: Backend.PP.HsModule
-    }
-
-{-------------------------------------------------------------------------------
-  Prepare input
-
-  TODO: <https://github.com/well-typed/hs-bindgen/issues/10>
-  This needs to include parameters for cross compilation.
-
-  TODO: <https://github.com/well-typed/hs-bindgen/issues/71>
-  This needs to have fields with paths, preprocessor defines, etc.
-
-  TODO: <https://github.com/well-typed/hs-bindgen/issues/75>
-  Support multiple C headers.
--------------------------------------------------------------------------------}
-
--- | Open C header
---
--- See section "Process the C input" for example functions you can pass as
--- arguments; the most important being 'parseCHeader'.
-withTranslationUnit ::
-     Tracer IO Diagnostic        -- ^ Tracer for warnings from @libclang@
-  -> ClangArgs                   -- ^ @libclang@ arguments
-  -> SourcePath                  -- ^ Input path
-  -> (CXTranslationUnit -> IO r)
-  -> IO r
-withTranslationUnit = C.withTranslationUnit
-
-parseCHeader ::
-     Tracer IO C.Skipped
-  -> Predicate
-  -> ExtBindings
-  -> CXTranslationUnit
-  -> IO CHeader
-parseCHeader traceSkipped p extBindings unit = do
-    (decls, finalDeclState) <-
-      C.foldTranslationUnitWith
-        unit
-        (C.runFoldState C.initDeclState)
-        (C.foldDecls traceSkipped p extBindings unit)
-
-    let decls' = [ d | C.TypeDecl _ d <- toList (C.typeDeclarations finalDeclState) ]
-    return $ WrapCHeader (C.Header $ decls ++ decls')
-
-bootstrapPrelude ::
-     Tracer IO String   -- ^ Messages
-  -> Tracer IO String   -- ^ Macros
-  -> CXTranslationUnit
-  -> IO [C.PreludeEntry]
-bootstrapPrelude msgTracer macroTracer unit = do
-    cursor <- clang_getTranslationUnitCursor unit
-    C.runFoldIdentity . HighLevel.clang_visitChildren cursor $
-      C.foldPrelude msgTracer' macroTracer' unit
-  where
-    -- We could take a tracer for 'C.GenPreludeMsg', but there is only a point
-    -- in doing so if we then also export that type.
-    msgTracer' :: Tracer IO C.GenPreludeMsg
-    msgTracer' = contramap prettyLogMsg msgTracer
-
-    macroTracer' :: Tracer IO (MultiLoc, C.Macro)
-    macroTracer' = contramap show macroTracer
-
--- | Return the target triple for translation unit
-getTargetTriple :: CXTranslationUnit -> IO Text
-getTargetTriple = C.getTranslationUnitTargetTriple
+-- | Parse a C header
+parseCHeader :: Pipeline.Opts -> Paths.CHeaderIncludePath -> IO CHeader
+parseCHeader opts = fmap (WrapCHeader . snd) . Pipeline.parseCHeader opts
 
 {-------------------------------------------------------------------------------
-  Translation
+  Preprocessor
 -------------------------------------------------------------------------------}
 
-genModule ::
-     CHeaderIncludePath
-  -> LowLevel.TranslationOpts
-  -> HsModuleOpts
+-- | Generate bindings for the given C header
+preprocessPure ::
+     Pipeline.Opts
+  -> Pipeline.PPOpts
+  -> Paths.CHeaderIncludePath
   -> CHeader
-  -> HsModule
-genModule headerIncludePath topts opts =
-      WrapHsModule
-    . Backend.PP.translateModule opts
-    . map SHs.translateDecl
-    . genHsDecls headerIncludePath topts
+  -> String
+preprocessPure opts ppOpts headerIncludePath =
+    Pipeline.preprocessPure opts ppOpts headerIncludePath . unwrapCHeader
 
-genTH ::
-     TH.Quote q
-  => CHeaderIncludePath
-  -> LowLevel.TranslationOpts
+-- | Generate bindings for the given C header
+preprocessIO ::
+     Pipeline.Opts
+  -> Pipeline.PPOpts
+  -> Paths.CHeaderIncludePath
+  -> Maybe FilePath -- ^ Output file or 'Nothing' for @STDOUT@
   -> CHeader
-  -> q [TH.Dec]
-genTH headerIncludePath topts cheader = do
-    fmap concat (traverse Backend.TH.mkDecl sdecls)
-  where
-    sdecls = map SHs.translateDecl (genHsDecls headerIncludePath topts cheader)
-
-genHsDecls ::
-     CHeaderIncludePath
-  -> LowLevel.TranslationOpts
-  -> CHeader
-  -> [Hs.Decl]
-genHsDecls headerIncludePath topts =
-    LowLevel.generateDeclarations headerIncludePath topts . unwrapCHeader
-
--- | Which extensions will be needed for the generated code.
---
--- Exposed for hs-bindgen internal tests
-genExtensions ::
-     CHeaderIncludePath
-  -> LowLevel.TranslationOpts
-  -> CHeader -> Set TH.Extension
-genExtensions headerIncludePath topts cheader = do
-    foldMap requiredExtensions sdecls
-  where
-    sdecls = map SHs.translateDecl (genHsDecls headerIncludePath topts cheader)
-
-{-------------------------------------------------------------------------------
-  Processing output
-
-  TODO: <https://github.com/well-typed/hs-bindgen/issues/75>
-  We might want to support generating multiple Haskell modules.
--------------------------------------------------------------------------------}
-
-prettyC :: CHeader -> IO ()
-prettyC = Pretty.dumpIO . unwrapCHeader
-
-prettyHs :: HsRenderOpts -> Maybe FilePath -> HsModule -> IO ()
-prettyHs opts fp = Backend.PP.renderIO opts fp . unwrapHsModule
+  -> IO ()
+preprocessIO opts ppOpts headerIncludePath fp =
+    Pipeline.preprocessIO opts ppOpts headerIncludePath fp . unwrapCHeader
 
 {-------------------------------------------------------------------------------
   Test generation
 -------------------------------------------------------------------------------}
 
 genTests ::
-     CHeaderIncludePath
-  -> CHeader
-  -> HsModuleOpts
-  -> HsRenderOpts
+     Pipeline.PPOpts
+  -> Paths.CHeaderIncludePath
   -> FilePath -- ^ Test suite directory path
+  -> CHeader
   -> IO ()
-genTests
-  headerIncludePath
-  cHeader
-  HsModuleOpts{hsModuleOptsName}
-  HsRenderOpts{hsLineLength} =
-    GenTests.genTests
-      headerIncludePath
-      (unwrapCHeader cHeader)
-      hsModuleOptsName
-      hsLineLength
+genTests ppOpts headerIncludePath testDir =
+    Pipeline.genTests ppOpts headerIncludePath testDir . unwrapCHeader
 
 {-------------------------------------------------------------------------------
-  Preprocessor API
+  Development/debugging
 -------------------------------------------------------------------------------}
 
-preprocessor ::
-     [CIncludePathDir]  -- ^ System include search path directories
-  -> [CIncludePathDir]  -- ^ Non-system include search path directories
-  -> ExtBindings        -- ^ External bindings
-  -> CHeaderIncludePath -- ^ Input header
-  -> IO String
-preprocessor sysIncPathDirs quoteIncPathDirs extBindings headerIncludePath = do
-    src <- resolveHeader args headerIncludePath
-    cheader <-
-      withTranslationUnit nullTracer args src $
-        parseCHeader nullTracer SelectFromMainFile extBindings
-    return $
-      Backend.PP.render renderOpts $
-        unwrapHsModule $ genModule headerIncludePath topts moduleOpts cheader
-  where
-    args :: ClangArgs
-    args = defaultClangArgs {
-        clangSystemIncludePathDirs = sysIncPathDirs
-      , clangQuoteIncludePathDirs  = quoteIncPathDirs
-      }
-
-    topts :: LowLevel.TranslationOpts
-    topts = LowLevel.defaultTranslationOpts
-
-    moduleOpts :: HsModuleOpts
-    moduleOpts = HsModuleOpts
-      { hsModuleOptsName = "Example"
-      }
-
-    renderOpts :: HsRenderOpts
-    renderOpts = HsRenderOpts
-      { hsLineLength = 120
-      }
+dumpCHeader :: CHeader -> IO ()
+dumpCHeader = Pretty.dumpIO . unwrapCHeader

--- a/hs-bindgen/src/HsBindgen/Orphans.hs
+++ b/hs-bindgen/src/HsBindgen/Orphans.hs
@@ -2,6 +2,7 @@
 
 module HsBindgen.Orphans () where
 
+import Control.Exception (Exception(displayException))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Data.GADT.Compare (GEq(geq))
@@ -19,7 +20,9 @@ import HsBindgen.Clang.Paths
 
 instance Aeson.FromJSON CHeaderIncludePath where
   parseJSON = Aeson.withText "CHeaderIncludePath" $
-    either Aeson.parseFail return . parseCHeaderIncludePath . Text.unpack
+      either (Aeson.parseFail . displayException) return
+    . parseCHeaderIncludePath
+    . Text.unpack
 
 deriving newtype instance Aeson.FromJSON CNameSpelling
 

--- a/hs-bindgen/src/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src/HsBindgen/Pipeline.hs
@@ -1,0 +1,223 @@
+module HsBindgen.Pipeline (
+    -- * Options
+    Opts(..)
+  , defaultOpts
+  , PPOpts(..)
+  , defaultPPOpts
+
+    -- * Translation pipeline components
+  , genHsDecls
+  , genSHsDecls
+  , genModule
+  , genPP
+  , genPPString
+  , genTH
+  , genExtensions
+
+    -- * Preprocessor API
+  , parseCHeader
+  , preprocessPure
+  , preprocessIO
+
+    -- * Template Haskell API
+  , genBindings
+  , genBindings'
+
+    -- * Test generation
+  , genTests
+  ) where
+
+import Data.Set qualified as Set
+import Language.Haskell.TH qualified as TH
+import Language.Haskell.TH.Syntax qualified as TH (addDependentFile)
+
+import HsBindgen.Backend.Extensions
+import HsBindgen.Backend.PP.Render (HsRenderOpts(..))
+import HsBindgen.Backend.PP.Render qualified as Backend.PP
+import HsBindgen.Backend.PP.Translation (HsModuleOpts(..))
+import HsBindgen.Backend.PP.Translation qualified as Backend.PP
+import HsBindgen.Backend.TH.Translation qualified as Backend.TH
+import HsBindgen.C.AST qualified as C
+import HsBindgen.C.Fold qualified as C
+import HsBindgen.C.Parser qualified as C
+import HsBindgen.C.Predicate (Predicate(..))
+import HsBindgen.Clang.Args
+import HsBindgen.Clang.HighLevel.Types
+import HsBindgen.Clang.Paths
+import HsBindgen.ExtBindings
+import HsBindgen.GenTests qualified as GenTests
+import HsBindgen.Hs.AST qualified as Hs
+import HsBindgen.Hs.NameMangler qualified as Hs
+import HsBindgen.Hs.Translation qualified as Hs
+import HsBindgen.Imports
+import HsBindgen.Resolve
+import HsBindgen.SHs.AST qualified as SHs
+import HsBindgen.SHs.Translation qualified as SHs
+import HsBindgen.Util.Tracer
+
+{-------------------------------------------------------------------------------
+  Options
+-------------------------------------------------------------------------------}
+
+-- | Options for both the preprocessor and TH APIs
+data Opts = Opts {
+      optsClangArgs   :: ClangArgs
+    , optsExtBindings :: ExtBindings
+    , optsTranslation :: Hs.TranslationOpts
+    , optsNameMangler :: Hs.NameMangler
+    , optsPredicate   :: Predicate
+    , optsDiagTracer  :: Tracer IO String
+    , optsSkipTracer  :: Tracer IO String
+    }
+
+defaultOpts :: Opts
+defaultOpts = Opts {
+      optsClangArgs   = defaultClangArgs
+    , optsExtBindings = emptyExtBindings
+    , optsTranslation = Hs.defaultTranslationOpts
+    , optsNameMangler = Hs.defaultNameMangler
+    , optsPredicate   = SelectFromMainFile
+    , optsDiagTracer  = nullTracer
+    , optsSkipTracer  = nullTracer
+    }
+
+-- | Additional options for the preprocessor API
+data PPOpts = PPOpts {
+      ppOptsModule :: HsModuleOpts -- ^ Default module name: @Generated@
+    , ppOptsRender :: HsRenderOpts -- ^ Default line length: 120
+    }
+
+defaultPPOpts :: PPOpts
+defaultPPOpts = PPOpts {
+      ppOptsModule = HsModuleOpts { hsModuleOptsName = "Generated" }
+    , ppOptsRender = HsRenderOpts { hsLineLength = 120 }
+    }
+
+{-------------------------------------------------------------------------------
+  Translation pipeline components
+-------------------------------------------------------------------------------}
+
+genHsDecls :: Opts -> CHeaderIncludePath -> C.Header -> [Hs.Decl]
+genHsDecls Opts{..} headerIncludePath =
+    Hs.generateDeclarations headerIncludePath optsTranslation optsNameMangler
+
+genSHsDecls :: [Hs.Decl] -> [SHs.SDecl]
+genSHsDecls = map SHs.translateDecl
+
+genModule :: PPOpts -> [SHs.SDecl] -> Backend.PP.HsModule
+genModule PPOpts{..} = Backend.PP.translateModule ppOptsModule
+
+genPP :: PPOpts -> Maybe FilePath -> Backend.PP.HsModule -> IO ()
+genPP PPOpts{..} fp = Backend.PP.renderIO ppOptsRender fp
+
+genPPString :: PPOpts -> Backend.PP.HsModule -> String
+genPPString PPOpts{..} = Backend.PP.render ppOptsRender
+
+genTH :: TH.Quote q => [SHs.SDecl] -> q [TH.Dec]
+genTH = fmap concat . traverse Backend.TH.mkDecl
+
+genExtensions :: [SHs.SDecl] -> Set TH.Extension
+genExtensions = foldMap requiredExtensions
+
+{-------------------------------------------------------------------------------
+  Preprocessor API
+-------------------------------------------------------------------------------}
+
+-- | Parse a C header
+parseCHeader :: Opts -> CHeaderIncludePath -> IO ([SourcePath], C.Header)
+parseCHeader Opts{..} headerIncludePath = do
+    src <- resolveHeader optsClangArgs headerIncludePath
+    C.withTranslationUnit diagTracer optsClangArgs src $
+      C.parseCHeader skipTracer optsExtBindings optsPredicate
+  where
+    diagTracer :: Tracer IO Diagnostic
+    diagTracer = contramap show optsDiagTracer
+
+    skipTracer :: Tracer IO C.Skipped
+    skipTracer = contramap prettyLogMsg optsSkipTracer
+
+-- | Generate bindings for the given C header
+preprocessPure ::
+     Opts
+  -> PPOpts
+  -> CHeaderIncludePath
+  -> C.Header
+  -> String
+preprocessPure opts ppOpts headerIncludePath =
+    genPPString ppOpts
+      . genModule ppOpts
+      . genSHsDecls
+      . genHsDecls opts headerIncludePath
+
+-- | Generate bindings for the given C header
+preprocessIO ::
+     Opts
+  -> PPOpts
+  -> CHeaderIncludePath
+  -> Maybe FilePath     -- ^ Output file or 'Nothing' for @STDOUT@
+  -> C.Header
+  -> IO ()
+preprocessIO opts ppOpts headerIncludePath fp =
+    genPP ppOpts fp
+      . genModule ppOpts
+      . genSHsDecls
+      . genHsDecls opts headerIncludePath
+
+{-------------------------------------------------------------------------------
+  Template Haskell API
+-------------------------------------------------------------------------------}
+
+-- | Generate bindings for the given C header
+genBindings ::
+     Opts
+  -> FilePath -- ^ Input header, as written in C @#include@
+  -> TH.Q [TH.Dec]
+genBindings opts fp = do
+    headerIncludePath <- either (TH.runIO . throwIO) return $
+      parseCHeaderIncludePath fp
+    (depPaths, cheader) <- TH.runIO $ parseCHeader opts headerIncludePath
+
+    -- record dependencies, including transitively included headers
+    mapM_ (TH.addDependentFile . getSourcePath) depPaths
+
+    let sdecls = genSHsDecls $ genHsDecls opts headerIncludePath cheader
+
+    -- extensions checks.
+    -- Potential TODO: we could also check which enabled extension may interfere with the generated code. (e.g. Strict/Data)
+    enabledExts <- Set.fromList <$> TH.extsEnabled
+    let requiredExts = genExtensions sdecls
+        missingExts  = requiredExts `Set.difference` enabledExts
+    unless (null missingExts) $ do
+      TH.reportError $ "Missing LANGUAGE extensions: "
+        ++ unwords (map show (toList missingExts))
+
+    -- generate TH declarations
+    genTH sdecls
+
+-- | Generate bindings for the given C header (simple)
+--
+-- This function uses default Clang arguments but allows you to add directories
+-- to the include search path.  Use 'genBindings' when more configuration is
+-- required.
+genBindings' ::
+     [FilePath] -- ^ Quote include search path directories
+  -> FilePath   -- ^ Input header, as written in C @#include@
+  -> TH.Q [TH.Dec]
+genBindings' quoteIncPathDirs = genBindings defaultOpts {
+      optsClangArgs = defaultClangArgs {
+          clangQuoteIncludePathDirs  = CIncludePathDir <$> quoteIncPathDirs
+        }
+    }
+
+{-------------------------------------------------------------------------------
+  Test generation
+-------------------------------------------------------------------------------}
+
+genTests :: PPOpts -> CHeaderIncludePath -> FilePath -> C.Header -> IO ()
+genTests PPOpts{..} headerIncludePath testDir cheader =
+    GenTests.genTests
+      headerIncludePath
+      cheader
+      (hsModuleOptsName ppOptsModule)
+      (hsLineLength ppOptsRender)
+      testDir

--- a/hs-bindgen/test-th/Test01.hs
+++ b/hs-bindgen/test-th/Test01.hs
@@ -1,6 +1,5 @@
 -- {-# OPTIONS_GHC -ddump-splices #-}
 {-# LANGUAGE CApiFFI #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExplicitForAll #-}
@@ -11,14 +10,9 @@
 
 module Test01 where
 
-import HsBindgen.Lib
-import System.FilePath ((</>))
-import Foreign.C.Types
+import HsBindgen.TH
 
-#ifdef MIN_VERSION_th_compat
-import Language.Haskell.TH.Syntax.Compat (getPackageRoot)
-#else
-import Language.Haskell.TH.Syntax (getPackageRoot)
-#endif
+-- Used by generated code
+import Foreign.C.Types
 
 $(getPackageRoot >>= \dir -> genBindings' [dir </> "examples"] "test_01.h")

--- a/hs-bindgen/test-th/Test02.hs
+++ b/hs-bindgen/test-th/Test02.hs
@@ -1,5 +1,4 @@
 -- {-# OPTIONS_GHC -ddump-splices #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -7,28 +6,24 @@
 
 module Test02 where
 
-import Data.String (IsString (..))
+import HsBindgen.TH
+
+-- Used by generated code
 import Data.Word qualified
-import Language.Haskell.TH qualified as TH
-import System.FilePath ((</>), joinPath)
-
-import HsBindgen.Lib
 import HsBindgen.Runtime.LibC qualified
-
-#ifdef MIN_VERSION_th_compat
-import Language.Haskell.TH.Syntax.Compat (getPackageRoot)
-#else
-import Language.Haskell.TH.Syntax (getPackageRoot)
-#endif
 
 $(do
     dir <- getPackageRoot
     let args = defaultClangArgs {
-            clangQuoteIncludePathDirs = [fromString (dir </> "examples")]
+            clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
-    extBindings <- TH.runIO $ loadExtBindings args [
+    extBindings <- loadExtBindings args [
         joinPath [dir, "bindings", "base.yaml"]
       , joinPath [dir, "bindings", "hs-bindgen-runtime.yaml"]
       ]
-    genBindings "test_02.h" extBindings args
+    let opts = defaultOpts {
+            optsClangArgs   = args
+          , optsExtBindings = extBindings
+          }
+    genBindings opts "test_02.h"
  )

--- a/hs-bindgen/tests/Misc.hs
+++ b/hs-bindgen/tests/Misc.hs
@@ -8,7 +8,7 @@ module Misc (
 import Data.ByteString qualified as BS
 import Data.ByteString.UTF8 qualified as UTF8
 import System.Directory (doesFileExist, setCurrentDirectory, getCurrentDirectory)
-import System.FilePath ((</>), (-<.>))
+import System.FilePath ((-<.>))
 import Test.Tasty (TestTree, TestName)
 
 import AnsiDiff (ansidiff)

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -19,7 +19,6 @@ import HsBindgen.ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name qualified as HsName
 import HsBindgen.Hs.AST.Type qualified as HsType
-import HsBindgen.Lib
 import HsBindgen.NameHint
 import HsBindgen.Runtime.Enum.Simple
 
@@ -38,8 +37,6 @@ instance ToExpr CInt where
 {-------------------------------------------------------------------------------
   hs-bindgen
 -------------------------------------------------------------------------------}
-
-instance ToExpr CHeader
 
 instance ToExpr C.Attribute
 instance ToExpr C.CName

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -15,6 +15,7 @@ import System.FilePath qualified as FilePath
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as CMacro
 import HsBindgen.Clang.Paths qualified as Paths
+import HsBindgen.ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name qualified as HsName
 import HsBindgen.Hs.AST.Type qualified as HsType


### PR DESCRIPTION
This PR is a first step toward improving our public API.

A new `HsBindgen.Pipeline` module is added.  This module serves two purposes:

* It defines high-level options types and defaults.  Type `Opts` contains all options that apply to both the preprocessor and TH APIs.  Type `PPOpts` contains additional options for the preprocessor API.  Note that we do not have any options specific to the TH API.
* It defines pipeline components (such as `genHsDecls`, `genTH`, etc.) and high-level API functions that are implemented using these pipeline components.  The same components are used for both the preprocessor and TH APIs, and these functions are implemented in the same module, which should help ensure that the behavior remains the same.  All of these functions are implemented using the high-level options types.

Note that `Opts` includes the name mangler as well as tracers.  With this PR, users are now able to use a different name mangler.  (Previously, the default name mangler was hard-coded in multiple places.)

Module `HsBindgen.Lib` provides an API for users who want to use `hs-bindgen` as a library.  This module should expose everything needed for users to implement preprocessing.  It should *not* export things just for our use in tests.  The module re-exports types and functions that are needed, including options types.  An exception is the `NameMangler` module, which exports a DSL; that module is exposed, and users should import from it directly when creating a custom name mangler.

Module `HsBindgen.Lib` defines opaque type `CHeader`, used because `C.Header` is not part of the public API.  It is needed because users may parse a header and then use the result to generate Haskell code (preprocessor) as well as generate tests for that code.  Functions are defined that wrap and unwrap this type, accordingly.  Note that this module should probably not define anything else; all "logic" should be implemented in non-exposed modules.

We have not decided if we should include development/debugging functionality in `HsBindgen.Lib`.  This PR removes the `dev bootstrap` command.  The function used by the `dev parse` command is still in the module, though, renamed to `dumpCHeader`.

The public API is simplified.  One notable change is that `withTranslationUnit` is no longer exposed.  Function `getTargetTriple` is re-implemented to use `CXUnsavedFile`, as the target triple depends on the Clang arguments but not the source header.

Module `HsBindgen.TH` provides the Template Haskell API.  Like `HsBindgen.Lib`, it re-exports types and functions that are needed, including options types.  A goal if this module is to reduce the amount of code that users have to write.  Note that we may want to add a function that uses `base` (and `hs-bingen-runtime`?) external bindings automatically, which would significantly reduce the code needed for that common case.  This is not done yet.

One way to reduce the amount of user code is to provide `IO` functions in the `Q` monad.  For example, the module exports a version of `loadExtBindings` in the `Q` monad.  In some cases, this allows users to avoid adding `template-haskell` as a direct dependency of their package.  The module also re-exports `getPackageRoot` from `template-haskell` or `th-compat`, allowing users to avoid the conditional dependency and `CPP` usage in their projects.

One Travis-ism that I would like to point out in case others find it unpalatable is that I strictly use qualified imports for everything (except `Prelude`) in the `HsBindgen.Lib` and `HsBindgen.TH` modules.  I like to do this for such re-exporting modules because it makes everything very clear (IMHO), but I can change it of other find it distasteful.

We need more types and functions to implement tests, as evidenced by the "exposed for the sake of tests" comment in the `.cabal` file.  This PR does not change this, and even more modules are exposed.  We should address this in our next step toward improving our public API; I will create an issue.