### PR TITLE
test ccall

### DIFF
--- a/hs-bindgen/fixtures/adios.th.txt
+++ b/hs-bindgen/fixtures/adios.th.txt
@@ -1,6 +1,6 @@
-foreign import capi safe "adios.h \978" cϒ :: IO Unit
-foreign import capi safe "adios.h \25308\25308" 拜拜 :: IO Unit
-foreign import capi safe "adios.h Say\25308\25308" say拜拜 :: IO Unit
+foreign import ccall safe "\978" cϒ :: IO Unit
+foreign import ccall safe "\25308\25308" 拜拜 :: IO Unit
+foreign import ccall safe "Say\25308\25308" say拜拜 :: IO Unit
 newtype Adio'0301s = Adio'0301s {un_Adio'0301s :: CInt}
 deriving newtype instance Storable Adio'0301s
 deriving stock instance Eq Adio'0301s

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -12,9 +12,8 @@ a_DEFINE_2 :: CInt
 a_DEFINE_2 = 2 :: CInt
 tWO_ARGS :: (,) CInt CInt
 tWO_ARGS = (,) (13398 :: CInt) (30874 :: CInt)
-foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: Ptr A_type_t ->
-                                                                  Uint32_t ->
-                                                                  Ptr Uint8_t -> IO Int32_t
+foreign import ccall safe "some_fun" some_fun :: Ptr A_type_t ->
+                                                 Uint32_t -> Ptr Uint8_t -> IO Int32_t
 data Another_typedef_struct_t
     = Another_typedef_struct_t {another_typedef_struct_t_foo :: CInt,
                                 another_typedef_struct_t_bar :: CChar}

--- a/hs-bindgen/fixtures/macro_in_fundecl.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.th.txt
@@ -67,36 +67,27 @@ deriving newtype instance FiniteBits S
 deriving newtype instance Integral S
 deriving newtype instance Num S
 deriving newtype instance Real S
-foreign import capi safe "macro_in_fundecl.h quux" quux :: F ->
-                                                           CChar -> IO CChar
-foreign import capi safe "macro_in_fundecl.h wam" wam :: CFloat ->
-                                                         Ptr C -> IO (Ptr C)
-foreign import capi safe "macro_in_fundecl.h foo1" foo1 :: CFloat ->
-                                                           FunPtr (CInt -> IO CInt) ->
-                                                           IO (Ptr CChar)
-foreign import capi safe "macro_in_fundecl.h foo2" foo2 :: F ->
-                                                           FunPtr (CInt -> IO CInt) ->
-                                                           IO (Ptr CChar)
-foreign import capi safe "macro_in_fundecl.h foo3" foo3 :: CFloat ->
-                                                           FunPtr (CInt -> IO CInt) -> IO (Ptr C)
-foreign import capi safe "macro_in_fundecl.h bar1" bar1 :: CLong ->
-                                                           IO (FunPtr (CShort -> IO CInt))
-foreign import capi safe "macro_in_fundecl.h bar2" bar2 :: L ->
-                                                           IO (FunPtr (CShort -> IO CInt))
-foreign import capi safe "macro_in_fundecl.h bar3" bar3 :: CLong ->
-                                                           IO (FunPtr (S -> IO CInt))
-foreign import capi safe "macro_in_fundecl.h bar4" bar4 :: CLong ->
-                                                           IO (FunPtr (CShort -> IO I))
-foreign import capi safe "macro_in_fundecl.h baz1" baz1 :: CInt ->
-                                                           IO (Ptr (ConstantArray 2
-                                                                                  (ConstantArray 3
-                                                                                                 CInt)))
-foreign import capi safe "macro_in_fundecl.h baz2" baz2 :: I ->
-                                                           IO (Ptr (ConstantArray 2
-                                                                                  (ConstantArray 3
-                                                                                                 CInt)))
-foreign import capi safe "macro_in_fundecl.h baz3" baz3 :: CInt ->
-                                                           IO (Ptr (ConstantArray 2
-                                                                                  (ConstantArray 3
-                                                                                                 I)))
-foreign import capi safe "macro_in_fundecl.h no_args_no_void" no_args_no_void :: IO I
+foreign import ccall safe "quux" quux :: F -> CChar -> IO CChar
+foreign import ccall safe "wam" wam :: CFloat ->
+                                       Ptr C -> IO (Ptr C)
+foreign import ccall safe "foo1" foo1 :: CFloat ->
+                                         FunPtr (CInt -> IO CInt) -> IO (Ptr CChar)
+foreign import ccall safe "foo2" foo2 :: F ->
+                                         FunPtr (CInt -> IO CInt) -> IO (Ptr CChar)
+foreign import ccall safe "foo3" foo3 :: CFloat ->
+                                         FunPtr (CInt -> IO CInt) -> IO (Ptr C)
+foreign import ccall safe "bar1" bar1 :: CLong ->
+                                         IO (FunPtr (CShort -> IO CInt))
+foreign import ccall safe "bar2" bar2 :: L ->
+                                         IO (FunPtr (CShort -> IO CInt))
+foreign import ccall safe "bar3" bar3 :: CLong ->
+                                         IO (FunPtr (S -> IO CInt))
+foreign import ccall safe "bar4" bar4 :: CLong ->
+                                         IO (FunPtr (CShort -> IO I))
+foreign import ccall safe "baz1" baz1 :: CInt ->
+                                         IO (Ptr (ConstantArray 2 (ConstantArray 3 CInt)))
+foreign import ccall safe "baz2" baz2 :: I ->
+                                         IO (Ptr (ConstantArray 2 (ConstantArray 3 CInt)))
+foreign import ccall safe "baz3" baz3 :: CInt ->
+                                         IO (Ptr (ConstantArray 2 (ConstantArray 3 I)))
+foreign import ccall safe "no_args_no_void" no_args_no_void :: IO I

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
@@ -12,23 +12,18 @@ deriving newtype instance FiniteBits MC
 deriving newtype instance Integral MC
 deriving newtype instance Num MC
 deriving newtype instance Real MC
-foreign import capi safe "macro_in_fundecl_vs_typedef.h quux1" quux1 :: MC ->
-                                                                        TC -> IO CChar
-foreign import capi safe "macro_in_fundecl_vs_typedef.h quux2" quux2 :: MC ->
-                                                                        CChar -> IO TC
-foreign import capi safe "macro_in_fundecl_vs_typedef.h wam1" wam1 :: CFloat ->
-                                                                      Ptr TC -> IO (Ptr MC)
-foreign import capi safe "macro_in_fundecl_vs_typedef.h wam2" wam2 :: CFloat ->
-                                                                      Ptr MC -> IO (Ptr TC)
-foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef1" struct_typedef1 :: Ptr Struct2 ->
-                                                                                            MC ->
-                                                                                            IO Unit
-foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef2" struct_typedef2 :: Ptr Struct3_t ->
-                                                                                            MC ->
-                                                                                            IO Unit
-foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef3" struct_typedef3 :: Ptr Struct4 ->
-                                                                                            MC ->
-                                                                                            IO Unit
+foreign import ccall safe "quux1" quux1 :: MC -> TC -> IO CChar
+foreign import ccall safe "quux2" quux2 :: MC -> CChar -> IO TC
+foreign import ccall safe "wam1" wam1 :: CFloat ->
+                                         Ptr TC -> IO (Ptr MC)
+foreign import ccall safe "wam2" wam2 :: CFloat ->
+                                         Ptr MC -> IO (Ptr TC)
+foreign import ccall safe "struct_typedef1" struct_typedef1 :: Ptr Struct2 ->
+                                                               MC -> IO Unit
+foreign import ccall safe "struct_typedef2" struct_typedef2 :: Ptr Struct3_t ->
+                                                               MC -> IO Unit
+foreign import ccall safe "struct_typedef3" struct_typedef3 :: Ptr Struct4 ->
+                                                               MC -> IO Unit
 newtype TC = TC {un_TC :: CChar}
 deriving newtype instance Storable TC
 deriving stock instance Eq TC

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -46,23 +46,20 @@ deriving newtype instance FiniteBits DAY
 deriving newtype instance Integral DAY
 deriving newtype instance Num DAY
 deriving newtype instance Real DAY
-foreign import capi safe "manual_examples.h mk_triple" mk_triple :: CInt ->
-                                                                    CInt ->
-                                                                    CInt -> Ptr Triple -> IO Unit
-foreign import capi safe "manual_examples.h index_triple" index_triple :: Ptr Triple ->
-                                                                          Index -> IO CInt
-foreign import capi safe "manual_examples.h sum_triple" sum_triple :: Ptr Triple ->
-                                                                      IO Sum
-foreign import capi safe "manual_examples.h average_triple" average_triple :: Ptr Triple ->
-                                                                              IO Average
-foreign import capi safe "manual_examples.h getYear" getYear :: Ptr Date ->
-                                                                IO YEAR
-foreign import capi safe "manual_examples.h print_occupation" print_occupation :: CInt ->
-                                                                                  Ptr Occupation ->
-                                                                                  IO Unit
-foreign import capi safe "manual_examples.h \25308\25308" 拜拜 :: IO Unit
-foreign import capi safe "manual_examples.h \978" cϒ :: IO Unit
-foreign import capi safe "manual_examples.h import" import' :: IO Unit
+foreign import ccall safe "mk_triple" mk_triple :: CInt ->
+                                                   CInt -> CInt -> Ptr Triple -> IO Unit
+foreign import ccall safe "index_triple" index_triple :: Ptr Triple ->
+                                                         Index -> IO CInt
+foreign import ccall safe "sum_triple" sum_triple :: Ptr Triple ->
+                                                     IO Sum
+foreign import ccall safe "average_triple" average_triple :: Ptr Triple ->
+                                                             IO Average
+foreign import ccall safe "getYear" getYear :: Ptr Date -> IO YEAR
+foreign import ccall safe "print_occupation" print_occupation :: CInt ->
+                                                                 Ptr Occupation -> IO Unit
+foreign import ccall safe "\25308\25308" 拜拜 :: IO Unit
+foreign import ccall safe "\978" cϒ :: IO Unit
+foreign import ccall safe "import" import' :: IO Unit
 data Triple
     = Triple {triple_a :: CInt, triple_b :: CInt, triple_c :: CInt}
 instance Storable Triple

--- a/hs-bindgen/fixtures/simple_func.th.txt
+++ b/hs-bindgen/fixtures/simple_func.th.txt
@@ -1,8 +1,6 @@
-foreign import capi safe "simple_func.h erf" erf :: CDouble ->
-                                                    IO CDouble
-foreign import capi safe "simple_func.h bad_fma" bad_fma :: CDouble ->
-                                                            CDouble -> CDouble -> IO CDouble
-foreign import capi safe "simple_func.h no_args" no_args :: IO Unit
-foreign import capi safe "simple_func.h no_args_no_void" no_args_no_void :: IO Unit
-foreign import capi safe "simple_func.h fun" fun :: CChar ->
-                                                    CDouble -> IO CInt
+foreign import ccall safe "erf" erf :: CDouble -> IO CDouble
+foreign import ccall safe "bad_fma" bad_fma :: CDouble ->
+                                               CDouble -> CDouble -> IO CDouble
+foreign import ccall safe "no_args" no_args :: IO Unit
+foreign import ccall safe "no_args_no_void" no_args_no_void :: IO Unit
+foreign import ccall safe "fun" fun :: CChar -> CDouble -> IO CInt

--- a/hs-bindgen/fixtures/weird01.th.txt
+++ b/hs-bindgen/fixtures/weird01.th.txt
@@ -1,5 +1,4 @@
-foreign import capi safe "weird01.h func" func :: Ptr Bar ->
-                                                  IO Unit
+foreign import ccall safe "func" func :: Ptr Bar -> IO Unit
 data Foo = Foo {foo_z :: CInt}
 instance Storable Foo
     where {sizeOf = \_ -> 4 :: Int;

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -324,8 +324,8 @@ mkDecl = \case
           singleton <$> TH.standaloneDerivWithStrategyD (Just s') (TH.cxt []) (mkType EmptyEnv ty)
 
       DForeignImport ForeignImport {..} ->
-           singleton . TH.ForeignD . TH.ImportF TH.CApi TH.Safe
-              (foreignImportHeader ++ " " ++ Text.unpack foreignImportOrigName) -- TODO: header
+           singleton . TH.ForeignD . TH.ImportF TH.CCall TH.Safe
+              (Text.unpack foreignImportOrigName) -- TODO: header
               (hsNameToTH foreignImportName)
               <$>
               (mkType EmptyEnv foreignImportType)


### PR DESCRIPTION
It won't work as is, as in test-th (and test-pp) we use header-only example library, so linker fails.

But this illustrates that we don't really need capi as such, it's mostly an additional safety check.

I want to see that this fails the same way on different operating systems, i.e. trigger CI.

work towards using userland-capi.