### PR TITLE
External bindings fixes

### DIFF
--- a/clang/src/Clang/CNameSpelling.hs
+++ b/clang/src/Clang/CNameSpelling.hs
@@ -3,6 +3,7 @@ module Clang.CNameSpelling (
     CNameSpelling(..)
   ) where
 
+import Data.String
 import Data.Text (Text)
 
 {-------------------------------------------------------------------------------
@@ -15,4 +16,5 @@ import Data.Text (Text)
 --
 -- Examples: @int8_t@, @struct tm@
 newtype CNameSpelling = CNameSpelling { getCNameSpelling :: Text }
-  deriving newtype (Eq, Ord, Show)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Eq, IsString, Ord, Show)

--- a/clang/src/Clang/Paths.hs
+++ b/clang/src/Clang/Paths.hs
@@ -16,10 +16,10 @@ module Clang.Paths (
   ) where
 
 import Control.Exception (Exception(displayException))
+import Data.String
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.List qualified as List
-import Data.String (IsString(fromString))
 import System.FilePath qualified as FilePath
 
 {-------------------------------------------------------------------------------
@@ -34,7 +34,8 @@ import System.FilePath qualified as FilePath
 -- The format of the path is platform-dependent.  For example, different
 -- directory separators are used on different platforms.
 newtype SourcePath = SourcePath Text
-  deriving newtype (Eq, Ord, Show)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Eq, IsString, Ord, Show)
 
 -- | Get the 'FilePath' representation of a 'SourcePath'
 getSourcePath :: SourcePath -> FilePath
@@ -130,7 +131,5 @@ renderCHeaderIncludePath = \case
 -- that contains 'CIncludePathDir' @/usr/include@ may resolve to 'SourcePath'
 -- @/usr/include/stdint.h@.
 newtype CIncludePathDir = CIncludePathDir { getCIncludePathDir :: FilePath }
-  deriving newtype (Eq, Ord, Show)
-
-instance IsString CIncludePathDir where
-  fromString = CIncludePathDir
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Eq, IsString, Ord, Show)

--- a/hs-bindgen/fixtures/bool.extbindings.yaml
+++ b/hs-bindgen/fixtures/bool.extbindings.yaml
@@ -1,4 +1,10 @@
 types:
+- cname: BOOL
+  headers:
+  - bool.h
+  identifier: BOOL
+  module: Example
+  package: example
 - cname: struct bools1
   headers:
   - bool.h

--- a/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
@@ -1,1 +1,31 @@
-types: []
+types:
+- cname: C
+  headers:
+  - macro_in_fundecl.h
+  identifier: C
+  module: Example
+  package: example
+- cname: F
+  headers:
+  - macro_in_fundecl.h
+  identifier: F
+  module: Example
+  package: example
+- cname: I
+  headers:
+  - macro_in_fundecl.h
+  identifier: I
+  module: Example
+  package: example
+- cname: L
+  headers:
+  - macro_in_fundecl.h
+  identifier: L
+  module: Example
+  package: example
+- cname: S
+  headers:
+  - macro_in_fundecl.h
+  identifier: S
+  module: Example
+  package: example

--- a/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
@@ -1,17 +1,5 @@
 types:
-- cname: foo
-  headers:
-  - opaque_declaration.h
-  identifier: Foo
-  module: Example
-  package: example
-- cname: opaque_union
-  headers:
-  - opaque_declaration.h
-  identifier: Opaque_union
-  module: Example
-  package: example
-- cname: quu
+- cname: enum quu
   headers:
   - opaque_declaration.h
   identifier: Quu
@@ -27,5 +15,17 @@ types:
   headers:
   - opaque_declaration.h
   identifier: Baz
+  module: Example
+  package: example
+- cname: struct foo
+  headers:
+  - opaque_declaration.h
+  identifier: Foo
+  module: Example
+  package: example
+- cname: struct opaque_union
+  headers:
+  - opaque_declaration.h
+  identifier: Opaque_union
   module: Example
   package: example

--- a/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
@@ -1,4 +1,22 @@
 types:
+- cname: M1
+  headers:
+  - typedef_vs_macro.h
+  identifier: M1
+  module: Example
+  package: example
+- cname: M2
+  headers:
+  - typedef_vs_macro.h
+  identifier: M2
+  module: Example
+  package: example
+- cname: M3
+  headers:
+  - typedef_vs_macro.h
+  identifier: M3
+  module: Example
+  package: example
 - cname: T1
   headers:
   - typedef_vs_macro.h
@@ -21,5 +39,11 @@ types:
   headers:
   - typedef_vs_macro.h
   identifier: Foo
+  module: Example
+  package: example
+- cname: uint64_t
+  headers:
+  - typedef_vs_macro.h
+  identifier: Uint64_t
   module: Example
   package: example

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -179,6 +179,7 @@ library
     , hs-bindgen:internal
   build-depends:
       -- Inherited dependencies
+    , containers
     , filepath
     , template-haskell
 

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
@@ -63,14 +63,16 @@ import HsBindgen.Resolve
 -- Example: @hs-bindgen-runtime@
 newtype HsPackageName = HsPackageName { getHsPackageName :: Text }
   deriving stock (Generic)
-  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, Ord, Show)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, IsString, Ord, Show)
 
 -- | Haskell module name
 --
 -- Example: @HsBindgen.Runtime.LibC@
 newtype HsModuleName = HsModuleName { getHsModuleName :: Text }
   deriving stock (Generic)
-  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, Ord, Show)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, IsString, Ord, Show)
 
 -- | Haskell identifier
 --
@@ -80,7 +82,8 @@ newtype HsModuleName = HsModuleName { getHsModuleName :: Text }
 -- include a 'HsBindgen.Hs.AST.Namespace'.
 newtype HsIdentifier = HsIdentifier { getHsIdentifier :: Text }
   deriving stock (Generic)
-  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, Ord, Show)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, IsString, Ord, Show)
 
 -- | External identifier
 data ExtIdentifier = ExtIdentifier {

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
@@ -108,7 +108,7 @@ newtype UnresolvedExtBindings = UnresolvedExtBindings {
       unresolvedExtBindingsTypes ::
         Map CNameSpelling [(Set CHeaderIncludePath, ExtIdentifier)]
     }
-  deriving Show
+  deriving (Eq, Show)
 
 -- | External bindings with resolved header paths
 newtype ExtBindings = ExtBindings {
@@ -118,7 +118,7 @@ newtype ExtBindings = ExtBindings {
       extBindingsTypes ::
         Map CNameSpelling [(Set SourcePath, ExtIdentifier)]
     }
-  deriving Show
+  deriving (Eq, Show)
 
 {-------------------------------------------------------------------------------
   Exceptions

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -8,6 +8,7 @@ import Data.Set qualified as Set
 
 import Clang.CNameSpelling
 import Clang.Paths
+import HsBindgen.C.AST.Macro qualified as C
 import HsBindgen.C.AST.Name
 import HsBindgen.C.AST.Type qualified as C
 import HsBindgen.ExtBindings
@@ -103,7 +104,8 @@ getNewtypeExtBindings hsNewtype = fmap (, hsId) . catMaybes $
         [Just (CNameSpelling (getCName typedefName))]
       Hs.NewtypeOriginUnion C.Union{..} ->
         getCNS "union " unionDeclPath : map (Just . getCNS_alias) unionAliases
-      Hs.NewtypeOriginMacro{} -> []
+      Hs.NewtypeOriginMacro C.Macro{..} ->
+        [Just (CNameSpelling (getCName macroName))]
   where
     hsId :: HsIdentifier
     hsId = HsIdentifier $ getHsName (Hs.newtypeName hsNewtype)

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -85,10 +85,10 @@ getEmptyDataExtBindings :: Hs.EmptyData -> [(CNameSpelling, HsIdentifier)]
 getEmptyDataExtBindings edata = fmap (, hsId) . catMaybes $
     case Hs.emptyDataOrigin edata of
       Hs.EmptyDataOriginOpaqueStruct C.OpaqueStruct{..} ->
-        Just (CNameSpelling (getCName opaqueStructTag))
+        Just (CNameSpelling ("struct " <> getCName opaqueStructTag))
           : map (Just . getCNS_alias) opaqueStructAliases
       Hs.EmptyDataOriginOpaqueEnum C.OpaqueEnum{..} ->
-        Just (CNameSpelling (getCName opaqueEnumTag))
+        Just (CNameSpelling ("enum " <> getCName opaqueEnumTag))
           : map (Just . getCNS_alias) opaqueEnumAliases
   where
     hsId :: HsIdentifier

--- a/hs-bindgen/src-internal/HsBindgen/Orphans.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Orphans.hs
@@ -25,7 +25,7 @@ instance Aeson.FromJSON CHeaderIncludePath where
     . Text.unpack
 
 instance Aeson.ToJSON CHeaderIncludePath where
-  toJSON = Aeson.String . Text.pack . getCHeaderIncludePath
+  toJSON = Aeson.String . Text.pack . renderCHeaderIncludePath
 
 deriving newtype instance Aeson.FromJSON CNameSpelling
 

--- a/hs-bindgen/src-internal/HsBindgen/Resolve.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Resolve.hs
@@ -29,7 +29,7 @@ import HsBindgen.Imports
 -- | Failed to resolve a header
 newtype ResolveHeaderException =
     ResolveHeaderNotFound CHeaderIncludePath
-  deriving stock (Show)
+  deriving stock (Eq, Ord, Show)
 
 instance Exception ResolveHeaderException where
   displayException = \case

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -49,6 +49,7 @@ module HsBindgen.TH (
   , THSyntax.getPackageRoot
   ) where
 
+import Data.Set (Set)
 import Language.Haskell.TH qualified as TH
 import System.FilePath qualified as FilePath
 
@@ -82,5 +83,5 @@ import Language.Haskell.TH.Syntax qualified as THSyntax
 loadExtBindings ::
      Args.ClangArgs
   -> [FilePath]
-  -> TH.Q ([Resolve.ResolveHeaderException], ExtBindings.ExtBindings)
+  -> TH.Q (Set Resolve.ResolveHeaderException, ExtBindings.ExtBindings)
 loadExtBindings args = TH.runIO . ExtBindings.loadExtBindings args


### PR DESCRIPTION
This PR makes various fixes and additions to external bindings code:

* Ignoring missing headers when resolving headers for external bindings was not implemented correctly.  This issue is fixed.
* Generated external bindings for opaque `struct`s and `enum`s did not use the necessary prefix.  This issue is fixed.
* External bindings for `newtype` wrappers representing `#define` macros of types are now generated.
* The wrong function was accidentally used in the `CNameSpelling` `ToJSON` instance.  This issue is fixed.
* External bindings errors now use `Set`.  This ensures that there are no duplicates and makes it easier to test for equality.
* `IsString` instances are added to various types.
* `Eq` instances are added to `UnresolvedExtBindings` and `ExtBindings` for use in tests.

Most of these changes were previously part of the #524 branch, but they are put into this separate PR to make code review easier.  Another separate PR will refactor tests, and then #524 will just add external bindings tests.