### PR TITLE
Redesign `DeclPath`

### DIFF
--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -43,13 +43,11 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathField
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              (Just (CName "S1"))
               (CName "c")
-              (DeclPathConstr
-                (DeclNameTag (CName "S1"))
-                DeclPathTop)),
+              DeclPathCtxtTop),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -118,13 +116,11 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathField
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "S1"))
                 (CName "c")
-                (DeclPathConstr
-                  (DeclNameTag (CName "S1"))
-                  DeclPathTop)),
+                DeclPathCtxtTop),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -198,13 +194,11 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "S1"))
                         (CName "c")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S1"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -280,13 +274,11 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "S1"))
                         (CName "c")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S1"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -348,13 +340,11 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "S1"))
                     (CName "c")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop))),
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "anonymous.h:6:5"}},
         Field {
@@ -376,9 +366,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S1"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S1")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -388,13 +378,11 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "S1"))
                     (CName "c")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop))),
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "anonymous.h:6:5"},
             StructField {
@@ -431,13 +419,11 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "S1"))
                       (CName "c")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "S1"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "anonymous.h:6:5"}},
           Field {
@@ -459,9 +445,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S1"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S1")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -471,13 +457,11 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "S1"))
                       (CName "c")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "S1"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "anonymous.h:6:5"},
               StructField {
@@ -519,13 +503,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S1"))
                               (CName "c")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S1"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:6:5"}},
                   Field {
@@ -547,9 +529,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -559,13 +541,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S1"))
                               (CName "c")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S1"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:6:5"},
                       StructField {
@@ -609,13 +589,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S1"))
                               (CName "c")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S1"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:6:5"}},
                   Field {
@@ -637,9 +615,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -649,13 +627,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S1"))
                               (CName "c")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S1"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:6:5"},
                       StructField {
@@ -713,17 +689,14 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathField
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              Nothing
               (CName "deep")
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathField
-                  (CName "inner")
-                  (DeclPathConstr
-                    (DeclNameTag (CName "S2"))
-                    DeclPathTop)))),
+              (DeclPathCtxtField
+                (Just (CName "S2"))
+                (CName "inner")
+                DeclPathCtxtTop)),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -768,17 +741,14 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathField
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                Nothing
                 (CName "deep")
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
-                    (CName "inner")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop)))),
+                (DeclPathCtxtField
+                  (Just (CName "S2"))
+                  (CName "inner")
+                  DeclPathCtxtTop)),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -828,17 +798,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        Nothing
                         (CName "deep")
-                        (DeclPathConstr
-                          DeclNameNone
-                          (DeclPathField
-                            (CName "inner")
-                            (DeclPathConstr
-                              (DeclNameTag (CName "S2"))
-                              DeclPathTop)))),
+                        (DeclPathCtxtField
+                          (Just (CName "S2"))
+                          (CName "inner")
+                          DeclPathCtxtTop)),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -888,17 +855,14 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        Nothing
                         (CName "deep")
-                        (DeclPathConstr
-                          DeclNameNone
-                          (DeclPathField
-                            (CName "inner")
-                            (DeclPathConstr
-                              (DeclNameTag (CName "S2"))
-                              DeclPathTop)))),
+                        (DeclPathCtxtField
+                          (Just (CName "S2"))
+                          (CName "inner")
+                          DeclPathCtxtTop)),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -973,29 +937,24 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    Nothing
                     (CName "deep")
-                    (DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
-                        (CName "inner")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S2"))
-                          DeclPathTop))))),
+                    (DeclPathCtxtField
+                      (Just (CName "S2"))
+                      (CName "inner")
+                      DeclPathCtxtTop))),
               fieldSourceLoc =
               "anonymous.h:17:7"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathField
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              (Just (CName "S2"))
               (CName "inner")
-              (DeclPathConstr
-                (DeclNameTag (CName "S2"))
-                DeclPathTop)),
+              DeclPathCtxtTop),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -1013,17 +972,14 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    Nothing
                     (CName "deep")
-                    (DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
-                        (CName "inner")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S2"))
-                          DeclPathTop))))),
+                    (DeclPathCtxtField
+                      (Just (CName "S2"))
+                      (CName "inner")
+                      DeclPathCtxtTop))),
               fieldSourceLoc =
               "anonymous.h:17:7"}],
           structFlam = Nothing,
@@ -1070,29 +1026,24 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      Nothing
                       (CName "deep")
-                      (DeclPathConstr
-                        DeclNameNone
-                        (DeclPathField
-                          (CName "inner")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "S2"))
-                            DeclPathTop))))),
+                      (DeclPathCtxtField
+                        (Just (CName "S2"))
+                        (CName "inner")
+                        DeclPathCtxtTop))),
                 fieldSourceLoc =
                 "anonymous.h:17:7"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathField
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "S2"))
                 (CName "inner")
-                (DeclPathConstr
-                  (DeclNameTag (CName "S2"))
-                  DeclPathTop)),
+                DeclPathCtxtTop),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -1110,17 +1061,14 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      Nothing
                       (CName "deep")
-                      (DeclPathConstr
-                        DeclNameNone
-                        (DeclPathField
-                          (CName "inner")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "S2"))
-                            DeclPathTop))))),
+                      (DeclPathCtxtField
+                        (Just (CName "S2"))
+                        (CName "inner")
+                        DeclPathCtxtTop))),
                 fieldSourceLoc =
                 "anonymous.h:17:7"}],
             structFlam = Nothing,
@@ -1172,29 +1120,24 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              Nothing
                               (CName "deep")
-                              (DeclPathConstr
-                                DeclNameNone
-                                (DeclPathField
-                                  (CName "inner")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "S2"))
-                                    DeclPathTop))))),
+                              (DeclPathCtxtField
+                                (Just (CName "S2"))
+                                (CName "inner")
+                                DeclPathCtxtTop))),
                         fieldSourceLoc =
                         "anonymous.h:17:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "S2"))
                         (CName "inner")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S2"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1212,17 +1155,14 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              Nothing
                               (CName "deep")
-                              (DeclPathConstr
-                                DeclNameNone
-                                (DeclPathField
-                                  (CName "inner")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "S2"))
-                                    DeclPathTop))))),
+                              (DeclPathCtxtField
+                                (Just (CName "S2"))
+                                (CName "inner")
+                                DeclPathCtxtTop))),
                         fieldSourceLoc =
                         "anonymous.h:17:7"}],
                     structFlam = Nothing,
@@ -1276,29 +1216,24 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              Nothing
                               (CName "deep")
-                              (DeclPathConstr
-                                DeclNameNone
-                                (DeclPathField
-                                  (CName "inner")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "S2"))
-                                    DeclPathTop))))),
+                              (DeclPathCtxtField
+                                (Just (CName "S2"))
+                                (CName "inner")
+                                DeclPathCtxtTop))),
                         fieldSourceLoc =
                         "anonymous.h:17:7"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "S2"))
                         (CName "inner")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "S2"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1316,17 +1251,14 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              Nothing
                               (CName "deep")
-                              (DeclPathConstr
-                                DeclNameNone
-                                (DeclPathField
-                                  (CName "inner")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "S2"))
-                                    DeclPathTop))))),
+                              (DeclPathCtxtField
+                                (Just (CName "S2"))
+                                (CName "inner")
+                                DeclPathCtxtTop))),
                         fieldSourceLoc =
                         "anonymous.h:17:7"}],
                     structFlam = Nothing,
@@ -1376,13 +1308,11 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "S2"))
                     (CName "inner")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop))),
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "anonymous.h:18:5"}},
         Field {
@@ -1404,9 +1334,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S2"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S2")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -1416,13 +1346,11 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "S2"))
                     (CName "inner")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop))),
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "anonymous.h:18:5"},
             StructField {
@@ -1461,13 +1389,11 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "S2"))
                       (CName "inner")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "S2"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "anonymous.h:18:5"}},
           Field {
@@ -1489,9 +1415,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S2"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S2")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -1501,13 +1427,11 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "S2"))
                       (CName "inner")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "S2"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "anonymous.h:18:5"},
               StructField {
@@ -1551,13 +1475,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S2"))
                               (CName "inner")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S2"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:18:5"}},
                   Field {
@@ -1579,9 +1501,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1591,13 +1513,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S2"))
                               (CName "inner")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S2"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:18:5"},
                       StructField {
@@ -1643,13 +1563,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S2"))
                               (CName "inner")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S2"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:18:5"}},
                   Field {
@@ -1671,9 +1589,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1683,13 +1601,11 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "S2"))
                               (CName "inner")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "S2"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "anonymous.h:18:5"},
                       StructField {

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -2,13 +2,11 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathField
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            (Just (CName "S1"))
             (CName "c")
-            (DeclPathConstr
-              (DeclNameTag (CName "S1"))
-              DeclPathTop)),
+            DeclPathCtxtTop),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -34,9 +32,9 @@ Header
         "anonymous.h:3:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S1"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S1")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -46,13 +44,11 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathField
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  (Just (CName "S1"))
                   (CName "c")
-                  (DeclPathConstr
-                    (DeclNameTag (CName "S1"))
-                    DeclPathTop))),
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "anonymous.h:6:5"},
           StructField {
@@ -68,17 +64,14 @@ Header
         "anonymous.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathField
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            Nothing
             (CName "deep")
-            (DeclPathConstr
-              DeclNameNone
-              (DeclPathField
-                (CName "inner")
-                (DeclPathConstr
-                  (DeclNameTag (CName "S2"))
-                  DeclPathTop)))),
+            (DeclPathCtxtField
+              (Just (CName "S2"))
+              (CName "inner")
+              DeclPathCtxtTop)),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -96,13 +89,11 @@ Header
         "anonymous.h:15:5"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathField
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            (Just (CName "S2"))
             (CName "inner")
-            (DeclPathConstr
-              (DeclNameTag (CName "S2"))
-              DeclPathTop)),
+            DeclPathCtxtTop),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -120,17 +111,14 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathField
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  Nothing
                   (CName "deep")
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
-                      (CName "inner")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "S2"))
-                        DeclPathTop))))),
+                  (DeclPathCtxtField
+                    (Just (CName "S2"))
+                    (CName "inner")
+                    DeclPathCtxtTop))),
             fieldSourceLoc =
             "anonymous.h:17:7"}],
         structFlam = Nothing,
@@ -138,9 +126,9 @@ Header
         "anonymous.h:13:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S2"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S2")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -150,13 +138,11 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathField
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  (Just (CName "S2"))
                   (CName "inner")
-                  (DeclPathConstr
-                    (DeclNameTag (CName "S2"))
-                    DeclPathTop))),
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "anonymous.h:18:5"},
           StructField {

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -107,9 +107,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "flags"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "flags")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -274,9 +274,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "flags"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "flags")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -446,9 +446,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "flags"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "flags")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -624,9 +624,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "flags"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "flags")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -779,10 +779,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "overflow32"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "overflow32")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -875,10 +874,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "overflow32"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "overflow32")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -976,10 +974,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1080,10 +1077,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1205,10 +1201,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "overflow32b"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "overflow32b")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 8,
@@ -1301,10 +1296,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "overflow32b"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "overflow32b")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 8,
@@ -1402,10 +1396,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32b"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32b")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1506,10 +1499,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32b"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32b")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1631,10 +1623,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "overflow32c"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "overflow32c")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1727,10 +1718,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "overflow32c"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "overflow32c")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1828,10 +1818,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32c"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32c")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1932,10 +1921,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow32c"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow32c")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2041,10 +2029,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "overflow64"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "overflow64")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -2113,10 +2100,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "overflow64"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "overflow64")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -2190,10 +2176,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow64"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow64")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2269,10 +2254,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "overflow64"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "overflow64")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2365,9 +2349,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "alignA"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "alignA")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -2436,9 +2420,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "alignA"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "alignA")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -2512,9 +2496,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "alignA"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "alignA")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -2590,9 +2574,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "alignA"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "alignA")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -2685,9 +2669,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "alignB"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "alignB")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -2756,9 +2740,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "alignB"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "alignB")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -2832,9 +2816,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "alignB"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "alignB")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2910,9 +2894,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "alignB"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "alignB")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "flags"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "flags")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -62,10 +62,9 @@ Header
         "bitfields.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "overflow32"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "overflow32")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -99,10 +98,9 @@ Header
         "bitfields.h:12:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "overflow32b"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "overflow32b")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 8,
@@ -136,10 +134,9 @@ Header
         "bitfields.h:18:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "overflow32c"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "overflow32c")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -173,10 +170,9 @@ Header
         "bitfields.h:24:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "overflow64"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "overflow64")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -202,9 +198,9 @@ Header
         "bitfields.h:30:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "alignA"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "alignA")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -230,9 +226,9 @@ Header
         "bitfields.h:36:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "alignB"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "alignB")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -121,9 +121,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bools1"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "bools1")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -187,9 +187,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bools1"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "bools1")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -257,9 +257,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -330,9 +330,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -414,9 +414,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bools2"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "bools2")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -480,9 +480,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bools2"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "bools2")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -550,9 +550,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -623,9 +623,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -709,9 +709,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bools3"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "bools3")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -780,9 +780,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bools3"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "bools3")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -856,9 +856,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -934,9 +934,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bools3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bools3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -18,9 +18,9 @@ Header
         "bool.h:13:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bools1"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "bools1")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,
@@ -42,9 +42,9 @@ Header
         structSourceLoc = "bool.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bools2"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "bools2")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,
@@ -66,9 +66,9 @@ Header
         structSourceLoc = "bool.h:8:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bools3"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "bools3")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -290,11 +290,10 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTypedef
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtTypedef
               (CName
-                "another_typedef_struct_t"))
-            DeclPathTop,
+                "another_typedef_struct_t")),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -363,11 +362,10 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTypedef
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
                 (CName
-                  "another_typedef_struct_t"))
-              DeclPathTop,
+                  "another_typedef_struct_t")),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -441,11 +439,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTypedef
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_struct_t"))
-                      DeclPathTop,
+                          "another_typedef_struct_t")),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -521,11 +518,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTypedef
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_struct_t"))
-                      DeclPathTop,
+                          "another_typedef_struct_t")),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -587,11 +583,10 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTypedef
+          enumDeclPath = DeclPathAnon
+            (DeclPathCtxtTypedef
               (CName
-                "another_typedef_enum_e"))
-            DeclPathTop,
+                "another_typedef_enum_e")),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -629,11 +624,10 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTypedef
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
                 (CName
-                  "another_typedef_enum_e"))
-              DeclPathTop,
+                  "another_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -676,11 +670,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop,
+                          "another_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -723,11 +716,10 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_enum_e"))
-                      DeclPathTop,
+                          "another_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -844,11 +836,10 @@
           typedefName = CName
             "another_typedef_enum_e",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTypedef
+            (DeclPathAnon
+              (DeclPathCtxtTypedef
                 (CName
-                  "another_typedef_enum_e"))
-              DeclPathTop),
+                  "another_typedef_enum_e"))),
           typedefSourceLoc =
           "distilled_lib_1.h:9:27"}},
   DeclNewtypeInstance
@@ -1457,11 +1448,10 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTypedef
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
                     (CName
-                      "another_typedef_struct_t"))
-                  DeclPathTop),
+                      "another_typedef_struct_t"))),
               fieldSourceLoc =
               "distilled_lib_1.h:40:31"}},
         Field {
@@ -1481,11 +1471,10 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTypedef
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
                       (CName
-                        "another_typedef_struct_t"))
-                    DeclPathTop)),
+                        "another_typedef_struct_t")))),
               fieldSourceLoc =
               "distilled_lib_1.h:41:31"}},
         Field {
@@ -1598,10 +1587,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "a_typedef_struct"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "a_typedef_struct")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 140,
           structAlignment = 1,
@@ -1642,11 +1630,10 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTypedef
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
                     (CName
-                      "another_typedef_struct_t"))
-                  DeclPathTop),
+                      "another_typedef_struct_t"))),
               fieldSourceLoc =
               "distilled_lib_1.h:40:31"},
             StructField {
@@ -1655,11 +1642,10 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTypedef
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
                       (CName
-                        "another_typedef_struct_t"))
-                    DeclPathTop)),
+                        "another_typedef_struct_t")))),
               fieldSourceLoc =
               "distilled_lib_1.h:41:31"},
             StructField {
@@ -1810,11 +1796,10 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTypedef
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
                       (CName
-                        "another_typedef_struct_t"))
-                    DeclPathTop),
+                        "another_typedef_struct_t"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:40:31"}},
           Field {
@@ -1834,11 +1819,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTypedef
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_struct_t"))
-                      DeclPathTop)),
+                          "another_typedef_struct_t")))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:41:31"}},
           Field {
@@ -1951,10 +1935,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "a_typedef_struct"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "a_typedef_struct")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 140,
             structAlignment = 1,
@@ -1995,11 +1978,10 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTypedef
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
                       (CName
-                        "another_typedef_struct_t"))
-                    DeclPathTop),
+                        "another_typedef_struct_t"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:40:31"},
               StructField {
@@ -2008,11 +1990,10 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTypedef
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
                         (CName
-                          "another_typedef_struct_t"))
-                      DeclPathTop)),
+                          "another_typedef_struct_t")))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:41:31"},
               StructField {
@@ -2168,11 +2149,10 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTypedef
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
                               (CName
-                                "another_typedef_struct_t"))
-                            DeclPathTop),
+                                "another_typedef_struct_t"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:40:31"}},
                   Field {
@@ -2192,11 +2172,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTypedef
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
                                 (CName
-                                  "another_typedef_struct_t"))
-                              DeclPathTop)),
+                                  "another_typedef_struct_t")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:41:31"}},
                   Field {
@@ -2309,10 +2288,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "a_typedef_struct"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "a_typedef_struct")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 140,
                     structAlignment = 1,
@@ -2353,11 +2331,10 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTypedef
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
                               (CName
-                                "another_typedef_struct_t"))
-                            DeclPathTop),
+                                "another_typedef_struct_t"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:40:31"},
                       StructField {
@@ -2366,11 +2343,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTypedef
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
                                 (CName
-                                  "another_typedef_struct_t"))
-                              DeclPathTop)),
+                                  "another_typedef_struct_t")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:41:31"},
                       StructField {
@@ -2537,11 +2513,10 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTypedef
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
                               (CName
-                                "another_typedef_struct_t"))
-                            DeclPathTop),
+                                "another_typedef_struct_t"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:40:31"}},
                   Field {
@@ -2561,11 +2536,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTypedef
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
                                 (CName
-                                  "another_typedef_struct_t"))
-                              DeclPathTop)),
+                                  "another_typedef_struct_t")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:41:31"}},
                   Field {
@@ -2678,10 +2652,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "a_typedef_struct"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "a_typedef_struct")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 140,
                     structAlignment = 1,
@@ -2722,11 +2695,10 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTypedef
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
                               (CName
-                                "another_typedef_struct_t"))
-                            DeclPathTop),
+                                "another_typedef_struct_t"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:40:31"},
                       StructField {
@@ -2735,11 +2707,10 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTypedef
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
                                 (CName
-                                  "another_typedef_struct_t"))
-                              DeclPathTop)),
+                                  "another_typedef_struct_t")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:41:31"},
                       StructField {
@@ -2848,10 +2819,9 @@
           typedefName = CName
             "a_typedef_struct_t",
           typedefType = TypeStruct
-            (DeclPathConstr
-              (DeclNameTag
-                (CName "a_typedef_struct"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "a_typedef_struct")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "distilled_lib_1.h:47:3"}},
   DeclNewtypeInstance
@@ -2878,10 +2848,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTypedef
-              (CName "a_typedef_enum_e"))
-            DeclPathTop,
+          enumDeclPath = DeclPathAnon
+            (DeclPathCtxtTypedef
+              (CName "a_typedef_enum_e")),
           enumAliases = [],
           enumType = TypePrim
             (PrimChar (Just Unsigned)),
@@ -2929,10 +2898,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTypedef
-                (CName "a_typedef_enum_e"))
-              DeclPathTop,
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "a_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar (Just Unsigned)),
@@ -2985,10 +2953,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
-                        (CName "a_typedef_enum_e"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "a_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
@@ -3041,10 +3008,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
-                        (CName "a_typedef_enum_e"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "a_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
@@ -3209,10 +3175,9 @@
           typedefName = CName
             "a_typedef_enum_e",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTypedef
-                (CName "a_typedef_enum_e"))
-              DeclPathTop),
+            (DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "a_typedef_enum_e"))),
           typedefSourceLoc =
           "distilled_lib_1.h:66:13"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -325,11 +325,10 @@ Header
         "distilled_lib_1.h:71:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTypedef
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtTypedef
             (CName
-              "another_typedef_struct_t"))
-          DeclPathTop,
+              "another_typedef_struct_t")),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -355,11 +354,10 @@ Header
         "distilled_lib_1.h:8:9"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTypedef
+        enumDeclPath = DeclPathAnon
+          (DeclPathCtxtTypedef
             (CName
-              "another_typedef_enum_e"))
-          DeclPathTop,
+              "another_typedef_enum_e")),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -383,11 +381,10 @@ Header
         typedefName = CName
           "another_typedef_enum_e",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTypedef
+          (DeclPathAnon
+            (DeclPathCtxtTypedef
               (CName
-                "another_typedef_enum_e"))
-            DeclPathTop),
+                "another_typedef_enum_e"))),
         typedefSourceLoc =
         "distilled_lib_1.h:9:27"},
     DeclTypedef
@@ -429,10 +426,9 @@ Header
         "alltypes.h:131:25"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "a_typedef_struct"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "a_typedef_struct")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 140,
         structAlignment = 1,
@@ -473,11 +469,10 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                (DeclNameTypedef
+              (DeclPathAnon
+                (DeclPathCtxtTypedef
                   (CName
-                    "another_typedef_struct_t"))
-                DeclPathTop),
+                    "another_typedef_struct_t"))),
             fieldSourceLoc =
             "distilled_lib_1.h:40:31"},
           StructField {
@@ -486,11 +481,10 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTypedef
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
                     (CName
-                      "another_typedef_struct_t"))
-                  DeclPathTop)),
+                      "another_typedef_struct_t")))),
             fieldSourceLoc =
             "distilled_lib_1.h:41:31"},
           StructField {
@@ -552,18 +546,16 @@ Header
         typedefName = CName
           "a_typedef_struct_t",
         typedefType = TypeStruct
-          (DeclPathConstr
-            (DeclNameTag
-              (CName "a_typedef_struct"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "a_typedef_struct")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "distilled_lib_1.h:47:3"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTypedef
-            (CName "a_typedef_enum_e"))
-          DeclPathTop,
+        enumDeclPath = DeclPathAnon
+          (DeclPathCtxtTypedef
+            (CName "a_typedef_enum_e")),
         enumAliases = [],
         enumType = TypePrim
           (PrimChar (Just Unsigned)),
@@ -597,10 +589,9 @@ Header
         typedefName = CName
           "a_typedef_enum_e",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTypedef
-              (CName "a_typedef_enum_e"))
-            DeclPathTop),
+          (DeclPathAnon
+            (DeclPathCtxtTypedef
+              (CName "a_typedef_enum_e"))),
         typedefSourceLoc =
         "distilled_lib_1.h:66:13"},
     DeclTypedef

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -17,9 +17,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "first"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "first")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -55,9 +55,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "first"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "first")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -98,9 +98,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "first"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "first")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -141,9 +141,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "first"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "first")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -253,9 +253,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "second"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "second")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Signed),
@@ -297,9 +297,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "second"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "second")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -346,9 +346,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "second"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "second")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -395,9 +395,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "second"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "second")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -532,9 +532,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "same"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "same")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -572,9 +572,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "same"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "same")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -616,9 +616,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "same"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "same")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -661,9 +661,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "same"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "same")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -764,9 +764,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "packad"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "packad")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimChar (Just Unsigned)),
@@ -809,9 +809,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "packad"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "packad")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimChar (Just Unsigned)),
@@ -858,9 +858,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "packad"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "packad")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
@@ -908,9 +908,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "packad"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "packad")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar (Just Unsigned)),
@@ -1045,10 +1045,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTypedef
-              (CName "enumA"))
-            DeclPathTop,
+          enumDeclPath = DeclPathAnon
+            (DeclPathCtxtTypedef
+              (CName "enumA")),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1086,10 +1085,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTypedef
-                (CName "enumA"))
-              DeclPathTop,
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "enumA")),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1131,10 +1129,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
-                        (CName "enumA"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "enumA")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1177,10 +1174,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTypedef
-                        (CName "enumA"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "enumA")),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1295,10 +1291,9 @@
         Typedef {
           typedefName = CName "enumA",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTypedef
-                (CName "enumA"))
-              DeclPathTop),
+            (DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "enumA"))),
           typedefSourceLoc =
           "enums.h:24:31"}},
   DeclNewtypeInstance
@@ -1325,9 +1320,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "enumB"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "enumB")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1365,9 +1360,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "enumB"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "enumB")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1410,9 +1405,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumB"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumB")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1455,9 +1450,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumB"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumB")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1573,9 +1568,9 @@
         Typedef {
           typedefName = CName "enumB",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTag (CName "enumB"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "enumB")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "enums.h:26:37"}},
   DeclNewtypeInstance
@@ -1602,9 +1597,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "enumC"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "enumC")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1642,9 +1637,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "enumC"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "enumC")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1686,9 +1681,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumC"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumC")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1731,9 +1726,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumC"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumC")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1848,9 +1843,9 @@
         Typedef {
           typedefName = CName "enumC",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTag (CName "enumC"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "enumC")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "enums.h:29:20"}},
   DeclNewtypeInstance
@@ -1877,9 +1872,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "enumD"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "enumD")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1917,9 +1912,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "enumD"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "enumD")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1961,9 +1956,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumD"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumD")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2006,9 +2001,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "enumD"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "enumD")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2123,9 +2118,9 @@
         Typedef {
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
-            (DeclPathConstr
-              (DeclNameTag (CName "enumD"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "enumD")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "enums.h:32:20"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -17,9 +17,9 @@ Header
         "enums.h:2:9"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "first"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "first")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -38,9 +38,9 @@ Header
         enumSourceLoc = "enums.h:4:6"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "second"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "second")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Signed),
@@ -65,9 +65,9 @@ Header
         enumSourceLoc = "enums.h:9:6"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "same"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "same")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -87,9 +87,9 @@ Header
         enumSourceLoc = "enums.h:15:6"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "packad"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "packad")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimChar (Just Unsigned)),
@@ -114,10 +114,9 @@ Header
         enumSourceLoc = "enums.h:20:6"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTypedef
-            (CName "enumA"))
-          DeclPathTop,
+        enumDeclPath = DeclPathAnon
+          (DeclPathCtxtTypedef
+            (CName "enumA")),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -139,17 +138,16 @@ Header
       Typedef {
         typedefName = CName "enumA",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTypedef
-              (CName "enumA"))
-            DeclPathTop),
+          (DeclPathAnon
+            (DeclPathCtxtTypedef
+              (CName "enumA"))),
         typedefSourceLoc =
         "enums.h:24:31"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "enumB"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "enumB")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -172,16 +170,16 @@ Header
       Typedef {
         typedefName = CName "enumB",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTag (CName "enumB"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "enumB")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "enums.h:26:37"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "enumC"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "enumC")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -203,16 +201,16 @@ Header
       Typedef {
         typedefName = CName "enumC",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTag (CName "enumC"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "enumC")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "enums.h:29:20"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "enumD"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "enumD")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -234,8 +232,8 @@ Header
       Typedef {
         typedefName = CName "enumD_t",
         typedefType = TypeEnum
-          (DeclPathConstr
-            (DeclNameTag (CName "enumD"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "enumD")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "enums.h:32:20"}]

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -85,9 +85,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "Example"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "Example")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 48,
           structAlignment = 4,
@@ -172,9 +172,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "Example"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "Example")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 48,
             structAlignment = 4,
@@ -264,9 +264,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Example"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Example")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 48,
                     structAlignment = 4,
@@ -358,9 +358,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Example"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Example")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 48,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -11,9 +11,9 @@ Header
         "fixedarray.h:1:13"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "Example"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "Example")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 48,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -251,9 +251,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -326,9 +326,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -406,9 +406,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -488,9 +488,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -18,9 +18,9 @@ Header
         "alltypes.h:131:25"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -27,9 +27,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "pascal"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "pascal")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -80,9 +80,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "pascal"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "pascal")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -137,9 +137,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "pascal"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "pascal")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -195,9 +195,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "pascal"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "pascal")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -266,9 +266,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "pascal"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "pascal")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -335,13 +335,11 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathField
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              (Just (CName "foo"))
               (CName "bar")
-              (DeclPathConstr
-                (DeclNameTag (CName "foo"))
-                DeclPathTop)),
+              DeclPathCtxtTop),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -409,13 +407,11 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathField
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "foo"))
                 (CName "bar")
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop)),
+                DeclPathCtxtTop),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -488,13 +484,11 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "foo"))
                         (CName "bar")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "foo"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -569,13 +563,11 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathField
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "foo"))
                         (CName "bar")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "foo"))
-                          DeclPathTop)),
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -646,9 +638,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -666,13 +658,11 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathField
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "foo"))
                     (CName "bar")
-                    (DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop))),
+                    DeclPathCtxtTop)),
               fieldSourceLoc = "flam.h:13:4"},
           structSourceLoc =
           "flam.h:8:8"}},
@@ -705,9 +695,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -725,13 +715,11 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "foo"))
                       (CName "bar")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "foo"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc = "flam.h:13:4"},
             structSourceLoc = "flam.h:8:8"}}
       StorableInstance {
@@ -768,9 +756,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -788,13 +776,11 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "foo"))
                               (CName "bar")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "foo"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc = "flam.h:13:4"},
                     structSourceLoc =
                     "flam.h:8:8"}})
@@ -832,9 +818,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -852,13 +838,11 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            DeclNameNone
-                            (DeclPathField
+                          (DeclPathAnon
+                            (DeclPathCtxtField
+                              (Just (CName "foo"))
                               (CName "bar")
-                              (DeclPathConstr
-                                (DeclNameTag (CName "foo"))
-                                DeclPathTop))),
+                              DeclPathCtxtTop)),
                         fieldSourceLoc = "flam.h:13:4"},
                     structSourceLoc = "flam.h:8:8"}}
               (Add 1)
@@ -905,9 +889,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -925,13 +909,11 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathField
+                  (DeclPathAnon
+                    (DeclPathCtxtField
+                      (Just (CName "foo"))
                       (CName "bar")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "foo"))
-                        DeclPathTop))),
+                      DeclPathCtxtTop)),
                 fieldSourceLoc = "flam.h:13:4"},
             structSourceLoc = "flam.h:8:8"}}
       (HsTypRef
@@ -983,9 +965,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "diff"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "diff")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1060,9 +1042,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "diff"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "diff")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1142,9 +1124,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "diff"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "diff")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1226,9 +1208,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "diff"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "diff")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1319,9 +1301,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "diff"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "diff")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "pascal"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "pascal")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -27,13 +27,11 @@ Header
         structSourceLoc = "flam.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathField
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            (Just (CName "foo"))
             (CName "bar")
-            (DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop)),
+            DeclPathCtxtTop),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -58,9 +56,9 @@ Header
         "flam.h:10:2"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -78,20 +76,18 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathField
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  (Just (CName "foo"))
                   (CName "bar")
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop))),
+                  DeclPathCtxtTop)),
             fieldSourceLoc = "flam.h:13:4"},
         structSourceLoc = "flam.h:8:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "diff"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "diff")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -27,9 +27,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S1"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S1")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -74,9 +74,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S1"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S1")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -126,9 +126,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -178,9 +178,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -231,9 +231,9 @@
         Typedef {
           typedefName = CName "S1_t",
           typedefType = TypeStruct
-            (DeclPathConstr
-              (DeclNameTag (CName "S1"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "S1")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "forward_declaration.h:1:19"}},
   DeclNewtypeInstance
@@ -268,9 +268,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S2"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S2")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -315,9 +315,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S2"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S2")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -367,9 +367,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -419,9 +419,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S1"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S1")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -24,16 +24,16 @@ Header
       Typedef {
         typedefName = CName "S1_t",
         typedefType = TypeStruct
-          (DeclPathConstr
-            (DeclNameTag (CName "S1"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "S1")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "forward_declaration.h:1:19"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S2"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S2")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -43,9 +43,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -114,9 +114,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -190,9 +190,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -268,9 +268,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -332,9 +332,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "foo")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "nested_types.h:7:16"}},
         Field {
@@ -350,17 +350,17 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "foo")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "nested_types.h:8:16"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bar"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "bar")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 4,
@@ -370,9 +370,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "foo")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "nested_types.h:7:16"},
             StructField {
@@ -380,9 +380,9 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "foo")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "nested_types.h:8:16"}],
           structFlam = Nothing,
@@ -411,9 +411,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "nested_types.h:7:16"}},
           Field {
@@ -429,17 +429,17 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "nested_types.h:8:16"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bar"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "bar")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 4,
@@ -449,9 +449,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "nested_types.h:7:16"},
               StructField {
@@ -459,9 +459,9 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "nested_types.h:8:16"}],
             structFlam = Nothing,
@@ -495,9 +495,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:7:16"}},
                   Field {
@@ -513,17 +513,17 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -533,9 +533,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:7:16"},
                       StructField {
@@ -543,9 +543,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
@@ -581,9 +581,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:7:16"}},
                   Field {
@@ -599,17 +599,17 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -619,9 +619,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:7:16"},
                       StructField {
@@ -629,9 +629,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathConstr
-                            (DeclNameTag (CName "foo"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "foo")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
@@ -681,9 +681,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "ex3"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "ex3")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -728,9 +728,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "ex3"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "ex3")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -780,9 +780,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ex3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -832,9 +832,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ex3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -907,22 +907,21 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "ex4_odd"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "ex4_odd")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "nested_types.h:26:25"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "ex4_even"))
-            (DeclPathPtr
-              (DeclPathField
+          structDeclPath = DeclPathName
+            (CName "ex4_even")
+            (DeclPathCtxtPtr
+              (DeclPathCtxtField
+                (Just (CName "ex4_odd"))
                 (CName "next")
-                (DeclPathConstr
-                  (DeclNameTag (CName "ex4_odd"))
-                  DeclPathTop))),
+                DeclPathCtxtTop)),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -941,9 +940,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "ex4_odd"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "ex4_odd")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "nested_types.h:26:25"}],
           structFlam = Nothing,
@@ -992,22 +991,21 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "ex4_odd"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "ex4_odd")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "nested_types.h:26:25"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "ex4_even"))
-              (DeclPathPtr
-                (DeclPathField
+            structDeclPath = DeclPathName
+              (CName "ex4_even")
+              (DeclPathCtxtPtr
+                (DeclPathCtxtField
+                  (Just (CName "ex4_odd"))
                   (CName "next")
-                  (DeclPathConstr
-                    (DeclNameTag (CName "ex4_odd"))
-                    DeclPathTop))),
+                  DeclPathCtxtTop)),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1026,9 +1024,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "ex4_odd"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "ex4_odd")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "nested_types.h:26:25"}],
             structFlam = Nothing,
@@ -1082,22 +1080,21 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_odd"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "ex4_odd")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex4_even"))
-                      (DeclPathPtr
-                        (DeclPathField
+                    structDeclPath = DeclPathName
+                      (CName "ex4_even")
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtField
+                          (Just (CName "ex4_odd"))
                           (CName "next")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "ex4_odd"))
-                            DeclPathTop))),
+                          DeclPathCtxtTop)),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1116,9 +1113,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_odd"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "ex4_odd")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
@@ -1174,22 +1171,21 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_odd"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "ex4_odd")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex4_even"))
-                      (DeclPathPtr
-                        (DeclPathField
+                    structDeclPath = DeclPathName
+                      (CName "ex4_even")
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtField
+                          (Just (CName "ex4_odd"))
                           (CName "next")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "ex4_odd"))
-                            DeclPathTop))),
+                          DeclPathCtxtTop)),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1208,9 +1204,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_odd"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "ex4_odd")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
@@ -1278,22 +1274,21 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "ex4_even"))
-                    (DeclPathPtr
-                      (DeclPathField
+                  (DeclPathName
+                    (CName "ex4_even")
+                    (DeclPathCtxtPtr
+                      (DeclPathCtxtField
+                        (Just (CName "ex4_odd"))
                         (CName "next")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "ex4_odd"))
-                          DeclPathTop))))),
+                        DeclPathCtxtTop)))),
               fieldSourceLoc =
               "nested_types.h:27:8"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "ex4_odd"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "ex4_odd")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1312,14 +1307,13 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "ex4_even"))
-                    (DeclPathPtr
-                      (DeclPathField
+                  (DeclPathName
+                    (CName "ex4_even")
+                    (DeclPathCtxtPtr
+                      (DeclPathCtxtField
+                        (Just (CName "ex4_odd"))
                         (CName "next")
-                        (DeclPathConstr
-                          (DeclNameTag (CName "ex4_odd"))
-                          DeclPathTop))))),
+                        DeclPathCtxtTop)))),
               fieldSourceLoc =
               "nested_types.h:27:8"}],
           structFlam = Nothing,
@@ -1368,22 +1362,21 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "ex4_even"))
-                      (DeclPathPtr
-                        (DeclPathField
+                    (DeclPathName
+                      (CName "ex4_even")
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtField
+                          (Just (CName "ex4_odd"))
                           (CName "next")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "ex4_odd"))
-                            DeclPathTop))))),
+                          DeclPathCtxtTop)))),
                 fieldSourceLoc =
                 "nested_types.h:27:8"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "ex4_odd"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "ex4_odd")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1402,14 +1395,13 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "ex4_even"))
-                      (DeclPathPtr
-                        (DeclPathField
+                    (DeclPathName
+                      (CName "ex4_even")
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtField
+                          (Just (CName "ex4_odd"))
                           (CName "next")
-                          (DeclPathConstr
-                            (DeclNameTag (CName "ex4_odd"))
-                            DeclPathTop))))),
+                          DeclPathCtxtTop)))),
                 fieldSourceLoc =
                 "nested_types.h:27:8"}],
             structFlam = Nothing,
@@ -1463,22 +1455,21 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_even"))
-                              (DeclPathPtr
-                                (DeclPathField
+                            (DeclPathName
+                              (CName "ex4_even")
+                              (DeclPathCtxtPtr
+                                (DeclPathCtxtField
+                                  (Just (CName "ex4_odd"))
                                   (CName "next")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "ex4_odd"))
-                                    DeclPathTop))))),
+                                  DeclPathCtxtTop)))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex4_odd"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ex4_odd")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1497,14 +1488,13 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_even"))
-                              (DeclPathPtr
-                                (DeclPathField
+                            (DeclPathName
+                              (CName "ex4_even")
+                              (DeclPathCtxtPtr
+                                (DeclPathCtxtField
+                                  (Just (CName "ex4_odd"))
                                   (CName "next")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "ex4_odd"))
-                                    DeclPathTop))))),
+                                  DeclPathCtxtTop)))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,
@@ -1560,22 +1550,21 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_even"))
-                              (DeclPathPtr
-                                (DeclPathField
+                            (DeclPathName
+                              (CName "ex4_even")
+                              (DeclPathCtxtPtr
+                                (DeclPathCtxtField
+                                  (Just (CName "ex4_odd"))
                                   (CName "next")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "ex4_odd"))
-                                    DeclPathTop))))),
+                                  DeclPathCtxtTop)))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "ex4_odd"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ex4_odd")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1594,14 +1583,13 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "ex4_even"))
-                              (DeclPathPtr
-                                (DeclPathField
+                            (DeclPathName
+                              (CName "ex4_even")
+                              (DeclPathCtxtPtr
+                                (DeclPathCtxtField
+                                  (Just (CName "ex4_odd"))
                                   (CName "next")
-                                  (DeclPathConstr
-                                    (DeclNameTag (CName "ex4_odd"))
-                                    DeclPathTop))))),
+                                  DeclPathCtxtTop)))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -30,9 +30,9 @@ Header
         "nested_types.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bar"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "bar")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 4,
@@ -42,9 +42,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                (DeclNameTag (CName "foo"))
-                DeclPathTop),
+              (DeclPathName
+                (CName "foo")
+                DeclPathCtxtTop),
             fieldSourceLoc =
             "nested_types.h:7:16"},
           StructField {
@@ -52,9 +52,9 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathConstr
-                (DeclNameTag (CName "foo"))
-                DeclPathTop),
+              (DeclPathName
+                (CName "foo")
+                DeclPathCtxtTop),
             fieldSourceLoc =
             "nested_types.h:8:16"}],
         structFlam = Nothing,
@@ -62,9 +62,9 @@ Header
         "nested_types.h:6:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "ex3"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "ex3")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -82,14 +82,13 @@ Header
         "nested_types.h:11:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "ex4_even"))
-          (DeclPathPtr
-            (DeclPathField
+        structDeclPath = DeclPathName
+          (CName "ex4_even")
+          (DeclPathCtxtPtr
+            (DeclPathCtxtField
+              (Just (CName "ex4_odd"))
               (CName "next")
-              (DeclPathConstr
-                (DeclNameTag (CName "ex4_odd"))
-                DeclPathTop))),
+              DeclPathCtxtTop)),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -108,9 +107,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "ex4_odd"))
-                  DeclPathTop)),
+                (DeclPathName
+                  (CName "ex4_odd")
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "nested_types.h:26:25"}],
         structFlam = Nothing,
@@ -118,9 +117,9 @@ Header
         "nested_types.h:24:12"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "ex4_odd"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "ex4_odd")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -139,14 +138,13 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "ex4_even"))
-                  (DeclPathPtr
-                    (DeclPathField
+                (DeclPathName
+                  (CName "ex4_even")
+                  (DeclPathCtxtPtr
+                    (DeclPathCtxtField
+                      (Just (CName "ex4_odd"))
                       (CName "next")
-                      (DeclPathConstr
-                        (DeclNameTag (CName "ex4_odd"))
-                        DeclPathTop))))),
+                      DeclPathCtxtTop)))),
             fieldSourceLoc =
             "nested_types.h:27:8"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -35,9 +35,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "opaque_declaration.h:5:17"}},
         Field {
@@ -55,17 +55,17 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "bar"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "bar")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "opaque_declaration.h:6:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bar"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "bar")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -76,9 +76,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "foo"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "foo")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "opaque_declaration.h:5:17"},
             StructField {
@@ -87,9 +87,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "bar"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "bar")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "opaque_declaration.h:6:17"}],
           structFlam = Nothing,
@@ -120,9 +120,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "opaque_declaration.h:5:17"}},
           Field {
@@ -140,17 +140,17 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "opaque_declaration.h:6:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bar"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "bar")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -161,9 +161,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "opaque_declaration.h:5:17"},
               StructField {
@@ -172,9 +172,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "opaque_declaration.h:6:17"}],
             structFlam = Nothing,
@@ -210,9 +210,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "foo"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "foo")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"}},
                   Field {
@@ -230,17 +230,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "bar"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "bar")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -251,9 +251,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "foo"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "foo")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"},
                       StructField {
@@ -262,9 +262,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "bar"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "bar")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
@@ -302,9 +302,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "foo"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "foo")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"}},
                   Field {
@@ -322,17 +322,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "bar"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "bar")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -343,9 +343,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "foo"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "foo")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"},
                       StructField {
@@ -354,9 +354,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag (CName "bar"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "bar")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
@@ -390,9 +390,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "baz"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "baz")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 0,
           structAlignment = 1,
@@ -413,9 +413,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "baz"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "baz")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 0,
             structAlignment = 1,
@@ -441,9 +441,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "baz"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "baz")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 0,
                     structAlignment = 1,
@@ -469,9 +469,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "baz"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "baz")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 0,
                     structAlignment = 1,

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -8,9 +8,9 @@ Header
         "opaque_declaration.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bar"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "bar")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -21,9 +21,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "foo"))
-                  DeclPathTop)),
+                (DeclPathName
+                  (CName "foo")
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "opaque_declaration.h:5:17"},
           StructField {
@@ -32,9 +32,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "bar"))
-                  DeclPathTop)),
+                (DeclPathName
+                  (CName "bar")
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "opaque_declaration.h:6:17"}],
         structFlam = Nothing,
@@ -42,9 +42,9 @@ Header
         "opaque_declaration.h:4:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "baz"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "baz")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 0,
         structAlignment = 1,

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -495,10 +495,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "primitive"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "primitive")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 176,
           structAlignment = 16,
@@ -1255,10 +1254,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "primitive"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "primitive")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 176,
             structAlignment = 16,
@@ -2020,10 +2018,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "primitive"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "primitive")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 176,
                     structAlignment = 16,
@@ -2814,10 +2811,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "primitive"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "primitive")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 176,
                     structAlignment = 16,

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -2,10 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "primitive"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "primitive")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 176,
         structAlignment = 16,

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -41,19 +41,17 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "linked_list_A_s"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "linked_list_A_s")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "recursive_struct.h:3:27"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "linked_list_A_s"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "linked_list_A_s")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -72,10 +70,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "linked_list_A_s"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "linked_list_A_s")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "recursive_struct.h:3:27"}],
           structFlam = Nothing,
@@ -124,19 +121,17 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_A_s"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "linked_list_A_s")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "recursive_struct.h:3:27"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "linked_list_A_s"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "linked_list_A_s")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -155,10 +150,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_A_s"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "linked_list_A_s")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "recursive_struct.h:3:27"}],
             structFlam = Nothing,
@@ -212,19 +206,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_A_s"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_A_s")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_A_s"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "linked_list_A_s")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -243,10 +235,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_A_s"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_A_s")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
@@ -302,19 +293,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_A_s"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_A_s")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_A_s"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "linked_list_A_s")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -333,10 +322,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_A_s"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_A_s")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
@@ -385,10 +373,9 @@
           typedefName = CName
             "linked_list_A_t",
           typedefType = TypeStruct
-            (DeclPathConstr
-              (DeclNameTag
-                (CName "linked_list_A_s"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "linked_list_A_s")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "recursive_struct.h:4:3"}},
   DeclNewtypeInstance
@@ -439,19 +426,17 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "linked_list_B_t"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "linked_list_B_t")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "recursive_struct.h:11:20"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "linked_list_B_t"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "linked_list_B_t")
+            DeclPathCtxtTop,
           structAliases = [
             CName "linked_list_B_t"],
           structSizeof = 16,
@@ -471,10 +456,9 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "linked_list_B_t"))
-                    DeclPathTop)),
+                  (DeclPathName
+                    (CName "linked_list_B_t")
+                    DeclPathCtxtTop)),
               fieldSourceLoc =
               "recursive_struct.h:11:20"}],
           structFlam = Nothing,
@@ -523,19 +507,17 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_B_t"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "linked_list_B_t")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "recursive_struct.h:11:20"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "linked_list_B_t"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "linked_list_B_t")
+              DeclPathCtxtTop,
             structAliases = [
               CName "linked_list_B_t"],
             structSizeof = 16,
@@ -555,10 +537,9 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_B_t"))
-                      DeclPathTop)),
+                    (DeclPathName
+                      (CName "linked_list_B_t")
+                      DeclPathCtxtTop)),
                 fieldSourceLoc =
                 "recursive_struct.h:11:20"}],
             structFlam = Nothing,
@@ -612,19 +593,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_B_t"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_B_t")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_B_t"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "linked_list_B_t")
+                      DeclPathCtxtTop,
                     structAliases = [
                       CName "linked_list_B_t"],
                     structSizeof = 16,
@@ -644,10 +623,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_B_t"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_B_t")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,
@@ -703,19 +681,17 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_B_t"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_B_t")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "linked_list_B_t"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "linked_list_B_t")
+                      DeclPathCtxtTop,
                     structAliases = [
                       CName "linked_list_B_t"],
                     structSizeof = 16,
@@ -735,10 +711,9 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathConstr
-                              (DeclNameTag
-                                (CName "linked_list_B_t"))
-                              DeclPathTop)),
+                            (DeclPathName
+                              (CName "linked_list_B_t")
+                              DeclPathCtxtTop)),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -2,10 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "linked_list_A_s"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "linked_list_A_s")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -24,10 +23,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag
-                    (CName "linked_list_A_s"))
-                  DeclPathTop)),
+                (DeclPathName
+                  (CName "linked_list_A_s")
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "recursive_struct.h:3:27"}],
         structFlam = Nothing,
@@ -38,18 +36,16 @@ Header
         typedefName = CName
           "linked_list_A_t",
         typedefType = TypeStruct
-          (DeclPathConstr
-            (DeclNameTag
-              (CName "linked_list_A_s"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "linked_list_A_s")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "recursive_struct.h:4:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "linked_list_B_t"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "linked_list_B_t")
+          DeclPathCtxtTop,
         structAliases = [
           CName "linked_list_B_t"],
         structSizeof = 16,
@@ -69,10 +65,9 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag
-                    (CName "linked_list_B_t"))
-                  DeclPathTop)),
+                (DeclPathName
+                  (CName "linked_list_B_t")
+                  DeclPathCtxtTop)),
             fieldSourceLoc =
             "recursive_struct.h:11:20"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -43,9 +43,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S1"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S1")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -114,9 +114,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S1"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S1")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -190,9 +190,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -268,9 +268,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S1"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S1")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -370,9 +370,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S2"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S2")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -465,9 +465,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S2"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S2")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -565,9 +565,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -668,9 +668,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -739,9 +739,9 @@
         Typedef {
           typedefName = CName "S2_t",
           typedefType = TypeStruct
-            (DeclPathConstr
-              (DeclNameTag (CName "S2"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "S2")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "simple_structs.h:12:3"}},
   DeclNewtypeInstance
@@ -776,9 +776,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTypedef (CName "S3_t"))
-            DeclPathTop,
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtTypedef
+              (CName "S3_t")),
           structAliases = [],
           structSizeof = 1,
           structAlignment = 1,
@@ -823,9 +823,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTypedef (CName "S3_t"))
-              DeclPathTop,
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "S3_t")),
             structAliases = [],
             structSizeof = 1,
             structAlignment = 1,
@@ -875,9 +875,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTypedef (CName "S3_t"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "S3_t")),
                     structAliases = [],
                     structSizeof = 1,
                     structAlignment = 1,
@@ -927,9 +927,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTypedef (CName "S3_t"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName "S3_t")),
                     structAliases = [],
                     structSizeof = 1,
                     structAlignment = 1,
@@ -1021,9 +1021,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S4"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S4")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1118,9 +1118,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S4"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S4")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1220,9 +1220,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S4"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S4")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1325,9 +1325,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S4"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S4")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1421,9 +1421,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S5"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S5")
+            DeclPathCtxtTop,
           structAliases = [CName "S5"],
           structSizeof = 8,
           structAlignment = 4,
@@ -1492,9 +1492,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S5"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S5")
+              DeclPathCtxtTop,
             structAliases = [CName "S5"],
             structSizeof = 8,
             structAlignment = 4,
@@ -1568,9 +1568,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S5"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S5")
+                      DeclPathCtxtTop,
                     structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1646,9 +1646,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S5"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S5")
+                      DeclPathCtxtTop,
                     structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1732,9 +1732,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "S6"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "S6")
+            DeclPathCtxtTop,
           structAliases = [CName "S6"],
           structSizeof = 8,
           structAlignment = 4,
@@ -1803,9 +1803,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "S6"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "S6")
+              DeclPathCtxtTop,
             structAliases = [CName "S6"],
             structSizeof = 8,
             structAlignment = 4,
@@ -1879,9 +1879,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S6"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S6")
+                      DeclPathCtxtTop,
                     structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1957,9 +1957,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "S6"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "S6")
+                      DeclPathCtxtTop,
                     structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2043,12 +2043,10 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathPtr
-              (DeclPathConstr
-                (DeclNameTypedef (CName "S7a"))
-                DeclPathTop)),
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtPtr
+              (DeclPathCtxtTypedef
+                (CName "S7a"))),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -2117,12 +2115,10 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathPtr
-                (DeclPathConstr
-                  (DeclNameTypedef (CName "S7a"))
-                  DeclPathTop)),
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtPtr
+                (DeclPathCtxtTypedef
+                  (CName "S7a"))),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -2196,12 +2192,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathPtr
-                        (DeclPathConstr
-                          (DeclNameTypedef (CName "S7a"))
-                          DeclPathTop)),
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtTypedef
+                          (CName "S7a"))),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2277,12 +2271,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathPtr
-                        (DeclPathConstr
-                          (DeclNameTypedef (CName "S7a"))
-                          DeclPathTop)),
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtTypedef
+                          (CName "S7a"))),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2350,12 +2342,10 @@
           typedefName = CName "S7a",
           typedefType = TypePointer
             (TypeStruct
-              (DeclPathConstr
-                DeclNameNone
-                (DeclPathPtr
-                  (DeclPathConstr
-                    (DeclNameTypedef (CName "S7a"))
-                    DeclPathTop)))),
+              (DeclPathAnon
+                (DeclPathCtxtPtr
+                  (DeclPathCtxtTypedef
+                    (CName "S7a"))))),
           typedefSourceLoc =
           "simple_structs.h:34:36"}},
   DeclNewtypeInstance
@@ -2406,14 +2396,12 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            DeclNameNone
-            (DeclPathPtr
-              (DeclPathPtr
-                (DeclPathPtr
-                  (DeclPathConstr
-                    (DeclNameTypedef (CName "S7b"))
-                    DeclPathTop)))),
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtPtr
+              (DeclPathCtxtPtr
+                (DeclPathCtxtPtr
+                  (DeclPathCtxtTypedef
+                    (CName "S7b"))))),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -2482,14 +2470,12 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              DeclNameNone
-              (DeclPathPtr
-                (DeclPathPtr
-                  (DeclPathPtr
-                    (DeclPathConstr
-                      (DeclNameTypedef (CName "S7b"))
-                      DeclPathTop)))),
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtPtr
+                (DeclPathCtxtPtr
+                  (DeclPathCtxtPtr
+                    (DeclPathCtxtTypedef
+                      (CName "S7b"))))),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -2563,14 +2549,12 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathPtr
-                        (DeclPathPtr
-                          (DeclPathPtr
-                            (DeclPathConstr
-                              (DeclNameTypedef (CName "S7b"))
-                              DeclPathTop)))),
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtPtr
+                          (DeclPathCtxtPtr
+                            (DeclPathCtxtTypedef
+                              (CName "S7b"))))),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2646,14 +2630,12 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      DeclNameNone
-                      (DeclPathPtr
-                        (DeclPathPtr
-                          (DeclPathPtr
-                            (DeclPathConstr
-                              (DeclNameTypedef (CName "S7b"))
-                              DeclPathTop)))),
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtPtr
+                          (DeclPathCtxtPtr
+                            (DeclPathCtxtTypedef
+                              (CName "S7b"))))),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2725,14 +2707,12 @@
             (TypePointer
               (TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    DeclNameNone
-                    (DeclPathPtr
-                      (DeclPathPtr
-                        (DeclPathPtr
-                          (DeclPathConstr
-                            (DeclNameTypedef (CName "S7b"))
-                            DeclPathTop)))))))),
+                  (DeclPathAnon
+                    (DeclPathCtxtPtr
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtPtr
+                          (DeclPathCtxtTypedef
+                            (CName "S7b"))))))))),
           typedefSourceLoc =
           "simple_structs.h:35:38"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S1"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S1")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -30,9 +30,9 @@ Header
         "simple_structs.h:2:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S2"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S2")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -68,16 +68,16 @@ Header
       Typedef {
         typedefName = CName "S2_t",
         typedefType = TypeStruct
-          (DeclPathConstr
-            (DeclNameTag (CName "S2"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "S2")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "simple_structs.h:12:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTypedef (CName "S3_t"))
-          DeclPathTop,
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtTypedef
+            (CName "S3_t")),
         structAliases = [],
         structSizeof = 1,
         structAlignment = 1,
@@ -95,9 +95,9 @@ Header
         "simple_structs.h:15:9"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S4"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S4")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -132,9 +132,9 @@ Header
         "simple_structs.h:19:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S5"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S5")
+          DeclPathCtxtTop,
         structAliases = [CName "S5"],
         structSizeof = 8,
         structAlignment = 4,
@@ -160,9 +160,9 @@ Header
         "simple_structs.h:26:16"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "S6"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "S6")
+          DeclPathCtxtTop,
         structAliases = [CName "S6"],
         structSizeof = 8,
         structAlignment = 4,
@@ -188,12 +188,10 @@ Header
         "simple_structs.h:31:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathPtr
-            (DeclPathConstr
-              (DeclNameTypedef (CName "S7a"))
-              DeclPathTop)),
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtPtr
+            (DeclPathCtxtTypedef
+              (CName "S7a"))),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -222,24 +220,20 @@ Header
         typedefName = CName "S7a",
         typedefType = TypePointer
           (TypeStruct
-            (DeclPathConstr
-              DeclNameNone
-              (DeclPathPtr
-                (DeclPathConstr
-                  (DeclNameTypedef (CName "S7a"))
-                  DeclPathTop)))),
+            (DeclPathAnon
+              (DeclPathCtxtPtr
+                (DeclPathCtxtTypedef
+                  (CName "S7a"))))),
         typedefSourceLoc =
         "simple_structs.h:34:36"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          DeclNameNone
-          (DeclPathPtr
-            (DeclPathPtr
-              (DeclPathPtr
-                (DeclPathConstr
-                  (DeclNameTypedef (CName "S7b"))
-                  DeclPathTop)))),
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtPtr
+            (DeclPathCtxtPtr
+              (DeclPathCtxtPtr
+                (DeclPathCtxtTypedef
+                  (CName "S7b"))))),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -270,13 +264,11 @@ Header
           (TypePointer
             (TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  DeclNameNone
-                  (DeclPathPtr
-                    (DeclPathPtr
-                      (DeclPathPtr
-                        (DeclPathConstr
-                          (DeclNameTypedef (CName "S7b"))
-                          DeclPathTop)))))))),
+                (DeclPathAnon
+                  (DeclPathCtxtPtr
+                    (DeclPathCtxtPtr
+                      (DeclPathCtxtPtr
+                        (DeclPathCtxtTypedef
+                          (CName "S7b"))))))))),
         typedefSourceLoc =
         "simple_structs.h:35:38"}]

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -540,10 +540,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "ExampleStruct"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "ExampleStruct")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 16,
           structAlignment = 4,
@@ -660,10 +659,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag
-                (CName "ExampleStruct"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "ExampleStruct")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 16,
             structAlignment = 4,
@@ -785,10 +783,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "ExampleStruct"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ExampleStruct")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -914,10 +911,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag
-                        (CName "ExampleStruct"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "ExampleStruct")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -1011,9 +1007,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 8,
@@ -1063,9 +1059,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 8,
@@ -1120,9 +1116,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1177,9 +1173,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -161,10 +161,9 @@ Header
         "typedef_vs_macro.h:2:14"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "ExampleStruct"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "ExampleStruct")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 16,
         structAlignment = 4,
@@ -206,9 +205,9 @@ Header
         "typedef_vs_macro.h:9:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -17,9 +17,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -57,9 +57,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -102,9 +102,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -147,9 +147,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -43,9 +43,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "Dim2"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "Dim2")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -114,9 +114,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "Dim2"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "Dim2")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -190,9 +190,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -268,9 +268,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim2"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim2")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -370,9 +370,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "Dim3"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "Dim3")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -465,9 +465,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "Dim3"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "Dim3")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -565,9 +565,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -668,9 +668,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim3"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim3")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -736,10 +736,9 @@
       newtypeOrigin =
       NewtypeOriginUnion
         Union {
-          unionDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "DimPayload"))
-            DeclPathTop,
+          unionDeclPath = DeclPathName
+            (CName "DimPayload")
+            DeclPathCtxtTop,
           unionAliases = [],
           unionSizeof = 8,
           unionAlignment = 4,
@@ -792,18 +791,17 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathConstr
-                  (DeclNameTag
-                    (CName "DimPayload"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "DimPayload")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "unions.h:19:22"}}],
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "Dim"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "Dim")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -821,10 +819,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathConstr
-                  (DeclNameTag
-                    (CName "DimPayload"))
-                  DeclPathTop),
+                (DeclPathName
+                  (CName "DimPayload")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "unions.h:19:22"}],
           structFlam = Nothing,
@@ -871,18 +868,17 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "DimPayload"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "DimPayload")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "unions.h:19:22"}}],
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "Dim"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "Dim")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -900,10 +896,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathConstr
-                    (DeclNameTag
-                      (CName "DimPayload"))
-                    DeclPathTop),
+                  (DeclPathName
+                    (CName "DimPayload")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "unions.h:19:22"}],
             structFlam = Nothing,
@@ -955,18 +950,17 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathConstr
-                            (DeclNameTag
-                              (CName "DimPayload"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "DimPayload")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:19:22"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -984,10 +978,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathConstr
-                            (DeclNameTag
-                              (CName "DimPayload"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "DimPayload")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:19:22"}],
                     structFlam = Nothing,
@@ -1041,18 +1034,17 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathConstr
-                            (DeclNameTag
-                              (CName "DimPayload"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "DimPayload")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:19:22"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "Dim"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "Dim")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1070,10 +1062,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathConstr
-                            (DeclNameTag
-                              (CName "DimPayload"))
-                            DeclPathTop),
+                          (DeclPathName
+                            (CName "DimPayload")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:19:22"}],
                     structFlam = Nothing,
@@ -1112,10 +1103,9 @@
       newtypeOrigin =
       NewtypeOriginUnion
         Union {
-          unionDeclPath = DeclPathConstr
-            (DeclNameTag
-              (CName "DimPayloadB"))
-            DeclPathTop,
+          unionDeclPath = DeclPathName
+            (CName "DimPayloadB")
+            DeclPathCtxtTop,
           unionAliases = [],
           unionSizeof = 8,
           unionAlignment = 4,
@@ -1151,10 +1141,9 @@
           typedefName = CName
             "DimPayloadB",
           typedefType = TypeUnion
-            (DeclPathConstr
-              (DeclNameTag
-                (CName "DimPayloadB"))
-              DeclPathTop),
+            (DeclPathName
+              (CName "DimPayloadB")
+              DeclPathCtxtTop),
           typedefSourceLoc =
           "unions.h:26:3"}},
   DeclNewtypeInstance
@@ -1209,9 +1198,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "DimB"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "DimB")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -1282,9 +1271,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "DimB"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "DimB")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -1360,9 +1349,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "DimB"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "DimB")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1440,9 +1429,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "DimB"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "DimB")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -2,9 +2,9 @@ Header
   [
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "Dim2"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "Dim2")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -30,9 +30,9 @@ Header
         "unions.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "Dim3"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "Dim3")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -66,10 +66,9 @@ Header
         "unions.h:6:8"},
     DeclUnion
       Union {
-        unionDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "DimPayload"))
-          DeclPathTop,
+        unionDeclPath = DeclPathName
+          (CName "DimPayload")
+          DeclPathCtxtTop,
         unionAliases = [],
         unionSizeof = 8,
         unionAlignment = 4,
@@ -77,9 +76,9 @@ Header
         "unions.h:12:7"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "Dim"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "Dim")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -97,10 +96,9 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypeUnion
-              (DeclPathConstr
-                (DeclNameTag
-                  (CName "DimPayload"))
-                DeclPathTop),
+              (DeclPathName
+                (CName "DimPayload")
+                DeclPathCtxtTop),
             fieldSourceLoc =
             "unions.h:19:22"}],
         structFlam = Nothing,
@@ -108,10 +106,9 @@ Header
         "unions.h:17:8"},
     DeclUnion
       Union {
-        unionDeclPath = DeclPathConstr
-          (DeclNameTag
-            (CName "DimPayloadB"))
-          DeclPathTop,
+        unionDeclPath = DeclPathName
+          (CName "DimPayloadB")
+          DeclPathCtxtTop,
         unionAliases = [],
         unionSizeof = 8,
         unionAlignment = 4,
@@ -122,17 +119,16 @@ Header
         typedefName = CName
           "DimPayloadB",
         typedefType = TypeUnion
-          (DeclPathConstr
-            (DeclNameTag
-              (CName "DimPayloadB"))
-            DeclPathTop),
+          (DeclPathName
+            (CName "DimPayloadB")
+            DeclPathCtxtTop),
         typedefSourceLoc =
         "unions.h:26:3"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "DimB"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "DimB")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -17,9 +17,9 @@
       newtypeOrigin =
       NewtypeOriginEnum
         Enu {
-          enumDeclPath = DeclPathConstr
-            (DeclNameTag (CName "MyEnum"))
-            DeclPathTop,
+          enumDeclPath = DeclPathName
+            (CName "MyEnum")
+            DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -59,9 +59,9 @@
             fieldOrigin = FieldOriginNone}],
         structOrigin = StructOriginEnum
           Enu {
-            enumDeclPath = DeclPathConstr
-              (DeclNameTag (CName "MyEnum"))
-              DeclPathTop,
+            enumDeclPath = DeclPathName
+              (CName "MyEnum")
+              DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -106,9 +106,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "MyEnum"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "MyEnum")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -153,9 +153,9 @@
                     fieldOrigin = FieldOriginNone}],
                 structOrigin = StructOriginEnum
                   Enu {
-                    enumDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "MyEnum"))
-                      DeclPathTop,
+                    enumDeclPath = DeclPathName
+                      (CName "MyEnum")
+                      DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -17,9 +17,9 @@ Header
         "uses_utf8.h:2:9"},
     DeclEnum
       Enu {
-        enumDeclPath = DeclPathConstr
-          (DeclNameTag (CName "MyEnum"))
-          DeclPathTop,
+        enumDeclPath = DeclPathName
+          (CName "MyEnum")
+          DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -20,9 +20,10 @@
             [
               TypePointer
                 (TypeStruct
-                  (DeclPathConstr
-                    (DeclNameTag (CName "bar"))
-                    (DeclPathPtr DeclPathTop)))]
+                  (DeclPathName
+                    (CName "bar")
+                    (DeclPathCtxtPtr
+                      DeclPathCtxtTop)))]
             TypeVoid,
           functionHeader = "weird01.h",
           functionSourceLoc =
@@ -55,9 +56,9 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "foo"))
-            DeclPathTop,
+          structDeclPath = DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -102,9 +103,9 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "foo"))
-              DeclPathTop,
+            structDeclPath = DeclPathName
+              (CName "foo")
+              DeclPathCtxtTop,
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -154,9 +155,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -206,9 +207,9 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "foo"))
-                      DeclPathTop,
+                    structDeclPath = DeclPathName
+                      (CName "foo")
+                      DeclPathCtxtTop,
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -267,9 +268,10 @@
       structOrigin =
       StructOriginStruct
         Struct {
-          structDeclPath = DeclPathConstr
-            (DeclNameTag (CName "bar"))
-            (DeclPathPtr DeclPathTop),
+          structDeclPath = DeclPathName
+            (CName "bar")
+            (DeclPathCtxtPtr
+              DeclPathCtxtTop),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -314,9 +316,10 @@
         structOrigin =
         StructOriginStruct
           Struct {
-            structDeclPath = DeclPathConstr
-              (DeclNameTag (CName "bar"))
-              (DeclPathPtr DeclPathTop),
+            structDeclPath = DeclPathName
+              (CName "bar")
+              (DeclPathCtxtPtr
+                DeclPathCtxtTop),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -366,9 +369,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      (DeclPathPtr DeclPathTop),
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      (DeclPathCtxtPtr
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -418,9 +422,10 @@
                 structOrigin =
                 StructOriginStruct
                   Struct {
-                    structDeclPath = DeclPathConstr
-                      (DeclNameTag (CName "bar"))
-                      (DeclPathPtr DeclPathTop),
+                    structDeclPath = DeclPathName
+                      (CName "bar")
+                      (DeclPathCtxtPtr
+                        DeclPathCtxtTop),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -7,18 +7,19 @@ Header
           [
             TypePointer
               (TypeStruct
-                (DeclPathConstr
-                  (DeclNameTag (CName "bar"))
-                  (DeclPathPtr DeclPathTop)))]
+                (DeclPathName
+                  (CName "bar")
+                  (DeclPathCtxtPtr
+                    DeclPathCtxtTop)))]
           TypeVoid,
         functionHeader = "weird01.h",
         functionSourceLoc =
         "weird01.h:8:6"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "foo"))
-          DeclPathTop,
+        structDeclPath = DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -36,9 +37,10 @@ Header
         "weird01.h:1:8"},
     DeclStruct
       Struct {
-        structDeclPath = DeclPathConstr
-          (DeclNameTag (CName "bar"))
-          (DeclPathPtr DeclPathTop),
+        structDeclPath = DeclPathName
+          (CName "bar")
+          (DeclPathCtxtPtr
+            DeclPathCtxtTop),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/src/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src/HsBindgen/C/AST.hs
@@ -59,7 +59,7 @@ module HsBindgen.C.AST (
   , pprTcMacroError
     -- * DeclPath
   , DeclPath(..)
-  , DeclName(..)
+  , DeclPathCtxt(..)
     -- * Source locations
   , SingleLoc(..)
   , MultiLoc(..)

--- a/hs-bindgen/src/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src/HsBindgen/ExtBindings/Gen.hs
@@ -107,14 +107,14 @@ getNewtypeExtBindings hsNewtype = fmap (, hsId) . catMaybes $
     hsId = HsIdentifier $ getHsName (Hs.newtypeName hsNewtype)
 
 getCNS :: Text -> C.DeclPath -> Maybe CNameSpelling
-getCNS prefix declPath = do
-    mDeclName <- case declPath of
-      C.DeclPathConstr declName _declPath -> Just declName
-      _otherwise                          -> Nothing
-    case mDeclName of
-      C.DeclNameTag     cname -> Just $ CNameSpelling (prefix <> getCName cname)
-      C.DeclNameTypedef cname -> Just $ CNameSpelling (getCName cname)
-      C.DeclNameNone          -> Nothing
+getCNS prefix (C.DeclPathName cname _ctxt) =
+    Just $ CNameSpelling (prefix <> getCName cname)
+getCNS _prefix (C.DeclPathAnon ctxt) =
+    case ctxt of
+      C.DeclPathCtxtTypedef typedefName ->
+        Just $ CNameSpelling (getCName typedefName)
+      _otherwise ->
+        Nothing
 
 getCNS_alias :: CName -> CNameSpelling
 getCNS_alias = CNameSpelling . getCName

--- a/hs-bindgen/src/HsBindgen/GenTests/C.hs
+++ b/hs-bindgen/src/HsBindgen/GenTests/C.hs
@@ -101,11 +101,14 @@ getTestSourceDefns cFunPrefix = \case
 getStructCTypeSpelling :: Hs.StructOrigin -> Maybe CTypeSpelling
 getStructCTypeSpelling = \case
     Hs.StructOriginStruct C.Struct{..} -> case structDeclPath of
-      C.DeclPathConstr declName _declPath -> case declName of
-        C.DeclNameNone -> Nothing
-        C.DeclNameTag cName -> Just $ "struct " ++ T.unpack (C.getCName cName)
-        C.DeclNameTypedef cName -> Just $ T.unpack (C.getCName cName)
-      _otherwise -> Nothing
+      C.DeclPathAnon ctxt ->
+        case ctxt of
+          C.DeclPathCtxtTypedef typedefName ->
+            Just $ T.unpack (C.getCName typedefName)
+          _otherwise ->
+            Nothing
+      C.DeclPathName cName _ctxt ->
+          Just $ "struct " ++ T.unpack (C.getCName cName)
     Hs.StructOriginEnum{} -> Nothing
 
 getFieldP :: Hs.Field -> FieldP

--- a/hs-bindgen/tests/Orphans.hs
+++ b/hs-bindgen/tests/Orphans.hs
@@ -41,8 +41,8 @@ instance ToExpr CInt where
 instance ToExpr C.Attribute
 instance ToExpr C.CName
 instance ToExpr C.Decl
-instance ToExpr C.DeclName
 instance ToExpr C.DeclPath
+instance ToExpr C.DeclPathCtxt
 instance ToExpr C.Enu
 instance ToExpr C.EnumValue
 instance ToExpr C.Function


### PR DESCRIPTION
This makes a very clear distinction between the type that is being declared, and the context in which it is declared.

It's not quite perfect yet, ideally we'd be able to insist on a non-empty context for anonymous type declarations, but I think this new design is at least a lot easier to understand, and will hopefully reduce friction working with these `DeclPath`s.

With this new definition, perhaps it would make sense to rename `DeclPath` to something else?