### PR TITLE
Thread C type for external bindings through ASTs

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -52,7 +52,7 @@ typeExtensions = \case
     TCon _    -> Set.empty
     TFun a b  -> typeExtensions a <> typeExtensions b
     TLit _    -> Set.singleton TH.DataKinds
-    TExt _    -> Set.empty
+    TExt _ _  -> Set.empty
     TBound _  -> Set.empty
     TApp f b  -> typeExtensions f <> typeExtensions b
     TForall _names _add preds b ->

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -182,7 +182,7 @@ prettyType env prec = \case
     TGlobal g -> pretty $ resolve g
     TCon n -> pretty n
     TLit n -> showToCtxDoc n
-    TExt i -> pretty i
+    TExt i _ctype -> pretty i
     TApp c x -> parensWhen (prec > 0) $
       prettyType env 1 c <+> prettyType env 1 x
     TFun a b -> parensWhen (prec > 0) $

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
@@ -205,7 +205,7 @@ resolveTypeImports = \case
     TGlobal g -> resolveGlobalImports g
     TCon _n -> mempty
     TLit _n -> mempty
-    TExt i -> resolveExtIdentifierImports i
+    TExt i _ctype -> resolveExtIdentifierImports i
     TApp c x -> resolveTypeImports c <> resolveTypeImports x
     TFun a b -> resolveTypeImports a <> resolveTypeImports b
     TBound {} -> mempty

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -426,7 +426,7 @@ mkType env = \case
             (map bndr xs)
             (traverse (mkType env') ctxt)
             (mkType env' body)
-    TExt ExtIdentifier{..} ->
+    TExt ExtIdentifier{..} _ctype ->
         TH.conT . TH.mkName $ concat [
               Text.unpack (getHsModuleName extIdentifierModule)
             , "."

--- a/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
@@ -64,7 +64,7 @@ data Type =
     --
     -- See <https://en.cppreference.com/w/c/language/array#Arrays_of_unknown_size>
   | TypeIncompleteArray Type
-  | TypeExtBinding ExtIdentifier
+  | TypeExtBinding ExtIdentifier Type
   deriving stock (Show, Eq, Generic)
   deriving Repr via ReprShow Type
 

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -133,7 +133,7 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
 
         mExtId <- lookupExtBinding (CNameSpelling name) sloc extBindings
         case mExtId of
-            Just extId -> addAlias ty $ TypeExtBinding extId
+            Just extId -> addAlias ty $ TypeExtBinding extId ctype
             Nothing -> do
                 tag <- CName <$> liftIO (clang_getCursorSpelling decl)
                 ty' <- liftIO $ getElaborated =<< clang_getTypedefDeclUnderlyingType decl
@@ -193,10 +193,11 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                   Left (AnonTopLevel replacement) ->
                     return replacement
                   Right (declPath, flavour) -> do
-                    addTypeDeclProcessing ty $ TypeStruct declPath
+                    let ctype = TypeStruct declPath
+                    addTypeDeclProcessing ty ctype
                     case flavour of
                       TypeDeclExternal extId ->
-                        addAlias ty $ TypeExtBinding extId
+                        addAlias ty $ TypeExtBinding extId ctype
                       TypeDeclOpaque name -> do
                         addDecl ty $ DeclOpaqueStruct OpaqueStruct {
                             opaqueStructTag       = name
@@ -275,10 +276,11 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                   Left (AnonTopLevel replacement) ->
                     return replacement
                   Right (declPath, flavour) -> do
-                    addTypeDeclProcessing ty $ TypeEnum declPath
+                    let ctype = TypeEnum declPath
+                    addTypeDeclProcessing ty ctype
                     case flavour of
                       TypeDeclExternal extId ->
-                        addAlias ty $ TypeExtBinding extId
+                        addAlias ty $ TypeExtBinding extId ctype
                       TypeDeclOpaque name ->
                         addDecl ty $ DeclOpaqueEnum OpaqueEnum {
                             opaqueEnumTag       = name

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
@@ -3,6 +3,7 @@ module HsBindgen.Hs.AST.Type (
   HsType (..)
 ) where
 
+import HsBindgen.C.AST qualified as C
 import HsBindgen.ExtBindings
 import HsBindgen.Imports
 import HsBindgen.Hs.AST.Name
@@ -57,7 +58,7 @@ data HsType =
   | HsFunPtr HsType
   | HsIO HsType
   | HsFun HsType HsType
-  | HsExtBinding ExtIdentifier
+  | HsExtBinding ExtIdentifier C.Type
   | HsByteArray
   | HsSizedByteArray Natural Natural
   deriving stock (Generic, Show)

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -491,8 +491,8 @@ typ' ctx nm = go ctx
         goArrayUnknownSize c ty
     go _ (C.TypeFun xs y) =
         foldr (\x res -> Hs.HsFun (go CFunArg x) res) (Hs.HsIO (go CFunRes y)) xs
-    go _ (C.TypeExtBinding extId) =
-        Hs.HsExtBinding extId
+    go _ (C.TypeExtBinding extId ty) =
+        Hs.HsExtBinding extId ty
 
     goPrim :: C.PrimType -> HsPrimType
     goPrim C.PrimBool                     = HsPrimCBool

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -19,6 +19,7 @@ module HsBindgen.SHs.AST (
     PatternSynonym (..),
 ) where
 
+import HsBindgen.C.AST qualified as C
 import HsBindgen.ExtBindings
 import HsBindgen.Imports
 import HsBindgen.NameHint
@@ -231,7 +232,7 @@ data SType ctx =
   | TCon (HsName NsTypeConstr)
   | TFun (SType ctx) (SType ctx)
   | TLit Natural
-  | TExt ExtIdentifier
+  | TExt ExtIdentifier C.Type
   | TBound (Idx ctx)
   | TApp (SType ctx) (SType ctx)
   | forall n ctx'. TForall (Vec n NameHint) (Add n ctx ctx') [SType ctx'] (SType ctx')

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -152,7 +152,7 @@ translateType (Hs.HsConstArray n t) = TGlobal ConstantArray `TApp` TLit n `TApp`
 translateType (Hs.HsType _)         = TGlobal (PrimType HsPrimVoid)
 translateType (Hs.HsIO t)           = TApp (TGlobal IO_type) (translateType t)
 translateType (Hs.HsFun a b)        = TFun (translateType a) (translateType b)
-translateType (Hs.HsExtBinding i)   = TExt i
+translateType (Hs.HsExtBinding i t) = TExt i t
 translateType Hs.HsByteArray        = TGlobal ByteArray_type
 translateType (Hs.HsSizedByteArray n m) = TGlobal SizedByteArray_type `TApp` TLit n `TApp` TLit m
 


### PR DESCRIPTION
The C `Type` is associated with external bindings.  This information is included in the `C`, `Hs`, and `SHs` ASTs.

@phadej Is this sufficient for your userland-capi needs, or do you need more details about the C type?