### PR TITLE
Clarify control flow

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST.hs
@@ -62,6 +62,7 @@ module HsBindgen.C.AST (
   , DeclPath(..)
   , DeclPathCtxt(..)
   , topLevel
+  , declPathName
     -- * Source locations
   , SingleLoc(..)
   , MultiLoc(..)

--- a/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
@@ -25,6 +25,7 @@ module HsBindgen.C.AST.Type (
   , DeclPath(..)
   , DeclPathCtxt(..)
   , topLevel
+  , declPathName
   ) where
 
 import Clang.HighLevel.Types (SingleLoc)
@@ -315,3 +316,8 @@ data DeclPathCtxt =
 
 topLevel :: CName -> DeclPath
 topLevel cname = DeclPathName cname DeclPathCtxtTop
+
+-- | Name of the declared type, or 'Nothing' if anonymous
+declPathName :: DeclPath -> Maybe CName
+declPathName (DeclPathName name _ctxt) = Just name
+declPathName (DeclPathAnon _ctxt) = Nothing


### PR DESCRIPTION
It was a little difficult to see which cases we were distinguishing exactly, and we had some repeated code paths also. This clarifies this control flow, and uses the same code paths in multiple places, clarifying where there are inconsistencies (e.g., external bindings for unions).