### PR TITLE
Parenthesize negative Int literals in patterns

### DIFF
--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -79,7 +79,7 @@ deriving stock instance Ord Second
 deriving newtype instance Enum Second
 
 pattern SECOND_A :: Second
-pattern SECOND_A = Second -1
+pattern SECOND_A = Second (-1)
 
 pattern SECOND_B :: Second
 pattern SECOND_B = Second 0

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -220,7 +220,7 @@ prettyExpr env prec = \case
 
     EIntegral i Nothing  -> showToCtxDoc i
     EIntegral i (Just t) -> parens $ hcat [
-          showToCtxDoc i
+          parensWhen (i < 0) (showToCtxDoc i)
         , " :: "
         , prettyPrimType t
         ]

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -200,7 +200,7 @@ instance Pretty PatExpr where
 
 prettyPatExpr :: Int -> PatExpr -> CtxDoc
 prettyPatExpr prec = \case
-    PELit i -> showToCtxDoc i
+    PELit i -> parensWhen (i < 0) $ showToCtxDoc i
     PEApps n ps -> parensWhen (prec > 3) $ pretty n <+> hsep (map (prettyPatExpr 4) ps)
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
It is a parse error without parentheses:

```
hs-bindgen/fixtures/enums.pp.hs:82:20: error: [GHC-07626]
    Parse error in pattern: Second - 1
   |
82 | pattern SECOND_A = Second -1
   |                    ^^^^^^^^^
Failed, no modules loaded.
```

Parenthesizing when negative resolves the issue.

I noticed that the `SExpr` instance implementation has the same problem.  I do not know of an example that would cause a negative value here, but I went ahead and fixed the implementation so that it does not fail if/when we generate such code in the future.