### PR TITLE
Fix `enum` eponymous `typedef` issue

### DIFF
--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -818,41 +818,6 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
-        "Another_typedef_enum_e",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "Another_typedef_enum_e",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_Another_typedef_enum_e",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "Another_typedef_enum_e"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName
-            "another_typedef_enum_e",
-          typedefType = TypeEnum
-            (DeclPathAnon
-              (DeclPathCtxtTypedef
-                (CName
-                  "another_typedef_enum_e"))),
-          typedefSourceLoc =
-          "distilled_lib_1.h:9:27"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "Another_typedef_enum_e"),
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
         "A_type_t",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1530,9 +1495,11 @@
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName
-                  "another_typedef_enum_e"),
+              fieldType = TypeEnum
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
+                    (CName
+                      "another_typedef_enum_e"))),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"}},
         Field {
@@ -1553,9 +1520,11 @@
               fieldWidth = Nothing,
               fieldType = TypeConstArray
                 4
-                (TypeTypedef
-                  (CName
-                    "another_typedef_enum_e")),
+                (TypeEnum
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
+                      (CName
+                        "another_typedef_enum_e")))),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"}},
         Field {
@@ -1580,9 +1549,11 @@
                 5
                 (TypeConstArray
                   3
-                  (TypeTypedef
-                    (CName
-                      "another_typedef_enum_e"))),
+                  (TypeEnum
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName
+                          "another_typedef_enum_e"))))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}}],
       structOrigin =
@@ -1671,9 +1642,11 @@
               fieldName = CName "field_8",
               fieldOffset = 480,
               fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName
-                  "another_typedef_enum_e"),
+              fieldType = TypeEnum
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
+                    (CName
+                      "another_typedef_enum_e"))),
               fieldSourceLoc =
               "distilled_lib_1.h:44:31"},
             StructField {
@@ -1682,9 +1655,11 @@
               fieldWidth = Nothing,
               fieldType = TypeConstArray
                 4
-                (TypeTypedef
-                  (CName
-                    "another_typedef_enum_e")),
+                (TypeEnum
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
+                      (CName
+                        "another_typedef_enum_e")))),
               fieldSourceLoc =
               "distilled_lib_1.h:45:31"},
             StructField {
@@ -1695,9 +1670,11 @@
                 5
                 (TypeConstArray
                   3
-                  (TypeTypedef
-                    (CName
-                      "another_typedef_enum_e"))),
+                  (TypeEnum
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName
+                          "another_typedef_enum_e"))))),
               fieldSourceLoc =
               "distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
@@ -1878,9 +1855,11 @@
                 fieldName = CName "field_8",
                 fieldOffset = 480,
                 fieldWidth = Nothing,
-                fieldType = TypeTypedef
-                  (CName
-                    "another_typedef_enum_e"),
+                fieldType = TypeEnum
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
+                      (CName
+                        "another_typedef_enum_e"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"}},
           Field {
@@ -1901,9 +1880,11 @@
                 fieldWidth = Nothing,
                 fieldType = TypeConstArray
                   4
-                  (TypeTypedef
-                    (CName
-                      "another_typedef_enum_e")),
+                  (TypeEnum
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName
+                          "another_typedef_enum_e")))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"}},
           Field {
@@ -1928,9 +1909,11 @@
                   5
                   (TypeConstArray
                     3
-                    (TypeTypedef
-                      (CName
-                        "another_typedef_enum_e"))),
+                    (TypeEnum
+                      (DeclPathAnon
+                        (DeclPathCtxtTypedef
+                          (CName
+                            "another_typedef_enum_e"))))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}}],
         structOrigin =
@@ -2019,9 +2002,11 @@
                 fieldName = CName "field_8",
                 fieldOffset = 480,
                 fieldWidth = Nothing,
-                fieldType = TypeTypedef
-                  (CName
-                    "another_typedef_enum_e"),
+                fieldType = TypeEnum
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
+                      (CName
+                        "another_typedef_enum_e"))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:44:31"},
               StructField {
@@ -2030,9 +2015,11 @@
                 fieldWidth = Nothing,
                 fieldType = TypeConstArray
                   4
-                  (TypeTypedef
-                    (CName
-                      "another_typedef_enum_e")),
+                  (TypeEnum
+                    (DeclPathAnon
+                      (DeclPathCtxtTypedef
+                        (CName
+                          "another_typedef_enum_e")))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:45:31"},
               StructField {
@@ -2043,9 +2030,11 @@
                   5
                   (TypeConstArray
                     3
-                    (TypeTypedef
-                      (CName
-                        "another_typedef_enum_e"))),
+                    (TypeEnum
+                      (DeclPathAnon
+                        (DeclPathCtxtTypedef
+                          (CName
+                            "another_typedef_enum_e"))))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:46:31"}],
             structFlam = Nothing,
@@ -2231,9 +2220,11 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName
-                            "another_typedef_enum_e"),
+                        fieldType = TypeEnum
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2254,9 +2245,11 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeTypedef
-                            (CName
-                              "another_typedef_enum_e")),
+                          (TypeEnum
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
+                                (CName
+                                  "another_typedef_enum_e")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2281,9 +2274,11 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeTypedef
-                              (CName
-                                "another_typedef_enum_e"))),
+                            (TypeEnum
+                              (DeclPathAnon
+                                (DeclPathCtxtTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
@@ -2372,9 +2367,11 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName
-                            "another_typedef_enum_e"),
+                        fieldType = TypeEnum
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2383,9 +2380,11 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeTypedef
-                            (CName
-                              "another_typedef_enum_e")),
+                          (TypeEnum
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
+                                (CName
+                                  "another_typedef_enum_e")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2396,9 +2395,11 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeTypedef
-                              (CName
-                                "another_typedef_enum_e"))),
+                            (TypeEnum
+                              (DeclPathAnon
+                                (DeclPathCtxtTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -2595,9 +2596,11 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName
-                            "another_typedef_enum_e"),
+                        fieldType = TypeEnum
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"}},
                   Field {
@@ -2618,9 +2621,11 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeTypedef
-                            (CName
-                              "another_typedef_enum_e")),
+                          (TypeEnum
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
+                                (CName
+                                  "another_typedef_enum_e")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"}},
                   Field {
@@ -2645,9 +2650,11 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeTypedef
-                              (CName
-                                "another_typedef_enum_e"))),
+                            (TypeEnum
+                              (DeclPathAnon
+                                (DeclPathCtxtTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}}],
                 structOrigin =
@@ -2736,9 +2743,11 @@
                         fieldName = CName "field_8",
                         fieldOffset = 480,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName
-                            "another_typedef_enum_e"),
+                        fieldType = TypeEnum
+                          (DeclPathAnon
+                            (DeclPathCtxtTypedef
+                              (CName
+                                "another_typedef_enum_e"))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:44:31"},
                       StructField {
@@ -2747,9 +2756,11 @@
                         fieldWidth = Nothing,
                         fieldType = TypeConstArray
                           4
-                          (TypeTypedef
-                            (CName
-                              "another_typedef_enum_e")),
+                          (TypeEnum
+                            (DeclPathAnon
+                              (DeclPathCtxtTypedef
+                                (CName
+                                  "another_typedef_enum_e")))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:45:31"},
                       StructField {
@@ -2760,9 +2771,11 @@
                           5
                           (TypeConstArray
                             3
-                            (TypeTypedef
-                              (CName
-                                "another_typedef_enum_e"))),
+                            (TypeEnum
+                              (DeclPathAnon
+                                (DeclPathCtxtTypedef
+                                  (CName
+                                    "another_typedef_enum_e"))))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
@@ -3153,40 +3166,6 @@
           valueValue = 3,
           valueSourceLoc =
           "distilled_lib_1.h:65:3"}},
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
-        "A_typedef_enum_e",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "A_typedef_enum_e",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_A_typedef_enum_e",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "A_typedef_enum_e"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName
-            "a_typedef_enum_e",
-          typedefType = TypeEnum
-            (DeclPathAnon
-              (DeclPathCtxtTypedef
-                (CName "a_typedef_enum_e"))),
-          typedefSourceLoc =
-          "distilled_lib_1.h:66:13"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "A_typedef_enum_e"),
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -108,12 +108,6 @@ pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
 
-newtype Another_typedef_enum_e = Another_typedef_enum_e
-  { un_Another_typedef_enum_e :: Another_typedef_enum_e
-  }
-
-deriving newtype instance F.Storable Another_typedef_enum_e
-
 newtype A_type_t = A_type_t
   { un_A_type_t :: FC.CInt
   }
@@ -380,12 +374,6 @@ pattern ENUM_CASE_2 = A_typedef_enum_e 2
 
 pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
-
-newtype A_typedef_enum_e = A_typedef_enum_e
-  { un_A_typedef_enum_e :: A_typedef_enum_e
-  }
-
-deriving newtype instance F.Storable A_typedef_enum_e
 
 newtype Int32_t = Int32_t
   { un_Int32_t :: FC.CInt

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -44,9 +44,6 @@ pattern FOO :: Another_typedef_enum_e
 pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
 pattern BAR = Another_typedef_enum_e 1
-newtype Another_typedef_enum_e
-    = Another_typedef_enum_e {un_Another_typedef_enum_e :: Another_typedef_enum_e}
-deriving newtype instance Storable Another_typedef_enum_e
 newtype A_type_t = A_type_t {un_A_type_t :: CInt}
 deriving newtype instance Storable A_type_t
 deriving stock instance Eq A_type_t
@@ -174,9 +171,6 @@ pattern ENUM_CASE_2 :: A_typedef_enum_e
 pattern ENUM_CASE_2 = A_typedef_enum_e 2
 pattern ENUM_CASE_3 :: A_typedef_enum_e
 pattern ENUM_CASE_3 = A_typedef_enum_e 3
-newtype A_typedef_enum_e
-    = A_typedef_enum_e {un_A_typedef_enum_e :: A_typedef_enum_e}
-deriving newtype instance Storable A_typedef_enum_e
 newtype Int32_t = Int32_t {un_Int32_t :: CInt}
 deriving newtype instance Storable Int32_t
 deriving stock instance Eq Int32_t

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -379,17 +379,6 @@ Header
         "distilled_lib_1.h:9:9"},
     DeclTypedef
       Typedef {
-        typedefName = CName
-          "another_typedef_enum_e",
-        typedefType = TypeEnum
-          (DeclPathAnon
-            (DeclPathCtxtTypedef
-              (CName
-                "another_typedef_enum_e"))),
-        typedefSourceLoc =
-        "distilled_lib_1.h:9:27"},
-    DeclTypedef
-      Typedef {
         typedefName = CName "a_type_t",
         typedefType = TypePrim
           (PrimIntegral PrimInt Signed),
@@ -510,9 +499,11 @@ Header
             fieldName = CName "field_8",
             fieldOffset = 480,
             fieldWidth = Nothing,
-            fieldType = TypeTypedef
-              (CName
-                "another_typedef_enum_e"),
+            fieldType = TypeEnum
+              (DeclPathAnon
+                (DeclPathCtxtTypedef
+                  (CName
+                    "another_typedef_enum_e"))),
             fieldSourceLoc =
             "distilled_lib_1.h:44:31"},
           StructField {
@@ -521,9 +512,11 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeConstArray
               4
-              (TypeTypedef
-                (CName
-                  "another_typedef_enum_e")),
+              (TypeEnum
+                (DeclPathAnon
+                  (DeclPathCtxtTypedef
+                    (CName
+                      "another_typedef_enum_e")))),
             fieldSourceLoc =
             "distilled_lib_1.h:45:31"},
           StructField {
@@ -534,9 +527,11 @@ Header
               5
               (TypeConstArray
                 3
-                (TypeTypedef
-                  (CName
-                    "another_typedef_enum_e"))),
+                (TypeEnum
+                  (DeclPathAnon
+                    (DeclPathCtxtTypedef
+                      (CName
+                        "another_typedef_enum_e"))))),
             fieldSourceLoc =
             "distilled_lib_1.h:46:31"}],
         structFlam = Nothing,
@@ -585,16 +580,6 @@ Header
             "distilled_lib_1.h:65:3"}],
         enumSourceLoc =
         "distilled_lib_1.h:60:9"},
-    DeclTypedef
-      Typedef {
-        typedefName = CName
-          "a_typedef_enum_e",
-        typedefType = TypeEnum
-          (DeclPathAnon
-            (DeclPathCtxtTypedef
-              (CName "a_typedef_enum_e"))),
-        typedefSourceLoc =
-        "distilled_lib_1.h:66:13"},
     DeclTypedef
       Typedef {
         typedefName = CName "int32_t",

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -1273,39 +1273,6 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
-        "EnumA",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "EnumA",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_EnumA",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "EnumA"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName "enumA",
-          typedefType = TypeEnum
-            (DeclPathAnon
-              (DeclPathCtxtTypedef
-                (CName "enumA"))),
-          typedefSourceLoc =
-          "enums.h:24:31"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "EnumA"),
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
         "EnumB",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1323,7 +1290,7 @@
           enumDeclPath = DeclPathName
             (CName "enumB")
             DeclPathCtxtTop,
-          enumAliases = [],
+          enumAliases = [CName "enumB"],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1363,7 +1330,7 @@
             enumDeclPath = DeclPathName
               (CName "enumB")
               DeclPathCtxtTop,
-            enumAliases = [],
+            enumAliases = [CName "enumB"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1408,7 +1375,7 @@
                     enumDeclPath = DeclPathName
                       (CName "enumB")
                       DeclPathCtxtTop,
-                    enumAliases = [],
+                    enumAliases = [CName "enumB"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1453,7 +1420,7 @@
                     enumDeclPath = DeclPathName
                       (CName "enumB")
                       DeclPathCtxtTop,
-                    enumAliases = [],
+                    enumAliases = [CName "enumB"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1550,39 +1517,6 @@
     Newtype {
       newtypeName = HsName
         "@NsTypeConstr"
-        "EnumB",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "EnumB",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_EnumB",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "EnumB"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName "enumB",
-          typedefType = TypeEnum
-            (DeclPathName
-              (CName "enumB")
-              DeclPathCtxtTop),
-          typedefSourceLoc =
-          "enums.h:26:37"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "EnumB"),
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
         "EnumC",
       newtypeConstr = HsName
         "@NsConstr"
@@ -1600,7 +1534,7 @@
           enumDeclPath = DeclPathName
             (CName "enumC")
             DeclPathCtxtTop,
-          enumAliases = [],
+          enumAliases = [CName "enumC"],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           enumSizeof = 4,
@@ -1640,7 +1574,7 @@
             enumDeclPath = DeclPathName
               (CName "enumC")
               DeclPathCtxtTop,
-            enumAliases = [],
+            enumAliases = [CName "enumC"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
             enumSizeof = 4,
@@ -1684,7 +1618,7 @@
                     enumDeclPath = DeclPathName
                       (CName "enumC")
                       DeclPathCtxtTop,
-                    enumAliases = [],
+                    enumAliases = [CName "enumC"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1729,7 +1663,7 @@
                     enumDeclPath = DeclPathName
                       (CName "enumC")
                       DeclPathCtxtTop,
-                    enumAliases = [],
+                    enumAliases = [CName "enumC"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
                     enumSizeof = 4,
@@ -1821,39 +1755,6 @@
           valueValue = 1,
           valueSourceLoc =
           "enums.h:28:21"}},
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
-        "EnumC",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "EnumC",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_EnumC",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "EnumC"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName "enumC",
-          typedefType = TypeEnum
-            (DeclPathName
-              (CName "enumC")
-              DeclPathCtxtTop),
-          typedefSourceLoc =
-          "enums.h:29:20"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "EnumC"),
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -201,12 +201,6 @@ pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
 
-newtype EnumA = EnumA
-  { un_EnumA :: EnumA
-  }
-
-deriving newtype instance F.Storable EnumA
-
 newtype EnumB = EnumB
   { un_EnumB :: FC.CUInt
   }
@@ -244,12 +238,6 @@ pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
 
-newtype EnumB = EnumB
-  { un_EnumB :: EnumB
-  }
-
-deriving newtype instance F.Storable EnumB
-
 newtype EnumC = EnumC
   { un_EnumC :: FC.CUInt
   }
@@ -286,12 +274,6 @@ pattern C_FOO = EnumC 0
 
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
-
-newtype EnumC = EnumC
-  { un_EnumC :: EnumC
-  }
-
-deriving newtype instance F.Storable EnumC
 
 newtype EnumD = EnumD
   { un_EnumD :: FC.CUInt

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -82,8 +82,6 @@ pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
-newtype EnumA = EnumA {un_EnumA :: EnumA}
-deriving newtype instance Storable EnumA
 newtype EnumB = EnumB {un_EnumB :: CUInt}
 instance Storable EnumB
     where {sizeOf = \_ -> 4 :: Int;
@@ -100,8 +98,6 @@ pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
-newtype EnumB = EnumB {un_EnumB :: EnumB}
-deriving newtype instance Storable EnumB
 newtype EnumC = EnumC {un_EnumC :: CUInt}
 instance Storable EnumC
     where {sizeOf = \_ -> 4 :: Int;
@@ -118,8 +114,6 @@ pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
-newtype EnumC = EnumC {un_EnumC :: EnumC}
-deriving newtype instance Storable EnumC
 newtype EnumD = EnumD {un_EnumD :: CUInt}
 instance Storable EnumD
     where {sizeOf = \_ -> 4 :: Int;

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -134,21 +134,12 @@ Header
             valueSourceLoc =
             "enums.h:24:23"}],
         enumSourceLoc = "enums.h:24:9"},
-    DeclTypedef
-      Typedef {
-        typedefName = CName "enumA",
-        typedefType = TypeEnum
-          (DeclPathAnon
-            (DeclPathCtxtTypedef
-              (CName "enumA"))),
-        typedefSourceLoc =
-        "enums.h:24:31"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
           (CName "enumB")
           DeclPathCtxtTop,
-        enumAliases = [],
+        enumAliases = [CName "enumB"],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -166,21 +157,12 @@ Header
             "enums.h:26:29"}],
         enumSourceLoc =
         "enums.h:26:14"},
-    DeclTypedef
-      Typedef {
-        typedefName = CName "enumB",
-        typedefType = TypeEnum
-          (DeclPathName
-            (CName "enumB")
-            DeclPathCtxtTop),
-        typedefSourceLoc =
-        "enums.h:26:37"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
           (CName "enumC")
           DeclPathCtxtTop,
-        enumAliases = [],
+        enumAliases = [CName "enumC"],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
         enumSizeof = 4,
@@ -197,15 +179,6 @@ Header
             valueSourceLoc =
             "enums.h:28:21"}],
         enumSourceLoc = "enums.h:28:6"},
-    DeclTypedef
-      Typedef {
-        typedefName = CName "enumC",
-        typedefType = TypeEnum
-          (DeclPathName
-            (CName "enumC")
-            DeclPathCtxtTop),
-        typedefSourceLoc =
-        "enums.h:29:20"},
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -155,6 +155,12 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     TypeStruct (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
                             addAlias ty use
 
+                    TypeEnum (DeclPathName declName _ctxt) | declName == tag -> do
+                            updateDeclAddAlias ty' tag
+                            addAlias ty use
+                    TypeEnum (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
+                            addAlias ty use
+
                     _ -> do
                         --
                         -- record name-path properly in underlying struct. (something like Path)


### PR DESCRIPTION
Do not generate a `newtype` with a conflicting name when a `typedef` for an `enum` as the same name as the tag: `typdef enum foo {..} foo;`.