### PR TITLE
Add `dev` flag to `cabal.project`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,10 @@ tests: True
 benchmarks: True
 
 package clang
+  flags: +dev
 
 package hs-bindgen
+  flags: +dev
 
 package hs-bindgen-runtime
 


### PR DESCRIPTION
This is a quick fix that adds the `dev` flag to the `cabal.project` configuration, so that we do not have to remember to specify it by hand.