### PR TITLE
Replace `prefixDecon` with `partDecon`

### DIFF
--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unBOOL",
+          "un_BOOL",
         fieldType = HsPrimType
           HsPrimCBool,
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/bool.pp.hs
+++ b/hs-bindgen/fixtures/bool.pp.hs
@@ -13,7 +13,7 @@ import qualified Foreign.C as FC
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 newtype BOOL = BOOL
-  { unBOOL :: FC.CBool
+  { un_BOOL :: FC.CBool
   }
 
 deriving newtype instance F.Storable BOOL

--- a/hs-bindgen/fixtures/bool.th.txt
+++ b/hs-bindgen/fixtures/bool.th.txt
@@ -1,4 +1,4 @@
-newtype BOOL = BOOL {unBOOL :: CBool}
+newtype BOOL = BOOL {un_BOOL :: CBool}
 deriving newtype instance Storable BOOL
 deriving stock instance Eq BOOL
 deriving stock instance Ord BOOL

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -577,7 +577,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unAnother_typedef_enum_e",
+          "un_Another_typedef_enum_e",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -619,7 +619,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unAnother_typedef_enum_e",
+              "un_Another_typedef_enum_e",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -665,7 +665,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unAnother_typedef_enum_e",
+                      "un_Another_typedef_enum_e",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -711,7 +711,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unAnother_typedef_enum_e",
+                      "un_Another_typedef_enum_e",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -825,7 +825,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unAnother_typedef_enum_e",
+          "un_Another_typedef_enum_e",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -860,7 +860,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unA_type_t",
+          "un_A_type_t",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -961,7 +961,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unVar_t",
+          "un_Var_t",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -1062,7 +1062,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint8_t",
+          "un_Uint8_t",
         fieldType = HsPrimType
           HsPrimCSChar,
         fieldOrigin = FieldOriginNone},
@@ -1163,7 +1163,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint16_t",
+          "un_Uint16_t",
         fieldType = HsPrimType
           HsPrimCUShort,
         fieldOrigin = FieldOriginNone},
@@ -1266,7 +1266,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint32_t",
+          "un_Uint32_t",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -2808,7 +2808,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unA_typedef_struct_t",
+          "un_A_typedef_struct_t",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -2842,7 +2842,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unA_typedef_enum_e",
+          "un_A_typedef_enum_e",
         fieldType = HsPrimType
           HsPrimCSChar,
         fieldOrigin = FieldOriginNone},
@@ -2893,7 +2893,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unA_typedef_enum_e",
+              "un_A_typedef_enum_e",
             fieldType = HsPrimType
               HsPrimCSChar,
             fieldOrigin = FieldOriginNone}],
@@ -2948,7 +2948,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unA_typedef_enum_e",
+                      "un_A_typedef_enum_e",
                     fieldType = HsPrimType
                       HsPrimCSChar,
                     fieldOrigin = FieldOriginNone}],
@@ -3003,7 +3003,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unA_typedef_enum_e",
+                      "un_A_typedef_enum_e",
                     fieldType = HsPrimType
                       HsPrimCSChar,
                     fieldOrigin = FieldOriginNone}],
@@ -3164,7 +3164,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unA_typedef_enum_e",
+          "un_A_typedef_enum_e",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -3198,7 +3198,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unInt32_t",
+          "un_Int32_t",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -3299,7 +3299,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unCallback_t",
+          "un_Callback_t",
         fieldType = HsFunPtr
           (HsFun
             (HsPtr (HsPrimType HsPrimVoid))

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -71,7 +71,7 @@ deriving stock instance Show Another_typedef_struct_t
 deriving stock instance Eq Another_typedef_struct_t
 
 newtype Another_typedef_enum_e = Another_typedef_enum_e
-  { unAnother_typedef_enum_e :: FC.CUInt
+  { un_Another_typedef_enum_e :: FC.CUInt
   }
 
 instance F.Storable Another_typedef_enum_e where
@@ -89,8 +89,8 @@ instance F.Storable Another_typedef_enum_e where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Another_typedef_enum_e unAnother_typedef_enum_e2 ->
-            F.pokeByteOff ptr0 (0 :: Int) unAnother_typedef_enum_e2
+          Another_typedef_enum_e un_Another_typedef_enum_e2 ->
+            F.pokeByteOff ptr0 (0 :: Int) un_Another_typedef_enum_e2
 
 deriving stock instance Show Another_typedef_enum_e
 
@@ -109,13 +109,13 @@ pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
 
 newtype Another_typedef_enum_e = Another_typedef_enum_e
-  { unAnother_typedef_enum_e :: Another_typedef_enum_e
+  { un_Another_typedef_enum_e :: Another_typedef_enum_e
   }
 
 deriving newtype instance F.Storable Another_typedef_enum_e
 
 newtype A_type_t = A_type_t
-  { unA_type_t :: FC.CInt
+  { un_A_type_t :: FC.CInt
   }
 
 deriving newtype instance F.Storable A_type_t
@@ -145,7 +145,7 @@ deriving newtype instance Num A_type_t
 deriving newtype instance Real A_type_t
 
 newtype Var_t = Var_t
-  { unVar_t :: FC.CInt
+  { un_Var_t :: FC.CInt
   }
 
 deriving newtype instance F.Storable Var_t
@@ -175,7 +175,7 @@ deriving newtype instance Num Var_t
 deriving newtype instance Real Var_t
 
 newtype Uint8_t = Uint8_t
-  { unUint8_t :: FC.CSChar
+  { un_Uint8_t :: FC.CSChar
   }
 
 deriving newtype instance F.Storable Uint8_t
@@ -205,7 +205,7 @@ deriving newtype instance Num Uint8_t
 deriving newtype instance Real Uint8_t
 
 newtype Uint16_t = Uint16_t
-  { unUint16_t :: FC.CUShort
+  { un_Uint16_t :: FC.CUShort
   }
 
 deriving newtype instance F.Storable Uint16_t
@@ -235,7 +235,7 @@ deriving newtype instance Num Uint16_t
 deriving newtype instance Real Uint16_t
 
 newtype Uint32_t = Uint32_t
-  { unUint32_t :: FC.CUInt
+  { un_Uint32_t :: FC.CUInt
   }
 
 deriving newtype instance F.Storable Uint32_t
@@ -332,13 +332,13 @@ deriving stock instance Show A_typedef_struct
 deriving stock instance Eq A_typedef_struct
 
 newtype A_typedef_struct_t = A_typedef_struct_t
-  { unA_typedef_struct_t :: A_typedef_struct
+  { un_A_typedef_struct_t :: A_typedef_struct
   }
 
 deriving newtype instance F.Storable A_typedef_struct_t
 
 newtype A_typedef_enum_e = A_typedef_enum_e
-  { unA_typedef_enum_e :: FC.CSChar
+  { un_A_typedef_enum_e :: FC.CSChar
   }
 
 instance F.Storable A_typedef_enum_e where
@@ -356,8 +356,8 @@ instance F.Storable A_typedef_enum_e where
     \ptr0 ->
       \s1 ->
         case s1 of
-          A_typedef_enum_e unA_typedef_enum_e2 ->
-            F.pokeByteOff ptr0 (0 :: Int) unA_typedef_enum_e2
+          A_typedef_enum_e un_A_typedef_enum_e2 ->
+            F.pokeByteOff ptr0 (0 :: Int) un_A_typedef_enum_e2
 
 deriving stock instance Show A_typedef_enum_e
 
@@ -382,13 +382,13 @@ pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
 
 newtype A_typedef_enum_e = A_typedef_enum_e
-  { unA_typedef_enum_e :: A_typedef_enum_e
+  { un_A_typedef_enum_e :: A_typedef_enum_e
   }
 
 deriving newtype instance F.Storable A_typedef_enum_e
 
 newtype Int32_t = Int32_t
-  { unInt32_t :: FC.CInt
+  { un_Int32_t :: FC.CInt
   }
 
 deriving newtype instance F.Storable Int32_t
@@ -418,7 +418,7 @@ deriving newtype instance Num Int32_t
 deriving newtype instance Real Int32_t
 
 newtype Callback_t = Callback_t
-  { unCallback_t :: F.FunPtr ((F.Ptr Void) -> Uint32_t -> IO Uint32_t)
+  { un_Callback_t :: F.FunPtr ((F.Ptr Void) -> Uint32_t -> IO Uint32_t)
   }
 
 deriving newtype instance F.Storable Callback_t

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -28,13 +28,13 @@ instance Storable Another_typedef_struct_t
 deriving stock instance Show Another_typedef_struct_t
 deriving stock instance Eq Another_typedef_struct_t
 newtype Another_typedef_enum_e
-    = Another_typedef_enum_e {unAnother_typedef_enum_e :: CUInt}
+    = Another_typedef_enum_e {un_Another_typedef_enum_e :: CUInt}
 instance Storable Another_typedef_enum_e
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Another_typedef_enum_e <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Another_typedef_enum_e unAnother_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) unAnother_typedef_enum_e_3}}
+                                    {Another_typedef_enum_e un_Another_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_Another_typedef_enum_e_3}}
 deriving stock instance Show Another_typedef_enum_e
 deriving stock instance Read Another_typedef_enum_e
 deriving stock instance Eq Another_typedef_enum_e
@@ -45,9 +45,9 @@ pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
 newtype Another_typedef_enum_e
-    = Another_typedef_enum_e {unAnother_typedef_enum_e :: Another_typedef_enum_e}
+    = Another_typedef_enum_e {un_Another_typedef_enum_e :: Another_typedef_enum_e}
 deriving newtype instance Storable Another_typedef_enum_e
-newtype A_type_t = A_type_t {unA_type_t :: CInt}
+newtype A_type_t = A_type_t {un_A_type_t :: CInt}
 deriving newtype instance Storable A_type_t
 deriving stock instance Eq A_type_t
 deriving stock instance Ord A_type_t
@@ -61,7 +61,7 @@ deriving newtype instance FiniteBits A_type_t
 deriving newtype instance Integral A_type_t
 deriving newtype instance Num A_type_t
 deriving newtype instance Real A_type_t
-newtype Var_t = Var_t {unVar_t :: CInt}
+newtype Var_t = Var_t {un_Var_t :: CInt}
 deriving newtype instance Storable Var_t
 deriving stock instance Eq Var_t
 deriving stock instance Ord Var_t
@@ -75,7 +75,7 @@ deriving newtype instance FiniteBits Var_t
 deriving newtype instance Integral Var_t
 deriving newtype instance Num Var_t
 deriving newtype instance Real Var_t
-newtype Uint8_t = Uint8_t {unUint8_t :: CSChar}
+newtype Uint8_t = Uint8_t {un_Uint8_t :: CSChar}
 deriving newtype instance Storable Uint8_t
 deriving stock instance Eq Uint8_t
 deriving stock instance Ord Uint8_t
@@ -89,7 +89,7 @@ deriving newtype instance FiniteBits Uint8_t
 deriving newtype instance Integral Uint8_t
 deriving newtype instance Num Uint8_t
 deriving newtype instance Real Uint8_t
-newtype Uint16_t = Uint16_t {unUint16_t :: CUShort}
+newtype Uint16_t = Uint16_t {un_Uint16_t :: CUShort}
 deriving newtype instance Storable Uint16_t
 deriving stock instance Eq Uint16_t
 deriving stock instance Ord Uint16_t
@@ -103,7 +103,7 @@ deriving newtype instance FiniteBits Uint16_t
 deriving newtype instance Integral Uint16_t
 deriving newtype instance Num Uint16_t
 deriving newtype instance Real Uint16_t
-newtype Uint32_t = Uint32_t {unUint32_t :: CUInt}
+newtype Uint32_t = Uint32_t {un_Uint32_t :: CUInt}
 deriving newtype instance Storable Uint32_t
 deriving stock instance Eq Uint32_t
 deriving stock instance Ord Uint32_t
@@ -151,16 +151,16 @@ instance Storable A_typedef_struct
 deriving stock instance Show A_typedef_struct
 deriving stock instance Eq A_typedef_struct
 newtype A_typedef_struct_t
-    = A_typedef_struct_t {unA_typedef_struct_t :: A_typedef_struct}
+    = A_typedef_struct_t {un_A_typedef_struct_t :: A_typedef_struct}
 deriving newtype instance Storable A_typedef_struct_t
 newtype A_typedef_enum_e
-    = A_typedef_enum_e {unA_typedef_enum_e :: CSChar}
+    = A_typedef_enum_e {un_A_typedef_enum_e :: CSChar}
 instance Storable A_typedef_enum_e
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure A_typedef_enum_e <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {A_typedef_enum_e unA_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) unA_typedef_enum_e_3}}
+                                    {A_typedef_enum_e un_A_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_A_typedef_enum_e_3}}
 deriving stock instance Show A_typedef_enum_e
 deriving stock instance Read A_typedef_enum_e
 deriving stock instance Eq A_typedef_enum_e
@@ -175,9 +175,9 @@ pattern ENUM_CASE_2 = A_typedef_enum_e 2
 pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
 newtype A_typedef_enum_e
-    = A_typedef_enum_e {unA_typedef_enum_e :: A_typedef_enum_e}
+    = A_typedef_enum_e {un_A_typedef_enum_e :: A_typedef_enum_e}
 deriving newtype instance Storable A_typedef_enum_e
-newtype Int32_t = Int32_t {unInt32_t :: CInt}
+newtype Int32_t = Int32_t {un_Int32_t :: CInt}
 deriving newtype instance Storable Int32_t
 deriving stock instance Eq Int32_t
 deriving stock instance Ord Int32_t
@@ -192,6 +192,6 @@ deriving newtype instance Integral Int32_t
 deriving newtype instance Num Int32_t
 deriving newtype instance Real Int32_t
 newtype Callback_t
-    = Callback_t {unCallback_t :: (FunPtr (Ptr Void ->
-                                           Uint32_t -> IO Uint32_t))}
+    = Callback_t {un_Callback_t :: (FunPtr (Ptr Void ->
+                                            Uint32_t -> IO Uint32_t))}
 deriving newtype instance Storable Callback_t

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unFirst",
+          "un_First",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -49,7 +49,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unFirst",
+              "un_First",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -92,7 +92,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unFirst",
+                      "un_First",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -135,7 +135,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unFirst",
+                      "un_First",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -246,7 +246,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unSecond",
+          "un_Second",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -291,7 +291,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unSecond",
+              "un_Second",
             fieldType = HsPrimType
               HsPrimCInt,
             fieldOrigin = FieldOriginNone}],
@@ -340,7 +340,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unSecond",
+                      "un_Second",
                     fieldType = HsPrimType
                       HsPrimCInt,
                     fieldOrigin = FieldOriginNone}],
@@ -389,7 +389,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unSecond",
+                      "un_Second",
                     fieldType = HsPrimType
                       HsPrimCInt,
                     fieldOrigin = FieldOriginNone}],
@@ -525,7 +525,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unSame",
+          "un_Same",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -566,7 +566,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unSame",
+              "un_Same",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -610,7 +610,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unSame",
+                      "un_Same",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -655,7 +655,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unSame",
+                      "un_Same",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -757,7 +757,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unPackad",
+          "un_Packad",
         fieldType = HsPrimType
           HsPrimCSChar,
         fieldOrigin = FieldOriginNone},
@@ -803,7 +803,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unPackad",
+              "un_Packad",
             fieldType = HsPrimType
               HsPrimCSChar,
             fieldOrigin = FieldOriginNone}],
@@ -852,7 +852,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unPackad",
+                      "un_Packad",
                     fieldType = HsPrimType
                       HsPrimCSChar,
                     fieldOrigin = FieldOriginNone}],
@@ -902,7 +902,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unPackad",
+                      "un_Packad",
                     fieldType = HsPrimType
                       HsPrimCSChar,
                     fieldOrigin = FieldOriginNone}],
@@ -1038,7 +1038,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumA",
+          "un_EnumA",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -1079,7 +1079,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unEnumA",
+              "un_EnumA",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -1123,7 +1123,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumA",
+                      "un_EnumA",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1168,7 +1168,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumA",
+                      "un_EnumA",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1280,7 +1280,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumA",
+          "un_EnumA",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -1313,7 +1313,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumB",
+          "un_EnumB",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -1354,7 +1354,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unEnumB",
+              "un_EnumB",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -1399,7 +1399,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumB",
+                      "un_EnumB",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1444,7 +1444,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumB",
+                      "un_EnumB",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1557,7 +1557,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumB",
+          "un_EnumB",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -1590,7 +1590,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumC",
+          "un_EnumC",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -1631,7 +1631,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unEnumC",
+              "un_EnumC",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -1675,7 +1675,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumC",
+                      "un_EnumC",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1720,7 +1720,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumC",
+                      "un_EnumC",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1832,7 +1832,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumC",
+          "un_EnumC",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -1865,7 +1865,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumD",
+          "un_EnumD",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -1906,7 +1906,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unEnumD",
+              "un_EnumD",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -1950,7 +1950,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumD",
+                      "un_EnumD",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -1995,7 +1995,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unEnumD",
+                      "un_EnumD",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -2107,7 +2107,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unEnumD_t",
+          "un_EnumD_t",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -11,7 +11,7 @@ import qualified Foreign.C as FC
 import Prelude ((<*>), Enum, Eq, Int, Ord, Read, Show, pure)
 
 newtype First = First
-  { unFirst :: FC.CUInt
+  { un_First :: FC.CUInt
   }
 
 instance F.Storable First where
@@ -29,7 +29,7 @@ instance F.Storable First where
     \ptr0 ->
       \s1 ->
         case s1 of
-          First unFirst2 -> F.pokeByteOff ptr0 (0 :: Int) unFirst2
+          First un_First2 -> F.pokeByteOff ptr0 (0 :: Int) un_First2
 
 deriving stock instance Show First
 
@@ -48,7 +48,7 @@ pattern FIRST2 :: First
 pattern FIRST2 = First 1
 
 newtype Second = Second
-  { unSecond :: FC.CInt
+  { un_Second :: FC.CInt
   }
 
 instance F.Storable Second where
@@ -66,7 +66,7 @@ instance F.Storable Second where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Second unSecond2 -> F.pokeByteOff ptr0 (0 :: Int) unSecond2
+          Second un_Second2 -> F.pokeByteOff ptr0 (0 :: Int) un_Second2
 
 deriving stock instance Show Second
 
@@ -88,7 +88,7 @@ pattern SECOND_C :: Second
 pattern SECOND_C = Second 1
 
 newtype Same = Same
-  { unSame :: FC.CUInt
+  { un_Same :: FC.CUInt
   }
 
 instance F.Storable Same where
@@ -106,7 +106,7 @@ instance F.Storable Same where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Same unSame2 -> F.pokeByteOff ptr0 (0 :: Int) unSame2
+          Same un_Same2 -> F.pokeByteOff ptr0 (0 :: Int) un_Same2
 
 deriving stock instance Show Same
 
@@ -125,7 +125,7 @@ pattern SAME_B :: Same
 pattern SAME_B = Same 1
 
 newtype Packad = Packad
-  { unPackad :: FC.CSChar
+  { un_Packad :: FC.CSChar
   }
 
 instance F.Storable Packad where
@@ -143,7 +143,7 @@ instance F.Storable Packad where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Packad unPackad2 -> F.pokeByteOff ptr0 (0 :: Int) unPackad2
+          Packad un_Packad2 -> F.pokeByteOff ptr0 (0 :: Int) un_Packad2
 
 deriving stock instance Show Packad
 
@@ -165,7 +165,7 @@ pattern PACKED_C :: Packad
 pattern PACKED_C = Packad 2
 
 newtype EnumA = EnumA
-  { unEnumA :: FC.CUInt
+  { un_EnumA :: FC.CUInt
   }
 
 instance F.Storable EnumA where
@@ -183,7 +183,7 @@ instance F.Storable EnumA where
     \ptr0 ->
       \s1 ->
         case s1 of
-          EnumA unEnumA2 -> F.pokeByteOff ptr0 (0 :: Int) unEnumA2
+          EnumA un_EnumA2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumA2
 
 deriving stock instance Show EnumA
 
@@ -202,13 +202,13 @@ pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
 
 newtype EnumA = EnumA
-  { unEnumA :: EnumA
+  { un_EnumA :: EnumA
   }
 
 deriving newtype instance F.Storable EnumA
 
 newtype EnumB = EnumB
-  { unEnumB :: FC.CUInt
+  { un_EnumB :: FC.CUInt
   }
 
 instance F.Storable EnumB where
@@ -226,7 +226,7 @@ instance F.Storable EnumB where
     \ptr0 ->
       \s1 ->
         case s1 of
-          EnumB unEnumB2 -> F.pokeByteOff ptr0 (0 :: Int) unEnumB2
+          EnumB un_EnumB2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumB2
 
 deriving stock instance Show EnumB
 
@@ -245,13 +245,13 @@ pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
 
 newtype EnumB = EnumB
-  { unEnumB :: EnumB
+  { un_EnumB :: EnumB
   }
 
 deriving newtype instance F.Storable EnumB
 
 newtype EnumC = EnumC
-  { unEnumC :: FC.CUInt
+  { un_EnumC :: FC.CUInt
   }
 
 instance F.Storable EnumC where
@@ -269,7 +269,7 @@ instance F.Storable EnumC where
     \ptr0 ->
       \s1 ->
         case s1 of
-          EnumC unEnumC2 -> F.pokeByteOff ptr0 (0 :: Int) unEnumC2
+          EnumC un_EnumC2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumC2
 
 deriving stock instance Show EnumC
 
@@ -288,13 +288,13 @@ pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
 
 newtype EnumC = EnumC
-  { unEnumC :: EnumC
+  { un_EnumC :: EnumC
   }
 
 deriving newtype instance F.Storable EnumC
 
 newtype EnumD = EnumD
-  { unEnumD :: FC.CUInt
+  { un_EnumD :: FC.CUInt
   }
 
 instance F.Storable EnumD where
@@ -312,7 +312,7 @@ instance F.Storable EnumD where
     \ptr0 ->
       \s1 ->
         case s1 of
-          EnumD unEnumD2 -> F.pokeByteOff ptr0 (0 :: Int) unEnumD2
+          EnumD un_EnumD2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumD2
 
 deriving stock instance Show EnumD
 
@@ -331,7 +331,7 @@ pattern D_BAR :: EnumD
 pattern D_BAR = EnumD 1
 
 newtype EnumD_t = EnumD_t
-  { unEnumD_t :: EnumD
+  { un_EnumD_t :: EnumD
   }
 
 deriving newtype instance F.Storable EnumD_t

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -1,10 +1,10 @@
-newtype First = First {unFirst :: CUInt}
+newtype First = First {un_First :: CUInt}
 instance Storable First
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure First <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {First unFirst_3 -> pokeByteOff ptr_1 (0 :: Int) unFirst_3}}
+                                    {First un_First_3 -> pokeByteOff ptr_1 (0 :: Int) un_First_3}}
 deriving stock instance Show First
 deriving stock instance Read First
 deriving stock instance Eq First
@@ -14,13 +14,13 @@ pattern FIRST1 :: First
 pattern FIRST1 = First 0
 pattern FIRST2 :: First
 pattern FIRST2 = First 1
-newtype Second = Second {unSecond :: CInt}
+newtype Second = Second {un_Second :: CInt}
 instance Storable Second
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Second <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Second unSecond_3 -> pokeByteOff ptr_1 (0 :: Int) unSecond_3}}
+                                    {Second un_Second_3 -> pokeByteOff ptr_1 (0 :: Int) un_Second_3}}
 deriving stock instance Show Second
 deriving stock instance Read Second
 deriving stock instance Eq Second
@@ -32,13 +32,13 @@ pattern SECOND_B :: Second
 pattern SECOND_B = Second 0
 pattern SECOND_C :: Second
 pattern SECOND_C = Second 1
-newtype Same = Same {unSame :: CUInt}
+newtype Same = Same {un_Same :: CUInt}
 instance Storable Same
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Same <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Same unSame_3 -> pokeByteOff ptr_1 (0 :: Int) unSame_3}}
+                                    {Same un_Same_3 -> pokeByteOff ptr_1 (0 :: Int) un_Same_3}}
 deriving stock instance Show Same
 deriving stock instance Read Same
 deriving stock instance Eq Same
@@ -48,13 +48,13 @@ pattern SAME_A :: Same
 pattern SAME_A = Same 1
 pattern SAME_B :: Same
 pattern SAME_B = Same 1
-newtype Packad = Packad {unPackad :: CSChar}
+newtype Packad = Packad {un_Packad :: CSChar}
 instance Storable Packad
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure Packad <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Packad unPackad_3 -> pokeByteOff ptr_1 (0 :: Int) unPackad_3}}
+                                    {Packad un_Packad_3 -> pokeByteOff ptr_1 (0 :: Int) un_Packad_3}}
 deriving stock instance Show Packad
 deriving stock instance Read Packad
 deriving stock instance Eq Packad
@@ -66,13 +66,13 @@ pattern PACKED_B :: Packad
 pattern PACKED_B = Packad 1
 pattern PACKED_C :: Packad
 pattern PACKED_C = Packad 2
-newtype EnumA = EnumA {unEnumA :: CUInt}
+newtype EnumA = EnumA {un_EnumA :: CUInt}
 instance Storable EnumA
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumA <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {EnumA unEnumA_3 -> pokeByteOff ptr_1 (0 :: Int) unEnumA_3}}
+                                    {EnumA un_EnumA_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumA_3}}
 deriving stock instance Show EnumA
 deriving stock instance Read EnumA
 deriving stock instance Eq EnumA
@@ -82,15 +82,15 @@ pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
-newtype EnumA = EnumA {unEnumA :: EnumA}
+newtype EnumA = EnumA {un_EnumA :: EnumA}
 deriving newtype instance Storable EnumA
-newtype EnumB = EnumB {unEnumB :: CUInt}
+newtype EnumB = EnumB {un_EnumB :: CUInt}
 instance Storable EnumB
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumB <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {EnumB unEnumB_3 -> pokeByteOff ptr_1 (0 :: Int) unEnumB_3}}
+                                    {EnumB un_EnumB_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumB_3}}
 deriving stock instance Show EnumB
 deriving stock instance Read EnumB
 deriving stock instance Eq EnumB
@@ -100,15 +100,15 @@ pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
-newtype EnumB = EnumB {unEnumB :: EnumB}
+newtype EnumB = EnumB {un_EnumB :: EnumB}
 deriving newtype instance Storable EnumB
-newtype EnumC = EnumC {unEnumC :: CUInt}
+newtype EnumC = EnumC {un_EnumC :: CUInt}
 instance Storable EnumC
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumC <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {EnumC unEnumC_3 -> pokeByteOff ptr_1 (0 :: Int) unEnumC_3}}
+                                    {EnumC un_EnumC_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumC_3}}
 deriving stock instance Show EnumC
 deriving stock instance Read EnumC
 deriving stock instance Eq EnumC
@@ -118,15 +118,15 @@ pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
-newtype EnumC = EnumC {unEnumC :: EnumC}
+newtype EnumC = EnumC {un_EnumC :: EnumC}
 deriving newtype instance Storable EnumC
-newtype EnumD = EnumD {unEnumD :: CUInt}
+newtype EnumD = EnumD {un_EnumD :: CUInt}
 instance Storable EnumD
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumD <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {EnumD unEnumD_3 -> pokeByteOff ptr_1 (0 :: Int) unEnumD_3}}
+                                    {EnumD un_EnumD_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumD_3}}
 deriving stock instance Show EnumD
 deriving stock instance Read EnumD
 deriving stock instance Eq EnumD
@@ -136,5 +136,5 @@ pattern D_FOO :: EnumD
 pattern D_FOO = EnumD 0
 pattern D_BAR :: EnumD
 pattern D_BAR = EnumD 1
-newtype EnumD_t = EnumD_t {unEnumD_t :: EnumD}
+newtype EnumD_t = EnumD_t {un_EnumD_t :: EnumD}
 deriving newtype instance Storable EnumD_t

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unTriple",
+          "un_Triple",
         fieldType = HsConstArray
           3
           (HsPrimType HsPrimCInt),

--- a/hs-bindgen/fixtures/fixedarray.pp.hs
+++ b/hs-bindgen/fixtures/fixedarray.pp.hs
@@ -12,7 +12,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 newtype Triple = Triple
-  { unTriple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
+  { un_Triple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
 
 deriving newtype instance F.Storable Triple

--- a/hs-bindgen/fixtures/fixedarray.th.txt
+++ b/hs-bindgen/fixtures/fixedarray.th.txt
@@ -1,4 +1,4 @@
-newtype Triple = Triple {unTriple :: (ConstantArray 3 CInt)}
+newtype Triple = Triple {un_Triple :: (ConstantArray 3 CInt)}
 deriving newtype instance Storable Triple
 data Example
     = Example {example_triple :: (ConstantArray 3 CInt),

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint64_t",
+          "un_Uint64_t",
         fieldType = HsPrimType
           HsPrimCULong,
         fieldOrigin = FieldOriginNone},
@@ -113,7 +113,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint32_t",
+          "un_Uint32_t",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/fixedwidth.pp.hs
+++ b/hs-bindgen/fixtures/fixedwidth.pp.hs
@@ -13,7 +13,7 @@ import qualified Foreign.C as FC
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 newtype Uint64_t = Uint64_t
-  { unUint64_t :: FC.CULong
+  { un_Uint64_t :: FC.CULong
   }
 
 deriving newtype instance F.Storable Uint64_t
@@ -43,7 +43,7 @@ deriving newtype instance Num Uint64_t
 deriving newtype instance Real Uint64_t
 
 newtype Uint32_t = Uint32_t
-  { unUint32_t :: FC.CUInt
+  { un_Uint32_t :: FC.CUInt
   }
 
 deriving newtype instance F.Storable Uint32_t

--- a/hs-bindgen/fixtures/fixedwidth.th.txt
+++ b/hs-bindgen/fixtures/fixedwidth.th.txt
@@ -1,4 +1,4 @@
-newtype Uint64_t = Uint64_t {unUint64_t :: CULong}
+newtype Uint64_t = Uint64_t {un_Uint64_t :: CULong}
 deriving newtype instance Storable Uint64_t
 deriving stock instance Eq Uint64_t
 deriving stock instance Ord Uint64_t
@@ -12,7 +12,7 @@ deriving newtype instance FiniteBits Uint64_t
 deriving newtype instance Integral Uint64_t
 deriving newtype instance Num Uint64_t
 deriving newtype instance Real Uint64_t
-newtype Uint32_t = Uint32_t {unUint32_t :: CUInt}
+newtype Uint32_t = Uint32_t {un_Uint32_t :: CUInt}
 deriving newtype instance Storable Uint32_t
 deriving stock instance Eq Uint32_t
 deriving stock instance Ord Uint32_t

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -222,7 +222,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unS1_t",
+          "un_S1_t",
         fieldType = HsTypRef
           (HsName "@NsTypeConstr" "S1"),
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/forward_declaration.pp.hs
+++ b/hs-bindgen/fixtures/forward_declaration.pp.hs
@@ -35,7 +35,7 @@ deriving stock instance Show S1
 deriving stock instance Eq S1
 
 newtype S1_t = S1_t
-  { unS1_t :: S1
+  { un_S1_t :: S1
   }
 
 deriving newtype instance F.Storable S1_t

--- a/hs-bindgen/fixtures/forward_declaration.th.txt
+++ b/hs-bindgen/fixtures/forward_declaration.th.txt
@@ -7,7 +7,7 @@ instance Storable S1
                                     {S1 s1_a_3 -> pokeByteOff ptr_1 (0 :: Int) s1_a_3}}
 deriving stock instance Show S1
 deriving stock instance Eq S1
-newtype S1_t = S1_t {unS1_t :: S1}
+newtype S1_t = S1_t {un_S1_t :: S1}
 deriving newtype instance Storable S1_t
 data S2 = S2 {s2_a :: CInt}
 instance Storable S2

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unI",
+          "un_I",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -94,7 +94,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unC",
+          "un_C",
         fieldType = HsPrimType
           HsPrimCChar,
         fieldOrigin = FieldOriginNone},
@@ -176,7 +176,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unF",
+          "un_F",
         fieldType = HsPrimType
           HsPrimCFloat,
         fieldOrigin = FieldOriginNone},
@@ -254,7 +254,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unL",
+          "un_L",
         fieldType = HsPrimType
           HsPrimCLong,
         fieldOrigin = FieldOriginNone},
@@ -338,7 +338,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unS",
+          "un_S",
         fieldType = HsPrimType
           HsPrimCShort,
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
@@ -15,7 +15,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 newtype I = I
-  { unI :: FC.CInt
+  { un_I :: FC.CInt
   }
 
 deriving newtype instance F.Storable I
@@ -45,7 +45,7 @@ deriving newtype instance Num I
 deriving newtype instance Real I
 
 newtype C = C
-  { unC :: FC.CChar
+  { un_C :: FC.CChar
   }
 
 deriving newtype instance F.Storable C
@@ -75,7 +75,7 @@ deriving newtype instance Num C
 deriving newtype instance Real C
 
 newtype F = F
-  { unF :: FC.CFloat
+  { un_F :: FC.CFloat
   }
 
 deriving newtype instance F.Storable F
@@ -103,7 +103,7 @@ deriving newtype instance RealFloat F
 deriving newtype instance RealFrac F
 
 newtype L = L
-  { unL :: FC.CLong
+  { un_L :: FC.CLong
   }
 
 deriving newtype instance F.Storable L
@@ -133,7 +133,7 @@ deriving newtype instance Num L
 deriving newtype instance Real L
 
 newtype S = S
-  { unS :: FC.CShort
+  { un_S :: FC.CShort
   }
 
 deriving newtype instance F.Storable S

--- a/hs-bindgen/fixtures/macro_in_fundecl.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.th.txt
@@ -1,4 +1,4 @@
-newtype I = I {unI :: CInt}
+newtype I = I {un_I :: CInt}
 deriving newtype instance Storable I
 deriving stock instance Eq I
 deriving stock instance Ord I
@@ -12,7 +12,7 @@ deriving newtype instance FiniteBits I
 deriving newtype instance Integral I
 deriving newtype instance Num I
 deriving newtype instance Real I
-newtype C = C {unC :: CChar}
+newtype C = C {un_C :: CChar}
 deriving newtype instance Storable C
 deriving stock instance Eq C
 deriving stock instance Ord C
@@ -26,7 +26,7 @@ deriving newtype instance FiniteBits C
 deriving newtype instance Integral C
 deriving newtype instance Num C
 deriving newtype instance Real C
-newtype F = F {unF :: CFloat}
+newtype F = F {un_F :: CFloat}
 deriving newtype instance Storable F
 deriving stock instance Eq F
 deriving stock instance Ord F
@@ -39,7 +39,7 @@ deriving newtype instance Num F
 deriving newtype instance Real F
 deriving newtype instance RealFloat F
 deriving newtype instance RealFrac F
-newtype L = L {unL :: CLong}
+newtype L = L {un_L :: CLong}
 deriving newtype instance Storable L
 deriving stock instance Eq L
 deriving stock instance Ord L
@@ -53,7 +53,7 @@ deriving newtype instance FiniteBits L
 deriving newtype instance Integral L
 deriving newtype instance Num L
 deriving newtype instance Real L
-newtype S = S {unS :: CShort}
+newtype S = S {un_S :: CShort}
 deriving newtype instance Storable S
 deriving stock instance Eq S
 deriving stock instance Ord S

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -361,7 +361,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unLinked_list_A_t",
+          "un_Linked_list_A_t",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"

--- a/hs-bindgen/fixtures/recursive_struct.pp.hs
+++ b/hs-bindgen/fixtures/recursive_struct.pp.hs
@@ -39,7 +39,7 @@ deriving stock instance Show Linked_list_A_s
 deriving stock instance Eq Linked_list_A_s
 
 newtype Linked_list_A_t = Linked_list_A_t
-  { unLinked_list_A_t :: Linked_list_A_s
+  { un_Linked_list_A_t :: Linked_list_A_s
   }
 
 deriving newtype instance F.Storable Linked_list_A_t

--- a/hs-bindgen/fixtures/recursive_struct.th.txt
+++ b/hs-bindgen/fixtures/recursive_struct.th.txt
@@ -11,7 +11,7 @@ instance Storable Linked_list_A_s
 deriving stock instance Show Linked_list_A_s
 deriving stock instance Eq Linked_list_A_s
 newtype Linked_list_A_t
-    = Linked_list_A_t {unLinked_list_A_t :: Linked_list_A_s}
+    = Linked_list_A_t {un_Linked_list_A_t :: Linked_list_A_s}
 deriving newtype instance Storable Linked_list_A_t
 data Linked_list_B_t
     = Linked_list_B_t {linked_list_B_t_x :: CInt,

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -730,7 +730,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unS2_t",
+          "un_S2_t",
         fieldType = HsTypRef
           (HsName "@NsTypeConstr" "S2"),
         fieldOrigin = FieldOriginNone},
@@ -2329,7 +2329,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unS7a",
+          "un_S7a",
         fieldType = HsPtr
           (HsTypRef
             (HsName
@@ -2690,7 +2690,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unS7b",
+          "un_S7b",
         fieldType = HsPtr
           (HsPtr
             (HsPtr

--- a/hs-bindgen/fixtures/simple_structs.pp.hs
+++ b/hs-bindgen/fixtures/simple_structs.pp.hs
@@ -71,7 +71,7 @@ deriving stock instance Show S2
 deriving stock instance Eq S2
 
 newtype S2_t = S2_t
-  { unS2_t :: S2
+  { un_S2_t :: S2
   }
 
 deriving newtype instance F.Storable S2_t
@@ -221,7 +221,7 @@ deriving stock instance Show S7a_Deref
 deriving stock instance Eq S7a_Deref
 
 newtype S7a = S7a
-  { unS7a :: F.Ptr S7a_Deref
+  { un_S7a :: F.Ptr S7a_Deref
   }
 
 deriving newtype instance F.Storable S7a
@@ -256,7 +256,7 @@ deriving stock instance Show S7b_Deref_Deref_Deref
 deriving stock instance Eq S7b_Deref_Deref_Deref
 
 newtype S7b = S7b
-  { unS7b :: F.Ptr (F.Ptr (F.Ptr S7b_Deref_Deref_Deref))
+  { un_S7b :: F.Ptr (F.Ptr (F.Ptr S7b_Deref_Deref_Deref))
   }
 
 deriving newtype instance F.Storable S7b

--- a/hs-bindgen/fixtures/simple_structs.th.txt
+++ b/hs-bindgen/fixtures/simple_structs.th.txt
@@ -19,7 +19,7 @@ instance Storable S2
                                         s2_c_5 -> pokeByteOff ptr_1 (0 :: Int) s2_a_3 >> (pokeByteOff ptr_1 (4 :: Int) s2_b_4 >> pokeByteOff ptr_1 (8 :: Int) s2_c_5)}}
 deriving stock instance Show S2
 deriving stock instance Eq S2
-newtype S2_t = S2_t {unS2_t :: S2}
+newtype S2_t = S2_t {un_S2_t :: S2}
 deriving newtype instance Storable S2_t
 data S3_t = S3_t {s3_t_a :: CChar}
 instance Storable S3_t
@@ -72,7 +72,7 @@ instance Storable S7a_Deref
                                                s7a_Deref_b_4 -> pokeByteOff ptr_1 (0 :: Int) s7a_Deref_a_3 >> pokeByteOff ptr_1 (4 :: Int) s7a_Deref_b_4}}
 deriving stock instance Show S7a_Deref
 deriving stock instance Eq S7a_Deref
-newtype S7a = S7a {unS7a :: (Ptr S7a_Deref)}
+newtype S7a = S7a {un_S7a :: (Ptr S7a_Deref)}
 deriving newtype instance Storable S7a
 data S7b_Deref_Deref_Deref
     = S7b_Deref_Deref_Deref {s7b_Deref_Deref_Deref_a :: CChar,
@@ -87,5 +87,5 @@ instance Storable S7b_Deref_Deref_Deref
 deriving stock instance Show S7b_Deref_Deref_Deref
 deriving stock instance Eq S7b_Deref_Deref_Deref
 newtype S7b
-    = S7b {unS7b :: (Ptr (Ptr (Ptr S7b_Deref_Deref_Deref)))}
+    = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Deref_Deref_Deref)))}
 deriving newtype instance Storable S7b

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unM1",
+          "un_M1",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -94,7 +94,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unM2",
+          "un_M2",
         fieldType = HsPrimType
           HsPrimCChar,
         fieldOrigin = FieldOriginNone},
@@ -176,7 +176,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unM3",
+          "un_M3",
         fieldType = HsConstArray
           3
           (HsPrimType HsPrimCInt),
@@ -215,7 +215,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unUint64_t",
+          "un_Uint64_t",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -325,7 +325,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unT1",
+          "un_T1",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -400,7 +400,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unT2",
+          "un_T2",
         fieldType = HsPrimType
           HsPrimCChar,
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
@@ -14,7 +14,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 newtype M1 = M1
-  { unM1 :: FC.CInt
+  { un_M1 :: FC.CInt
   }
 
 deriving newtype instance F.Storable M1
@@ -44,7 +44,7 @@ deriving newtype instance Num M1
 deriving newtype instance Real M1
 
 newtype M2 = M2
-  { unM2 :: FC.CChar
+  { un_M2 :: FC.CChar
   }
 
 deriving newtype instance F.Storable M2
@@ -74,13 +74,13 @@ deriving newtype instance Num M2
 deriving newtype instance Real M2
 
 newtype M3 = M3
-  { unM3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
+  { un_M3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
 
 deriving newtype instance F.Storable M3
 
 newtype Uint64_t = Uint64_t
-  { unUint64_t :: FC.CInt
+  { un_Uint64_t :: FC.CInt
   }
 
 deriving newtype instance F.Storable Uint64_t
@@ -110,7 +110,7 @@ deriving newtype instance Num Uint64_t
 deriving newtype instance Real Uint64_t
 
 newtype T1 = T1
-  { unT1 :: FC.CInt
+  { un_T1 :: FC.CInt
   }
 
 deriving newtype instance F.Storable T1
@@ -140,7 +140,7 @@ deriving newtype instance Num T1
 deriving newtype instance Real T1
 
 newtype T2 = T2
-  { unT2 :: FC.CChar
+  { un_T2 :: FC.CChar
   }
 
 deriving newtype instance F.Storable T2

--- a/hs-bindgen/fixtures/typedef_vs_macro.th.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.th.txt
@@ -1,4 +1,4 @@
-newtype M1 = M1 {unM1 :: CInt}
+newtype M1 = M1 {un_M1 :: CInt}
 deriving newtype instance Storable M1
 deriving stock instance Eq M1
 deriving stock instance Ord M1
@@ -12,7 +12,7 @@ deriving newtype instance FiniteBits M1
 deriving newtype instance Integral M1
 deriving newtype instance Num M1
 deriving newtype instance Real M1
-newtype M2 = M2 {unM2 :: CChar}
+newtype M2 = M2 {un_M2 :: CChar}
 deriving newtype instance Storable M2
 deriving stock instance Eq M2
 deriving stock instance Ord M2
@@ -26,9 +26,9 @@ deriving newtype instance FiniteBits M2
 deriving newtype instance Integral M2
 deriving newtype instance Num M2
 deriving newtype instance Real M2
-newtype M3 = M3 {unM3 :: (ConstantArray 3 CInt)}
+newtype M3 = M3 {un_M3 :: (ConstantArray 3 CInt)}
 deriving newtype instance Storable M3
-newtype Uint64_t = Uint64_t {unUint64_t :: CInt}
+newtype Uint64_t = Uint64_t {un_Uint64_t :: CInt}
 deriving newtype instance Storable Uint64_t
 deriving stock instance Eq Uint64_t
 deriving stock instance Ord Uint64_t
@@ -42,7 +42,7 @@ deriving newtype instance FiniteBits Uint64_t
 deriving newtype instance Integral Uint64_t
 deriving newtype instance Num Uint64_t
 deriving newtype instance Real Uint64_t
-newtype T1 = T1 {unT1 :: CInt}
+newtype T1 = T1 {un_T1 :: CInt}
 deriving newtype instance Storable T1
 deriving stock instance Eq T1
 deriving stock instance Ord T1
@@ -56,7 +56,7 @@ deriving newtype instance FiniteBits T1
 deriving newtype instance Integral T1
 deriving newtype instance Num T1
 deriving newtype instance Real T1
-newtype T2 = T2 {unT2 :: CChar}
+newtype T2 = T2 {un_T2 :: CChar}
 deriving newtype instance Storable T2
 deriving stock instance Eq T2
 deriving stock instance Ord T2

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unMyint",
+          "un_Myint",
         fieldType = HsPrimType
           HsPrimCInt,
         fieldOrigin = FieldOriginNone},
@@ -111,7 +111,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unIntptr",
+          "un_Intptr",
         fieldType = HsPtr
           (HsPrimType HsPrimCInt),
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/typedefs.pp.hs
+++ b/hs-bindgen/fixtures/typedefs.pp.hs
@@ -13,7 +13,7 @@ import qualified Foreign.C as FC
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 newtype Myint = Myint
-  { unMyint :: FC.CInt
+  { un_Myint :: FC.CInt
   }
 
 deriving newtype instance F.Storable Myint
@@ -43,7 +43,7 @@ deriving newtype instance Num Myint
 deriving newtype instance Real Myint
 
 newtype Intptr = Intptr
-  { unIntptr :: F.Ptr FC.CInt
+  { un_Intptr :: F.Ptr FC.CInt
   }
 
 deriving newtype instance F.Storable Intptr

--- a/hs-bindgen/fixtures/typedefs.th.txt
+++ b/hs-bindgen/fixtures/typedefs.th.txt
@@ -1,4 +1,4 @@
-newtype Myint = Myint {unMyint :: CInt}
+newtype Myint = Myint {un_Myint :: CInt}
 deriving newtype instance Storable Myint
 deriving stock instance Eq Myint
 deriving stock instance Ord Myint
@@ -12,5 +12,5 @@ deriving newtype instance FiniteBits Myint
 deriving newtype instance Integral Myint
 deriving newtype instance Num Myint
 deriving newtype instance Real Myint
-newtype Intptr = Intptr {unIntptr :: (Ptr CInt)}
+newtype Intptr = Intptr {un_Intptr :: (Ptr CInt)}
 deriving newtype instance Storable Intptr

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unFoo",
+          "un_Foo",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -51,7 +51,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unFoo",
+              "un_Foo",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -96,7 +96,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unFoo",
+                      "un_Foo",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -141,7 +141,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unFoo",
+                      "un_Foo",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -244,7 +244,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unFoo",
+          "un_Foo",
         fieldType = HsPrimType
           HsPrimCDouble,
         fieldOrigin = FieldOriginNone},

--- a/hs-bindgen/fixtures/typenames.pp.hs
+++ b/hs-bindgen/fixtures/typenames.pp.hs
@@ -11,7 +11,7 @@ import qualified Foreign.C as FC
 import Prelude ((<*>), Enum, Eq, Floating, Fractional, Int, Num, Ord, Read, Real, RealFloat, RealFrac, Show, pure)
 
 newtype Foo = Foo
-  { unFoo :: FC.CUInt
+  { un_Foo :: FC.CUInt
   }
 
 instance F.Storable Foo where
@@ -29,7 +29,7 @@ instance F.Storable Foo where
     \ptr0 ->
       \s1 ->
         case s1 of
-          Foo unFoo2 -> F.pokeByteOff ptr0 (0 :: Int) unFoo2
+          Foo un_Foo2 -> F.pokeByteOff ptr0 (0 :: Int) un_Foo2
 
 deriving stock instance Show Foo
 
@@ -48,7 +48,7 @@ pattern FOO2 :: Foo
 pattern FOO2 = Foo 1
 
 newtype Foo = Foo
-  { unFoo :: FC.CDouble
+  { un_Foo :: FC.CDouble
   }
 
 deriving newtype instance F.Storable Foo

--- a/hs-bindgen/fixtures/typenames.th.txt
+++ b/hs-bindgen/fixtures/typenames.th.txt
@@ -1,10 +1,10 @@
-newtype Foo = Foo {unFoo :: CUInt}
+newtype Foo = Foo {un_Foo :: CUInt}
 instance Storable Foo
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {Foo unFoo_3 -> pokeByteOff ptr_1 (0 :: Int) unFoo_3}}
+                                    {Foo un_Foo_3 -> pokeByteOff ptr_1 (0 :: Int) un_Foo_3}}
 deriving stock instance Show Foo
 deriving stock instance Read Foo
 deriving stock instance Eq Foo
@@ -14,7 +14,7 @@ pattern FOO1 :: Foo
 pattern FOO1 = Foo 0
 pattern FOO2 :: Foo
 pattern FOO2 = Foo 1
-newtype Foo = Foo {unFoo :: CDouble}
+newtype Foo = Foo {un_Foo :: CDouble}
 deriving newtype instance Storable Foo
 deriving stock instance Eq Foo
 deriving stock instance Ord Foo

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -730,7 +730,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unDimPayload",
+          "un_DimPayload",
         fieldType = HsByteArray,
         fieldOrigin = FieldOriginNone},
       newtypeOrigin =
@@ -1150,7 +1150,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unDimPayloadB",
+          "un_DimPayloadB",
         fieldType = HsByteArray,
         fieldOrigin = FieldOriginNone},
       newtypeOrigin =
@@ -1235,7 +1235,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unDimPayloadB",
+          "un_DimPayloadB",
         fieldType = HsTypRef
           (HsName
             "@NsTypeConstr"
@@ -2234,7 +2234,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unAnonA",
+          "un_AnonA",
         fieldType = HsByteArray,
         fieldOrigin = FieldOriginNone},
       newtypeOrigin =

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -76,7 +76,7 @@ deriving stock instance Show Dim3
 deriving stock instance Eq Dim3
 
 newtype DimPayload = DimPayload
-  { unDimPayload :: Data.Array.Byte.ByteArray
+  { un_DimPayload :: Data.Array.Byte.ByteArray
   }
 
 deriving via (HsBindgen.Runtime.SizedByteArray.SizedByteArray 8) 4 instance F.Storable DimPayload
@@ -123,7 +123,7 @@ deriving stock instance Show Dim
 deriving stock instance Eq Dim
 
 newtype DimPayloadB = DimPayloadB
-  { unDimPayloadB :: Data.Array.Byte.ByteArray
+  { un_DimPayloadB :: Data.Array.Byte.ByteArray
   }
 
 deriving via (HsBindgen.Runtime.SizedByteArray.SizedByteArray 8) 4 instance F.Storable DimPayloadB
@@ -141,7 +141,7 @@ set_dimPayloadB_dim3 :: Dim2 -> DimPayloadB
 set_dimPayloadB_dim3 = HsBindgen.Runtime.ByteArray.setUnionPayload
 
 newtype DimPayloadB = DimPayloadB
-  { unDimPayloadB :: DimPayloadB
+  { un_DimPayloadB :: DimPayloadB
   }
 
 deriving newtype instance F.Storable DimPayloadB
@@ -234,7 +234,7 @@ deriving stock instance Show AnonA_polar
 deriving stock instance Eq AnonA_polar
 
 newtype AnonA = AnonA
-  { unAnonA :: Data.Array.Byte.ByteArray
+  { un_AnonA :: Data.Array.Byte.ByteArray
   }
 
 deriving via (HsBindgen.Runtime.SizedByteArray.SizedByteArray 16) 8 instance F.Storable AnonA

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -19,7 +19,7 @@ instance Storable Dim3
                                           dim3_z_5 -> pokeByteOff ptr_1 (0 :: Int) dim3_x_3 >> (pokeByteOff ptr_1 (4 :: Int) dim3_y_4 >> pokeByteOff ptr_1 (8 :: Int) dim3_z_5)}}
 deriving stock instance Show Dim3
 deriving stock instance Eq Dim3
-newtype DimPayload = DimPayload {unDimPayload :: ByteArray}
+newtype DimPayload = DimPayload {un_DimPayload :: ByteArray}
 deriving via (SizedByteArray 8 4) instance Storable DimPayload
 get_dimPayload_dim2 :: DimPayload -> Dim2
 get_dimPayload_dim2 = getUnionPayload
@@ -39,7 +39,7 @@ instance Storable Dim
                                          dim_payload_4 -> pokeByteOff ptr_1 (0 :: Int) dim_tag_3 >> pokeByteOff ptr_1 (4 :: Int) dim_payload_4}}
 deriving stock instance Show Dim
 deriving stock instance Eq Dim
-newtype DimPayloadB = DimPayloadB {unDimPayloadB :: ByteArray}
+newtype DimPayloadB = DimPayloadB {un_DimPayloadB :: ByteArray}
 deriving via (SizedByteArray 8 4) instance Storable DimPayloadB
 get_dimPayloadB_dim2 :: DimPayloadB -> Dim2
 get_dimPayloadB_dim2 = getUnionPayload
@@ -49,7 +49,7 @@ get_dimPayloadB_dim3 :: DimPayloadB -> Dim2
 get_dimPayloadB_dim3 = getUnionPayload
 set_dimPayloadB_dim3 :: Dim2 -> DimPayloadB
 set_dimPayloadB_dim3 = setUnionPayload
-newtype DimPayloadB = DimPayloadB {unDimPayloadB :: DimPayloadB}
+newtype DimPayloadB = DimPayloadB {un_DimPayloadB :: DimPayloadB}
 deriving newtype instance Storable DimPayloadB
 data DimB = DimB {dimB_tag :: CInt, dimB_payload :: DimPayloadB}
 instance Storable DimB
@@ -83,7 +83,7 @@ instance Storable AnonA_polar
                                                  anonA_polar_p_4 -> pokeByteOff ptr_1 (0 :: Int) anonA_polar_r_3 >> pokeByteOff ptr_1 (8 :: Int) anonA_polar_p_4}}
 deriving stock instance Show AnonA_polar
 deriving stock instance Eq AnonA_polar
-newtype AnonA = AnonA {unAnonA :: ByteArray}
+newtype AnonA = AnonA {un_AnonA :: ByteArray}
 deriving via (SizedByteArray 16 8) instance Storable AnonA
 get_anonA_xy :: AnonA -> AnonA_xy
 get_anonA_xy = getUnionPayload

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -10,7 +10,7 @@
       newtypeField = Field {
         fieldName = HsName
           "@NsVar"
-          "unMyEnum",
+          "un_MyEnum",
         fieldType = HsPrimType
           HsPrimCUInt,
         fieldOrigin = FieldOriginNone},
@@ -53,7 +53,7 @@
           Field {
             fieldName = HsName
               "@NsVar"
-              "unMyEnum",
+              "un_MyEnum",
             fieldType = HsPrimType
               HsPrimCUInt,
             fieldOrigin = FieldOriginNone}],
@@ -100,7 +100,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unMyEnum",
+                      "un_MyEnum",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],
@@ -147,7 +147,7 @@
                   Field {
                     fieldName = HsName
                       "@NsVar"
-                      "unMyEnum",
+                      "un_MyEnum",
                     fieldType = HsPrimType
                       HsPrimCUInt,
                     fieldOrigin = FieldOriginNone}],

--- a/hs-bindgen/fixtures/uses_utf8.pp.hs
+++ b/hs-bindgen/fixtures/uses_utf8.pp.hs
@@ -11,7 +11,7 @@ import qualified Foreign.C as FC
 import Prelude ((<*>), Enum, Eq, Int, Ord, Read, Show, pure)
 
 newtype MyEnum = MyEnum
-  { unMyEnum :: FC.CUInt
+  { un_MyEnum :: FC.CUInt
   }
 
 instance F.Storable MyEnum where
@@ -29,7 +29,7 @@ instance F.Storable MyEnum where
     \ptr0 ->
       \s1 ->
         case s1 of
-          MyEnum unMyEnum2 -> F.pokeByteOff ptr0 (0 :: Int) unMyEnum2
+          MyEnum un_MyEnum2 -> F.pokeByteOff ptr0 (0 :: Int) un_MyEnum2
 
 deriving stock instance Show MyEnum
 

--- a/hs-bindgen/fixtures/uses_utf8.th.txt
+++ b/hs-bindgen/fixtures/uses_utf8.th.txt
@@ -1,10 +1,10 @@
-newtype MyEnum = MyEnum {unMyEnum :: CUInt}
+newtype MyEnum = MyEnum {un_MyEnum :: CUInt}
 instance Storable MyEnum
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure MyEnum <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
-                                    {MyEnum unMyEnum_3 -> pokeByteOff ptr_1 (0 :: Int) unMyEnum_3}}
+                                    {MyEnum un_MyEnum_3 -> pokeByteOff ptr_1 (0 :: Int) un_MyEnum_3}}
 deriving stock instance Show MyEnum
 deriving stock instance Read MyEnum
 deriving stock instance Eq MyEnum

--- a/hs-bindgen/src-internal/HsBindgen/Hs/NameMangler/DSL/ProduceCandidate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/NameMangler/DSL/ProduceCandidate.hs
@@ -41,6 +41,9 @@ data ProduceCandidate = ProduceCandidate {
       -- | Prefix used for 'NameDatacon'
     , partDatacon :: Text
 
+      -- | Prefix used for 'NameDecon'
+    , partDecon :: Text
+
       -- | Suffix to be used when constructing a name for 'DeclPathCtxtPtr'
     , partCtxtPtr :: Text
 
@@ -49,13 +52,6 @@ data ProduceCandidate = ProduceCandidate {
 
       -- | Prefix used for 'NameBuilder'
     , partBuilder :: Text
-
-      -- | Prefix used for 'NameDecon'
-      --
-      -- TODO: This is called @prefixDecon@ rather than @partDecon@ because in
-      -- the default name mangler we add @un@ rather than @un_@. This is
-      -- inconsistent with everything else, we might want to reconsider this.
-    , prefixDecon :: Text
     }
 
 {-------------------------------------------------------------------------------
@@ -67,10 +63,10 @@ produceCandidateDefault = ProduceCandidate {
       processCName  = id
     , prefixPart    = prefixSnakeCase
     , partDatacon   = ""
+    , partDecon     = "un"
     , partCtxtPtr   = "Deref"
     , partGetter    = "get"
     , partBuilder   = "set"
-    , prefixDecon   = "un"
     }
 
 -- | Attempt to produce idiomatic Haskell names
@@ -110,7 +106,7 @@ produceCandidate nm prod = aux
         prefixPart prod (partDatacon prod) <$>
           generatedName (NameTycon declPath)
     aux (NameDecon declPath) =
-        mappend (prefixDecon prod) <$>
+        prefixPart prod (partDecon prod) <$>
           generatedName (NameTycon declPath)
     aux (NameGetter declPath cname) =
         prefixPart prod (partGetter prod) <$>


### PR DESCRIPTION
As part of #527 it became apparent that we were somewhat inconsistent in the default name mangler; given something like

```c
typedef int myint;
```

we would generate

```haskell
newtype Myint = Myint
  { unMyint :: FC.CInt
  }
```

but everywhere else the default name mangler uses snake case to separate parts of a name. This PR fixes this, so that we now generate

```haskell
newtype Myint = Myint
  { un_Myint :: FC.CInt
  }
```

This makes the code very consistent (see the change to `ProduceCandidate`), and I think the output also more consistent.