### PR TITLE
Support structs defined inside union

### DIFF
--- a/hs-bindgen/examples/unions.h
+++ b/hs-bindgen/examples/unions.h
@@ -29,3 +29,9 @@ struct DimB {
     int tag;
     DimPayloadB payload;
 };
+
+// union with anonymous struct fields
+union AnonA {
+    struct { double x; double y; } xy;
+    struct { double r; double p; } polar;
+};

--- a/hs-bindgen/fixtures/unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/unions.extbindings.yaml
@@ -29,6 +29,12 @@ types:
   identifier: DimB
   module: Example
   package: example
+- cname: union AnonA
+  headers:
+  - unions.h
+  identifier: AnonA
+  module: Example
+  package: example
 - cname: union DimPayload
   headers:
   - unions.h

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -1576,4 +1576,739 @@
   DeclNewtypeInstance
     DeriveStock
     Eq
-    (HsName "@NsTypeConstr" "DimB")]
+    (HsName "@NsTypeConstr" "DimB"),
+  DeclData
+    Struct {
+      structName = HsName
+        "@NsTypeConstr"
+        "AnonA_xy",
+      structConstr = HsName
+        "@NsConstr"
+        "AnonA_xy",
+      structFields = [
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "anonA_xy_x",
+          fieldType = HsPrimType
+            HsPrimCDouble,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "x",
+              fieldOffset = 0,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:35:21"}},
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "anonA_xy_y",
+          fieldType = HsPrimType
+            HsPrimCDouble,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "y",
+              fieldOffset = 64,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:35:31"}}],
+      structOrigin =
+      StructOriginStruct
+        Struct {
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              (Just (CName "AnonA"))
+              (CName "xy")
+              DeclPathCtxtTop),
+          structAliases = [],
+          structSizeof = 16,
+          structAlignment = 8,
+          structFields = [
+            StructField {
+              fieldName = CName "x",
+              fieldOffset = 0,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:35:21"},
+            StructField {
+              fieldName = CName "y",
+              fieldOffset = 64,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:35:31"}],
+          structFlam = Nothing,
+          structSourceLoc =
+          "unions.h:35:5"}},
+  DeclInstance
+    (InstanceStorable
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "AnonA_xy",
+        structConstr = HsName
+          "@NsConstr"
+          "AnonA_xy",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "anonA_xy_x",
+            fieldType = HsPrimType
+              HsPrimCDouble,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "x",
+                fieldOffset = 0,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:35:21"}},
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "anonA_xy_y",
+            fieldType = HsPrimType
+              HsPrimCDouble,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "y",
+                fieldOffset = 64,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:35:31"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "AnonA"))
+                (CName "xy")
+                DeclPathCtxtTop),
+            structAliases = [],
+            structSizeof = 16,
+            structAlignment = 8,
+            structFields = [
+              StructField {
+                fieldName = CName "x",
+                fieldOffset = 0,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:35:21"},
+              StructField {
+                fieldName = CName "y",
+                fieldOffset = 64,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:35:31"}],
+            structFlam = Nothing,
+            structSourceLoc =
+            "unions.h:35:5"}}
+      StorableInstance {
+        storableSizeOf = 16,
+        storableAlignment = 8,
+        storablePeek = Lambda
+          (NameHint "ptr")
+          (Ap
+            (StructCon
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "AnonA_xy",
+                structConstr = HsName
+                  "@NsConstr"
+                  "AnonA_xy",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_xy_x",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "x",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:21"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_xy_y",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "y",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:31"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "AnonA"))
+                        (CName "xy")
+                        DeclPathCtxtTop),
+                    structAliases = [],
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "x",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:21"},
+                      StructField {
+                        fieldName = CName "y",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:31"}],
+                    structFlam = Nothing,
+                    structSourceLoc =
+                    "unions.h:35:5"}})
+            [
+              PeekByteOff (Idx 0) 0,
+              PeekByteOff (Idx 0) 8]),
+        storablePoke = Lambda
+          (NameHint "ptr")
+          (Lambda
+            (NameHint "s")
+            (ElimStruct
+              (Idx 0)
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "AnonA_xy",
+                structConstr = HsName
+                  "@NsConstr"
+                  "AnonA_xy",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_xy_x",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "x",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:21"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_xy_y",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "y",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:31"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "AnonA"))
+                        (CName "xy")
+                        DeclPathCtxtTop),
+                    structAliases = [],
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "x",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:21"},
+                      StructField {
+                        fieldName = CName "y",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:35:31"}],
+                    structFlam = Nothing,
+                    structSourceLoc =
+                    "unions.h:35:5"}}
+              (Add 2)
+              (Seq
+                [
+                  PokeByteOff (Idx 3) 0 (Idx 0),
+                  PokeByteOff
+                    (Idx 3)
+                    8
+                    (Idx 1)])))}),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName
+      "@NsTypeConstr"
+      "AnonA_xy"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "AnonA_xy"),
+  DeclData
+    Struct {
+      structName = HsName
+        "@NsTypeConstr"
+        "AnonA_polar",
+      structConstr = HsName
+        "@NsConstr"
+        "AnonA_polar",
+      structFields = [
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "anonA_polar_r",
+          fieldType = HsPrimType
+            HsPrimCDouble,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "r",
+              fieldOffset = 0,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:36:21"}},
+        Field {
+          fieldName = HsName
+            "@NsVar"
+            "anonA_polar_p",
+          fieldType = HsPrimType
+            HsPrimCDouble,
+          fieldOrigin =
+          FieldOriginStructField
+            StructField {
+              fieldName = CName "p",
+              fieldOffset = 64,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:36:31"}}],
+      structOrigin =
+      StructOriginStruct
+        Struct {
+          structDeclPath = DeclPathAnon
+            (DeclPathCtxtField
+              (Just (CName "AnonA"))
+              (CName "polar")
+              DeclPathCtxtTop),
+          structAliases = [],
+          structSizeof = 16,
+          structAlignment = 8,
+          structFields = [
+            StructField {
+              fieldName = CName "r",
+              fieldOffset = 0,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:36:21"},
+            StructField {
+              fieldName = CName "p",
+              fieldOffset = 64,
+              fieldWidth = Nothing,
+              fieldType = TypePrim
+                (PrimFloating PrimDouble),
+              fieldSourceLoc =
+              "unions.h:36:31"}],
+          structFlam = Nothing,
+          structSourceLoc =
+          "unions.h:36:5"}},
+  DeclInstance
+    (InstanceStorable
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "AnonA_polar",
+        structConstr = HsName
+          "@NsConstr"
+          "AnonA_polar",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "anonA_polar_r",
+            fieldType = HsPrimType
+              HsPrimCDouble,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "r",
+                fieldOffset = 0,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:36:21"}},
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "anonA_polar_p",
+            fieldType = HsPrimType
+              HsPrimCDouble,
+            fieldOrigin =
+            FieldOriginStructField
+              StructField {
+                fieldName = CName "p",
+                fieldOffset = 64,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:36:31"}}],
+        structOrigin =
+        StructOriginStruct
+          Struct {
+            structDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "AnonA"))
+                (CName "polar")
+                DeclPathCtxtTop),
+            structAliases = [],
+            structSizeof = 16,
+            structAlignment = 8,
+            structFields = [
+              StructField {
+                fieldName = CName "r",
+                fieldOffset = 0,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:36:21"},
+              StructField {
+                fieldName = CName "p",
+                fieldOffset = 64,
+                fieldWidth = Nothing,
+                fieldType = TypePrim
+                  (PrimFloating PrimDouble),
+                fieldSourceLoc =
+                "unions.h:36:31"}],
+            structFlam = Nothing,
+            structSourceLoc =
+            "unions.h:36:5"}}
+      StorableInstance {
+        storableSizeOf = 16,
+        storableAlignment = 8,
+        storablePeek = Lambda
+          (NameHint "ptr")
+          (Ap
+            (StructCon
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "AnonA_polar",
+                structConstr = HsName
+                  "@NsConstr"
+                  "AnonA_polar",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_polar_r",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "r",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:21"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_polar_p",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "p",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:31"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "AnonA"))
+                        (CName "polar")
+                        DeclPathCtxtTop),
+                    structAliases = [],
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "r",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:21"},
+                      StructField {
+                        fieldName = CName "p",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:31"}],
+                    structFlam = Nothing,
+                    structSourceLoc =
+                    "unions.h:36:5"}})
+            [
+              PeekByteOff (Idx 0) 0,
+              PeekByteOff (Idx 0) 8]),
+        storablePoke = Lambda
+          (NameHint "ptr")
+          (Lambda
+            (NameHint "s")
+            (ElimStruct
+              (Idx 0)
+              Struct {
+                structName = HsName
+                  "@NsTypeConstr"
+                  "AnonA_polar",
+                structConstr = HsName
+                  "@NsConstr"
+                  "AnonA_polar",
+                structFields = [
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_polar_r",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "r",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:21"}},
+                  Field {
+                    fieldName = HsName
+                      "@NsVar"
+                      "anonA_polar_p",
+                    fieldType = HsPrimType
+                      HsPrimCDouble,
+                    fieldOrigin =
+                    FieldOriginStructField
+                      StructField {
+                        fieldName = CName "p",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:31"}}],
+                structOrigin =
+                StructOriginStruct
+                  Struct {
+                    structDeclPath = DeclPathAnon
+                      (DeclPathCtxtField
+                        (Just (CName "AnonA"))
+                        (CName "polar")
+                        DeclPathCtxtTop),
+                    structAliases = [],
+                    structSizeof = 16,
+                    structAlignment = 8,
+                    structFields = [
+                      StructField {
+                        fieldName = CName "r",
+                        fieldOffset = 0,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:21"},
+                      StructField {
+                        fieldName = CName "p",
+                        fieldOffset = 64,
+                        fieldWidth = Nothing,
+                        fieldType = TypePrim
+                          (PrimFloating PrimDouble),
+                        fieldSourceLoc =
+                        "unions.h:36:31"}],
+                    structFlam = Nothing,
+                    structSourceLoc =
+                    "unions.h:36:5"}}
+              (Add 2)
+              (Seq
+                [
+                  PokeByteOff (Idx 3) 0 (Idx 0),
+                  PokeByteOff
+                    (Idx 3)
+                    8
+                    (Idx 1)])))}),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName
+      "@NsTypeConstr"
+      "AnonA_polar"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "AnonA_polar"),
+  DeclNewtype
+    Newtype {
+      newtypeName = HsName
+        "@NsTypeConstr"
+        "AnonA",
+      newtypeConstr = HsName
+        "@NsConstr"
+        "AnonA",
+      newtypeField = Field {
+        fieldName = HsName
+          "@NsVar"
+          "unAnonA",
+        fieldType = HsByteArray,
+        fieldOrigin = FieldOriginNone},
+      newtypeOrigin =
+      NewtypeOriginUnion
+        Union {
+          unionDeclPath = DeclPathName
+            (CName "AnonA")
+            DeclPathCtxtTop,
+          unionAliases = [],
+          unionSizeof = 16,
+          unionAlignment = 8,
+          unionFields = [
+            UnionField {
+              ufieldName = CName "xy",
+              ufieldType = TypeStruct
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "AnonA"))
+                    (CName "xy")
+                    DeclPathCtxtTop)),
+              ufieldSourceLoc =
+              "unions.h:35:36"},
+            UnionField {
+              ufieldName = CName "polar",
+              ufieldType = TypeStruct
+                (DeclPathAnon
+                  (DeclPathCtxtField
+                    (Just (CName "AnonA"))
+                    (CName "polar")
+                    DeclPathCtxtTop)),
+              ufieldSourceLoc =
+              "unions.h:36:36"}],
+          unionSourceLoc =
+          "unions.h:34:7"}},
+  DeclNewtypeInstance
+    (DeriveVia
+      (HsSizedByteArray 16 8))
+    Storable
+    (HsName
+      "@NsTypeConstr"
+      "AnonA"),
+  DeclUnionGetter
+    (HsName "@NsTypeConstr" "AnonA")
+    (HsTypRef
+      (HsName
+        "@NsTypeConstr"
+        "AnonA_xy"))
+    (HsName
+      "@NsVar"
+      "get_anonA_xy"),
+  DeclUnionSetter
+    (HsName "@NsTypeConstr" "AnonA")
+    (HsTypRef
+      (HsName
+        "@NsTypeConstr"
+        "AnonA_xy"))
+    (HsName
+      "@NsVar"
+      "set_anonA_xy"),
+  DeclUnionGetter
+    (HsName "@NsTypeConstr" "AnonA")
+    (HsTypRef
+      (HsName
+        "@NsTypeConstr"
+        "AnonA_polar"))
+    (HsName
+      "@NsVar"
+      "get_anonA_polar"),
+  DeclUnionSetter
+    (HsName "@NsTypeConstr" "AnonA")
+    (HsTypRef
+      (HsName
+        "@NsTypeConstr"
+        "AnonA_polar"))
+    (HsName
+      "@NsVar"
+      "set_anonA_polar")]

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -174,3 +174,79 @@ instance F.Storable DimB where
 deriving stock instance Show DimB
 
 deriving stock instance Eq DimB
+
+data AnonA_xy = AnonA_xy
+  { anonA_xy_x :: FC.CDouble
+  , anonA_xy_y :: FC.CDouble
+  }
+
+instance F.Storable AnonA_xy where
+
+  sizeOf = \_ -> (16 :: Int)
+
+  alignment = \_ -> (8 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure AnonA_xy
+      <*> F.peekByteOff ptr0 (0 :: Int)
+      <*> F.peekByteOff ptr0 (8 :: Int)
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          AnonA_xy anonA_xy_x2 anonA_xy_y3 ->
+               F.pokeByteOff ptr0 (0 :: Int) anonA_xy_x2
+            >> F.pokeByteOff ptr0 (8 :: Int) anonA_xy_y3
+
+deriving stock instance Show AnonA_xy
+
+deriving stock instance Eq AnonA_xy
+
+data AnonA_polar = AnonA_polar
+  { anonA_polar_r :: FC.CDouble
+  , anonA_polar_p :: FC.CDouble
+  }
+
+instance F.Storable AnonA_polar where
+
+  sizeOf = \_ -> (16 :: Int)
+
+  alignment = \_ -> (8 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure AnonA_polar
+      <*> F.peekByteOff ptr0 (0 :: Int)
+      <*> F.peekByteOff ptr0 (8 :: Int)
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          AnonA_polar anonA_polar_r2 anonA_polar_p3 ->
+               F.pokeByteOff ptr0 (0 :: Int) anonA_polar_r2
+            >> F.pokeByteOff ptr0 (8 :: Int) anonA_polar_p3
+
+deriving stock instance Show AnonA_polar
+
+deriving stock instance Eq AnonA_polar
+
+newtype AnonA = AnonA
+  { unAnonA :: Data.Array.Byte.ByteArray
+  }
+
+deriving via (HsBindgen.Runtime.SizedByteArray.SizedByteArray 16) 8 instance F.Storable AnonA
+
+get_anonA_xy :: AnonA -> AnonA_xy
+get_anonA_xy = HsBindgen.Runtime.ByteArray.getUnionPayload
+
+set_anonA_xy :: AnonA_xy -> AnonA
+set_anonA_xy = HsBindgen.Runtime.ByteArray.setUnionPayload
+
+get_anonA_polar :: AnonA -> AnonA_polar
+get_anonA_polar = HsBindgen.Runtime.ByteArray.getUnionPayload
+
+set_anonA_polar :: AnonA_polar -> AnonA
+set_anonA_polar = HsBindgen.Runtime.ByteArray.setUnionPayload

--- a/hs-bindgen/fixtures/unions.rs
+++ b/hs-bindgen/fixtures/unions.rs
@@ -88,3 +88,58 @@ const _: () = {
     ["Offset of field: DimB::tag"][::std::mem::offset_of!(DimB, tag) - 0usize];
     ["Offset of field: DimB::payload"][::std::mem::offset_of!(DimB, payload) - 4usize];
 };
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union AnonA {
+    pub xy: AnonA__bindgen_ty_1,
+    pub polar: AnonA__bindgen_ty_2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AnonA__bindgen_ty_1 {
+    pub x: f64,
+    pub y: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of AnonA__bindgen_ty_1",
+    ][::std::mem::size_of::<AnonA__bindgen_ty_1>() - 16usize];
+    [
+        "Alignment of AnonA__bindgen_ty_1",
+    ][::std::mem::align_of::<AnonA__bindgen_ty_1>() - 8usize];
+    [
+        "Offset of field: AnonA__bindgen_ty_1::x",
+    ][::std::mem::offset_of!(AnonA__bindgen_ty_1, x) - 0usize];
+    [
+        "Offset of field: AnonA__bindgen_ty_1::y",
+    ][::std::mem::offset_of!(AnonA__bindgen_ty_1, y) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AnonA__bindgen_ty_2 {
+    pub r: f64,
+    pub p: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of AnonA__bindgen_ty_2",
+    ][::std::mem::size_of::<AnonA__bindgen_ty_2>() - 16usize];
+    [
+        "Alignment of AnonA__bindgen_ty_2",
+    ][::std::mem::align_of::<AnonA__bindgen_ty_2>() - 8usize];
+    [
+        "Offset of field: AnonA__bindgen_ty_2::r",
+    ][::std::mem::offset_of!(AnonA__bindgen_ty_2, r) - 0usize];
+    [
+        "Offset of field: AnonA__bindgen_ty_2::p",
+    ][::std::mem::offset_of!(AnonA__bindgen_ty_2, p) - 8usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AnonA"][::std::mem::size_of::<AnonA>() - 16usize];
+    ["Alignment of AnonA"][::std::mem::align_of::<AnonA>() - 8usize];
+    ["Offset of field: AnonA::xy"][::std::mem::offset_of!(AnonA, xy) - 0usize];
+    ["Offset of field: AnonA::polar"][::std::mem::offset_of!(AnonA, polar) - 0usize];
+};

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -61,3 +61,35 @@ instance Storable DimB
                                           dimB_payload_4 -> pokeByteOff ptr_1 (0 :: Int) dimB_tag_3 >> pokeByteOff ptr_1 (4 :: Int) dimB_payload_4}}
 deriving stock instance Show DimB
 deriving stock instance Eq DimB
+data AnonA_xy
+    = AnonA_xy {anonA_xy_x :: CDouble, anonA_xy_y :: CDouble}
+instance Storable AnonA_xy
+    where {sizeOf = \_ -> 16 :: Int;
+           alignment = \_ -> 8 :: Int;
+           peek = \ptr_0 -> (pure AnonA_xy <*> peekByteOff ptr_0 (0 :: Int)) <*> peekByteOff ptr_0 (8 :: Int);
+           poke = \ptr_1 -> \s_2 -> case s_2 of
+                                    {AnonA_xy anonA_xy_x_3
+                                              anonA_xy_y_4 -> pokeByteOff ptr_1 (0 :: Int) anonA_xy_x_3 >> pokeByteOff ptr_1 (8 :: Int) anonA_xy_y_4}}
+deriving stock instance Show AnonA_xy
+deriving stock instance Eq AnonA_xy
+data AnonA_polar
+    = AnonA_polar {anonA_polar_r :: CDouble, anonA_polar_p :: CDouble}
+instance Storable AnonA_polar
+    where {sizeOf = \_ -> 16 :: Int;
+           alignment = \_ -> 8 :: Int;
+           peek = \ptr_0 -> (pure AnonA_polar <*> peekByteOff ptr_0 (0 :: Int)) <*> peekByteOff ptr_0 (8 :: Int);
+           poke = \ptr_1 -> \s_2 -> case s_2 of
+                                    {AnonA_polar anonA_polar_r_3
+                                                 anonA_polar_p_4 -> pokeByteOff ptr_1 (0 :: Int) anonA_polar_r_3 >> pokeByteOff ptr_1 (8 :: Int) anonA_polar_p_4}}
+deriving stock instance Show AnonA_polar
+deriving stock instance Eq AnonA_polar
+newtype AnonA = AnonA {unAnonA :: ByteArray}
+deriving via (SizedByteArray 16 8) instance Storable AnonA
+get_anonA_xy :: AnonA -> AnonA_xy
+get_anonA_xy = getUnionPayload
+set_anonA_xy :: AnonA_xy -> AnonA
+set_anonA_xy = setUnionPayload
+get_anonA_polar :: AnonA -> AnonA_polar
+get_anonA_polar = getUnionPayload
+set_anonA_polar :: AnonA_polar -> AnonA
+set_anonA_polar = setUnionPayload

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -185,4 +185,95 @@ Header
             "unions.h:30:17"}],
         structFlam = Nothing,
         structSourceLoc =
-        "unions.h:28:8"}]
+        "unions.h:28:8"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            (Just (CName "AnonA"))
+            (CName "xy")
+            DeclPathCtxtTop),
+        structAliases = [],
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "x",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "unions.h:35:21"},
+          StructField {
+            fieldName = CName "y",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "unions.h:35:31"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "unions.h:35:5"},
+    DeclStruct
+      Struct {
+        structDeclPath = DeclPathAnon
+          (DeclPathCtxtField
+            (Just (CName "AnonA"))
+            (CName "polar")
+            DeclPathCtxtTop),
+        structAliases = [],
+        structSizeof = 16,
+        structAlignment = 8,
+        structFields = [
+          StructField {
+            fieldName = CName "r",
+            fieldOffset = 0,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "unions.h:36:21"},
+          StructField {
+            fieldName = CName "p",
+            fieldOffset = 64,
+            fieldWidth = Nothing,
+            fieldType = TypePrim
+              (PrimFloating PrimDouble),
+            fieldSourceLoc =
+            "unions.h:36:31"}],
+        structFlam = Nothing,
+        structSourceLoc =
+        "unions.h:36:5"},
+    DeclUnion
+      Union {
+        unionDeclPath = DeclPathName
+          (CName "AnonA")
+          DeclPathCtxtTop,
+        unionAliases = [],
+        unionSizeof = 16,
+        unionAlignment = 8,
+        unionFields = [
+          UnionField {
+            ufieldName = CName "xy",
+            ufieldType = TypeStruct
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  (Just (CName "AnonA"))
+                  (CName "xy")
+                  DeclPathCtxtTop)),
+            ufieldSourceLoc =
+            "unions.h:35:36"},
+          UnionField {
+            ufieldName = CName "polar",
+            ufieldType = TypeStruct
+              (DeclPathAnon
+                (DeclPathCtxtField
+                  (Just (CName "AnonA"))
+                  (CName "polar")
+                  DeclPathCtxtTop)),
+            ufieldSourceLoc =
+            "unions.h:36:36"}],
+        unionSourceLoc =
+        "unions.h:34:7"}]

--- a/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src/HsBindgen/C/Fold/Type.hs
@@ -729,8 +729,8 @@ mkUnionField extBindings unit mUnionName ctxt current = do
 
         return $ Just $ UnionField{ufieldName, ufieldType, ufieldSourceLoc}
 
-      -- TODO: inner definitions
-      -- Right CXCursor_StructDecl -> return Nothing
+      -- inner structs: skip, processed as part of fields if needed.
+      Right CXCursor_StructDecl -> return Nothing
 
       _other ->
         unrecognizedCursor current


### PR DESCRIPTION
Note that

```c
union AnonB {
    struct { double x; double y; };
    struct { double r; double p; };
};
```

doesn't work, for the same reason such no-field no-name structs don't work inside structs either.