### PR TITLE
Use location to construct unique identifier in userland-capi

### DIFF
--- a/userland-capi/examples/example02.hs
+++ b/userland-capi/examples/example02.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI, TemplateHaskell #-}
 {-# OPTIONS_GHC -ddump-splices #-}
+
 module Main (main) where
 
 import UserlandCApi
@@ -8,10 +9,7 @@ import Foreign.C.String
 
 foreign import capi "stdio.h printf" my_printf :: CString -> CInt -> IO ()
 
-localname :: ()
-localname = ()
-
-$(userlandCApi 'localname $ do
+$(userlandCApi $ do
     addInclude "<stdio.h>"
     w <- freshCName "printf"
     addC $ "void " ++ w ++ "(const char *fmt, int x) { printf(fmt, x); }"


### PR DESCRIPTION
Turns out we can get unitid of the place where splice is run. No need to pass arbitrary Name.