### PR TITLE
Delete `DeclConstr`

### DIFF
--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -44,12 +44,10 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "c")
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "S1"))
                 DeclPathTop)),
           structAliases = [],
@@ -121,12 +119,10 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "c")
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "S1"))
                   DeclPathTop)),
             structAliases = [],
@@ -203,12 +199,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "c")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S1"))
                           DeclPathTop)),
                     structAliases = [],
@@ -287,12 +281,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "c")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S1"))
                           DeclPathTop)),
                     structAliases = [],
@@ -357,12 +349,10 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "c")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -387,7 +377,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structAliases = [],
@@ -400,12 +389,10 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "c")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -445,12 +432,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "c")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -475,7 +460,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structAliases = [],
@@ -488,12 +472,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "c")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "S1"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -538,12 +520,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -568,7 +548,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -581,12 +560,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -633,12 +610,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -663,7 +638,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -676,12 +650,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "c")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S1"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -742,17 +714,14 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "deep")
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "inner")
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "S2"))
                     DeclPathTop)))),
           structAliases = [],
@@ -800,17 +769,14 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "deep")
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop)))),
             structAliases = [],
@@ -863,17 +829,14 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "deep")
                         (DeclPathConstr
-                          DeclConstrStruct
                           DeclNameNone
                           (DeclPathField
                             (CName "inner")
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "S2"))
                               DeclPathTop)))),
                     structAliases = [],
@@ -926,17 +889,14 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "deep")
                         (DeclPathConstr
-                          DeclConstrStruct
                           DeclNameNone
                           (DeclPathField
                             (CName "inner")
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "S2"))
                               DeclPathTop)))),
                     structAliases = [],
@@ -1014,17 +974,14 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "deep")
                     (DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1033,12 +990,10 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "inner")
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "S2"))
                 DeclPathTop)),
           structAliases = [],
@@ -1059,17 +1014,14 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "deep")
                     (DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1119,17 +1071,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "deep")
                       (DeclPathConstr
-                        DeclConstrStruct
                         DeclNameNone
                         (DeclPathField
                           (CName "inner")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1138,12 +1087,10 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "inner")
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "S2"))
                   DeclPathTop)),
             structAliases = [],
@@ -1164,17 +1111,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "deep")
                       (DeclPathConstr
-                        DeclConstrStruct
                         DeclNameNone
                         (DeclPathField
                           (CName "inner")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "S2"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1229,17 +1173,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1248,12 +1189,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop)),
                     structAliases = [],
@@ -1274,17 +1213,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1341,17 +1277,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1360,12 +1293,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "inner")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "S2"))
                           DeclPathTop)),
                     structAliases = [],
@@ -1386,17 +1317,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "deep")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 DeclNameNone
                                 (DeclPathField
                                   (CName "inner")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "S2"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1449,12 +1377,10 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -1479,7 +1405,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structAliases = [],
@@ -1492,12 +1417,10 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "inner")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop))),
               fieldSourceLoc =
@@ -1539,12 +1462,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -1569,7 +1490,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structAliases = [],
@@ -1582,12 +1502,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))),
                 fieldSourceLoc =
@@ -1634,12 +1552,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1664,7 +1580,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],
@@ -1677,12 +1592,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1731,12 +1644,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =
@@ -1761,7 +1672,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],
@@ -1774,12 +1684,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "inner")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "S2"))
                                 DeclPathTop))),
                         fieldSourceLoc =

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -3,12 +3,10 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "c")
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop)),
         structAliases = [],
@@ -37,7 +35,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structAliases = [],
@@ -50,12 +47,10 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "c")
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "S1"))
                     DeclPathTop))),
             fieldSourceLoc =
@@ -74,17 +69,14 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "deep")
             (DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "inner")
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "S2"))
                   DeclPathTop)))),
         structAliases = [],
@@ -105,12 +97,10 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "inner")
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop)),
         structAliases = [],
@@ -131,17 +121,14 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "deep")
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "inner")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "S2"))
                         DeclPathTop))))),
             fieldSourceLoc =
@@ -152,7 +139,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structAliases = [],
@@ -165,12 +151,10 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "inner")
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "S2"))
                     DeclPathTop))),
             fieldSourceLoc =

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -108,7 +108,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "flags"))
             DeclPathTop,
           structAliases = [],
@@ -276,7 +275,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "flags"))
               DeclPathTop,
             structAliases = [],
@@ -449,7 +447,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "flags"))
                       DeclPathTop,
                     structAliases = [],
@@ -628,7 +625,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "flags"))
                       DeclPathTop,
                     structAliases = [],
@@ -784,7 +780,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32"))
             DeclPathTop,
@@ -881,7 +876,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32"))
               DeclPathTop,
@@ -983,7 +977,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32"))
                       DeclPathTop,
@@ -1088,7 +1081,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32"))
                       DeclPathTop,
@@ -1214,7 +1206,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32b"))
             DeclPathTop,
@@ -1311,7 +1302,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32b"))
               DeclPathTop,
@@ -1413,7 +1403,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32b"))
                       DeclPathTop,
@@ -1518,7 +1507,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32b"))
                       DeclPathTop,
@@ -1644,7 +1632,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "overflow32c"))
             DeclPathTop,
@@ -1741,7 +1728,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow32c"))
               DeclPathTop,
@@ -1843,7 +1829,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32c"))
                       DeclPathTop,
@@ -1948,7 +1933,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow32c"))
                       DeclPathTop,
@@ -2058,7 +2042,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "overflow64"))
             DeclPathTop,
@@ -2131,7 +2114,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "overflow64"))
               DeclPathTop,
@@ -2209,7 +2191,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow64"))
                       DeclPathTop,
@@ -2289,7 +2270,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "overflow64"))
                       DeclPathTop,
@@ -2386,7 +2366,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "alignA"))
             DeclPathTop,
           structAliases = [],
@@ -2458,7 +2437,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "alignA"))
               DeclPathTop,
             structAliases = [],
@@ -2535,7 +2513,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "alignA"))
                       DeclPathTop,
                     structAliases = [],
@@ -2614,7 +2591,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "alignA"))
                       DeclPathTop,
                     structAliases = [],
@@ -2710,7 +2686,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "alignB"))
             DeclPathTop,
           structAliases = [],
@@ -2782,7 +2757,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "alignB"))
               DeclPathTop,
             structAliases = [],
@@ -2859,7 +2833,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "alignB"))
                       DeclPathTop,
                     structAliases = [],
@@ -2938,7 +2911,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "alignB"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "flags"))
           DeclPathTop,
         structAliases = [],
@@ -64,7 +63,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32"))
           DeclPathTop,
@@ -102,7 +100,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32b"))
           DeclPathTop,
@@ -140,7 +137,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "overflow32c"))
           DeclPathTop,
@@ -178,7 +174,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "overflow64"))
           DeclPathTop,
@@ -208,7 +203,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "alignA"))
           DeclPathTop,
         structAliases = [],
@@ -237,7 +231,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "alignB"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -122,7 +122,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bools1"))
             DeclPathTop,
           structAliases = [],
@@ -189,7 +188,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bools1"))
               DeclPathTop,
             structAliases = [],
@@ -260,7 +258,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools1"))
                       DeclPathTop,
                     structAliases = [],
@@ -334,7 +331,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools1"))
                       DeclPathTop,
                     structAliases = [],
@@ -419,7 +415,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bools2"))
             DeclPathTop,
           structAliases = [],
@@ -486,7 +481,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bools2"))
               DeclPathTop,
             structAliases = [],
@@ -557,7 +551,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools2"))
                       DeclPathTop,
                     structAliases = [],
@@ -631,7 +624,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools2"))
                       DeclPathTop,
                     structAliases = [],
@@ -718,7 +710,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bools3"))
             DeclPathTop,
           structAliases = [],
@@ -790,7 +781,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bools3"))
               DeclPathTop,
             structAliases = [],
@@ -867,7 +857,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools3"))
                       DeclPathTop,
                     structAliases = [],
@@ -946,7 +935,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bools3"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -19,7 +19,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bools1"))
           DeclPathTop,
         structAliases = [],
@@ -44,7 +43,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bools2"))
           DeclPathTop,
         structAliases = [],
@@ -69,7 +67,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bools3"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -291,7 +291,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTypedef
               (CName
                 "another_typedef_struct_t"))
@@ -365,7 +364,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef
                 (CName
                   "another_typedef_struct_t"))
@@ -444,7 +442,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -525,7 +522,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -592,7 +588,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTypedef
               (CName
                 "another_typedef_enum_e"))
@@ -635,7 +630,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTypedef
                 (CName
                   "another_typedef_enum_e"))
@@ -683,7 +677,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName
                           "another_typedef_enum_e"))
@@ -731,7 +724,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName
                           "another_typedef_enum_e"))
@@ -829,6 +821,42 @@
           valueValue = 1,
           valueSourceLoc =
           "distilled_lib_1.h:9:21"}},
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
+        "Another_typedef_enum_e",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "Another_typedef_enum_e",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unAnother_typedef_enum_e",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "Another_typedef_enum_e"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName
+            "another_typedef_enum_e",
+          typedefType = TypeEnum
+            (DeclPathConstr
+              (DeclNameTypedef
+                (CName
+                  "another_typedef_enum_e"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "distilled_lib_1.h:9:27"}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "Another_typedef_enum_e"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1430,7 +1458,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -1455,7 +1482,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1514,13 +1540,9 @@
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldWidth = Nothing,
-              fieldType = TypeEnum
-                (DeclPathConstr
-                  DeclConstrEnum
-                  (DeclNameTypedef
-                    (CName
-                      "another_typedef_enum_e"))
-                  DeclPathTop),
+              fieldType = TypeTypedef
+                (CName
+                  "another_typedef_enum_e"),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"}},
         Field {
@@ -1541,13 +1563,9 @@
               fieldWidth = Nothing,
               fieldType = TypeConstArray
                 4
-                (TypeEnum
-                  (DeclPathConstr
-                    DeclConstrEnum
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_enum_e"))
-                    DeclPathTop)),
+                (TypeTypedef
+                  (CName
+                    "another_typedef_enum_e")),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"}},
         Field {
@@ -1572,20 +1590,15 @@
                 5
                 (TypeConstArray
                   3
-                  (TypeEnum
-                    (DeclPathConstr
-                      DeclConstrEnum
-                      (DeclNameTypedef
-                        (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop))),
+                  (TypeTypedef
+                    (CName
+                      "another_typedef_enum_e"))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "a_typedef_struct"))
             DeclPathTop,
@@ -1630,7 +1643,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -1644,7 +1656,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1673,13 +1684,9 @@
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldWidth = Nothing,
-              fieldType = TypeEnum
-                (DeclPathConstr
-                  DeclConstrEnum
-                  (DeclNameTypedef
-                    (CName
-                      "another_typedef_enum_e"))
-                  DeclPathTop),
+              fieldType = TypeTypedef
+                (CName
+                  "another_typedef_enum_e"),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"},
             StructField {
@@ -1688,13 +1695,9 @@
               fieldWidth = Nothing,
               fieldType = TypeConstArray
                 4
-                (TypeEnum
-                  (DeclPathConstr
-                    DeclConstrEnum
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_enum_e"))
-                    DeclPathTop)),
+                (TypeTypedef
+                  (CName
+                    "another_typedef_enum_e")),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"},
             StructField {
@@ -1705,13 +1708,9 @@
                 5
                 (TypeConstArray
                   3
-                  (TypeEnum
-                    (DeclPathConstr
-                      DeclConstrEnum
-                      (DeclNameTypedef
-                        (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop))),
+                  (TypeTypedef
+                    (CName
+                      "another_typedef_enum_e"))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
@@ -1812,7 +1811,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -1837,7 +1835,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -1896,13 +1893,9 @@
                 fieldName = CName "field_8",
                 fieldOffset = 480,
                 fieldWidth = Nothing,
-                fieldType = TypeEnum
-                  (DeclPathConstr
-                    DeclConstrEnum
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_enum_e"))
-                    DeclPathTop),
+                fieldType = TypeTypedef
+                  (CName
+                    "another_typedef_enum_e"),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"}},
           Field {
@@ -1923,13 +1916,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypeConstArray
                   4
-                  (TypeEnum
-                    (DeclPathConstr
-                      DeclConstrEnum
-                      (DeclNameTypedef
-                        (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop)),
+                  (TypeTypedef
+                    (CName
+                      "another_typedef_enum_e")),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"}},
           Field {
@@ -1954,20 +1943,15 @@
                   5
                   (TypeConstArray
                     3
-                    (TypeEnum
-                      (DeclPathConstr
-                        DeclConstrEnum
-                        (DeclNameTypedef
-                          (CName
-                            "another_typedef_enum_e"))
-                        DeclPathTop))),
+                    (TypeTypedef
+                      (CName
+                        "another_typedef_enum_e"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop,
@@ -2012,7 +1996,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef
                       (CName
                         "another_typedef_struct_t"))
@@ -2026,7 +2009,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef
                         (CName
                           "another_typedef_struct_t"))
@@ -2055,13 +2037,9 @@
                 fieldName = CName "field_8",
                 fieldOffset = 480,
                 fieldWidth = Nothing,
-                fieldType = TypeEnum
-                  (DeclPathConstr
-                    DeclConstrEnum
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_enum_e"))
-                    DeclPathTop),
+                fieldType = TypeTypedef
+                  (CName
+                    "another_typedef_enum_e"),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"},
               StructField {
@@ -2070,13 +2048,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypeConstArray
                   4
-                  (TypeEnum
-                    (DeclPathConstr
-                      DeclConstrEnum
-                      (DeclNameTypedef
-                        (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop)),
+                  (TypeTypedef
+                    (CName
+                      "another_typedef_enum_e")),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"},
               StructField {
@@ -2087,13 +2061,9 @@
                   5
                   (TypeConstArray
                     3
-                    (TypeEnum
-                      (DeclPathConstr
-                        DeclConstrEnum
-                        (DeclNameTypedef
-                          (CName
-                            "another_typedef_enum_e"))
-                        DeclPathTop))),
+                    (TypeTypedef
+                      (CName
+                        "another_typedef_enum_e"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}],
             structFlam = Nothing,
@@ -2199,7 +2169,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2224,7 +2193,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2283,13 +2251,9 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeEnum
-                          (DeclPathConstr
-                            DeclConstrEnum
-                            (DeclNameTypedef
-                              (CName
-                                "another_typedef_enum_e"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName
+                            "another_typedef_enum_e"),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2310,13 +2274,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeEnum
-                            (DeclPathConstr
-                              DeclConstrEnum
-                              (DeclNameTypedef
-                                (CName
-                                  "another_typedef_enum_e"))
-                              DeclPathTop)),
+                          (TypeTypedef
+                            (CName
+                              "another_typedef_enum_e")),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2341,20 +2301,15 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeEnum
-                              (DeclPathConstr
-                                DeclConstrEnum
-                                (DeclNameTypedef
-                                  (CName
-                                    "another_typedef_enum_e"))
-                                DeclPathTop))),
+                            (TypeTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "a_typedef_struct"))
                       DeclPathTop,
@@ -2399,7 +2354,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2413,7 +2367,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2442,13 +2395,9 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeEnum
-                          (DeclPathConstr
-                            DeclConstrEnum
-                            (DeclNameTypedef
-                              (CName
-                                "another_typedef_enum_e"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName
+                            "another_typedef_enum_e"),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2457,13 +2406,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeEnum
-                            (DeclPathConstr
-                              DeclConstrEnum
-                              (DeclNameTypedef
-                                (CName
-                                  "another_typedef_enum_e"))
-                              DeclPathTop)),
+                          (TypeTypedef
+                            (CName
+                              "another_typedef_enum_e")),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2474,13 +2419,9 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeEnum
-                              (DeclPathConstr
-                                DeclConstrEnum
-                                (DeclNameTypedef
-                                  (CName
-                                    "another_typedef_enum_e"))
-                                DeclPathTop))),
+                            (TypeTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -2597,7 +2538,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2622,7 +2562,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2681,13 +2620,9 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeEnum
-                          (DeclPathConstr
-                            DeclConstrEnum
-                            (DeclNameTypedef
-                              (CName
-                                "another_typedef_enum_e"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName
+                            "another_typedef_enum_e"),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2708,13 +2643,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeEnum
-                            (DeclPathConstr
-                              DeclConstrEnum
-                              (DeclNameTypedef
-                                (CName
-                                  "another_typedef_enum_e"))
-                              DeclPathTop)),
+                          (TypeTypedef
+                            (CName
+                              "another_typedef_enum_e")),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2739,20 +2670,15 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeEnum
-                              (DeclPathConstr
-                                DeclConstrEnum
-                                (DeclNameTypedef
-                                  (CName
-                                    "another_typedef_enum_e"))
-                                DeclPathTop))),
+                            (TypeTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "a_typedef_struct"))
                       DeclPathTop,
@@ -2797,7 +2723,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTypedef
                               (CName
                                 "another_typedef_struct_t"))
@@ -2811,7 +2736,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef
                                 (CName
                                   "another_typedef_struct_t"))
@@ -2840,13 +2764,9 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeEnum
-                          (DeclPathConstr
-                            DeclConstrEnum
-                            (DeclNameTypedef
-                              (CName
-                                "another_typedef_enum_e"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName
+                            "another_typedef_enum_e"),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2855,13 +2775,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeEnum
-                            (DeclPathConstr
-                              DeclConstrEnum
-                              (DeclNameTypedef
-                                (CName
-                                  "another_typedef_enum_e"))
-                              DeclPathTop)),
+                          (TypeTypedef
+                            (CName
+                              "another_typedef_enum_e")),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2872,13 +2788,9 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeEnum
-                              (DeclPathConstr
-                                DeclConstrEnum
-                                (DeclNameTypedef
-                                  (CName
-                                    "another_typedef_enum_e"))
-                                DeclPathTop))),
+                            (TypeTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -2937,7 +2849,6 @@
             "a_typedef_struct_t",
           typedefType = TypeStruct
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "a_typedef_struct"))
               DeclPathTop),
@@ -2968,7 +2879,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTypedef
               (CName "a_typedef_enum_e"))
             DeclPathTop,
@@ -3020,7 +2930,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTypedef
                 (CName "a_typedef_enum_e"))
               DeclPathTop,
@@ -3077,7 +2986,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName "a_typedef_enum_e"))
                       DeclPathTop,
@@ -3134,7 +3042,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName "a_typedef_enum_e"))
                       DeclPathTop,
@@ -3279,6 +3186,41 @@
           valueValue = 3,
           valueSourceLoc =
           "distilled_lib_1.h:65:3"}},
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
+        "A_typedef_enum_e",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "A_typedef_enum_e",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unA_typedef_enum_e",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "A_typedef_enum_e"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName
+            "a_typedef_enum_e",
+          typedefType = TypeEnum
+            (DeclPathConstr
+              (DeclNameTypedef
+                (CName "a_typedef_enum_e"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "distilled_lib_1.h:66:13"}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "A_typedef_enum_e"),
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -108,6 +108,12 @@ pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
 
+newtype Another_typedef_enum_e = Another_typedef_enum_e
+  { unAnother_typedef_enum_e :: Another_typedef_enum_e
+  }
+
+deriving newtype instance F.Storable Another_typedef_enum_e
+
 newtype A_type_t = A_type_t
   { unA_type_t :: FC.CInt
   }
@@ -374,6 +380,12 @@ pattern ENUM_CASE_2 = A_typedef_enum_e 2
 
 pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
+
+newtype A_typedef_enum_e = A_typedef_enum_e
+  { unA_typedef_enum_e :: A_typedef_enum_e
+  }
+
+deriving newtype instance F.Storable A_typedef_enum_e
 
 newtype Int32_t = Int32_t
   { unInt32_t :: FC.CInt

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -44,6 +44,9 @@ pattern FOO :: Another_typedef_enum_e
 pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
+newtype Another_typedef_enum_e
+    = Another_typedef_enum_e {unAnother_typedef_enum_e :: Another_typedef_enum_e}
+deriving newtype instance Storable Another_typedef_enum_e
 newtype A_type_t = A_type_t {unA_type_t :: CInt}
 deriving newtype instance Storable A_type_t
 deriving stock instance Eq A_type_t
@@ -171,6 +174,9 @@ pattern ENUM_CASE_2 :: A_typedef_enum_e
 pattern ENUM_CASE_2 = A_typedef_enum_e 2
 pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
+newtype A_typedef_enum_e
+    = A_typedef_enum_e {unA_typedef_enum_e :: A_typedef_enum_e}
+deriving newtype instance Storable A_typedef_enum_e
 newtype Int32_t = Int32_t {unInt32_t :: CInt}
 deriving newtype instance Storable Int32_t
 deriving stock instance Eq Int32_t

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -326,7 +326,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTypedef
             (CName
               "another_typedef_struct_t"))
@@ -357,7 +356,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTypedef
             (CName
               "another_typedef_enum_e"))
@@ -380,6 +378,18 @@ Header
             "distilled_lib_1.h:9:21"}],
         enumSourceLoc =
         "distilled_lib_1.h:9:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "another_typedef_enum_e",
+        typedefType = TypeEnum
+          (DeclPathConstr
+            (DeclNameTypedef
+              (CName
+                "another_typedef_enum_e"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "distilled_lib_1.h:9:27"},
     DeclTypedef
       Typedef {
         typedefName = CName "a_type_t",
@@ -420,7 +430,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "a_typedef_struct"))
           DeclPathTop,
@@ -465,7 +474,6 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTypedef
                   (CName
                     "another_typedef_struct_t"))
@@ -479,7 +487,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef
                     (CName
                       "another_typedef_struct_t"))
@@ -508,13 +515,9 @@ Header
             fieldName = CName "field_8",
             fieldOffset = 480,
             fieldWidth = Nothing,
-            fieldType = TypeEnum
-              (DeclPathConstr
-                DeclConstrEnum
-                (DeclNameTypedef
-                  (CName
-                    "another_typedef_enum_e"))
-                DeclPathTop),
+            fieldType = TypeTypedef
+              (CName
+                "another_typedef_enum_e"),
             fieldSourceLoc =
             "distilled_lib_1.h:44:31"},
           StructField {
@@ -523,13 +526,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeConstArray
               4
-              (TypeEnum
-                (DeclPathConstr
-                  DeclConstrEnum
-                  (DeclNameTypedef
-                    (CName
-                      "another_typedef_enum_e"))
-                  DeclPathTop)),
+              (TypeTypedef
+                (CName
+                  "another_typedef_enum_e")),
             fieldSourceLoc =
             "distilled_lib_1.h:45:31"},
           StructField {
@@ -540,13 +539,9 @@ Header
               5
               (TypeConstArray
                 3
-                (TypeEnum
-                  (DeclPathConstr
-                    DeclConstrEnum
-                    (DeclNameTypedef
-                      (CName
-                        "another_typedef_enum_e"))
-                    DeclPathTop))),
+                (TypeTypedef
+                  (CName
+                    "another_typedef_enum_e"))),
             fieldSourceLoc =
             "distilled_lib_1.h:46:31"}],
         structFlam = Nothing,
@@ -558,7 +553,6 @@ Header
           "a_typedef_struct_t",
         typedefType = TypeStruct
           (DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "a_typedef_struct"))
             DeclPathTop),
@@ -567,7 +561,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTypedef
             (CName "a_typedef_enum_e"))
           DeclPathTop,
@@ -599,6 +592,17 @@ Header
             "distilled_lib_1.h:65:3"}],
         enumSourceLoc =
         "distilled_lib_1.h:60:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "a_typedef_enum_e",
+        typedefType = TypeEnum
+          (DeclPathConstr
+            (DeclNameTypedef
+              (CName "a_typedef_enum_e"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "distilled_lib_1.h:66:13"},
     DeclTypedef
       Typedef {
         typedefName = CName "int32_t",

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -18,7 +18,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "first"))
             DeclPathTop,
           enumAliases = [],
@@ -57,7 +56,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "first"))
               DeclPathTop,
             enumAliases = [],
@@ -101,7 +99,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "first"))
                       DeclPathTop,
                     enumAliases = [],
@@ -145,7 +142,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "first"))
                       DeclPathTop,
                     enumAliases = [],
@@ -258,7 +254,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "second"))
             DeclPathTop,
           enumAliases = [],
@@ -303,7 +298,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "second"))
               DeclPathTop,
             enumAliases = [],
@@ -353,7 +347,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "second"))
                       DeclPathTop,
                     enumAliases = [],
@@ -403,7 +396,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "second"))
                       DeclPathTop,
                     enumAliases = [],
@@ -541,7 +533,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "same"))
             DeclPathTop,
           enumAliases = [],
@@ -582,7 +573,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "same"))
               DeclPathTop,
             enumAliases = [],
@@ -627,7 +617,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "same"))
                       DeclPathTop,
                     enumAliases = [],
@@ -673,7 +662,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "same"))
                       DeclPathTop,
                     enumAliases = [],
@@ -777,7 +765,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "packad"))
             DeclPathTop,
           enumAliases = [],
@@ -823,7 +810,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "packad"))
               DeclPathTop,
             enumAliases = [],
@@ -873,7 +859,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "packad"))
                       DeclPathTop,
                     enumAliases = [],
@@ -924,7 +909,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "packad"))
                       DeclPathTop,
                     enumAliases = [],
@@ -1062,7 +1046,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTypedef
               (CName "enumA"))
             DeclPathTop,
@@ -1104,7 +1087,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTypedef
                 (CName "enumA"))
               DeclPathTop,
@@ -1150,7 +1132,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName "enumA"))
                       DeclPathTop,
@@ -1197,7 +1178,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTypedef
                         (CName "enumA"))
                       DeclPathTop,
@@ -1297,6 +1277,40 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
+        "EnumA",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "EnumA",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unEnumA",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "EnumA"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName "enumA",
+          typedefType = TypeEnum
+            (DeclPathConstr
+              (DeclNameTypedef
+                (CName "enumA"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "enums.h:24:31"}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "EnumA"),
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
         "EnumB",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1312,15 +1326,9 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "enumB"))
             DeclPathTop,
-          enumAliases = [
-            DeclPathConstr
-              DeclConstrStruct
-              (DeclNameTypedef
-                (CName "enumB"))
-              DeclPathTop],
+          enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1358,15 +1366,9 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "enumB"))
               DeclPathTop,
-            enumAliases = [
-              DeclPathConstr
-                DeclConstrStruct
-                (DeclNameTypedef
-                  (CName "enumB"))
-                DeclPathTop],
+            enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1409,15 +1411,9 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumB"))
                       DeclPathTop,
-                    enumAliases = [
-                      DeclPathConstr
-                        DeclConstrStruct
-                        (DeclNameTypedef
-                          (CName "enumB"))
-                        DeclPathTop],
+                    enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1460,15 +1456,9 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumB"))
                       DeclPathTop,
-                    enumAliases = [
-                      DeclPathConstr
-                        DeclConstrStruct
-                        (DeclNameTypedef
-                          (CName "enumB"))
-                        DeclPathTop],
+                    enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1565,6 +1555,39 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
+        "EnumB",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "EnumB",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unEnumB",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "EnumB"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName "enumB",
+          typedefType = TypeEnum
+            (DeclPathConstr
+              (DeclNameTag (CName "enumB"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "enums.h:26:37"}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "EnumB"),
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
         "EnumC",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1580,15 +1603,9 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "enumC"))
             DeclPathTop,
-          enumAliases = [
-            DeclPathConstr
-              DeclConstrStruct
-              (DeclNameTypedef
-                (CName "enumC"))
-              DeclPathTop],
+          enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1626,15 +1643,9 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "enumC"))
               DeclPathTop,
-            enumAliases = [
-              DeclPathConstr
-                DeclConstrStruct
-                (DeclNameTypedef
-                  (CName "enumC"))
-                DeclPathTop],
+            enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1676,15 +1687,9 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumC"))
                       DeclPathTop,
-                    enumAliases = [
-                      DeclPathConstr
-                        DeclConstrStruct
-                        (DeclNameTypedef
-                          (CName "enumC"))
-                        DeclPathTop],
+                    enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1727,15 +1732,9 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumC"))
                       DeclPathTop,
-                    enumAliases = [
-                      DeclPathConstr
-                        DeclConstrStruct
-                        (DeclNameTypedef
-                          (CName "enumC"))
-                        DeclPathTop],
+                    enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1831,6 +1830,39 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
+        "EnumC",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "EnumC",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unEnumC",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "EnumC"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName "enumC",
+          typedefType = TypeEnum
+            (DeclPathConstr
+              (DeclNameTag (CName "enumC"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "enums.h:29:20"}},
+  DeclNewtypeInstance
+    DeriveNewtype
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "EnumC"),
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
         "EnumD",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1846,7 +1878,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "enumD"))
             DeclPathTop,
           enumAliases = [],
@@ -1887,7 +1918,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "enumD"))
               DeclPathTop,
             enumAliases = [],
@@ -1932,7 +1962,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumD"))
                       DeclPathTop,
                     enumAliases = [],
@@ -1978,7 +2007,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "enumD"))
                       DeclPathTop,
                     enumAliases = [],
@@ -2096,7 +2124,6 @@
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
             (DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "enumD"))
               DeclPathTop),
           typedefSourceLoc =

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -201,6 +201,12 @@ pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
 
+newtype EnumA = EnumA
+  { unEnumA :: EnumA
+  }
+
+deriving newtype instance F.Storable EnumA
+
 newtype EnumB = EnumB
   { unEnumB :: FC.CUInt
   }
@@ -238,6 +244,12 @@ pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
 
+newtype EnumB = EnumB
+  { unEnumB :: EnumB
+  }
+
+deriving newtype instance F.Storable EnumB
+
 newtype EnumC = EnumC
   { unEnumC :: FC.CUInt
   }
@@ -274,6 +286,12 @@ pattern C_FOO = EnumC 0
 
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
+
+newtype EnumC = EnumC
+  { unEnumC :: EnumC
+  }
+
+deriving newtype instance F.Storable EnumC
 
 newtype EnumD = EnumD
   { unEnumD :: FC.CUInt

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -82,6 +82,8 @@ pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
+newtype EnumA = EnumA {unEnumA :: EnumA}
+deriving newtype instance Storable EnumA
 newtype EnumB = EnumB {unEnumB :: CUInt}
 instance Storable EnumB
     where {sizeOf = \_ -> 4 :: Int;
@@ -98,6 +100,8 @@ pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
+newtype EnumB = EnumB {unEnumB :: EnumB}
+deriving newtype instance Storable EnumB
 newtype EnumC = EnumC {unEnumC :: CUInt}
 instance Storable EnumC
     where {sizeOf = \_ -> 4 :: Int;
@@ -114,6 +118,8 @@ pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
+newtype EnumC = EnumC {unEnumC :: EnumC}
+deriving newtype instance Storable EnumC
 newtype EnumD = EnumD {unEnumD :: CUInt}
 instance Storable EnumD
     where {sizeOf = \_ -> 4 :: Int;

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -18,7 +18,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "first"))
           DeclPathTop,
         enumAliases = [],
@@ -40,7 +39,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "second"))
           DeclPathTop,
         enumAliases = [],
@@ -68,7 +66,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "same"))
           DeclPathTop,
         enumAliases = [],
@@ -91,7 +88,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "packad"))
           DeclPathTop,
         enumAliases = [],
@@ -119,7 +115,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTypedef
             (CName "enumA"))
           DeclPathTop,
@@ -140,18 +135,22 @@ Header
             valueSourceLoc =
             "enums.h:24:23"}],
         enumSourceLoc = "enums.h:24:9"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "enumA",
+        typedefType = TypeEnum
+          (DeclPathConstr
+            (DeclNameTypedef
+              (CName "enumA"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "enums.h:24:31"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "enumB"))
           DeclPathTop,
-        enumAliases = [
-          DeclPathConstr
-            DeclConstrStruct
-            (DeclNameTypedef
-              (CName "enumB"))
-            DeclPathTop],
+        enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -169,18 +168,21 @@ Header
             "enums.h:26:29"}],
         enumSourceLoc =
         "enums.h:26:14"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "enumB",
+        typedefType = TypeEnum
+          (DeclPathConstr
+            (DeclNameTag (CName "enumB"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "enums.h:26:37"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "enumC"))
           DeclPathTop,
-        enumAliases = [
-          DeclPathConstr
-            DeclConstrStruct
-            (DeclNameTypedef
-              (CName "enumC"))
-            DeclPathTop],
+        enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -197,10 +199,18 @@ Header
             valueSourceLoc =
             "enums.h:28:21"}],
         enumSourceLoc = "enums.h:28:6"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName "enumC",
+        typedefType = TypeEnum
+          (DeclPathConstr
+            (DeclNameTag (CName "enumC"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "enums.h:29:20"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "enumD"))
           DeclPathTop,
         enumAliases = [],
@@ -225,7 +235,6 @@ Header
         typedefName = CName "enumD_t",
         typedefType = TypeEnum
           (DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "enumD"))
             DeclPathTop),
         typedefSourceLoc =

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -86,7 +86,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "Example"))
             DeclPathTop,
           structAliases = [],
@@ -174,7 +173,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "Example"))
               DeclPathTop,
             structAliases = [],
@@ -267,7 +265,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Example"))
                       DeclPathTop,
                     structAliases = [],
@@ -362,7 +359,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Example"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -12,7 +12,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "Example"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -252,7 +252,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structAliases = [],
@@ -328,7 +327,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -409,7 +407,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -492,7 +489,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -19,7 +19,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -28,7 +28,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "pascal"))
             DeclPathTop,
           structAliases = [],
@@ -82,7 +81,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "pascal"))
               DeclPathTop,
             structAliases = [],
@@ -140,7 +138,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "pascal"))
                       DeclPathTop,
                     structAliases = [],
@@ -199,7 +196,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "pascal"))
                       DeclPathTop,
                     structAliases = [],
@@ -271,7 +267,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "pascal"))
               DeclPathTop,
             structAliases = [],
@@ -341,12 +336,10 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathField
               (CName "bar")
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop)),
           structAliases = [],
@@ -417,12 +410,10 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathField
                 (CName "bar")
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop)),
             structAliases = [],
@@ -498,12 +489,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "bar")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "foo"))
                           DeclPathTop)),
                     structAliases = [],
@@ -581,12 +570,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathField
                         (CName "bar")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "foo"))
                           DeclPathTop)),
                     structAliases = [],
@@ -660,7 +647,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structAliases = [],
@@ -681,12 +667,10 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathField
                     (CName "bar")
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop))),
               fieldSourceLoc = "flam.h:13:4"},
@@ -722,7 +706,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -743,12 +726,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "bar")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "foo"))
                         DeclPathTop))),
                 fieldSourceLoc = "flam.h:13:4"},
@@ -788,7 +769,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -809,12 +789,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "bar")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
                         fieldSourceLoc = "flam.h:13:4"},
@@ -855,7 +833,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -876,12 +853,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             DeclNameNone
                             (DeclPathField
                               (CName "bar")
                               (DeclPathConstr
-                                DeclConstrStruct
                                 (DeclNameTag (CName "foo"))
                                 DeclPathTop))),
                         fieldSourceLoc = "flam.h:13:4"},
@@ -931,7 +906,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -952,12 +926,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathField
                       (CName "bar")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "foo"))
                         DeclPathTop))),
                 fieldSourceLoc = "flam.h:13:4"},
@@ -1012,7 +984,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "diff"))
             DeclPathTop,
           structAliases = [],
@@ -1090,7 +1061,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "diff"))
               DeclPathTop,
             structAliases = [],
@@ -1173,7 +1143,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "diff"))
                       DeclPathTop,
                     structAliases = [],
@@ -1258,7 +1227,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "diff"))
                       DeclPathTop,
                     structAliases = [],
@@ -1352,7 +1320,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "diff"))
               DeclPathTop,
             structAliases = [],

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "pascal"))
           DeclPathTop,
         structAliases = [],
@@ -29,12 +28,10 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathField
             (CName "bar")
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop)),
         structAliases = [],
@@ -62,7 +59,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structAliases = [],
@@ -83,12 +79,10 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathField
                   (CName "bar")
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop))),
             fieldSourceLoc = "flam.h:13:4"},
@@ -96,7 +90,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "diff"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -28,7 +28,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structAliases = [],
@@ -76,7 +75,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structAliases = [],
@@ -129,7 +127,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -182,7 +179,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -236,7 +232,6 @@
           typedefName = CName "S1_t",
           typedefType = TypeStruct
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop),
           typedefSourceLoc =
@@ -274,7 +269,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structAliases = [],
@@ -322,7 +316,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structAliases = [],
@@ -375,7 +368,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],
@@ -428,7 +420,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structAliases = [],
@@ -26,7 +25,6 @@ Header
         typedefName = CName "S1_t",
         typedefType = TypeStruct
           (DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop),
         typedefSourceLoc =
@@ -34,7 +32,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -44,7 +44,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structAliases = [],
@@ -116,7 +115,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -193,7 +191,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -272,7 +269,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -337,7 +333,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -356,7 +351,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -365,7 +359,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             DeclPathTop,
           structAliases = [],
@@ -378,7 +371,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -389,7 +381,6 @@
               fieldWidth = Nothing,
               fieldType = TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop),
               fieldSourceLoc =
@@ -421,7 +412,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -440,7 +430,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -449,7 +438,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               DeclPathTop,
             structAliases = [],
@@ -462,7 +450,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -473,7 +460,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop),
                 fieldSourceLoc =
@@ -510,7 +496,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -529,7 +514,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -538,7 +522,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structAliases = [],
@@ -551,7 +534,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -562,7 +544,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -601,7 +582,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -620,7 +600,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -629,7 +608,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structAliases = [],
@@ -642,7 +620,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -653,7 +630,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "foo"))
                             DeclPathTop),
                         fieldSourceLoc =
@@ -706,7 +682,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "ex3"))
             DeclPathTop,
           structAliases = [],
@@ -754,7 +729,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "ex3"))
               DeclPathTop,
             structAliases = [],
@@ -807,7 +781,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex3"))
                       DeclPathTop,
                     structAliases = [],
@@ -860,7 +833,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex3"))
                       DeclPathTop,
                     structAliases = [],
@@ -936,7 +908,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -945,13 +916,11 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "ex4_even"))
             (DeclPathPtr
               (DeclPathField
                 (CName "next")
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_odd"))
                   DeclPathTop))),
           structAliases = [],
@@ -973,7 +942,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -1025,7 +993,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -1034,13 +1001,11 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "ex4_even"))
               (DeclPathPtr
                 (DeclPathField
                   (CName "next")
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_odd"))
                     DeclPathTop))),
             structAliases = [],
@@ -1062,7 +1027,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -1119,7 +1083,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1128,13 +1091,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))),
                     structAliases = [],
@@ -1156,7 +1117,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1215,7 +1175,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1224,13 +1183,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))),
                     structAliases = [],
@@ -1252,7 +1209,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_odd"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -1323,13 +1279,11 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_even"))
                     (DeclPathPtr
                       (DeclPathField
                         (CName "next")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1338,7 +1292,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "ex4_odd"))
             DeclPathTop,
           structAliases = [],
@@ -1360,13 +1313,11 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "ex4_even"))
                     (DeclPathPtr
                       (DeclPathField
                         (CName "next")
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTag (CName "ex4_odd"))
                           DeclPathTop))))),
               fieldSourceLoc =
@@ -1418,13 +1369,11 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1433,7 +1382,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "ex4_odd"))
               DeclPathTop,
             structAliases = [],
@@ -1455,13 +1403,11 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_even"))
                       (DeclPathPtr
                         (DeclPathField
                           (CName "next")
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTag (CName "ex4_odd"))
                             DeclPathTop))))),
                 fieldSourceLoc =
@@ -1518,13 +1464,11 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1533,7 +1477,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
                     structAliases = [],
@@ -1555,13 +1498,11 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1620,13 +1561,11 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =
@@ -1635,7 +1574,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "ex4_odd"))
                       DeclPathTop,
                     structAliases = [],
@@ -1657,13 +1595,11 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "ex4_even"))
                               (DeclPathPtr
                                 (DeclPathField
                                   (CName "next")
                                   (DeclPathConstr
-                                    DeclConstrStruct
                                     (DeclNameTag (CName "ex4_odd"))
                                     DeclPathTop))))),
                         fieldSourceLoc =

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structAliases = [],
@@ -32,7 +31,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           DeclPathTop,
         structAliases = [],
@@ -45,7 +43,6 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop),
             fieldSourceLoc =
@@ -56,7 +53,6 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "foo"))
                 DeclPathTop),
             fieldSourceLoc =
@@ -67,7 +63,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "ex3"))
           DeclPathTop,
         structAliases = [],
@@ -88,13 +83,11 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "ex4_even"))
           (DeclPathPtr
             (DeclPathField
               (CName "next")
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTag (CName "ex4_odd"))
                 DeclPathTop))),
         structAliases = [],
@@ -116,7 +109,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_odd"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -127,7 +119,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "ex4_odd"))
           DeclPathTop,
         structAliases = [],
@@ -149,13 +140,11 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "ex4_even"))
                   (DeclPathPtr
                     (DeclPathField
                       (CName "next")
                       (DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTag (CName "ex4_odd"))
                         DeclPathTop))))),
             fieldSourceLoc =

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -36,7 +36,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -57,7 +56,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -66,7 +64,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             DeclPathTop,
           structAliases = [],
@@ -80,7 +77,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "foo"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -92,7 +88,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     DeclPathTop)),
               fieldSourceLoc =
@@ -126,7 +121,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -147,7 +141,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -156,7 +149,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               DeclPathTop,
             structAliases = [],
@@ -170,7 +162,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -182,7 +173,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop)),
                 fieldSourceLoc =
@@ -221,7 +211,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -242,7 +231,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -251,7 +239,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structAliases = [],
@@ -265,7 +252,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -277,7 +263,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -318,7 +303,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -339,7 +323,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -348,7 +331,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       DeclPathTop,
                     structAliases = [],
@@ -362,7 +344,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "foo"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -374,7 +355,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag (CName "bar"))
                               DeclPathTop)),
                         fieldSourceLoc =
@@ -411,7 +391,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "baz"))
             DeclPathTop,
           structAliases = [],
@@ -435,7 +414,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "baz"))
               DeclPathTop,
             structAliases = [],
@@ -464,7 +442,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "baz"))
                       DeclPathTop,
                     structAliases = [],
@@ -493,7 +470,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "baz"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -9,7 +9,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           DeclPathTop,
         structAliases = [],
@@ -23,7 +22,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "foo"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -35,7 +33,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "bar"))
                   DeclPathTop)),
             fieldSourceLoc =
@@ -46,7 +43,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "baz"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -496,7 +496,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "primitive"))
             DeclPathTop,
@@ -1257,7 +1256,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "primitive"))
               DeclPathTop,
@@ -2023,7 +2021,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "primitive"))
                       DeclPathTop,
@@ -2818,7 +2815,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "primitive"))
                       DeclPathTop,

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "primitive"))
           DeclPathTop,

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -42,7 +42,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
@@ -52,7 +51,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_A_s"))
             DeclPathTop,
@@ -75,7 +73,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_A_s"))
                     DeclPathTop)),
@@ -128,7 +125,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
@@ -138,7 +134,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop,
@@ -161,7 +156,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop)),
@@ -219,7 +213,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -229,7 +222,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop,
@@ -252,7 +244,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -312,7 +303,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -322,7 +312,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_A_s"))
                       DeclPathTop,
@@ -345,7 +334,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_A_s"))
                               DeclPathTop)),
@@ -398,7 +386,6 @@
             "linked_list_A_t",
           typedefType = TypeStruct
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_A_s"))
               DeclPathTop),
@@ -453,7 +440,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
@@ -463,13 +449,11 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_B_t"))
             DeclPathTop,
           structAliases = [
             DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef
                 (CName "linked_list_B_t"))
               DeclPathTop],
@@ -491,7 +475,6 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag
                       (CName "linked_list_B_t"))
                     DeclPathTop)),
@@ -544,7 +527,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
@@ -554,13 +536,11 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "linked_list_B_t"))
               DeclPathTop,
             structAliases = [
               DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTypedef
                   (CName "linked_list_B_t"))
                 DeclPathTop],
@@ -582,7 +562,6 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop)),
@@ -640,7 +619,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -650,13 +628,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef
                           (CName "linked_list_B_t"))
                         DeclPathTop],
@@ -678,7 +654,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -738,7 +713,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),
@@ -748,13 +722,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "linked_list_B_t"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef
                           (CName "linked_list_B_t"))
                         DeclPathTop],
@@ -776,7 +748,6 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTag
                                 (CName "linked_list_B_t"))
                               DeclPathTop)),

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "linked_list_A_s"))
           DeclPathTop,
@@ -26,7 +25,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag
                     (CName "linked_list_A_s"))
                   DeclPathTop)),
@@ -41,7 +39,6 @@ Header
           "linked_list_A_t",
         typedefType = TypeStruct
           (DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "linked_list_A_s"))
             DeclPathTop),
@@ -50,13 +47,11 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "linked_list_B_t"))
           DeclPathTop,
         structAliases = [
           DeclPathConstr
-            DeclConstrStruct
             (DeclNameTypedef
               (CName "linked_list_B_t"))
             DeclPathTop],
@@ -78,7 +73,6 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag
                     (CName "linked_list_B_t"))
                   DeclPathTop)),

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -44,7 +44,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S1"))
             DeclPathTop,
           structAliases = [],
@@ -116,7 +115,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S1"))
               DeclPathTop,
             structAliases = [],
@@ -193,7 +191,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -272,7 +269,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S1"))
                       DeclPathTop,
                     structAliases = [],
@@ -375,7 +371,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop,
           structAliases = [],
@@ -471,7 +466,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop,
             structAliases = [],
@@ -572,7 +566,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],
@@ -676,7 +669,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S2"))
                       DeclPathTop,
                     structAliases = [],
@@ -748,7 +740,6 @@
           typedefName = CName "S2_t",
           typedefType = TypeStruct
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S2"))
               DeclPathTop),
           typedefSourceLoc =
@@ -786,7 +777,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTypedef (CName "S3_t"))
             DeclPathTop,
           structAliases = [],
@@ -834,7 +824,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef (CName "S3_t"))
               DeclPathTop,
             structAliases = [],
@@ -887,7 +876,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef (CName "S3_t"))
                       DeclPathTop,
                     structAliases = [],
@@ -940,7 +928,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef (CName "S3_t"))
                       DeclPathTop,
                     structAliases = [],
@@ -1035,7 +1022,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S4"))
             DeclPathTop,
           structAliases = [],
@@ -1133,7 +1119,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S4"))
               DeclPathTop,
             structAliases = [],
@@ -1236,7 +1221,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S4"))
                       DeclPathTop,
                     structAliases = [],
@@ -1342,7 +1326,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S4"))
                       DeclPathTop,
                     structAliases = [],
@@ -1439,12 +1422,10 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S5"))
             DeclPathTop,
           structAliases = [
             DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef (CName "S5"))
               DeclPathTop],
           structSizeof = 8,
@@ -1515,12 +1496,10 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S5"))
               DeclPathTop,
             structAliases = [
               DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTypedef (CName "S5"))
                 DeclPathTop],
             structSizeof = 8,
@@ -1596,12 +1575,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef (CName "S5"))
                         DeclPathTop],
                     structSizeof = 8,
@@ -1679,12 +1656,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef (CName "S5"))
                         DeclPathTop],
                     structSizeof = 8,
@@ -1770,12 +1745,10 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S6"))
             DeclPathTop,
           structAliases = [
             DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef (CName "S6"))
               DeclPathTop],
           structSizeof = 8,
@@ -1846,12 +1819,10 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "S6"))
               DeclPathTop,
             structAliases = [
               DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTypedef (CName "S6"))
                 DeclPathTop],
             structSizeof = 8,
@@ -1927,12 +1898,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef (CName "S6"))
                         DeclPathTop],
                     structSizeof = 8,
@@ -2010,12 +1979,10 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
                     structAliases = [
                       DeclPathConstr
-                        DeclConstrStruct
                         (DeclNameTypedef (CName "S6"))
                         DeclPathTop],
                     structSizeof = 8,
@@ -2101,11 +2068,9 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathPtr
               (DeclPathConstr
-                DeclConstrStruct
                 (DeclNameTypedef (CName "S7a"))
                 DeclPathTop)),
           structAliases = [],
@@ -2177,11 +2142,9 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7a"))
                   DeclPathTop)),
             structAliases = [],
@@ -2258,11 +2221,9 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7a"))
                           DeclPathTop)),
                     structAliases = [],
@@ -2341,11 +2302,9 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7a"))
                           DeclPathTop)),
                     structAliases = [],
@@ -2416,11 +2375,9 @@
           typedefType = TypePointer
             (TypeStruct
               (DeclPathConstr
-                DeclConstrStruct
                 DeclNameNone
                 (DeclPathPtr
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef (CName "S7a"))
                     DeclPathTop)))),
           typedefSourceLoc =
@@ -2474,13 +2431,11 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             DeclNameNone
             (DeclPathPtr
               (DeclPathPtr
                 (DeclPathPtr
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTypedef (CName "S7b"))
                     DeclPathTop)))),
           structAliases = [],
@@ -2552,13 +2507,11 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
                 (DeclPathPtr
                   (DeclPathPtr
                     (DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTypedef (CName "S7b"))
                       DeclPathTop)))),
             structAliases = [],
@@ -2635,13 +2588,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathPtr
                           (DeclPathPtr
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef (CName "S7b"))
                               DeclPathTop)))),
                     structAliases = [],
@@ -2720,13 +2671,11 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       DeclNameNone
                       (DeclPathPtr
                         (DeclPathPtr
                           (DeclPathPtr
                             (DeclPathConstr
-                              DeclConstrStruct
                               (DeclNameTypedef (CName "S7b"))
                               DeclPathTop)))),
                     structAliases = [],
@@ -2801,13 +2750,11 @@
               (TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     DeclNameNone
                     (DeclPathPtr
                       (DeclPathPtr
                         (DeclPathPtr
                           (DeclPathConstr
-                            DeclConstrStruct
                             (DeclNameTypedef (CName "S7b"))
                             DeclPathTop)))))))),
           typedefSourceLoc =

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S1"))
           DeclPathTop,
         structAliases = [],
@@ -32,7 +31,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S2"))
           DeclPathTop,
         structAliases = [],
@@ -71,7 +69,6 @@ Header
         typedefName = CName "S2_t",
         typedefType = TypeStruct
           (DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "S2"))
             DeclPathTop),
         typedefSourceLoc =
@@ -79,7 +76,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTypedef (CName "S3_t"))
           DeclPathTop,
         structAliases = [],
@@ -100,7 +96,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S4"))
           DeclPathTop,
         structAliases = [],
@@ -138,12 +133,10 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S5"))
           DeclPathTop,
         structAliases = [
           DeclPathConstr
-            DeclConstrStruct
             (DeclNameTypedef (CName "S5"))
             DeclPathTop],
         structSizeof = 8,
@@ -171,12 +164,10 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "S6"))
           DeclPathTop,
         structAliases = [
           DeclPathConstr
-            DeclConstrStruct
             (DeclNameTypedef (CName "S6"))
             DeclPathTop],
         structSizeof = 8,
@@ -204,11 +195,9 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathPtr
             (DeclPathConstr
-              DeclConstrStruct
               (DeclNameTypedef (CName "S7a"))
               DeclPathTop)),
         structAliases = [],
@@ -240,11 +229,9 @@ Header
         typedefType = TypePointer
           (TypeStruct
             (DeclPathConstr
-              DeclConstrStruct
               DeclNameNone
               (DeclPathPtr
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7a"))
                   DeclPathTop)))),
         typedefSourceLoc =
@@ -252,13 +239,11 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           DeclNameNone
           (DeclPathPtr
             (DeclPathPtr
               (DeclPathPtr
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTypedef (CName "S7b"))
                   DeclPathTop)))),
         structAliases = [],
@@ -292,13 +277,11 @@ Header
             (TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   DeclNameNone
                   (DeclPathPtr
                     (DeclPathPtr
                       (DeclPathPtr
                         (DeclPathConstr
-                          DeclConstrStruct
                           (DeclNameTypedef (CName "S7b"))
                           DeclPathTop)))))))),
         typedefSourceLoc =

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -541,7 +541,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag
               (CName "ExampleStruct"))
             DeclPathTop,
@@ -662,7 +661,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag
                 (CName "ExampleStruct"))
               DeclPathTop,
@@ -788,7 +786,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "ExampleStruct"))
                       DeclPathTop,
@@ -918,7 +915,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag
                         (CName "ExampleStruct"))
                       DeclPathTop,
@@ -1016,7 +1012,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structAliases = [],
@@ -1069,7 +1064,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -1127,7 +1121,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -1185,7 +1178,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -162,7 +162,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag
             (CName "ExampleStruct"))
           DeclPathTop,
@@ -208,7 +207,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structAliases = [],

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -18,7 +18,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           enumAliases = [],
@@ -59,7 +58,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             enumAliases = [],
@@ -105,7 +103,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     enumAliases = [],
@@ -151,7 +148,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     enumAliases = [],

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         enumAliases = [],

--- a/hs-bindgen/fixtures/unions.exts.txt
+++ b/hs-bindgen/fixtures/unions.exts.txt
@@ -2,3 +2,4 @@ DataKinds
 StandaloneDeriving
 DerivingStrategies
 DerivingVia
+GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -44,7 +44,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "Dim2"))
             DeclPathTop,
           structAliases = [],
@@ -116,7 +115,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "Dim2"))
               DeclPathTop,
             structAliases = [],
@@ -193,7 +191,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim2"))
                       DeclPathTop,
                     structAliases = [],
@@ -272,7 +269,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim2"))
                       DeclPathTop,
                     structAliases = [],
@@ -375,7 +371,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "Dim3"))
             DeclPathTop,
           structAliases = [],
@@ -471,7 +466,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "Dim3"))
               DeclPathTop,
             structAliases = [],
@@ -572,7 +566,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim3"))
                       DeclPathTop,
                     structAliases = [],
@@ -676,7 +669,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim3"))
                       DeclPathTop,
                     structAliases = [],
@@ -745,7 +737,6 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathConstr
-            DeclConstrUnion
             (DeclNameTag
               (CName "DimPayload"))
             DeclPathTop,
@@ -802,7 +793,6 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathConstr
-                  DeclConstrUnion
                   (DeclNameTag
                     (CName "DimPayload"))
                   DeclPathTop),
@@ -812,7 +802,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "Dim"))
             DeclPathTop,
           structAliases = [],
@@ -833,7 +822,6 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathConstr
-                  DeclConstrUnion
                   (DeclNameTag
                     (CName "DimPayload"))
                   DeclPathTop),
@@ -884,7 +872,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathConstr
-                    DeclConstrUnion
                     (DeclNameTag
                       (CName "DimPayload"))
                     DeclPathTop),
@@ -894,7 +881,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "Dim"))
               DeclPathTop,
             structAliases = [],
@@ -915,7 +901,6 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathConstr
-                    DeclConstrUnion
                     (DeclNameTag
                       (CName "DimPayload"))
                     DeclPathTop),
@@ -971,7 +956,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathConstr
-                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -981,7 +965,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim"))
                       DeclPathTop,
                     structAliases = [],
@@ -1002,7 +985,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathConstr
-                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -1060,7 +1042,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathConstr
-                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -1070,7 +1051,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "Dim"))
                       DeclPathTop,
                     structAliases = [],
@@ -1091,7 +1071,6 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathConstr
-                            DeclConstrUnion
                             (DeclNameTag
                               (CName "DimPayload"))
                             DeclPathTop),
@@ -1134,16 +1113,10 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathConstr
-            DeclConstrUnion
             (DeclNameTag
               (CName "DimPayloadB"))
             DeclPathTop,
-          unionAliases = [
-            DeclPathConstr
-              DeclConstrStruct
-              (DeclNameTypedef
-                (CName "DimPayloadB"))
-              DeclPathTop],
+          unionAliases = [],
           unionSizeof = 8,
           unionAlignment = 4,
           unionSourceLoc =
@@ -1151,6 +1124,41 @@
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 8 4))
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "DimPayloadB"),
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
+        "DimPayloadB",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "DimPayloadB",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unDimPayloadB",
+        fieldType = HsTypRef
+          (HsName
+            "@NsTypeConstr"
+            "DimPayloadB"),
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginTypedef
+        Typedef {
+          typedefName = CName
+            "DimPayloadB",
+          typedefType = TypeUnion
+            (DeclPathConstr
+              (DeclNameTag
+                (CName "DimPayloadB"))
+              DeclPathTop),
+          typedefSourceLoc =
+          "unions.h:26:3"}},
+  DeclNewtypeInstance
+    DeriveNewtype
     Storable
     (HsName
       "@NsTypeConstr"
@@ -1194,19 +1202,14 @@
               fieldName = CName "payload",
               fieldOffset = 32,
               fieldWidth = Nothing,
-              fieldType = TypeUnion
-                (DeclPathConstr
-                  DeclConstrUnion
-                  (DeclNameTag
-                    (CName "DimPayloadB"))
-                  DeclPathTop),
+              fieldType = TypeTypedef
+                (CName "DimPayloadB"),
               fieldSourceLoc =
               "unions.h:30:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "DimB"))
             DeclPathTop,
           structAliases = [],
@@ -1225,12 +1228,8 @@
               fieldName = CName "payload",
               fieldOffset = 32,
               fieldWidth = Nothing,
-              fieldType = TypeUnion
-                (DeclPathConstr
-                  DeclConstrUnion
-                  (DeclNameTag
-                    (CName "DimPayloadB"))
-                  DeclPathTop),
+              fieldType = TypeTypedef
+                (CName "DimPayloadB"),
               fieldSourceLoc =
               "unions.h:30:17"}],
           structFlam = Nothing,
@@ -1276,19 +1275,14 @@
                 fieldName = CName "payload",
                 fieldOffset = 32,
                 fieldWidth = Nothing,
-                fieldType = TypeUnion
-                  (DeclPathConstr
-                    DeclConstrUnion
-                    (DeclNameTag
-                      (CName "DimPayloadB"))
-                    DeclPathTop),
+                fieldType = TypeTypedef
+                  (CName "DimPayloadB"),
                 fieldSourceLoc =
                 "unions.h:30:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "DimB"))
               DeclPathTop,
             structAliases = [],
@@ -1307,12 +1301,8 @@
                 fieldName = CName "payload",
                 fieldOffset = 32,
                 fieldWidth = Nothing,
-                fieldType = TypeUnion
-                  (DeclPathConstr
-                    DeclConstrUnion
-                    (DeclNameTag
-                      (CName "DimPayloadB"))
-                    DeclPathTop),
+                fieldType = TypeTypedef
+                  (CName "DimPayloadB"),
                 fieldSourceLoc =
                 "unions.h:30:17"}],
             structFlam = Nothing,
@@ -1363,19 +1353,14 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeUnion
-                          (DeclPathConstr
-                            DeclConstrUnion
-                            (DeclNameTag
-                              (CName "DimPayloadB"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName "DimPayloadB"),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "DimB"))
                       DeclPathTop,
                     structAliases = [],
@@ -1394,12 +1379,8 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeUnion
-                          (DeclPathConstr
-                            DeclConstrUnion
-                            (DeclNameTag
-                              (CName "DimPayloadB"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName "DimPayloadB"),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,
@@ -1452,19 +1433,14 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeUnion
-                          (DeclPathConstr
-                            DeclConstrUnion
-                            (DeclNameTag
-                              (CName "DimPayloadB"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName "DimPayloadB"),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "DimB"))
                       DeclPathTop,
                     structAliases = [],
@@ -1483,12 +1459,8 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeUnion
-                          (DeclPathConstr
-                            DeclConstrUnion
-                            (DeclNameTag
-                              (CName "DimPayloadB"))
-                            DeclPathTop),
+                        fieldType = TypeTypedef
+                          (CName "DimPayloadB"),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
@@ -113,6 +114,12 @@ newtype DimPayloadB = DimPayloadB
   }
 
 deriving via (HsBindgen.Runtime.SizedByteArray.SizedByteArray 8) 4 instance F.Storable DimPayloadB
+
+newtype DimPayloadB = DimPayloadB
+  { unDimPayloadB :: DimPayloadB
+  }
+
+deriving newtype instance F.Storable DimPayloadB
 
 data DimB = DimB
   { dimB_tag :: FC.CInt

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -33,6 +33,8 @@ deriving stock instance Show Dim
 deriving stock instance Eq Dim
 newtype DimPayloadB = DimPayloadB {unDimPayloadB :: ByteArray}
 deriving via (SizedByteArray 8 4) instance Storable DimPayloadB
+newtype DimPayloadB = DimPayloadB {unDimPayloadB :: DimPayloadB}
+deriving newtype instance Storable DimPayloadB
 data DimB = DimB {dimB_tag :: CInt, dimB_payload :: DimPayloadB}
 instance Storable DimB
     where {sizeOf = \_ -> 12 :: Int;

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -3,7 +3,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "Dim2"))
           DeclPathTop,
         structAliases = [],
@@ -32,7 +31,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "Dim3"))
           DeclPathTop,
         structAliases = [],
@@ -69,7 +67,6 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathConstr
-          DeclConstrUnion
           (DeclNameTag
             (CName "DimPayload"))
           DeclPathTop,
@@ -81,7 +78,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "Dim"))
           DeclPathTop,
         structAliases = [],
@@ -102,7 +98,6 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeUnion
               (DeclPathConstr
-                DeclConstrUnion
                 (DeclNameTag
                   (CName "DimPayload"))
                 DeclPathTop),
@@ -114,24 +109,28 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathConstr
-          DeclConstrUnion
           (DeclNameTag
             (CName "DimPayloadB"))
           DeclPathTop,
-        unionAliases = [
-          DeclPathConstr
-            DeclConstrStruct
-            (DeclNameTypedef
-              (CName "DimPayloadB"))
-            DeclPathTop],
+        unionAliases = [],
         unionSizeof = 8,
         unionAlignment = 4,
         unionSourceLoc =
         "unions.h:23:15"},
+    DeclTypedef
+      Typedef {
+        typedefName = CName
+          "DimPayloadB",
+        typedefType = TypeUnion
+          (DeclPathConstr
+            (DeclNameTag
+              (CName "DimPayloadB"))
+            DeclPathTop),
+        typedefSourceLoc =
+        "unions.h:26:3"},
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "DimB"))
           DeclPathTop,
         structAliases = [],
@@ -150,12 +149,8 @@ Header
             fieldName = CName "payload",
             fieldOffset = 32,
             fieldWidth = Nothing,
-            fieldType = TypeUnion
-              (DeclPathConstr
-                DeclConstrUnion
-                (DeclNameTag
-                  (CName "DimPayloadB"))
-                DeclPathTop),
+            fieldType = TypeTypedef
+              (CName "DimPayloadB"),
             fieldSourceLoc =
             "unions.h:30:17"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -18,7 +18,6 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathConstr
-            DeclConstrEnum
             (DeclNameTag (CName "MyEnum"))
             DeclPathTop,
           enumAliases = [],
@@ -61,7 +60,6 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathConstr
-              DeclConstrEnum
               (DeclNameTag (CName "MyEnum"))
               DeclPathTop,
             enumAliases = [],
@@ -109,7 +107,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "MyEnum"))
                       DeclPathTop,
                     enumAliases = [],
@@ -157,7 +154,6 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathConstr
-                      DeclConstrEnum
                       (DeclNameTag (CName "MyEnum"))
                       DeclPathTop,
                     enumAliases = [],

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -18,7 +18,6 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathConstr
-          DeclConstrEnum
           (DeclNameTag (CName "MyEnum"))
           DeclPathTop,
         enumAliases = [],

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -21,7 +21,6 @@
               TypePointer
                 (TypeStruct
                   (DeclPathConstr
-                    DeclConstrStruct
                     (DeclNameTag (CName "bar"))
                     (DeclPathPtr DeclPathTop)))]
             TypeVoid,
@@ -57,7 +56,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "foo"))
             DeclPathTop,
           structAliases = [],
@@ -105,7 +103,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "foo"))
               DeclPathTop,
             structAliases = [],
@@ -158,7 +155,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -211,7 +207,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "foo"))
                       DeclPathTop,
                     structAliases = [],
@@ -273,7 +268,6 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathConstr
-            DeclConstrStruct
             (DeclNameTag (CName "bar"))
             (DeclPathPtr DeclPathTop),
           structAliases = [],
@@ -321,7 +315,6 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathConstr
-              DeclConstrStruct
               (DeclNameTag (CName "bar"))
               (DeclPathPtr DeclPathTop),
             structAliases = [],
@@ -374,7 +367,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       (DeclPathPtr DeclPathTop),
                     structAliases = [],
@@ -427,7 +419,6 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathConstr
-                      DeclConstrStruct
                       (DeclNameTag (CName "bar"))
                       (DeclPathPtr DeclPathTop),
                     structAliases = [],

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -8,7 +8,6 @@ Header
             TypePointer
               (TypeStruct
                 (DeclPathConstr
-                  DeclConstrStruct
                   (DeclNameTag (CName "bar"))
                   (DeclPathPtr DeclPathTop)))]
           TypeVoid,
@@ -18,7 +17,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "foo"))
           DeclPathTop,
         structAliases = [],
@@ -39,7 +37,6 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathConstr
-          DeclConstrStruct
           (DeclNameTag (CName "bar"))
           (DeclPathPtr DeclPathTop),
         structAliases = [],

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -59,7 +59,6 @@ module HsBindgen.C.AST (
   , pprTcMacroError
     -- * DeclPath
   , DeclPath(..)
-  , DeclConstr(..)
   , DeclName(..)
     -- * Source locations
   , SingleLoc(..)

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -22,7 +22,6 @@ module HsBindgen.C.AST.Type (
   , Typedef(..)
     -- * DeclPath
   , DeclPath(..)
-  , DeclConstr(..)
   , DeclName(..)
   ) where
 
@@ -274,17 +273,10 @@ data Typedef = Typedef {
 -- processed.
 data DeclPath
     = DeclPathTop
-    | DeclPathConstr DeclConstr DeclName DeclPath
+    | DeclPathConstr DeclName DeclPath
     | DeclPathField CName DeclPath
     | DeclPathPtr DeclPath
     -- TODO | DeclPathConstArray Natural Path
-  deriving stock (Eq, Generic, Show)
-  deriving anyclass (PrettyVal)
-
-data DeclConstr =
-    DeclConstrStruct
-  | DeclConstrUnion
-  | DeclConstrEnum
   deriving stock (Eq, Generic, Show)
   deriving anyclass (PrettyVal)
 

--- a/hs-bindgen/src/HsBindgen/GenTests/C.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests/C.hs
@@ -101,7 +101,7 @@ getTestSourceDefns cFunPrefix = \case
 getStructCTypeSpelling :: Hs.StructOrigin -> Maybe CTypeSpelling
 getStructCTypeSpelling = \case
     Hs.StructOriginStruct C.Struct{..} -> case structDeclPath of
-      C.DeclPathConstr C.DeclConstrStruct declName _declPath -> case declName of
+      C.DeclPathConstr declName _declPath -> case declName of
         C.DeclNameNone -> Nothing
         C.DeclNameTag cName -> Just $ "struct " ++ T.unpack (C.getCName cName)
         C.DeclNameTypedef cName -> Just $ T.unpack (C.getCName cName)

--- a/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
+++ b/hs-bindgen/src/HsBindgen/Hs/NameMangler.hs
@@ -354,7 +354,7 @@ translateDeclPath
     getCName' :: DeclPath -> Maybe CName
     getCName' = \case
       DeclPathTop -> Nothing
-      DeclPathConstr _constr declName _declPath -> case declName of
+      DeclPathConstr declName _declPath -> case declName of
         DeclNameNone         -> Nothing
         DeclNameTag name     -> Just name
         DeclNameTypedef name -> Just name
@@ -368,7 +368,7 @@ getDeclPathParts = aux
     aux :: DeclPath -> [CName]
     aux = \case
       DeclPathTop -> ["ANONYMOUS"] -- shouldn't happen
-      DeclPathConstr _constr declName path -> case declName of
+      DeclPathConstr declName path -> case declName of
         DeclNameNone      -> aux path
         DeclNameTag n     -> [n]
         DeclNameTypedef n -> [n]

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -42,7 +42,6 @@ instance ToExpr C.Attribute
 instance ToExpr C.CName
 instance ToExpr C.Decl
 instance ToExpr C.DeclName
-instance ToExpr C.DeclConstr
 instance ToExpr C.DeclPath
 instance ToExpr C.Enu
 instance ToExpr C.EnumValue


### PR DESCRIPTION
We only need it for Haskell-to-C translation, and in that case, we actually have sufficient information externally.

More improvements to `DeclPath` to come.