### PR TITLE
Rename `EString` to `ECString`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -236,7 +236,7 @@ prettyExpr env prec = \case
         <+> case mbUnicode of { Nothing -> "Nothing"; Just c -> parens ("Just" <+> string (show c)) }
       where
         (str, len) = addrLiteral ba
-    EString bs ->
+    ECString bs ->
       -- Use unboxed Addr# literals to turn a string literal into a
       -- value of type CStringLen.
       let (str, len) = addrLiteral bs

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
@@ -175,8 +175,8 @@ resolveExprImports = \case
                   , CharValue_constructor
                   , CharValue_fromAddr
                   ]
-    EString {} -> resolvePrimTypeImports Hs.HsPrimCStringLen
-               <> resolveGlobalImports Ptr_constructor
+    ECString {} -> resolvePrimTypeImports Hs.HsPrimCStringLen
+                <> resolveGlobalImports Ptr_constructor
     EFloat _ t -> resolvePrimTypeImports t
     EDouble _ t -> resolvePrimTypeImports t
     EApp f x -> resolveExprImports f <> resolveExprImports x

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -220,7 +220,7 @@ mkExpr env = \case
           )
           (mkPrimType t)
       EChar c -> [| c |]
-      EString ba@(ByteArray ba#) ->
+      ECString ba@(ByteArray ba#) ->
         let
           len :: Integer
           len = fromIntegral (I# (sizeofByteArray# ba#))

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -156,7 +156,7 @@ data SExpr ctx =
   | EFloat Float HsPrimType -- ^ Type annotation to distinguish Float/CFLoat
   | EDouble Double HsPrimType
   | EChar CExpr.CharValue
-  | EString ByteArray
+  | ECString ByteArray
   | EApp (SExpr ctx) (SExpr ctx)
   | EInfix Global (SExpr ctx) (SExpr ctx)
   | ELam NameHint (SExpr (S ctx))

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -313,7 +313,7 @@ translateBody (Hs.VarDeclFloat f)                   = EFloat f HsPrimCFloat
 translateBody (Hs.VarDeclDouble d)                  = EDouble d HsPrimCDouble
 translateBody (Hs.VarDeclIntegral i ty)             = EIntegral i (Just ty)
 translateBody (Hs.VarDeclChar c)                    = EChar c
-translateBody (Hs.VarDeclString s)                  = EString s
+translateBody (Hs.VarDeclString s)                  = ECString s
 translateBody (Hs.VarDeclLambda (Hs.Lambda hint b)) = ELam hint (translateBody b)
 translateBody (Hs.VarDeclApp f as)                  = foldl' EApp (translateAppHead f) (map translateBody as)
 


### PR DESCRIPTION
Simple expression `EString ByteArray` is used to encode C strings.  I need to generate code with a string literal
(`TH.LitE (TH.StringL "...")`), and this expression type is not appropriate.  This commit renames this `SExp` constructor to `ECString` to make room for a new `EString String`.