### PR TITLE
Fix codegen for eponymous union/typedef

### DIFF
--- a/hs-bindgen/fixtures/unions.exts.txt
+++ b/hs-bindgen/fixtures/unions.exts.txt
@@ -2,4 +2,3 @@ DataKinds
 StandaloneDeriving
 DerivingStrategies
 DerivingVia
-GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -1159,7 +1159,8 @@
           unionDeclPath = DeclPathName
             (CName "DimPayloadB")
             DeclPathCtxtTop,
-          unionAliases = [],
+          unionAliases = [
+            CName "DimPayloadB"],
           unionSizeof = 8,
           unionAlignment = 4,
           unionFields = [
@@ -1224,40 +1225,6 @@
     (HsName
       "@NsVar"
       "set_dimPayloadB_dim3"),
-  DeclNewtype
-    Newtype {
-      newtypeName = HsName
-        "@NsTypeConstr"
-        "DimPayloadB",
-      newtypeConstr = HsName
-        "@NsConstr"
-        "DimPayloadB",
-      newtypeField = Field {
-        fieldName = HsName
-          "@NsVar"
-          "un_DimPayloadB",
-        fieldType = HsTypRef
-          (HsName
-            "@NsTypeConstr"
-            "DimPayloadB"),
-        fieldOrigin = FieldOriginNone},
-      newtypeOrigin =
-      NewtypeOriginTypedef
-        Typedef {
-          typedefName = CName
-            "DimPayloadB",
-          typedefType = TypeUnion
-            (DeclPathName
-              (CName "DimPayloadB")
-              DeclPathCtxtTop),
-          typedefSourceLoc =
-          "unions.h:26:3"}},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName
-      "@NsTypeConstr"
-      "DimPayloadB"),
   DeclData
     Struct {
       structName = HsName
@@ -1297,8 +1264,10 @@
               fieldName = CName "payload",
               fieldOffset = 32,
               fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "DimPayloadB"),
+              fieldType = TypeUnion
+                (DeclPathName
+                  (CName "DimPayloadB")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "unions.h:30:17"}}],
       structOrigin =
@@ -1323,8 +1292,10 @@
               fieldName = CName "payload",
               fieldOffset = 32,
               fieldWidth = Nothing,
-              fieldType = TypeTypedef
-                (CName "DimPayloadB"),
+              fieldType = TypeUnion
+                (DeclPathName
+                  (CName "DimPayloadB")
+                  DeclPathCtxtTop),
               fieldSourceLoc =
               "unions.h:30:17"}],
           structFlam = Nothing,
@@ -1370,8 +1341,10 @@
                 fieldName = CName "payload",
                 fieldOffset = 32,
                 fieldWidth = Nothing,
-                fieldType = TypeTypedef
-                  (CName "DimPayloadB"),
+                fieldType = TypeUnion
+                  (DeclPathName
+                    (CName "DimPayloadB")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "unions.h:30:17"}}],
         structOrigin =
@@ -1396,8 +1369,10 @@
                 fieldName = CName "payload",
                 fieldOffset = 32,
                 fieldWidth = Nothing,
-                fieldType = TypeTypedef
-                  (CName "DimPayloadB"),
+                fieldType = TypeUnion
+                  (DeclPathName
+                    (CName "DimPayloadB")
+                    DeclPathCtxtTop),
                 fieldSourceLoc =
                 "unions.h:30:17"}],
             structFlam = Nothing,
@@ -1448,8 +1423,10 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName "DimPayloadB"),
+                        fieldType = TypeUnion
+                          (DeclPathName
+                            (CName "DimPayloadB")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
@@ -1474,8 +1451,10 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName "DimPayloadB"),
+                        fieldType = TypeUnion
+                          (DeclPathName
+                            (CName "DimPayloadB")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,
@@ -1528,8 +1507,10 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName "DimPayloadB"),
+                        fieldType = TypeUnion
+                          (DeclPathName
+                            (CName "DimPayloadB")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
@@ -1554,8 +1535,10 @@
                         fieldName = CName "payload",
                         fieldOffset = 32,
                         fieldWidth = Nothing,
-                        fieldType = TypeTypedef
-                          (CName "DimPayloadB"),
+                        fieldType = TypeUnion
+                          (DeclPathName
+                            (CName "DimPayloadB")
+                            DeclPathCtxtTop),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
@@ -139,12 +138,6 @@ get_dimPayloadB_dim3 = HsBindgen.Runtime.ByteArray.getUnionPayload
 
 set_dimPayloadB_dim3 :: Dim2 -> DimPayloadB
 set_dimPayloadB_dim3 = HsBindgen.Runtime.ByteArray.setUnionPayload
-
-newtype DimPayloadB = DimPayloadB
-  { un_DimPayloadB :: DimPayloadB
-  }
-
-deriving newtype instance F.Storable DimPayloadB
 
 data DimB = DimB
   { dimB_tag :: FC.CInt

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -49,8 +49,6 @@ get_dimPayloadB_dim3 :: DimPayloadB -> Dim2
 get_dimPayloadB_dim3 = getUnionPayload
 set_dimPayloadB_dim3 :: Dim2 -> DimPayloadB
 set_dimPayloadB_dim3 = setUnionPayload
-newtype DimPayloadB = DimPayloadB {un_DimPayloadB :: DimPayloadB}
-deriving newtype instance Storable DimPayloadB
 data DimB = DimB {dimB_tag :: CInt, dimB_payload :: DimPayloadB}
 instance Storable DimB
     where {sizeOf = \_ -> 12 :: Int;

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -126,7 +126,8 @@ Header
         unionDeclPath = DeclPathName
           (CName "DimPayloadB")
           DeclPathCtxtTop,
-        unionAliases = [],
+        unionAliases = [
+          CName "DimPayloadB"],
         unionSizeof = 8,
         unionAlignment = 4,
         unionFields = [
@@ -148,16 +149,6 @@ Header
             "unions.h:25:17"}],
         unionSourceLoc =
         "unions.h:23:15"},
-    DeclTypedef
-      Typedef {
-        typedefName = CName
-          "DimPayloadB",
-        typedefType = TypeUnion
-          (DeclPathName
-            (CName "DimPayloadB")
-            DeclPathCtxtTop),
-        typedefSourceLoc =
-        "unions.h:26:3"},
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
@@ -179,8 +170,10 @@ Header
             fieldName = CName "payload",
             fieldOffset = 32,
             fieldWidth = Nothing,
-            fieldType = TypeTypedef
-              (CName "DimPayloadB"),
+            fieldType = TypeUnion
+              (DeclPathName
+                (CName "DimPayloadB")
+                DeclPathCtxtTop),
             fieldSourceLoc =
             "unions.h:30:17"}],
         structFlam = Nothing,

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -161,6 +161,12 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     TypeEnum (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
                             addAlias ty use
 
+                    TypeUnion (DeclPathName declName _ctxt) | declName == tag -> do
+                            updateDeclAddAlias ty' tag
+                            addAlias ty use
+                    TypeUnion (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
+                            addAlias ty use
+
                     _ -> do
                         --
                         -- record name-path properly in underlying struct. (something like Path)


### PR DESCRIPTION
This is similar to #555, but for the `union` case rather than the `enum` case.

This is a regression also, we already had a testcase for this.