### PR TITLE
Use `DeclPath` for opaque structs and enums

### DIFF
--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -43,11 +43,13 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "c")
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "S1"))
                 DeclPathTop)),
           structSizeof = 8,
@@ -117,11 +119,13 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "c")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "S1"))
                   DeclPathTop)),
             structSizeof = 8,
@@ -196,11 +200,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "c")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S1"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -277,11 +283,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "c")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S1"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -344,11 +352,13 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "c")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -372,7 +382,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structSizeof = 12,
@@ -383,11 +394,13 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "c")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -426,11 +439,13 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "c")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -454,7 +469,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structSizeof = 12,
@@ -465,11 +481,13 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "c")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -513,11 +531,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -541,7 +561,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -552,11 +573,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -602,11 +625,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -630,7 +655,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -641,11 +667,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -705,15 +733,18 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "deep")
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "inner")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "S2"))
                     DeclPathTop)))),
           structSizeof = 4,
@@ -759,15 +790,18 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "deep")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop)))),
             structSizeof = 4,
@@ -818,15 +852,18 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "deep")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           DeclNameNone
                           (DeclPathField
                             (CName "inner")
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "S2"))
                               DeclPathTop)))),
                     structSizeof = 4,
@@ -877,15 +914,18 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "deep")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           DeclNameNone
                           (DeclPathField
                             (CName "inner")
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "S2"))
                               DeclPathTop)))),
                     structSizeof = 4,
@@ -961,15 +1001,18 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "deep")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -977,11 +1020,13 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "inner")
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "S2"))
                 DeclPathTop)),
           structSizeof = 8,
@@ -1000,15 +1045,18 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "deep")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1057,15 +1105,18 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "deep")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         DeclNameNone
                         (DeclPathField
                           (CName "inner")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1073,11 +1124,13 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "inner")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "S2"))
                   DeclPathTop)),
             structSizeof = 8,
@@ -1096,15 +1149,18 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "deep")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         DeclNameNone
                         (DeclPathField
                           (CName "inner")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1158,15 +1214,18 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1174,11 +1233,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -1197,15 +1258,18 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1261,15 +1325,18 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1277,11 +1344,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -1300,15 +1369,18 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1360,11 +1432,13 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -1388,7 +1462,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structSizeof = 12,
@@ -1399,11 +1474,13 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -1444,11 +1521,13 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -1472,7 +1551,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structSizeof = 12,
@@ -1483,11 +1563,13 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -1533,11 +1615,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1561,7 +1645,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -1572,11 +1657,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1624,11 +1711,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1652,7 +1741,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -1663,11 +1753,13 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -2,11 +2,13 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "c")
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop)),
         structSizeof = 8,
@@ -33,7 +35,8 @@ Header
         "anonymous.h:3:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structSizeof = 12,
@@ -44,11 +47,13 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "c")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "S1"))
                     DeclPathTop))),
             fieldSourceLoc =
@@ -66,15 +71,18 @@ Header
         "anonymous.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "deep")
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "inner")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "S2"))
                   DeclPathTop)))),
         structSizeof = 4,
@@ -93,11 +101,13 @@ Header
         "anonymous.h:15:5"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "inner")
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop)),
         structSizeof = 8,
@@ -116,15 +126,18 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "deep")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))))),
             fieldSourceLoc =
@@ -134,7 +147,8 @@ Header
         "anonymous.h:13:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structSizeof = 12,
@@ -145,11 +159,13 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "inner")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "S2"))
                     DeclPathTop))),
             fieldSourceLoc =

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -107,7 +107,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "flags"))
             DeclPathTop,
           structSizeof = 4,
@@ -273,7 +274,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "flags"))
               DeclPathTop,
             structSizeof = 4,
@@ -444,7 +446,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "flags"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -621,7 +624,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "flags"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -775,7 +779,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32"))
             DeclPathTop,
@@ -870,7 +875,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32"))
               DeclPathTop,
@@ -970,7 +976,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32"))
                       DeclPathTop,
@@ -1073,7 +1080,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32"))
                       DeclPathTop,
@@ -1197,7 +1205,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32b"))
             DeclPathTop,
@@ -1292,7 +1301,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32b"))
               DeclPathTop,
@@ -1392,7 +1402,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32b"))
                       DeclPathTop,
@@ -1495,7 +1506,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32b"))
                       DeclPathTop,
@@ -1619,7 +1631,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32c"))
             DeclPathTop,
@@ -1714,7 +1727,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32c"))
               DeclPathTop,
@@ -1814,7 +1828,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32c"))
                       DeclPathTop,
@@ -1917,7 +1932,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32c"))
                       DeclPathTop,
@@ -2025,7 +2041,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "overflow64"))
             DeclPathTop,
@@ -2096,7 +2113,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow64"))
               DeclPathTop,
@@ -2172,7 +2190,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow64"))
                       DeclPathTop,
@@ -2250,7 +2269,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow64"))
                       DeclPathTop,
@@ -2345,7 +2365,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "alignA"))
             DeclPathTop,
           structSizeof = 4,
@@ -2415,7 +2436,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "alignA"))
               DeclPathTop,
             structSizeof = 4,
@@ -2490,7 +2512,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "alignA"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -2567,7 +2590,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "alignA"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -2661,7 +2685,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "alignB"))
             DeclPathTop,
           structSizeof = 8,
@@ -2731,7 +2756,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "alignB"))
               DeclPathTop,
             structSizeof = 8,
@@ -2806,7 +2832,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "alignB"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -2883,7 +2910,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "alignB"))
                       DeclPathTop,
                     structSizeof = 8,

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "flags"))
           DeclPathTop,
         structSizeof = 4,
@@ -61,7 +62,8 @@ Header
         "bitfields.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32"))
           DeclPathTop,
@@ -97,7 +99,8 @@ Header
         "bitfields.h:12:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32b"))
           DeclPathTop,
@@ -133,7 +136,8 @@ Header
         "bitfields.h:18:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32c"))
           DeclPathTop,
@@ -169,7 +173,8 @@ Header
         "bitfields.h:24:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "overflow64"))
           DeclPathTop,
@@ -197,7 +202,8 @@ Header
         "bitfields.h:30:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "alignA"))
           DeclPathTop,
         structSizeof = 4,
@@ -224,7 +230,8 @@ Header
         "bitfields.h:36:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "alignB"))
           DeclPathTop,
         structSizeof = 8,

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -121,7 +121,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bools1"))
             DeclPathTop,
           structSizeof = 2,
@@ -186,7 +187,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bools1"))
               DeclPathTop,
             structSizeof = 2,
@@ -255,7 +257,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools1"))
                       DeclPathTop,
                     structSizeof = 2,
@@ -327,7 +330,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools1"))
                       DeclPathTop,
                     structSizeof = 2,
@@ -410,7 +414,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bools2"))
             DeclPathTop,
           structSizeof = 2,
@@ -475,7 +480,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bools2"))
               DeclPathTop,
             structSizeof = 2,
@@ -544,7 +550,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools2"))
                       DeclPathTop,
                     structSizeof = 2,
@@ -616,7 +623,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools2"))
                       DeclPathTop,
                     structSizeof = 2,
@@ -701,7 +709,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bools3"))
             DeclPathTop,
           structSizeof = 2,
@@ -771,7 +780,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bools3"))
               DeclPathTop,
             structSizeof = 2,
@@ -846,7 +856,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools3"))
                       DeclPathTop,
                     structSizeof = 2,
@@ -923,7 +934,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bools3"))
                       DeclPathTop,
                     structSizeof = 2,

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -18,7 +18,8 @@ Header
         "bool.h:13:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bools1"))
           DeclPathTop,
         structSizeof = 2,
@@ -41,7 +42,8 @@ Header
         structSourceLoc = "bool.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bools2"))
           DeclPathTop,
         structSizeof = 2,
@@ -64,7 +66,8 @@ Header
         structSourceLoc = "bool.h:8:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bools3"))
           DeclPathTop,
         structSizeof = 2,

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -587,8 +587,12 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName
-            "another_typedef_enum_e",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTypedef
+              (CName
+                "another_typedef_enum_e"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -625,8 +629,12 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName
-              "another_typedef_enum_e",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTypedef
+                (CName
+                  "another_typedef_enum_e"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -668,8 +676,12 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName
-                      "another_typedef_enum_e",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -711,8 +723,12 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName
-                      "another_typedef_enum_e",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1491,8 +1507,12 @@
               fieldOffset = 480,
               fieldWidth = Nothing,
               fieldType = TypeEnum
-                (CName
-                  "another_typedef_enum_e"),
+                (DeclPathConstr
+                  DeclConstrEnum
+                  (DeclNameTypedef
+                    (CName
+                      "another_typedef_enum_e"))
+                  DeclPathTop),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"}},
         Field {
@@ -1514,8 +1534,12 @@
               fieldType = TypeConstArray
                 4
                 (TypeEnum
-                  (CName
-                    "another_typedef_enum_e")),
+                  (DeclPathConstr
+                    DeclConstrEnum
+                    (DeclNameTypedef
+                      (CName
+                        "another_typedef_enum_e"))
+                    DeclPathTop)),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"}},
         Field {
@@ -1541,8 +1565,12 @@
                 (TypeConstArray
                   3
                   (TypeEnum
-                    (CName
-                      "another_typedef_enum_e"))),
+                    (DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}}],
       structOrigin =
@@ -1637,8 +1665,12 @@
               fieldOffset = 480,
               fieldWidth = Nothing,
               fieldType = TypeEnum
-                (CName
-                  "another_typedef_enum_e"),
+                (DeclPathConstr
+                  DeclConstrEnum
+                  (DeclNameTypedef
+                    (CName
+                      "another_typedef_enum_e"))
+                  DeclPathTop),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"},
             StructField {
@@ -1648,8 +1680,12 @@
               fieldType = TypeConstArray
                 4
                 (TypeEnum
-                  (CName
-                    "another_typedef_enum_e")),
+                  (DeclPathConstr
+                    DeclConstrEnum
+                    (DeclNameTypedef
+                      (CName
+                        "another_typedef_enum_e"))
+                    DeclPathTop)),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"},
             StructField {
@@ -1661,8 +1697,12 @@
                 (TypeConstArray
                   3
                   (TypeEnum
-                    (CName
-                      "another_typedef_enum_e"))),
+                    (DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
@@ -1848,8 +1888,12 @@
                 fieldOffset = 480,
                 fieldWidth = Nothing,
                 fieldType = TypeEnum
-                  (CName
-                    "another_typedef_enum_e"),
+                  (DeclPathConstr
+                    DeclConstrEnum
+                    (DeclNameTypedef
+                      (CName
+                        "another_typedef_enum_e"))
+                    DeclPathTop),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"}},
           Field {
@@ -1871,8 +1915,12 @@
                 fieldType = TypeConstArray
                   4
                   (TypeEnum
-                    (CName
-                      "another_typedef_enum_e")),
+                    (DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop)),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"}},
           Field {
@@ -1898,8 +1946,12 @@
                   (TypeConstArray
                     3
                     (TypeEnum
-                      (CName
-                        "another_typedef_enum_e"))),
+                      (DeclPathConstr
+                        DeclConstrEnum
+                        (DeclNameTypedef
+                          (CName
+                            "another_typedef_enum_e"))
+                        DeclPathTop))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}}],
         structOrigin =
@@ -1994,8 +2046,12 @@
                 fieldOffset = 480,
                 fieldWidth = Nothing,
                 fieldType = TypeEnum
-                  (CName
-                    "another_typedef_enum_e"),
+                  (DeclPathConstr
+                    DeclConstrEnum
+                    (DeclNameTypedef
+                      (CName
+                        "another_typedef_enum_e"))
+                    DeclPathTop),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"},
               StructField {
@@ -2005,8 +2061,12 @@
                 fieldType = TypeConstArray
                   4
                   (TypeEnum
-                    (CName
-                      "another_typedef_enum_e")),
+                    (DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName
+                          "another_typedef_enum_e"))
+                      DeclPathTop)),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"},
               StructField {
@@ -2018,8 +2078,12 @@
                   (TypeConstArray
                     3
                     (TypeEnum
-                      (CName
-                        "another_typedef_enum_e"))),
+                      (DeclPathConstr
+                        DeclConstrEnum
+                        (DeclNameTypedef
+                          (CName
+                            "another_typedef_enum_e"))
+                        DeclPathTop))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}],
             structFlam = Nothing,
@@ -2210,8 +2274,12 @@
                         fieldOffset = 480,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (CName
-                            "another_typedef_enum_e"),
+                          (DeclPathConstr
+                            DeclConstrEnum
+                            (DeclNameTypedef
+                              (CName
+                                "another_typedef_enum_e"))
+                            DeclPathTop),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2233,8 +2301,12 @@
                         fieldType = TypeConstArray
                           4
                           (TypeEnum
-                            (CName
-                              "another_typedef_enum_e")),
+                            (DeclPathConstr
+                              DeclConstrEnum
+                              (DeclNameTypedef
+                                (CName
+                                  "another_typedef_enum_e"))
+                              DeclPathTop)),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2260,8 +2332,12 @@
                           (TypeConstArray
                             3
                             (TypeEnum
-                              (CName
-                                "another_typedef_enum_e"))),
+                              (DeclPathConstr
+                                DeclConstrEnum
+                                (DeclNameTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))
+                                DeclPathTop))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
@@ -2356,8 +2432,12 @@
                         fieldOffset = 480,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (CName
-                            "another_typedef_enum_e"),
+                          (DeclPathConstr
+                            DeclConstrEnum
+                            (DeclNameTypedef
+                              (CName
+                                "another_typedef_enum_e"))
+                            DeclPathTop),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2367,8 +2447,12 @@
                         fieldType = TypeConstArray
                           4
                           (TypeEnum
-                            (CName
-                              "another_typedef_enum_e")),
+                            (DeclPathConstr
+                              DeclConstrEnum
+                              (DeclNameTypedef
+                                (CName
+                                  "another_typedef_enum_e"))
+                              DeclPathTop)),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2380,8 +2464,12 @@
                           (TypeConstArray
                             3
                             (TypeEnum
-                              (CName
-                                "another_typedef_enum_e"))),
+                              (DeclPathConstr
+                                DeclConstrEnum
+                                (DeclNameTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))
+                                DeclPathTop))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -2583,8 +2671,12 @@
                         fieldOffset = 480,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (CName
-                            "another_typedef_enum_e"),
+                          (DeclPathConstr
+                            DeclConstrEnum
+                            (DeclNameTypedef
+                              (CName
+                                "another_typedef_enum_e"))
+                            DeclPathTop),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2606,8 +2698,12 @@
                         fieldType = TypeConstArray
                           4
                           (TypeEnum
-                            (CName
-                              "another_typedef_enum_e")),
+                            (DeclPathConstr
+                              DeclConstrEnum
+                              (DeclNameTypedef
+                                (CName
+                                  "another_typedef_enum_e"))
+                              DeclPathTop)),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2633,8 +2729,12 @@
                           (TypeConstArray
                             3
                             (TypeEnum
-                              (CName
-                                "another_typedef_enum_e"))),
+                              (DeclPathConstr
+                                DeclConstrEnum
+                                (DeclNameTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))
+                                DeclPathTop))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
@@ -2729,8 +2829,12 @@
                         fieldOffset = 480,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (CName
-                            "another_typedef_enum_e"),
+                          (DeclPathConstr
+                            DeclConstrEnum
+                            (DeclNameTypedef
+                              (CName
+                                "another_typedef_enum_e"))
+                            DeclPathTop),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2740,8 +2844,12 @@
                         fieldType = TypeConstArray
                           4
                           (TypeEnum
-                            (CName
-                              "another_typedef_enum_e")),
+                            (DeclPathConstr
+                              DeclConstrEnum
+                              (DeclNameTypedef
+                                (CName
+                                  "another_typedef_enum_e"))
+                              DeclPathTop)),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2753,8 +2861,12 @@
                           (TypeConstArray
                             3
                             (TypeEnum
-                              (CName
-                                "another_typedef_enum_e"))),
+                              (DeclPathConstr
+                                DeclConstrEnum
+                                (DeclNameTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))
+                                DeclPathTop))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -2843,8 +2955,11 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName
-            "a_typedef_enum_e",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTypedef
+              (CName "a_typedef_enum_e"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimChar (Just Unsigned)),
           enumSizeof = 1,
@@ -2891,8 +3006,11 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName
-              "a_typedef_enum_e",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTypedef
+                (CName "a_typedef_enum_e"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimChar (Just Unsigned)),
             enumSizeof = 1,
@@ -2944,8 +3062,11 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName
-                      "a_typedef_enum_e",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName "a_typedef_enum_e"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
                     enumSizeof = 1,
@@ -2997,8 +3118,11 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName
-                      "a_typedef_enum_e",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName "a_typedef_enum_e"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
                     enumSizeof = 1,

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -290,7 +290,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTypedef
               (CName
                 "another_typedef_struct_t"))
@@ -362,7 +363,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTypedef
                 (CName
                   "another_typedef_struct_t"))
@@ -439,7 +441,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -518,7 +521,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -1401,7 +1405,8 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -1425,7 +1430,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1542,7 +1548,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "a_typedef_struct"))
             DeclPathTop,
@@ -1585,7 +1592,8 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -1598,7 +1606,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1753,7 +1762,8 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1777,7 +1787,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -1894,7 +1905,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop,
@@ -1937,7 +1949,8 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1950,7 +1963,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -2110,7 +2124,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2134,7 +2149,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2251,7 +2267,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "a_typedef_struct"))
                       DeclPathTop,
@@ -2294,7 +2311,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2307,7 +2325,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2478,7 +2497,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2502,7 +2522,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2619,7 +2640,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "a_typedef_struct"))
                       DeclPathTop,
@@ -2662,7 +2684,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2675,7 +2698,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2788,7 +2812,8 @@
           typedefName = CName
             "a_typedef_struct_t",
           typedefType = TypeStruct
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop),

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -325,7 +325,8 @@ Header
         "distilled_lib_1.h:71:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTypedef
             (CName
               "another_typedef_struct_t"))
@@ -412,7 +413,8 @@ Header
         "alltypes.h:131:25"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "a_typedef_struct"))
           DeclPathTop,
@@ -455,7 +457,8 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTypedef
                   (CName
                     "another_typedef_struct_t"))
@@ -468,7 +471,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -534,7 +538,8 @@ Header
         typedefName = CName
           "a_typedef_struct_t",
         typedefType = TypeStruct
-          (DeclPathStruct
+          (DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "a_typedef_struct"))
             DeclPathTop),

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -355,8 +355,12 @@ Header
         "distilled_lib_1.h:8:9"},
     DeclEnum
       Enu {
-        enumTag = CName
-          "another_typedef_enum_e",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTypedef
+            (CName
+              "another_typedef_enum_e"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -502,8 +506,12 @@ Header
             fieldOffset = 480,
             fieldWidth = Nothing,
             fieldType = TypeEnum
-              (CName
-                "another_typedef_enum_e"),
+              (DeclPathConstr
+                DeclConstrEnum
+                (DeclNameTypedef
+                  (CName
+                    "another_typedef_enum_e"))
+                DeclPathTop),
             fieldSourceLoc =
             "distilled_lib_1.h:44:31"},
           StructField {
@@ -513,8 +521,12 @@ Header
             fieldType = TypeConstArray
               4
               (TypeEnum
-                (CName
-                  "another_typedef_enum_e")),
+                (DeclPathConstr
+                  DeclConstrEnum
+                  (DeclNameTypedef
+                    (CName
+                      "another_typedef_enum_e"))
+                  DeclPathTop)),
             fieldSourceLoc =
             "distilled_lib_1.h:45:31"},
           StructField {
@@ -526,8 +538,12 @@ Header
               (TypeConstArray
                 3
                 (TypeEnum
-                  (CName
-                    "another_typedef_enum_e"))),
+                  (DeclPathConstr
+                    DeclConstrEnum
+                    (DeclNameTypedef
+                      (CName
+                        "another_typedef_enum_e"))
+                    DeclPathTop))),
             fieldSourceLoc =
             "distilled_lib_1.h:46:31"}],
         structFlam = Nothing,
@@ -547,8 +563,11 @@ Header
         "distilled_lib_1.h:47:3"},
     DeclEnum
       Enu {
-        enumTag = CName
-          "a_typedef_enum_e",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTypedef
+            (CName "a_typedef_enum_e"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimChar (Just Unsigned)),
         enumSizeof = 1,

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -17,7 +17,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "first",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "first"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -52,7 +55,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "first",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "first"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -92,7 +98,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "first",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "first"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -132,7 +141,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "first",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "first"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -241,7 +253,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "second",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "second"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Signed),
           enumSizeof = 4,
@@ -282,7 +297,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "second",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "second"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
             enumSizeof = 4,
@@ -328,7 +346,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "second",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "second"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
                     enumSizeof = 4,
@@ -374,7 +395,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "second",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "second"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
                     enumSizeof = 4,
@@ -508,7 +532,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "same",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "same"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -545,7 +572,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "same",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "same"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -586,7 +616,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "same",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "same"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -628,7 +661,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "same",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "same"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -728,7 +764,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "packad",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "packad"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimChar (Just Unsigned)),
           enumSizeof = 1,
@@ -770,7 +809,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "packad",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "packad"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimChar (Just Unsigned)),
             enumSizeof = 1,
@@ -816,7 +858,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "packad",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "packad"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
                     enumSizeof = 1,
@@ -863,7 +908,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "packad",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "packad"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
                     enumSizeof = 1,
@@ -997,7 +1045,11 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "enumA",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTypedef
+              (CName "enumA"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1034,7 +1086,11 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "enumA",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTypedef
+                (CName "enumA"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1075,7 +1131,11 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumA",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName "enumA"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1117,7 +1177,11 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumA",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTypedef
+                        (CName "enumA"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1227,7 +1291,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "enumB",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "enumB"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1264,7 +1331,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "enumB",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "enumB"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1306,7 +1376,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumB",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumB"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1348,7 +1421,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumB",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumB"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1459,7 +1535,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "enumC",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "enumC"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1496,7 +1575,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "enumC",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "enumC"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1537,7 +1619,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumC",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumC"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1579,7 +1664,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumC",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumC"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1689,7 +1777,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "enumD",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "enumD"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1726,7 +1817,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "enumD",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "enumD"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1767,7 +1861,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumD",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumD"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1809,7 +1906,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "enumD",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "enumD"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1923,7 +2023,10 @@
         Typedef {
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
-            (CName "enumD"),
+            (DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "enumD"))
+              DeclPathTop),
           typedefSourceLoc =
           "enums.h:32:20"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -17,7 +17,10 @@ Header
         "enums.h:2:9"},
     DeclEnum
       Enu {
-        enumTag = CName "first",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "first"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -35,7 +38,10 @@ Header
         enumSourceLoc = "enums.h:4:6"},
     DeclEnum
       Enu {
-        enumTag = CName "second",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "second"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Signed),
         enumSizeof = 4,
@@ -59,7 +65,10 @@ Header
         enumSourceLoc = "enums.h:9:6"},
     DeclEnum
       Enu {
-        enumTag = CName "same",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "same"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -78,7 +87,10 @@ Header
         enumSourceLoc = "enums.h:15:6"},
     DeclEnum
       Enu {
-        enumTag = CName "packad",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "packad"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimChar (Just Unsigned)),
         enumSizeof = 1,
@@ -102,7 +114,11 @@ Header
         enumSourceLoc = "enums.h:20:6"},
     DeclEnum
       Enu {
-        enumTag = CName "enumA",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTypedef
+            (CName "enumA"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -121,7 +137,10 @@ Header
         enumSourceLoc = "enums.h:24:9"},
     DeclEnum
       Enu {
-        enumTag = CName "enumB",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "enumB"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -141,7 +160,10 @@ Header
         "enums.h:26:14"},
     DeclEnum
       Enu {
-        enumTag = CName "enumC",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "enumC"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -160,7 +182,10 @@ Header
         enumSourceLoc = "enums.h:28:6"},
     DeclEnum
       Enu {
-        enumTag = CName "enumD",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "enumD"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -181,6 +206,9 @@ Header
       Typedef {
         typedefName = CName "enumD_t",
         typedefType = TypeEnum
-          (CName "enumD"),
+          (DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "enumD"))
+            DeclPathTop),
         typedefSourceLoc =
         "enums.h:32:20"}]

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -85,7 +85,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "Example"))
             DeclPathTop,
           structSizeof = 48,
@@ -171,7 +172,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "Example"))
               DeclPathTop,
             structSizeof = 48,
@@ -262,7 +264,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Example"))
                       DeclPathTop,
                     structSizeof = 48,
@@ -355,7 +358,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Example"))
                       DeclPathTop,
                     structSizeof = 48,

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -11,7 +11,8 @@ Header
         "fixedarray.h:1:13"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "Example"))
           DeclPathTop,
         structSizeof = 48,

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -251,7 +251,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structSizeof = 16,
@@ -325,7 +326,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 16,
@@ -404,7 +406,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -485,7 +488,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 16,

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -18,7 +18,8 @@ Header
         "alltypes.h:131:25"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structSizeof = 16,

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -27,7 +27,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "pascal"))
             DeclPathTop,
           structSizeof = 4,
@@ -79,7 +80,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "pascal"))
               DeclPathTop,
             structSizeof = 4,
@@ -135,7 +137,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "pascal"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -192,7 +195,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "pascal"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -262,7 +266,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "pascal"))
               DeclPathTop,
             structSizeof = 4,
@@ -330,11 +335,13 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "bar")
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop)),
           structSizeof = 8,
@@ -403,11 +410,13 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "bar")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop)),
             structSizeof = 8,
@@ -481,11 +490,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "bar")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "foo"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -561,11 +572,13 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "bar")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "foo"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -637,7 +650,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structSizeof = 4,
@@ -656,11 +670,13 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "bar")
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop))),
               fieldSourceLoc = "flam.h:13:4"},
@@ -695,7 +711,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 4,
@@ -714,11 +731,13 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "bar")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "foo"))
                         DeclPathTop))),
                 fieldSourceLoc = "flam.h:13:4"},
@@ -757,7 +776,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -776,11 +796,13 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "bar")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
                         fieldSourceLoc = "flam.h:13:4"},
@@ -820,7 +842,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -839,11 +862,13 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "bar")
-                              (DeclPathStruct
+                              (DeclPathConstr
+                                DeclConstrStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
                         fieldSourceLoc = "flam.h:13:4"},
@@ -892,7 +917,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 4,
@@ -911,11 +937,13 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "bar")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "foo"))
                         DeclPathTop))),
                 fieldSourceLoc = "flam.h:13:4"},
@@ -969,7 +997,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "diff"))
             DeclPathTop,
           structSizeof = 16,
@@ -1045,7 +1074,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "diff"))
               DeclPathTop,
             structSizeof = 16,
@@ -1126,7 +1156,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "diff"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1209,7 +1240,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "diff"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1301,7 +1333,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "diff"))
               DeclPathTop,
             structSizeof = 16,

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "pascal"))
           DeclPathTop,
         structSizeof = 4,
@@ -26,11 +27,13 @@ Header
         structSourceLoc = "flam.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "bar")
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop)),
         structSizeof = 8,
@@ -56,7 +59,8 @@ Header
         "flam.h:10:2"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structSizeof = 4,
@@ -75,18 +79,21 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "bar")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop))),
             fieldSourceLoc = "flam.h:13:4"},
         structSourceLoc = "flam.h:8:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "diff"))
           DeclPathTop,
         structSizeof = 16,

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -27,7 +27,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structSizeof = 4,
@@ -73,7 +74,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structSizeof = 4,
@@ -124,7 +126,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -175,7 +178,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -227,7 +231,8 @@
         Typedef {
           typedefName = CName "S1_t",
           typedefType = TypeStruct
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop),
           typedefSourceLoc =
@@ -264,7 +269,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structSizeof = 4,
@@ -310,7 +316,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structSizeof = 4,
@@ -361,7 +368,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -412,7 +420,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 4,

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structSizeof = 4,
@@ -23,14 +24,16 @@ Header
       Typedef {
         typedefName = CName "S1_t",
         typedefType = TypeStruct
-          (DeclPathStruct
+          (DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop),
         typedefSourceLoc =
         "forward_declaration.h:1:19"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structSizeof = 4,

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -43,7 +43,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structSizeof = 8,
@@ -113,7 +114,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 8,
@@ -188,7 +190,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -265,7 +268,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -328,7 +332,8 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -346,7 +351,8 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -354,7 +360,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             DeclPathTop,
           structSizeof = 16,
@@ -365,7 +372,8 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -375,7 +383,8 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -406,7 +415,8 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -424,7 +434,8 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -432,7 +443,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               DeclPathTop,
             structSizeof = 16,
@@ -443,7 +455,8 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -453,7 +466,8 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -489,7 +503,8 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -507,7 +522,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -515,7 +531,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -526,7 +543,8 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -536,7 +554,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -574,7 +593,8 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -592,7 +612,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -600,7 +621,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -611,7 +633,8 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -621,7 +644,8 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -673,7 +697,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "ex3"))
             DeclPathTop,
           structSizeof = 12,
@@ -719,7 +744,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "ex3"))
               DeclPathTop,
             structSizeof = 12,
@@ -770,7 +796,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex3"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -821,7 +848,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex3"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -895,7 +923,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -903,12 +932,14 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "ex4_even"))
             (DeclPathPtr
               (DeclPathField
                 (CName "next")
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_odd"))
                   DeclPathTop))),
           structSizeof = 16,
@@ -928,7 +959,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -979,7 +1011,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -987,12 +1020,14 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "ex4_even"))
               (DeclPathPtr
                 (DeclPathField
                   (CName "next")
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop))),
             structSizeof = 16,
@@ -1012,7 +1047,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -1068,7 +1104,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1076,12 +1113,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))),
                     structSizeof = 16,
@@ -1101,7 +1140,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1159,7 +1199,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1167,12 +1208,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))),
                     structSizeof = 16,
@@ -1192,7 +1235,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1262,12 +1306,14 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_even"))
                     (DeclPathPtr
                       (DeclPathField
                         (CName "next")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1275,7 +1321,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "ex4_odd"))
             DeclPathTop,
           structSizeof = 16,
@@ -1295,12 +1342,14 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_even"))
                     (DeclPathPtr
                       (DeclPathField
                         (CName "next")
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1351,12 +1400,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1364,7 +1415,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "ex4_odd"))
               DeclPathTop,
             structSizeof = 16,
@@ -1384,12 +1436,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1445,12 +1499,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1458,7 +1514,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1478,12 +1535,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1541,12 +1600,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1554,7 +1615,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1574,12 +1636,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
-                                  (DeclPathStruct
+                                  (DeclPathConstr
+                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structSizeof = 8,
@@ -29,7 +30,8 @@ Header
         "nested_types.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           DeclPathTop,
         structSizeof = 16,
@@ -40,7 +42,8 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop),
             fieldSourceLoc =
@@ -50,7 +53,8 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop),
             fieldSourceLoc =
@@ -60,7 +64,8 @@ Header
         "nested_types.h:6:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "ex3"))
           DeclPathTop,
         structSizeof = 12,
@@ -79,12 +84,14 @@ Header
         "nested_types.h:11:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "ex4_even"))
           (DeclPathPtr
             (DeclPathField
               (CName "next")
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTag (CName "ex4_odd"))
                 DeclPathTop))),
         structSizeof = 16,
@@ -104,7 +111,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_odd"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -114,7 +122,8 @@ Header
         "nested_types.h:24:12"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "ex4_odd"))
           DeclPathTop,
         structSizeof = 16,
@@ -134,12 +143,14 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_even"))
                   (DeclPathPtr
                     (DeclPathField
                       (CName "next")
-                      (DeclPathStruct
+                      (DeclPathConstr
+                        DeclConstrStruct
                         (DeclNameTag (CName "ex4_odd"))
                         DeclPathTop))))),
             fieldSourceLoc =

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -25,7 +25,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -45,7 +46,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -53,7 +55,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             DeclPathTop,
           structSizeof = 16,
@@ -65,7 +68,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -76,7 +80,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -109,7 +114,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -129,7 +135,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -137,7 +144,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               DeclPathTop,
             structSizeof = 16,
@@ -149,7 +157,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -160,7 +169,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -198,7 +208,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -218,7 +229,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -226,7 +238,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -238,7 +251,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -249,7 +263,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -289,7 +304,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -309,7 +325,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -317,7 +334,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -329,7 +347,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -340,7 +359,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -376,7 +396,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "baz"))
             DeclPathTop,
           structSizeof = 0,
@@ -398,7 +419,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "baz"))
               DeclPathTop,
             structSizeof = 0,
@@ -425,7 +447,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "baz"))
                       DeclPathTop,
                     structSizeof = 0,
@@ -452,7 +475,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "baz"))
                       DeclPathTop,
                     structSizeof = 0,

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -2,7 +2,11 @@ Header
   [
     DeclOpaqueStruct
       OpaqueStruct {
-        opaqueStructTag = CName "foo",
+        opaqueStructDeclPath =
+        DeclPathConstr
+          DeclConstrStruct
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
         opaqueStructSourceLoc =
         "opaque_declaration.h:1:8"},
     DeclStruct
@@ -55,12 +59,20 @@ Header
         "opaque_declaration.h:9:8"},
     DeclOpaqueEnum
       OpaqueEnum {
-        opaqueEnumTag = CName "quu",
+        opaqueEnumDeclPath =
+        DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "quu"))
+          DeclPathTop,
         opaqueEnumSourceLoc =
         "opaque_declaration.h:11:6"},
     DeclOpaqueStruct
       OpaqueStruct {
-        opaqueStructTag = CName
-          "opaque_union",
+        opaqueStructDeclPath =
+        DeclPathConstr
+          DeclConstrUnion
+          (DeclNameTag
+            (CName "opaque_union"))
+          DeclPathTop,
         opaqueStructSourceLoc =
         "opaque_declaration.h:13:7"}]

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -7,7 +7,8 @@ Header
         "opaque_declaration.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           DeclPathTop,
         structSizeof = 16,
@@ -19,7 +20,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -30,7 +32,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "bar"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -40,7 +43,8 @@ Header
         "opaque_declaration.h:4:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "baz"))
           DeclPathTop,
         structSizeof = 0,

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -495,7 +495,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "primitive"))
             DeclPathTop,
@@ -1254,7 +1255,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "primitive"))
               DeclPathTop,
@@ -2018,7 +2020,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "primitive"))
                       DeclPathTop,
@@ -2811,7 +2814,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "primitive"))
                       DeclPathTop,

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "primitive"))
           DeclPathTop,

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -41,7 +41,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
@@ -50,7 +51,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_A_s"))
             DeclPathTop,
@@ -71,7 +73,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
@@ -123,7 +126,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
@@ -132,7 +136,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop,
@@ -153,7 +158,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
@@ -210,7 +216,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -219,7 +226,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop,
@@ -240,7 +248,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -299,7 +308,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -308,7 +318,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop,
@@ -329,7 +340,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -381,7 +393,8 @@
           typedefName = CName
             "linked_list_A_t",
           typedefType = TypeStruct
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop),
@@ -435,7 +448,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
@@ -444,7 +458,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_B_t"))
             DeclPathTop,
@@ -465,7 +480,8 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
@@ -517,7 +533,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
@@ -526,7 +543,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_B_t"))
               DeclPathTop,
@@ -547,7 +565,8 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
@@ -604,7 +623,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -613,7 +633,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop,
@@ -634,7 +655,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -693,7 +715,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -702,7 +725,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop,
@@ -723,7 +747,8 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "linked_list_A_s"))
           DeclPathTop,
@@ -23,7 +24,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag
                     (CName "linked_list_A_s"))
                   DeclPathTop)),
@@ -37,7 +39,8 @@ Header
         typedefName = CName
           "linked_list_A_t",
         typedefType = TypeStruct
-          (DeclPathStruct
+          (DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_A_s"))
             DeclPathTop),
@@ -45,7 +48,8 @@ Header
         "recursive_struct.h:4:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "linked_list_B_t"))
           DeclPathTop,
@@ -66,7 +70,8 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag
                     (CName "linked_list_B_t"))
                   DeclPathTop)),

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -43,7 +43,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structSizeof = 8,
@@ -113,7 +114,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structSizeof = 8,
@@ -188,7 +190,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -265,7 +268,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -366,7 +370,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structSizeof = 12,
@@ -460,7 +465,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structSizeof = 12,
@@ -559,7 +565,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -661,7 +668,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -731,7 +739,8 @@
         Typedef {
           typedefName = CName "S2_t",
           typedefType = TypeStruct
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop),
           typedefSourceLoc =
@@ -768,7 +777,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTypedef (CName "S3_t"))
             DeclPathTop,
           structSizeof = 1,
@@ -814,7 +824,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTypedef (CName "S3_t"))
               DeclPathTop,
             structSizeof = 1,
@@ -865,7 +876,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef (CName "S3_t"))
                       DeclPathTop,
                     structSizeof = 1,
@@ -916,7 +928,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef (CName "S3_t"))
                       DeclPathTop,
                     structSizeof = 1,
@@ -1009,7 +1022,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S4"))
             DeclPathTop,
           structSizeof = 16,
@@ -1105,7 +1119,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S4"))
               DeclPathTop,
             structSizeof = 16,
@@ -1206,7 +1221,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S4"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1310,7 +1326,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S4"))
                       DeclPathTop,
                     structSizeof = 16,
@@ -1405,7 +1422,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S5"))
             DeclPathTop,
           structSizeof = 8,
@@ -1475,7 +1493,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S5"))
               DeclPathTop,
             structSizeof = 8,
@@ -1550,7 +1569,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -1627,7 +1647,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -1712,7 +1733,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S6"))
             DeclPathTop,
           structSizeof = 8,
@@ -1782,7 +1804,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "S6"))
               DeclPathTop,
             structSizeof = 8,
@@ -1857,7 +1880,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -1934,7 +1958,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -2019,10 +2044,12 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathPtr
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 (DeclNameTypedef (CName "S7a"))
                 DeclPathTop)),
           structSizeof = 8,
@@ -2092,10 +2119,12 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7a"))
                   DeclPathTop)),
             structSizeof = 8,
@@ -2170,10 +2199,12 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7a"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -2250,10 +2281,12 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7a"))
                           DeclPathTop)),
                     structSizeof = 8,
@@ -2322,10 +2355,12 @@
           typedefName = CName "S7a",
           typedefType = TypePointer
             (TypeStruct
-              (DeclPathStruct
+              (DeclPathConstr
+                DeclConstrStruct
                 DeclNameNone
                 (DeclPathPtr
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef (CName "S7a"))
                     DeclPathTop)))),
           typedefSourceLoc =
@@ -2378,12 +2413,14 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             DeclNameNone
             (DeclPathPtr
               (DeclPathPtr
                 (DeclPathPtr
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTypedef (CName "S7b"))
                     DeclPathTop)))),
           structSizeof = 8,
@@ -2453,12 +2490,14 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
                 (DeclPathPtr
                   (DeclPathPtr
-                    (DeclPathStruct
+                    (DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTypedef (CName "S7b"))
                       DeclPathTop)))),
             structSizeof = 8,
@@ -2533,12 +2572,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathPtr
                           (DeclPathPtr
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef (CName "S7b"))
                               DeclPathTop)))),
                     structSizeof = 8,
@@ -2615,12 +2656,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathPtr
                           (DeclPathPtr
-                            (DeclPathStruct
+                            (DeclPathConstr
+                              DeclConstrStruct
                               (DeclNameTypedef (CName "S7b"))
                               DeclPathTop)))),
                     structSizeof = 8,
@@ -2693,12 +2736,14 @@
             (TypePointer
               (TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathPtr
                       (DeclPathPtr
                         (DeclPathPtr
-                          (DeclPathStruct
+                          (DeclPathConstr
+                            DeclConstrStruct
                             (DeclNameTypedef (CName "S7b"))
                             DeclPathTop)))))))),
           typedefSourceLoc =

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structSizeof = 8,
@@ -29,7 +30,8 @@ Header
         "simple_structs.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structSizeof = 12,
@@ -66,14 +68,16 @@ Header
       Typedef {
         typedefName = CName "S2_t",
         typedefType = TypeStruct
-          (DeclPathStruct
+          (DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop),
         typedefSourceLoc =
         "simple_structs.h:12:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTypedef (CName "S3_t"))
           DeclPathTop,
         structSizeof = 1,
@@ -92,7 +96,8 @@ Header
         "simple_structs.h:15:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S4"))
           DeclPathTop,
         structSizeof = 16,
@@ -128,7 +133,8 @@ Header
         "simple_structs.h:19:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S5"))
           DeclPathTop,
         structSizeof = 8,
@@ -155,7 +161,8 @@ Header
         "simple_structs.h:26:16"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "S6"))
           DeclPathTop,
         structSizeof = 8,
@@ -182,10 +189,12 @@ Header
         "simple_structs.h:31:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathPtr
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               (DeclNameTypedef (CName "S7a"))
               DeclPathTop)),
         structSizeof = 8,
@@ -215,22 +224,26 @@ Header
         typedefName = CName "S7a",
         typedefType = TypePointer
           (TypeStruct
-            (DeclPathStruct
+            (DeclPathConstr
+              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7a"))
                   DeclPathTop)))),
         typedefSourceLoc =
         "simple_structs.h:34:36"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           DeclNameNone
           (DeclPathPtr
             (DeclPathPtr
               (DeclPathPtr
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7b"))
                   DeclPathTop)))),
         structSizeof = 8,
@@ -262,12 +275,14 @@ Header
           (TypePointer
             (TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathPtr
                     (DeclPathPtr
                       (DeclPathPtr
-                        (DeclPathStruct
+                        (DeclPathConstr
+                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7b"))
                           DeclPathTop)))))))),
         typedefSourceLoc =

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -540,7 +540,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag
               (CName "ExampleStruct"))
             DeclPathTop,
@@ -659,7 +660,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag
                 (CName "ExampleStruct"))
               DeclPathTop,
@@ -783,7 +785,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "ExampleStruct"))
                       DeclPathTop,
@@ -911,7 +914,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag
                         (CName "ExampleStruct"))
                       DeclPathTop,
@@ -1007,7 +1011,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structSizeof = 8,
@@ -1058,7 +1063,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 8,
@@ -1114,7 +1120,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -1170,7 +1177,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 8,

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -161,7 +161,8 @@ Header
         "typedef_vs_macro.h:2:14"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag
             (CName "ExampleStruct"))
           DeclPathTop,
@@ -205,7 +206,8 @@ Header
         "typedef_vs_macro.h:9:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structSizeof = 8,

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -17,7 +17,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "foo",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "foo"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -54,7 +57,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "foo",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "foo"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -96,7 +102,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "foo",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "foo"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -138,7 +147,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "foo",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "foo"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -2,7 +2,10 @@ Header
   [
     DeclEnum
       Enu {
-        enumTag = CName "foo",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "foo"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -43,7 +43,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "Dim2"))
             DeclPathTop,
           structSizeof = 8,
@@ -113,7 +114,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "Dim2"))
               DeclPathTop,
             structSizeof = 8,
@@ -188,7 +190,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim2"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -265,7 +268,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim2"))
                       DeclPathTop,
                     structSizeof = 8,
@@ -366,7 +370,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "Dim3"))
             DeclPathTop,
           structSizeof = 12,
@@ -460,7 +465,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "Dim3"))
               DeclPathTop,
             structSizeof = 12,
@@ -559,7 +565,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim3"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -661,7 +668,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim3"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -755,7 +763,8 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathUnion
+                (DeclPathConstr
+                  DeclConstrUnion
                   (DeclNameTag
                     (CName "DimPayload"))
                   DeclPathTop),
@@ -764,7 +773,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "Dim"))
             DeclPathTop,
           structSizeof = 12,
@@ -783,7 +793,8 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathUnion
+                (DeclPathConstr
+                  DeclConstrUnion
                   (DeclNameTag
                     (CName "DimPayload"))
                   DeclPathTop),
@@ -833,7 +844,8 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathUnion
+                  (DeclPathConstr
+                    DeclConstrUnion
                     (DeclNameTag
                       (CName "DimPayload"))
                     DeclPathTop),
@@ -842,7 +854,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "Dim"))
               DeclPathTop,
             structSizeof = 12,
@@ -861,7 +874,8 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathUnion
+                  (DeclPathConstr
+                    DeclConstrUnion
                     (DeclNameTag
                       (CName "DimPayload"))
                     DeclPathTop),
@@ -916,7 +930,8 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathUnion
+                          (DeclPathConstr
+                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -925,7 +940,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -944,7 +960,8 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathUnion
+                          (DeclPathConstr
+                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -1001,7 +1018,8 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathUnion
+                          (DeclPathConstr
+                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -1010,7 +1028,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "Dim"))
                       DeclPathTop,
                     structSizeof = 12,
@@ -1029,7 +1048,8 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathUnion
+                          (DeclPathConstr
+                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -2,7 +2,8 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "Dim2"))
           DeclPathTop,
         structSizeof = 8,
@@ -29,7 +30,8 @@ Header
         "unions.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "Dim3"))
           DeclPathTop,
         structSizeof = 12,
@@ -64,7 +66,8 @@ Header
         "unions.h:6:8"},
     DeclUnion
       Union {
-        unionDeclPath = DeclPathUnion
+        unionDeclPath = DeclPathConstr
+          DeclConstrUnion
           (DeclNameTag
             (CName "DimPayload"))
           DeclPathTop,
@@ -74,7 +77,8 @@ Header
         "unions.h:12:7"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "Dim"))
           DeclPathTop,
         structSizeof = 12,
@@ -93,7 +97,8 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeUnion
-              (DeclPathUnion
+              (DeclPathConstr
+                DeclConstrUnion
                 (DeclNameTag
                   (CName "DimPayload"))
                 DeclPathTop),

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -17,7 +17,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumTag = CName "MyEnum",
+          enumDeclPath = DeclPathConstr
+            DeclConstrEnum
+            (DeclNameTag (CName "MyEnum"))
+            DeclPathTop,
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -56,7 +59,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumTag = CName "MyEnum",
+            enumDeclPath = DeclPathConstr
+              DeclConstrEnum
+              (DeclNameTag (CName "MyEnum"))
+              DeclPathTop,
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -100,7 +106,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "MyEnum",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "MyEnum"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -144,7 +153,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumTag = CName "MyEnum",
+                    enumDeclPath = DeclPathConstr
+                      DeclConstrEnum
+                      (DeclNameTag (CName "MyEnum"))
+                      DeclPathTop,
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -17,7 +17,10 @@ Header
         "uses_utf8.h:2:9"},
     DeclEnum
       Enu {
-        enumTag = CName "MyEnum",
+        enumDeclPath = DeclPathConstr
+          DeclConstrEnum
+          (DeclNameTag (CName "MyEnum"))
+          DeclPathTop,
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -20,7 +20,8 @@
             [
               TypePointer
                 (TypeStruct
-                  (DeclPathStruct
+                  (DeclPathConstr
+                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     (DeclPathPtr DeclPathTop)))]
             TypeVoid,
@@ -55,7 +56,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structSizeof = 4,
@@ -101,7 +103,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structSizeof = 4,
@@ -152,7 +155,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -203,7 +207,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structSizeof = 4,
@@ -263,7 +268,8 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathStruct
+          structDeclPath = DeclPathConstr
+            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             (DeclPathPtr DeclPathTop),
           structSizeof = 4,
@@ -309,7 +315,8 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathStruct
+            structDeclPath = DeclPathConstr
+              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               (DeclPathPtr DeclPathTop),
             structSizeof = 4,
@@ -360,7 +367,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       (DeclPathPtr DeclPathTop),
                     structSizeof = 4,
@@ -411,7 +419,8 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathStruct
+                    structDeclPath = DeclPathConstr
+                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       (DeclPathPtr DeclPathTop),
                     structSizeof = 4,

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -7,7 +7,8 @@ Header
           [
             TypePointer
               (TypeStruct
-                (DeclPathStruct
+                (DeclPathConstr
+                  DeclConstrStruct
                   (DeclNameTag (CName "bar"))
                   (DeclPathPtr DeclPathTop)))]
           TypeVoid,
@@ -16,7 +17,8 @@ Header
         "weird01.h:8:6"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structSizeof = 4,
@@ -35,7 +37,8 @@ Header
         "weird01.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathStruct
+        structDeclPath = DeclPathConstr
+          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           (DeclPathPtr DeclPathTop),
         structSizeof = 4,

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -59,6 +59,7 @@ module HsBindgen.C.AST (
   , pprTcMacroError
     -- * DeclPath
   , DeclPath(..)
+  , DeclConstr(..)
   , DeclName(..)
     -- * Source locations
   , SingleLoc(..)

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -179,7 +179,7 @@ data StructField = StructField {
 --
 -- > struct foo;
 data OpaqueStruct = OpaqueStruct {
-      opaqueStructTag       :: CName
+      opaqueStructDeclPath  :: DeclPath
     , opaqueStructSourceLoc :: SingleLoc
     }
   deriving stock (Show, Eq, Generic)
@@ -230,7 +230,7 @@ data EnumValue = EnumValue {
 --
 -- > enum foo;
 data OpaqueEnum = OpaqueEnum {
-      opaqueEnumTag       :: CName
+      opaqueEnumDeclPath  :: DeclPath
     , opaqueEnumSourceLoc :: SingleLoc
     }
   deriving stock (Show, Eq, Generic)

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -40,7 +40,7 @@ data Type =
     TypePrim PrimType
   | TypeStruct DeclPath
   | TypeUnion DeclPath
-  | TypeEnum CName
+  | TypeEnum DeclPath
   | TypeTypedef CName
   | TypePointer Type
   | TypeConstArray Natural Type
@@ -205,7 +205,7 @@ data Union = Union {
 -------------------------------------------------------------------------------}
 
 data Enu = Enu {
-      enumTag       :: CName
+      enumDeclPath  :: DeclPath
     , enumType      :: Type
     , enumSizeof    :: Int
     , enumAlignment :: Int
@@ -275,6 +275,7 @@ data DeclPath
 data DeclConstr =
     DeclConstrStruct
   | DeclConstrUnion
+  | DeclConstrEnum
   deriving stock (Eq, Generic, Show)
   deriving anyclass (PrettyVal)
 

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -22,6 +22,7 @@ module HsBindgen.C.AST.Type (
   , Typedef(..)
     -- * DeclPath
   , DeclPath(..)
+  , DeclConstr(..)
   , DeclName(..)
   ) where
 
@@ -264,11 +265,16 @@ data Typedef = Typedef {
 -- creation of the corresponding Haskell name.
 data DeclPath
     = DeclPathTop
-    | DeclPathStruct DeclName DeclPath
-    | DeclPathUnion DeclName DeclPath
+    | DeclPathConstr DeclConstr DeclName DeclPath
     | DeclPathField CName DeclPath
     | DeclPathPtr DeclPath
     -- TODO | DeclPathConstArray Natural Path
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (PrettyVal)
+
+data DeclConstr =
+    DeclConstrStruct
+  | DeclConstrUnion
   deriving stock (Eq, Generic, Show)
   deriving anyclass (PrettyVal)
 

--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -187,13 +187,6 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                           Just n  -> DeclPathConstr DeclConstrStruct (DeclNameTag (CName n))        path
                           Nothing -> DeclPathConstr DeclConstrStruct (DeclNameTypedef (CName name)) path
 
-                -- name for opaque types.
-                let name'
-                      | anon      = ""
-                      | otherwise =  case T.stripPrefix "struct " name of
-                          Just n  -> n
-                          Nothing -> name
-
                 if declPath == DeclPathConstr DeclConstrStruct DeclNameNone DeclPathTop
                 then do
                     -- Anonymous top-level declaration: nothing to do but warn, as there
@@ -215,7 +208,7 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                         Nothing -> liftIO (HighLevel.classifyDeclaration decl) >>= \case
                             DeclarationOpaque ->
                                 addDecl ty $ DeclOpaqueStruct OpaqueStruct {
-                                      opaqueStructTag       = CName name'
+                                      opaqueStructDeclPath  = declPath
                                     , opaqueStructSourceLoc = sloc
                                     }
 
@@ -253,13 +246,6 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                           Just n  -> DeclPathConstr DeclConstrUnion (DeclNameTag (CName n))        path
                           Nothing -> DeclPathConstr DeclConstrUnion (DeclNameTypedef (CName name)) path
 
-                -- name for opaque types.
-                let name'
-                      | anon      = ""
-                      | otherwise =  case T.stripPrefix "union " name of
-                          Just n  -> n
-                          Nothing -> name
-
                 if declPath == DeclPathConstr DeclConstrUnion DeclNameNone DeclPathTop
                 then do
                     -- Anonymous top-level declaration: nothing to do but warn, as there
@@ -277,7 +263,7 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                             DeclarationOpaque ->
                                 -- opaque struct and opaque union look the same.
                                 addDecl ty $ DeclOpaqueStruct OpaqueStruct {
-                                      opaqueStructTag       = CName name'
+                                      opaqueStructDeclPath  = declPath
                                     , opaqueStructSourceLoc = sloc
                                     }
 
@@ -322,13 +308,6 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                       Just n  -> DeclPathConstr DeclConstrEnum (DeclNameTag (CName n))        path
                       Nothing -> DeclPathConstr DeclConstrEnum (DeclNameTypedef (CName name)) path
 
-            -- name for opaque types.
-            let name'
-                  | anon      = ""
-                  | otherwise =  case T.stripPrefix "enum " name of
-                      Just n  -> n
-                      Nothing -> name
-
             addTypeDeclProcessing ty $ TypeEnum declPath
             sloc <- liftIO $
                 HighLevel.clang_getExpansionLocation
@@ -340,7 +319,7 @@ processTypeDecl' path extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                 Nothing -> liftIO (HighLevel.classifyDeclaration decl) >>= \case
                     DeclarationOpaque -> do
                         addDecl ty $ DeclOpaqueEnum OpaqueEnum {
-                            opaqueEnumTag       = CName name'
+                            opaqueEnumDeclPath  = declPath
                           , opaqueEnumSourceLoc = sloc
                           }
 

--- a/hs-bindgen/src/HsBindgen/GenTests/C.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests/C.hs
@@ -101,7 +101,7 @@ getTestSourceDefns cFunPrefix = \case
 getStructCTypeSpelling :: Hs.StructOrigin -> Maybe CTypeSpelling
 getStructCTypeSpelling = \case
     Hs.StructOriginStruct C.Struct{..} -> case structDeclPath of
-      C.DeclPathStruct declName _declPath -> case declName of
+      C.DeclPathConstr C.DeclConstrStruct declName _declPath -> case declName of
         C.DeclNameNone -> Nothing
         C.DeclNameTag cName -> Just $ "struct " ++ T.unpack (C.getCName cName)
         C.DeclNameTypedef cName -> Just $ T.unpack (C.getCName cName)

--- a/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
@@ -354,11 +354,7 @@ translateDeclPath
     getCName' :: DeclPath -> Maybe CName
     getCName' = \case
       DeclPathTop -> Nothing
-      DeclPathStruct declName _declPath -> case declName of
-        DeclNameNone         -> Nothing
-        DeclNameTag name     -> Just name
-        DeclNameTypedef name -> Just name
-      DeclPathUnion declName _declPath -> case declName of
+      DeclPathConstr _constr declName _declPath -> case declName of
         DeclNameNone         -> Nothing
         DeclNameTag name     -> Just name
         DeclNameTypedef name -> Just name
@@ -372,11 +368,7 @@ getDeclPathParts = aux
     aux :: DeclPath -> [CName]
     aux = \case
       DeclPathTop -> ["ANONYMOUS"] -- shouldn't happen
-      DeclPathStruct declName path -> case declName of
-        DeclNameNone      -> aux path
-        DeclNameTag n     -> [n]
-        DeclNameTypedef n -> [n]
-      DeclPathUnion declName path -> case declName of
+      DeclPathConstr _constr declName path -> case declName of
         DeclNameNone      -> aux path
         DeclNameTag n     -> [n]
         DeclNameTypedef n -> [n]

--- a/hs-bindgen/src/HsBindgen/Hs/NameMangler/Easy.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/NameMangler/Easy.hs
@@ -39,7 +39,7 @@ mangleFieldName nm declPath fname = NM.mangleVarName nm ctx
     ctx = NM.FieldVarContext (toCtx declPath) fname
 
 -- | Create destructor name, @name Tycon = Datacon { decon :: ... }@
-mangleDeconName :: NM.NameMangler -> NM.CName -> HsName NsVar
+mangleDeconName :: ToTypeConstrContext ctx => NM.NameMangler -> ctx -> HsName NsVar
 mangleDeconName nm declPath = NM.mangleVarName nm ctx
   where
     ctx = NM.EnumVarContext $ toCtx declPath

--- a/hs-bindgen/src/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/Translation.hs
@@ -129,9 +129,9 @@ instance ToHs C.Decl where
   type InHs C.Decl = [Hs.Decl]
   toHs _ opts nm (C.DeclStruct struct)  = reifyStructFields struct $ structDecs opts nm struct
   toHs _ opts nm (C.DeclUnion union)    = unionDecs opts nm union
-  toHs _ opts nm (C.DeclOpaqueStruct o) = opaqueStructDecs opts nm $ C.opaqueStructTag o
+  toHs _ opts nm (C.DeclOpaqueStruct o) = opaqueStructDecs opts nm $ C.opaqueStructDeclPath o
   toHs _ opts nm (C.DeclEnum e)         = enumDecs opts nm e
-  toHs _ opts nm (C.DeclOpaqueEnum o)   = opaqueStructDecs opts nm $ C.opaqueEnumTag o -- TODO?
+  toHs _ opts nm (C.DeclOpaqueEnum o)   = opaqueStructDecs opts nm $ C.opaqueEnumDeclPath o -- TODO?
   toHs _ opts nm (C.DeclTypedef d)      = typedefDecs opts nm d
   toHs _ opts nm (C.DeclMacro m)        = macroDecs opts nm m
   toHs p opts nm (C.DeclFunction f)     = functionDecs p opts nm f
@@ -205,7 +205,7 @@ structDecs opts nm struct fields = concat
   Opaque struct
 -------------------------------------------------------------------------------}
 
-opaqueStructDecs :: TranslationOpts -> NameMangler -> C.CName -> [Hs.Decl]
+opaqueStructDecs :: TranslationOpts -> NameMangler -> C.DeclPath -> [Hs.Decl]
 opaqueStructDecs _opts nm cname =
     [ Hs.DeclEmpty hsName
     ]

--- a/hs-bindgen/src/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/Translation.hs
@@ -238,11 +238,11 @@ enumDecs opts nm e = concat [
     , valueDecls
     ]
   where
-    cEnumName     = C.enumTag e
-    newtypeName   = mangleTyconName nm cEnumName
-    newtypeConstr = mangleDataconName nm cEnumName
+    declPath      = C.enumDeclPath e
+    newtypeName   = mangleTyconName nm declPath
+    newtypeConstr = mangleDataconName nm declPath
     newtypeField  = Hs.Field {
-        fieldName   = mangleDeconName nm cEnumName
+        fieldName   = mangleDeconName nm declPath
       , fieldType   = typ nm (C.enumType e)
       , fieldOrigin = Hs.FieldOriginNone
       }

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -42,6 +42,7 @@ instance ToExpr C.Attribute
 instance ToExpr C.CName
 instance ToExpr C.Decl
 instance ToExpr C.DeclName
+instance ToExpr C.DeclConstr
 instance ToExpr C.DeclPath
 instance ToExpr C.Enu
 instance ToExpr C.EnumValue


### PR DESCRIPTION
Builds on #505 and #506.