### PR TITLE
Use `CName` instead of `DeclPath` for aliases

### DIFF
--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -453,10 +453,7 @@
               (CName "linked_list_B_t"))
             DeclPathTop,
           structAliases = [
-            DeclPathConstr
-              (DeclNameTypedef
-                (CName "linked_list_B_t"))
-              DeclPathTop],
+            CName "linked_list_B_t"],
           structSizeof = 16,
           structAlignment = 8,
           structFields = [
@@ -540,10 +537,7 @@
                 (CName "linked_list_B_t"))
               DeclPathTop,
             structAliases = [
-              DeclPathConstr
-                (DeclNameTypedef
-                  (CName "linked_list_B_t"))
-                DeclPathTop],
+              CName "linked_list_B_t"],
             structSizeof = 16,
             structAlignment = 8,
             structFields = [
@@ -632,10 +626,7 @@
                         (CName "linked_list_B_t"))
                       DeclPathTop,
                     structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef
-                          (CName "linked_list_B_t"))
-                        DeclPathTop],
+                      CName "linked_list_B_t"],
                     structSizeof = 16,
                     structAlignment = 8,
                     structFields = [
@@ -726,10 +717,7 @@
                         (CName "linked_list_B_t"))
                       DeclPathTop,
                     structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef
-                          (CName "linked_list_B_t"))
-                        DeclPathTop],
+                      CName "linked_list_B_t"],
                     structSizeof = 16,
                     structAlignment = 8,
                     structFields = [

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -51,10 +51,7 @@ Header
             (CName "linked_list_B_t"))
           DeclPathTop,
         structAliases = [
-          DeclPathConstr
-            (DeclNameTypedef
-              (CName "linked_list_B_t"))
-            DeclPathTop],
+          CName "linked_list_B_t"],
         structSizeof = 16,
         structAlignment = 8,
         structFields = [

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -1424,10 +1424,7 @@
           structDeclPath = DeclPathConstr
             (DeclNameTag (CName "S5"))
             DeclPathTop,
-          structAliases = [
-            DeclPathConstr
-              (DeclNameTypedef (CName "S5"))
-              DeclPathTop],
+          structAliases = [CName "S5"],
           structSizeof = 8,
           structAlignment = 4,
           structFields = [
@@ -1498,10 +1495,7 @@
             structDeclPath = DeclPathConstr
               (DeclNameTag (CName "S5"))
               DeclPathTop,
-            structAliases = [
-              DeclPathConstr
-                (DeclNameTypedef (CName "S5"))
-                DeclPathTop],
+            structAliases = [CName "S5"],
             structSizeof = 8,
             structAlignment = 4,
             structFields = [
@@ -1577,10 +1571,7 @@
                     structDeclPath = DeclPathConstr
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
-                    structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef (CName "S5"))
-                        DeclPathTop],
+                    structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
                     structFields = [
@@ -1658,10 +1649,7 @@
                     structDeclPath = DeclPathConstr
                       (DeclNameTag (CName "S5"))
                       DeclPathTop,
-                    structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef (CName "S5"))
-                        DeclPathTop],
+                    structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
                     structFields = [
@@ -1747,10 +1735,7 @@
           structDeclPath = DeclPathConstr
             (DeclNameTag (CName "S6"))
             DeclPathTop,
-          structAliases = [
-            DeclPathConstr
-              (DeclNameTypedef (CName "S6"))
-              DeclPathTop],
+          structAliases = [CName "S6"],
           structSizeof = 8,
           structAlignment = 4,
           structFields = [
@@ -1821,10 +1806,7 @@
             structDeclPath = DeclPathConstr
               (DeclNameTag (CName "S6"))
               DeclPathTop,
-            structAliases = [
-              DeclPathConstr
-                (DeclNameTypedef (CName "S6"))
-                DeclPathTop],
+            structAliases = [CName "S6"],
             structSizeof = 8,
             structAlignment = 4,
             structFields = [
@@ -1900,10 +1882,7 @@
                     structDeclPath = DeclPathConstr
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
-                    structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef (CName "S6"))
-                        DeclPathTop],
+                    structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,
                     structFields = [
@@ -1981,10 +1960,7 @@
                     structDeclPath = DeclPathConstr
                       (DeclNameTag (CName "S6"))
                       DeclPathTop,
-                    structAliases = [
-                      DeclPathConstr
-                        (DeclNameTypedef (CName "S6"))
-                        DeclPathTop],
+                    structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,
                     structFields = [

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -135,10 +135,7 @@ Header
         structDeclPath = DeclPathConstr
           (DeclNameTag (CName "S5"))
           DeclPathTop,
-        structAliases = [
-          DeclPathConstr
-            (DeclNameTypedef (CName "S5"))
-            DeclPathTop],
+        structAliases = [CName "S5"],
         structSizeof = 8,
         structAlignment = 4,
         structFields = [
@@ -166,10 +163,7 @@ Header
         structDeclPath = DeclPathConstr
           (DeclNameTag (CName "S6"))
           DeclPathTop,
-        structAliases = [
-          DeclPathConstr
-            (DeclNameTypedef (CName "S6"))
-            DeclPathTop],
+        structAliases = [CName "S6"],
         structSizeof = 8,
         structAlignment = 4,
         structFields = [

--- a/hs-bindgen/src/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST/Type.hs
@@ -147,7 +147,7 @@ data PrimSign = Signed | Unsigned
 -- | Definition of a struct
 data Struct = Struct {
       structDeclPath  :: DeclPath
-    , structAliases   :: [DeclPath]
+    , structAliases   :: [CName]
     , structSizeof    :: Int
     , structAlignment :: Int
     , structFields    :: [StructField]
@@ -173,7 +173,7 @@ data StructField = StructField {
 -- > struct foo;
 data OpaqueStruct = OpaqueStruct {
       opaqueStructTag       :: CName
-    , opaqueStructAliases   :: [DeclPath]
+    , opaqueStructAliases   :: [CName]
     , opaqueStructSourceLoc :: SingleLoc
     }
   deriving stock (Show, Eq, Generic)
@@ -185,7 +185,7 @@ data OpaqueStruct = OpaqueStruct {
 -- | Definition of an union
 data Union = Union {
       unionDeclPath  :: DeclPath
-    , unionAliases   :: [DeclPath]
+    , unionAliases   :: [CName]
     , unionSizeof    :: Int
     , unionAlignment :: Int
     -- TODO: , unionFields    :: [UnionField]
@@ -199,7 +199,7 @@ data Union = Union {
 
 data Enu = Enu {
       enumDeclPath  :: DeclPath
-    , enumAliases   :: [DeclPath]
+    , enumAliases   :: [CName]
     , enumType      :: Type
     , enumSizeof    :: Int
     , enumAlignment :: Int
@@ -223,7 +223,7 @@ data EnumValue = EnumValue {
 -- > enum foo;
 data OpaqueEnum = OpaqueEnum {
       opaqueEnumTag       :: CName
-    , opaqueEnumAliases   :: [DeclPath]
+    , opaqueEnumAliases   :: [CName]
     , opaqueEnumSourceLoc :: SingleLoc
     }
   deriving stock (Show, Eq, Generic)

--- a/hs-bindgen/src/HsBindgen/C/Fold/DeclState.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/DeclState.hs
@@ -16,7 +16,7 @@ import Data.Set qualified as Set
 
 import Data.DynGraph (DynGraph)
 import Data.DynGraph qualified as DynGraph
-import HsBindgen.C.AST (CName, Decl, DeclPath, Type)
+import HsBindgen.C.AST (CName, Decl, Type)
 import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Clang.HighLevel.Types
 import HsBindgen.Clang.LowLevel.Core
@@ -57,7 +57,7 @@ data TypeDecl
       -- are mapped to the same C AST node, when a @typedef@ name is the same
       -- as a @struct@, @union@, or @enum@ tag.  This is a subset of the
       -- aliases tracked in the following constructor.
-      TypeDeclProcessing Type [DeclPath]
+      TypeDeclProcessing Type [CName]
     | -- | An alias, for @typedef@s, etc.
       TypeDeclAlias Type
     | TypeDecl Type Decl


### PR DESCRIPTION
Aliases are always top-level. Perhaps `getCNS` and `getCNS_alias` can be simplified further once we refactor `DeclPath`.