### PR TITLE
Support non-prototype functions

### DIFF
--- a/hs-bindgen/examples/macro_in_fundecl.h
+++ b/hs-bindgen/examples/macro_in_fundecl.h
@@ -48,3 +48,6 @@ I (*baz3(const int i))[2][3] {
     arr[1][1] = i;
     return &arr;
 }
+
+// neither arguments nor keyword void
+I no_args_no_void();

--- a/hs-bindgen/examples/simple_func.h
+++ b/hs-bindgen/examples/simple_func.h
@@ -6,4 +6,6 @@ static inline double bad_fma(double x, double y, double z) {
 
 void no_args(void);
 
+void no_args_no_void();
+
 int fun(char x, double y);

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -844,4 +844,28 @@
           functionHeader =
           "macro_in_fundecl.h",
           functionSourceLoc =
-          "macro_in_fundecl.h:43:5"}}]
+          "macro_in_fundecl.h:43:5"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
+        "no_args_no_void",
+      foreignImportType = HsIO
+        (HsTypRef
+          (HsName "@NsTypeConstr" "I")),
+      foreignImportOrigName =
+      "no_args_no_void",
+      foreignImportHeader =
+      "macro_in_fundecl.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName
+            "no_args_no_void",
+          functionArgs = [],
+          functionRes = TypeTypedef
+            (CName "I"),
+          functionHeader =
+          "macro_in_fundecl.h",
+          functionSourceLoc =
+          "macro_in_fundecl.h:53:3"}}]

--- a/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
@@ -185,3 +185,5 @@ foreign import capi safe "macro_in_fundecl.h baz1" baz1 :: FC.CInt -> IO (F.Ptr 
 foreign import capi safe "macro_in_fundecl.h baz2" baz2 :: I -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
 foreign import capi safe "macro_in_fundecl.h baz3" baz3 :: FC.CInt -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) I)))
+
+foreign import capi safe "macro_in_fundecl.h no_args_no_void" no_args_no_void :: IO I

--- a/hs-bindgen/fixtures/macro_in_fundecl.rs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.rs
@@ -73,3 +73,6 @@ extern "C" {
         i: ::std::os::raw::c_int,
     ) -> *mut [[::std::os::raw::c_int; 3usize]; 2usize];
 }
+extern "C" {
+    pub fn no_args_no_void() -> ::std::os::raw::c_int;
+}

--- a/hs-bindgen/fixtures/macro_in_fundecl.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.th.txt
@@ -99,3 +99,4 @@ foreign import capi safe "macro_in_fundecl.h baz3" baz3 :: CInt ->
                                                            IO (Ptr (ConstantArray 2
                                                                                   (ConstantArray 3
                                                                                                  I)))
+foreign import capi safe "macro_in_fundecl.h no_args_no_void" no_args_no_void :: IO I

--- a/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
@@ -299,4 +299,15 @@ Header
         functionHeader =
         "macro_in_fundecl.h",
         functionSourceLoc =
-        "macro_in_fundecl.h:43:5"}]
+        "macro_in_fundecl.h:43:5"},
+    DeclFunction
+      Function {
+        functionName = CName
+          "no_args_no_void",
+        functionArgs = [],
+        functionRes = TypeTypedef
+          (CName "I"),
+        functionHeader =
+        "macro_in_fundecl.h",
+        functionSourceLoc =
+        "macro_in_fundecl.h:53:3"}]

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -83,6 +83,28 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
+        "no_args_no_void",
+      foreignImportType = HsIO
+        (HsPrimType HsPrimUnit),
+      foreignImportOrigName =
+      "no_args_no_void",
+      foreignImportHeader =
+      "simple_func.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName
+            "no_args_no_void",
+          functionArgs = [],
+          functionRes = TypeVoid,
+          functionHeader =
+          "simple_func.h",
+          functionSourceLoc =
+          "simple_func.h:9:6"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
         "fun",
       foreignImportType = HsFun
         (HsPrimType HsPrimCChar)
@@ -105,4 +127,4 @@
           functionHeader =
           "simple_func.h",
           functionSourceLoc =
-          "simple_func.h:9:5"}}]
+          "simple_func.h:11:5"}}]

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -12,4 +12,6 @@ foreign import capi safe "simple_func.h bad_fma" bad_fma :: FC.CDouble -> FC.CDo
 
 foreign import capi safe "simple_func.h no_args" no_args :: IO ()
 
+foreign import capi safe "simple_func.h no_args_no_void" no_args_no_void :: IO ()
+
 foreign import capi safe "simple_func.h fun" fun :: FC.CChar -> FC.CDouble -> IO FC.CInt

--- a/hs-bindgen/fixtures/simple_func.rs
+++ b/hs-bindgen/fixtures/simple_func.rs
@@ -7,5 +7,8 @@ extern "C" {
     pub fn no_args();
 }
 extern "C" {
+    pub fn no_args_no_void();
+}
+extern "C" {
     pub fn fun(x: ::std::os::raw::c_char, y: f64) -> ::std::os::raw::c_int;
 }

--- a/hs-bindgen/fixtures/simple_func.th.txt
+++ b/hs-bindgen/fixtures/simple_func.th.txt
@@ -3,5 +3,6 @@ foreign import capi safe "simple_func.h erf" erf :: CDouble ->
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: CDouble ->
                                                             CDouble -> CDouble -> IO CDouble
 foreign import capi safe "simple_func.h no_args" no_args :: IO Unit
+foreign import capi safe "simple_func.h no_args_no_void" no_args_no_void :: IO Unit
 foreign import capi safe "simple_func.h fun" fun :: CChar ->
                                                     CDouble -> IO CInt

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -39,6 +39,16 @@ Header
         "simple_func.h:7:6"},
     DeclFunction
       Function {
+        functionName = CName
+          "no_args_no_void",
+        functionArgs = [],
+        functionRes = TypeVoid,
+        functionHeader =
+        "simple_func.h",
+        functionSourceLoc =
+        "simple_func.h:9:6"},
+    DeclFunction
+      Function {
         functionName = CName "fun",
         functionArgs = [
           TypePrim (PrimChar Nothing),
@@ -49,4 +59,4 @@ Header
         functionHeader =
         "simple_func.h",
         functionSourceLoc =
-        "simple_func.h:9:5"}]
+        "simple_func.h:11:5"}]


### PR DESCRIPTION
Non-prototype functions are treated as functions of no arguments, like in C23.

Closes #561