### PR TITLE
Add external bindings tests

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -69,6 +69,15 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: echo "LLVM_CONFIG=$LLVM_PATH/bin/llvm-config" >> "$GITHUB_ENV"
 
+      - name: ICU PKG_CONFIG_PATH (macos)
+        shell: bash
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
+          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
+          echo "${PKG_CONFIG_PATH}"
+          ls -l "${PKG_CONFIG_PATH}"
+
       # https://stackoverflow.com/questions/63342521/clang-on-macos-having-problems-with-its-includes
       - name: macOS SDKROOT
         shell: bash

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -69,15 +69,6 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: echo "LLVM_CONFIG=$LLVM_PATH/bin/llvm-config" >> "$GITHUB_ENV"
 
-      - name: ICU PKG_CONFIG_PATH (macos)
-        shell: bash
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: |
-          export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
-          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
-          echo "${PKG_CONFIG_PATH}"
-          ls -l "${PKG_CONFIG_PATH}"
-
       # https://stackoverflow.com/questions/63342521/clang-on-macos-having-problems-with-its-includes
       - name: macOS SDKROOT
         shell: bash
@@ -86,13 +77,6 @@ jobs:
           export SDKROOT=$(xcrun --show-sdk-path --sdk macosx)
           echo $SDKROOT
           echo "SDKROOT=$SDKROOT" >> "$GITHUB_ENV"
-
-      - name: Install ICU (windows)
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: |
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-          $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-          pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -87,6 +87,13 @@ jobs:
           echo $SDKROOT
           echo "SDKROOT=$SDKROOT" >> "$GITHUB_ENV"
 
+      - name: Install ICU (windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+          $env:PATH = "C:\msys64\usr\bin;$env:PATH"
+          pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -259,8 +259,12 @@ test-suite test-internal
   hs-source-dirs: test/internal
   other-modules:
       Test.HsBindgen.C.Parser
+      Test.HsBindgen.ExtBindings
       Test.Internal.Misc
+      Test.Internal.QuickCheck
+      Test.Internal.QuickCheck.Orphans
       Test.Internal.Rust
+      Test.Internal.Tasty
       Test.Internal.TastyGolden
       Test.Internal.TH
       Test.Internal.TreeDiff.Orphans
@@ -274,23 +278,28 @@ test-suite test-internal
   build-depends:
       -- Inherited dependencies
     , bytestring
+    , containers
     , debruijn
     , mtl
     , template-haskell
+    , text
     , vec
   build-depends:
       -- External dependencies
     , ansi-diff
     , deepseq
-    , directory     ^>=1.3.6.2
-    , filepath      ^>=1.4.2.2 || ^>=1.5.2.0
+    , directory        ^>=1.3.6.2
+    , filepath         ^>=1.4.2.2 || ^>=1.5.2.0
     , process
-    , syb           ^>=0.7.2.4
-    , tasty         ^>=1.5
-    , tasty-hunit   ^>=0.10.2
+    , QuickCheck       ^>=2.15.0.1
+    , syb              ^>=0.7.2.4
+    , tasty            ^>=1.5
+    , tasty-hunit      ^>=0.10.2
+    , tasty-quickcheck ^>=0.11.1
     , temporary
-    , tree-diff     ^>=0.3.4
-    , utf8-string   ^>=1.0.2
+    , text-icu         ^>=0.8
+    , tree-diff        ^>=0.3.4
+    , utf8-string      ^>=1.0.2
 
 test-suite test-th
   type:           exitcode-stdio-1.0

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -297,9 +297,11 @@ test-suite test-internal
     , tasty-hunit      ^>=0.10.2
     , tasty-quickcheck ^>=0.11.1
     , temporary
-    , text-icu         ^>=0.8
     , tree-diff        ^>=0.3.4
     , utf8-string      ^>=1.0.2
+  if os(linux)
+    build-depends:
+      , text-icu ^>=0.8
 
 test-suite test-th
   type:           exitcode-stdio-1.0

--- a/hs-bindgen/test/internal/Test/HsBindgen/ExtBindings.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/ExtBindings.hs
@@ -1,0 +1,40 @@
+module Test.HsBindgen.ExtBindings (tests) where
+
+import Control.Exception (throwIO)
+import System.FilePath ((</>))
+import Test.QuickCheck.Monadic qualified as QCM
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Property, testProperty)
+
+import HsBindgen.ExtBindings
+
+import Test.Internal.QuickCheck.Orphans ()
+import Test.Internal.Tasty
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "HsBindgen.ExtBindings" [
+      withTmpDir $ \getTmpDir -> testGroup "configuration"  [
+          testProperty "writeLoadJsonEq" $ prop_writeLoadJsonEq getTmpDir
+        , testProperty "writeLoadYamlEq" $ prop_writeLoadYamlEq getTmpDir
+        ]
+    ]
+
+prop_writeLoadJsonEq :: IO FilePath -> UnresolvedExtBindings -> Property
+prop_writeLoadJsonEq getTmpDir bindings = QCM.monadicIO $ do
+    path <- (</> "writeLoadJsonEq.json") <$> QCM.run getTmpDir
+    bindings' <- QCM.run $ do
+      either throwIO return =<< writeUnresolvedExtBindings path bindings
+      either throwIO return =<< loadUnresolvedExtBindings path
+    QCM.assert $ bindings' == bindings
+
+prop_writeLoadYamlEq :: IO FilePath -> UnresolvedExtBindings -> Property
+prop_writeLoadYamlEq getTmpDir bindings = QCM.monadicIO $ do
+    path <- (</> "writeLoadYamlEq.yaml") <$> QCM.run getTmpDir
+    bindings' <- QCM.run $ do
+      either throwIO return =<< writeUnresolvedExtBindings path bindings
+      either throwIO return =<< loadUnresolvedExtBindings path
+    QCM.assert $ bindings' == bindings

--- a/hs-bindgen/test/internal/Test/Internal/QuickCheck.hs
+++ b/hs-bindgen/test/internal/Test/Internal/QuickCheck.hs
@@ -1,0 +1,43 @@
+module Test.Internal.QuickCheck (
+    -- * Generators
+    frequency_
+  , vectorOfU
+  , vectorOfS
+  , vectorOfF
+  ) where
+
+import Test.QuickCheck
+
+{-------------------------------------------------------------------------------
+  Generators
+-------------------------------------------------------------------------------}
+
+-- | Generates one of the given values, with a weighted random distribution
+--
+-- The input list must be non-empty.
+frequency_ :: [(Int, a)] -> Gen a
+frequency_ = frequency . map (fmap pure)
+
+-- | Generate a list of length determined by a uniform random distribution over
+-- the specified bounds
+vectorOfU :: Int -> Int -> Gen a -> Gen [a]
+vectorOfU minB maxB gen = do
+    n <- choose (minB, minB `max` maxB)
+    vectorOf n gen
+
+-- | Generate a list of length determined by a uniform random distribution over
+-- the specified bounds, where the maximum bound depends on the size parameter
+--
+-- Inspired by @Cabal-QuickCheck@
+vectorOfS :: Int -> Int -> Gen a -> Gen [a]
+vectorOfS minB maxB gen = sized $ \size -> do
+    n <- choose (minB, minB `max` ((size `div` 2) `min` maxB))
+    vectorOf n gen
+
+-- | Generate a list of length determined by a weighted random distribution
+--
+-- The input list must be non-empty.
+vectorOfF :: [(Int, Int)] -> Gen a -> Gen [a]
+vectorOfF ns gen = do
+    n <- frequency_ ns
+    vectorOf n gen

--- a/hs-bindgen/test/internal/Test/Internal/QuickCheck/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/QuickCheck/Orphans.hs
@@ -1,0 +1,239 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Internal.QuickCheck.Orphans () where
+
+import Control.Monad (liftM2)
+import Data.Char qualified as Char
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Data.Text.ICU.Char as ICU
+import Test.QuickCheck
+
+import Clang.CNameSpelling
+import Clang.Paths
+import HsBindgen.C.AST qualified as C
+import HsBindgen.ExtBindings
+import HsBindgen.Imports
+
+import Test.Internal.QuickCheck
+
+{-------------------------------------------------------------------------------
+  clang Clang.CNameSpelling
+-------------------------------------------------------------------------------}
+
+instance Arbitrary CNameSpelling where
+  arbitrary = do
+    mPrefix <- elements [Just "struct ", Just "enum ", Just "union ", Nothing]
+    cname <- C.getCName <$> arbitrary
+    return $ CNameSpelling (fromMaybe "" mPrefix <> cname)
+
+{-------------------------------------------------------------------------------
+  clang Clang.Paths
+-------------------------------------------------------------------------------}
+
+instance Arbitrary SourcePath where
+  arbitrary =
+    SourcePath . Text.pack . ("/usr/include/" ++) . getCHeaderIncludePath
+      <$> arbitrary
+
+instance Arbitrary CHeaderIncludePath where
+  arbitrary = do
+      path <- (++ ".h") . List.intercalate "/" <$> vectorOfS 1 3 genPart
+      construct <- elements [CHeaderSystemIncludePath, CHeaderQuoteIncludePath]
+      return $ construct path
+    where
+      genPart :: Gen String
+      genPart = vectorOfS 1 10 $ elements charset
+
+      charset :: String
+      charset = "-._~" ++ ['0'..'9'] ++ ['A'..'Z'] ++ ['a'..'z']
+
+{-------------------------------------------------------------------------------
+  hs-bindgen:internal HsBindgen.C.AST.Name
+-------------------------------------------------------------------------------}
+
+instance Arbitrary C.CName where
+  arbitrary = frequency [
+        (14, aux genStartCharAscii   genContCharAscii)
+      , (5,  aux genStartCharUnicode genContCharUnicode)
+      , (1,  elements reservedCNames)
+      ]
+    where
+      aux :: Gen Char -> Gen Char -> Gen C.CName
+      aux genStartChar genContChar = do
+        let genPart = liftM2 (<>) genUnderscores (genContPart genContChar)
+        tL <- frequency [
+            (9, genStartPart genStartChar genContChar)
+          , (1, genPart)
+          ]
+        tC <- concat <$> vectorOfF [(13, 0), (4, 1), (2, 2), (1, 3)] genPart
+        tR <- frequency [(9, pure ""), (1, genUnderscores)]
+        return . C.CName $ Text.pack (tL ++ tC ++ tR)
+
+      genStartPart :: Gen Char -> Gen Char -> Gen String
+      genStartPart genStartChar genContChar = do
+        cL <- genStartChar
+        sR <- vectorOfS 0 5 genContChar
+        return $ cL : sR
+
+      genContPart :: Gen Char -> Gen String
+      genContPart = vectorOfS 1 6
+
+      genUnderscores :: Gen String
+      genUnderscores = frequency_ [(16, "_"), (3, "__"), (1, "___")]
+
+      genStartCharAscii, genContCharAscii :: Gen Char
+      genStartCharAscii = elements startCharset
+      genContCharAscii  = elements contCharset
+
+      startCharset, contCharset :: String
+      startCharset = ['A'..'Z'] ++ ['a'..'z']
+      contCharset  = ['0'..'9'] ++ startCharset
+
+      genStartCharUnicode, genContCharUnicode :: Gen Char
+      genStartCharUnicode =
+        frequency [
+            (19, arbitraryUnicodeChar `suchThat` isXidStartLetter)
+          , (1, arbitraryUnicodeChar `suchThat` isXidStartNotLetter)
+          ]
+      genContCharUnicode =
+        frequency [
+            (19, arbitraryUnicodeChar `suchThat` isXidContAlphaNum)
+          , (1, arbitraryUnicodeChar `suchThat` isXidContNotAlphaNum)
+          ]
+
+      isXidStartLetter, isXidStartNotLetter :: Char -> Bool
+      isXidStartLetter =
+        liftA2 (&&) (ICU.property ICU.XidStart) Char.isLetter
+      isXidStartNotLetter =
+        liftA2 (&&) (ICU.property ICU.XidStart) (not . Char.isLetter)
+
+      isXidContAlphaNum, isXidContNotAlphaNum :: Char -> Bool
+      isXidContAlphaNum =
+        liftA2 (&&) (ICU.property ICU.XidContinue) Char.isAlphaNum
+      isXidContNotAlphaNum =
+        liftA2 (&&) (ICU.property ICU.XidContinue) (not . Char.isAlphaNum)
+
+      reservedCNames :: [C.CName]
+      reservedCNames = [
+          "data"
+        , "default"
+        , "family"
+        , "group"
+        , "instance"
+        , "label"
+        , "module"
+        , "pattern"
+        , "role"
+        , "type"
+        ]
+
+{-------------------------------------------------------------------------------
+  hs-bindgen:internal HsBindgen.ExtBindings
+-------------------------------------------------------------------------------}
+
+instance Arbitrary HsPackageName where
+  arbitrary =
+      HsPackageName . Text.pack . List.intercalate "-"
+        <$> vectorOfF [(10, 1), (7, 2), (2, 3), (1, 4)] genPart
+    where
+      genPart :: Gen String
+      genPart =
+        vectorOfS 1 6 (elements charset)
+          `suchThat` (liftA2 (&&) (not . all Char.isDigit) (/= "all"))
+
+      charset :: String
+      charset = filter Char.isAlphaNum ['\0'..'\127']
+
+instance Arbitrary HsModuleName where
+  arbitrary =
+      HsModuleName . Text.pack . List.intercalate "."
+        <$> vectorOfS 1 4 genPart
+    where
+      genPart :: Gen String
+      genPart = do
+        cL <- elements startCharset
+        sR <- vectorOfS 1 10 $ elements contCharset
+        return $ cL : sR
+
+      startCharset, contCharset, ussq :: String
+      startCharset = ['A'..'Z']
+      contCharset =
+        filter (liftA2 (||) Char.isAlphaNum (`elem` ussq)) ['\0'..'\255']
+      ussq = "_'"
+
+instance Arbitrary HsIdentifier where
+  arbitrary = frequency [
+        (7, aux genStartCharAscii   genContCharAscii)
+      , (3, aux genStartCharUnicode genContCharUnicode)
+      ]
+    where
+      aux :: Gen Char -> Gen Char -> Gen HsIdentifier
+      aux genStartChar genContChar = do
+        cL <- genStartChar
+        sR <- vectorOfS 0 11 genContChar
+        return . HsIdentifier $ Text.pack (cL : sR)
+
+      genStartCharAscii, genContCharAscii :: Gen Char
+      genStartCharAscii = elements startCharset
+      genContCharAscii  = elements contCharset
+
+      startCharset, contCharset :: String
+      startCharset = ['A'..'Z'] ++ ['a'..'z']
+      contCharset  = ['0'..'9'] ++ '_' : '\'' : startCharset
+
+      genStartCharUnicode, genContCharUnicode :: Gen Char
+      genStartCharUnicode = arbitraryUnicodeChar `suchThat` Char.isLetter
+      genContCharUnicode  = arbitraryUnicodeChar `suchThat` isContChar
+
+      isContChar :: Char -> Bool
+      isContChar = liftA2 (||) Char.isAlphaNum (`elem` ussq)
+
+      ussq :: String
+      ussq = "_'"
+
+instance Arbitrary ExtIdentifier where
+  arbitrary = do
+    extIdentifierPackage    <- arbitrary
+    extIdentifierModule     <- arbitrary
+    extIdentifierIdentifier <- arbitrary
+    return ExtIdentifier{..}
+
+instance Arbitrary UnresolvedExtBindings where
+  arbitrary = do
+    unresolvedExtBindingsTypes <- genCNameSpellingMap
+    return UnresolvedExtBindings{..}
+
+instance Arbitrary ExtBindings where
+  arbitrary = do
+    extBindingsTypes <- genCNameSpellingMap
+    return ExtBindings{..}
+
+genCNameSpellingMap :: forall a.
+     (Arbitrary a, Ord a)
+  => Gen (Map CNameSpelling [(Set a, ExtIdentifier)])
+genCNameSpellingMap = genMap `suchThat` isValid
+  where
+    genMap :: Gen (Map CNameSpelling [(Set a, ExtIdentifier)])
+    genMap = Map.fromList <$> vectorOfS 0 20 genEntry
+
+    genEntry :: Gen (CNameSpelling, [(Set a, ExtIdentifier)])
+    genEntry = do
+      cname <- arbitrary
+      ps <- vectorOfF [(15, 1), (4, 2), (1, 3)] $ do
+        xs <- vectorOfF [(14, 1), (4, 2), (1, 3), (1, 4)] arbitrary
+        extId <- arbitrary
+        return (Set.fromList xs, extId)
+      return (cname, ps)
+
+    isValid :: Map CNameSpelling [(Set a, ExtIdentifier)] -> Bool
+    isValid = all (isDisjoint Set.empty . map fst) . Map.elems
+
+    isDisjoint :: Set a -> [Set a] -> Bool
+    isDisjoint acc = \case
+      s:ss
+        | s `Set.disjoint` acc -> isDisjoint (s <> acc) ss
+        | otherwise            -> False
+      []                       -> True

--- a/hs-bindgen/test/internal/Test/Internal/Tasty.hs
+++ b/hs-bindgen/test/internal/Test/Internal/Tasty.hs
@@ -1,0 +1,26 @@
+module Test.Internal.Tasty (
+    -- * Resources
+    withTmpDir
+  ) where
+
+import Control.Exception (catch)
+import System.Directory qualified as Dir
+import System.IO.Temp qualified as Temp
+import Test.Tasty (TestTree, withResource)
+
+{-------------------------------------------------------------------------------
+  Resources
+-------------------------------------------------------------------------------}
+
+-- | Create a temporary directory to use during a test tree and remove it
+-- afterwards
+withTmpDir :: (IO FilePath -> TestTree) -> TestTree
+withTmpDir =
+    withResource
+      ( flip Temp.createTempDirectory "hs-bindgen-test-"
+          =<< Temp.getCanonicalTemporaryDirectory
+      )
+      (ignoringIOErrors . Dir.removeDirectoryRecursive)
+  where
+    ignoringIOErrors :: IO () -> IO ()
+    ignoringIOErrors ioe = ioe `catch` (\e -> const (return ()) (e :: IOError))

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -18,6 +18,7 @@ import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 
 import Test.HsBindgen.C.Parser qualified
+import Test.HsBindgen.ExtBindings qualified
 import Test.Internal.Misc
 import Test.Internal.Rust
 import Test.Internal.TastyGolden (goldenTestSteps)
@@ -43,6 +44,7 @@ main = do
 tests :: FilePath -> IO FilePath -> TestTree
 tests packageRoot rustBindgen = testGroup "test-internal" [
       Test.HsBindgen.C.Parser.tests args
+    , Test.HsBindgen.ExtBindings.tests
     , testGroup "examples" [
           golden "simple_structs"
         , golden "recursive_struct"


### PR DESCRIPTION
This PR adds unit tests for the *internal* API.  In general the objective of such tests is to confirm the behavior both now an in the future, making it easier/safer to maintain the implementation.

We had only one unit test (for `getTargetTriple`) that was tacked onto the golden tests.  This PR refactors the test suite to put unit tests and golden tests in different test groups.  (The source is renamed from `golden.hs` to `Main.hs`, and the test suite is renamed to `tests`.)  Unit tests are put into `Test` modules; for example tests for `HsBindgen.ExtBindings` are put into a `HsBindgen.ExtBindings.Test` module.

I plan on discussing this with @edsko on Thursday.  If this is not a convention that we would like to use in this project, I am happy to change it.

Regarding external bindings, I made a number of fixes.

Additions:

* External bindings for `newtype` wrappers representing `#define` macros of types are now generated.

Bug fixes:

* Ignoring missing headers when resolving headers for external bindings was no implemented correctly.  This issue is fixed.
* Generated external bindings for opaque `struct`s and `enum`s did not use the necessary prefix.  This issue is fixed.

Minor changes:

* When resolving the headers for external bindings, the API now returns a set of of errors instead of a list.  They were already a set internally, so this is not a significant change.  It just makes it easier to compare the errors (in tests).
* Similarly, conflicting names when merging external bindings is now stored in a set instead of a list.
* Some `Eq` instances are added to error types.