### PR TITLE
Move `isDeclared` and `mkDeclared` into CEnum class

### DIFF
--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -809,7 +809,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["FOO"]),
-          _×_ 1 (NE.fromList ["BAR"])])),
+          _×_ 1 (NE.fromList ["BAR"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -3260,8 +3261,8 @@
             (NE.fromList ["ENUM_CASE_2"]),
           _×_
             3
-            (NE.fromList
-              ["ENUM_CASE_3"])])),
+            (NE.fromList ["ENUM_CASE_3"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -114,6 +114,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Another_typedef_enum_e where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FOO"), (1, Data.List.NonEmpty.singleton "BAR")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Another_typedef_enum_e where
 
   minDeclaredValue = FOO
@@ -396,6 +400,10 @@ instance HsBindgen.Runtime.CEnum.CEnum A_typedef_enum_e where
                                , (2, Data.List.NonEmpty.singleton "ENUM_CASE_2")
                                , (3, Data.List.NonEmpty.singleton "ENUM_CASE_3")
                                ]
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum A_typedef_enum_e where
 

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -48,7 +48,9 @@ instance CEnum Another_typedef_enum_e
            fromCEnumZ = Another_typedef_enum_e;
            toCEnumZ = un_Another_typedef_enum_e;
            declaredValues = \_ -> fromList [(0, singleton "FOO"),
-                                            (1, singleton "BAR")]}
+                                            (1, singleton "BAR")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Another_typedef_enum_e
     where {minDeclaredValue = FOO; maxDeclaredValue = BAR}
 instance Show Another_typedef_enum_e
@@ -181,7 +183,9 @@ instance CEnum A_typedef_enum_e
            declaredValues = \_ -> fromList [(0, singleton "ENUM_CASE_0"),
                                             (1, singleton "ENUM_CASE_1"),
                                             (2, singleton "ENUM_CASE_2"),
-                                            (3, singleton "ENUM_CASE_3")]}
+                                            (3, singleton "ENUM_CASE_3")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum A_typedef_enum_e
     where {minDeclaredValue = ENUM_CASE_0;
            maxDeclaredValue = ENUM_CASE_3}

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -227,9 +227,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["FIRST1"]),
-          _×_
-            1
-            (NE.fromList ["FIRST2"])])),
+          _×_ 1 (NE.fromList ["FIRST2"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -612,7 +611,8 @@
             (NE.fromList ["SECOND_B"]),
           _×_
             1
-            (NE.fromList ["SECOND_C"])])),
+            (NE.fromList ["SECOND_C"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -994,7 +994,8 @@
           _×_
             1
             (NE.fromList
-              ["SAME_B", "SAME_A"])])),
+              ["SAME_B", "SAME_A"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -1381,7 +1382,8 @@
             (NE.fromList ["NONSEQ_B"]),
           _×_
             404
-            (NE.fromList ["NONSEQ_C"])])),
+            (NE.fromList ["NONSEQ_C"])])
+      False),
   DeclInstance
     (InstanceCEnumShow
       Struct {
@@ -1751,7 +1753,8 @@
             (NE.fromList ["PACKED_B"]),
           _×_
             2
-            (NE.fromList ["PACKED_C"])])),
+            (NE.fromList ["PACKED_C"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -2137,9 +2140,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["A_FOO"]),
-          _×_
-            1
-            (NE.fromList ["A_BAR"])])),
+          _×_ 1 (NE.fromList ["A_BAR"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -2497,9 +2499,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["B_FOO"]),
-          _×_
-            1
-            (NE.fromList ["B_BAR"])])),
+          _×_ 1 (NE.fromList ["B_BAR"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -2855,9 +2856,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["C_FOO"]),
-          _×_
-            1
-            (NE.fromList ["C_BAR"])])),
+          _×_ 1 (NE.fromList ["C_BAR"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -3212,9 +3212,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["D_FOO"]),
-          _×_
-            1
-            (NE.fromList ["D_BAR"])])),
+          _×_ 1 (NE.fromList ["D_BAR"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -53,6 +53,10 @@ instance HsBindgen.Runtime.CEnum.CEnum First where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FIRST1"), (1, Data.List.NonEmpty.singleton "FIRST2")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum First where
 
   minDeclaredValue = FIRST1
@@ -111,6 +115,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Second where
                                , (1, Data.List.NonEmpty.singleton "SECOND_C")
                                ]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Second where
 
   minDeclaredValue = SECOND_A
@@ -168,6 +176,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Same where
   declaredValues =
     \_ ->
       Data.Map.Strict.fromList [(1, ("SAME_B" Data.List.NonEmpty.:| ["SAME_A"]))]
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Same where
 
@@ -282,6 +294,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Packad where
                                , (2, Data.List.NonEmpty.singleton "PACKED_C")
                                ]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Packad where
 
   minDeclaredValue = PACKED_A
@@ -340,6 +356,10 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "A_FOO"), (1, Data.List.NonEmpty.singleton "A_BAR")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumA where
 
   minDeclaredValue = A_FOO
@@ -394,6 +414,10 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumB where
   declaredValues =
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "B_FOO"), (1, Data.List.NonEmpty.singleton "B_BAR")]
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumB where
 
@@ -450,6 +474,10 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumC where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "C_FOO"), (1, Data.List.NonEmpty.singleton "C_BAR")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumC where
 
   minDeclaredValue = C_FOO
@@ -504,6 +532,10 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumD where
   declaredValues =
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "D_FOO"), (1, Data.List.NonEmpty.singleton "D_BAR")]
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumD where
 

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -14,7 +14,9 @@ instance CEnum First
            fromCEnumZ = First;
            toCEnumZ = un_First;
            declaredValues = \_ -> fromList [(0, singleton "FIRST1"),
-                                            (1, singleton "FIRST2")]}
+                                            (1, singleton "FIRST2")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum First
     where {minDeclaredValue = FIRST1; maxDeclaredValue = FIRST2}
 instance Show First
@@ -39,7 +41,9 @@ instance CEnum Second
            toCEnumZ = un_Second;
            declaredValues = \_ -> fromList [(-1, singleton "SECOND_A"),
                                             (0, singleton "SECOND_B"),
-                                            (1, singleton "SECOND_C")]}
+                                            (1, singleton "SECOND_C")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Second
     where {minDeclaredValue = SECOND_A; maxDeclaredValue = SECOND_C}
 instance Show Second
@@ -64,7 +68,9 @@ instance CEnum Same
     where {type CEnumZ Same = CUInt;
            fromCEnumZ = Same;
            toCEnumZ = un_Same;
-           declaredValues = \_ -> fromList [(1, "SAME_B" :| ["SAME_A"])]}
+           declaredValues = \_ -> fromList [(1, "SAME_B" :| ["SAME_A"])];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Same
     where {minDeclaredValue = SAME_B; maxDeclaredValue = SAME_B}
 instance Show Same
@@ -114,7 +120,9 @@ instance CEnum Packad
            toCEnumZ = un_Packad;
            declaredValues = \_ -> fromList [(0, singleton "PACKED_A"),
                                             (1, singleton "PACKED_B"),
-                                            (2, singleton "PACKED_C")]}
+                                            (2, singleton "PACKED_C")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Packad
     where {minDeclaredValue = PACKED_A; maxDeclaredValue = PACKED_C}
 instance Show Packad
@@ -140,7 +148,9 @@ instance CEnum EnumA
            fromCEnumZ = EnumA;
            toCEnumZ = un_EnumA;
            declaredValues = \_ -> fromList [(0, singleton "A_FOO"),
-                                            (1, singleton "A_BAR")]}
+                                            (1, singleton "A_BAR")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
     where {minDeclaredValue = A_FOO; maxDeclaredValue = A_BAR}
 instance Show EnumA
@@ -164,7 +174,9 @@ instance CEnum EnumB
            fromCEnumZ = EnumB;
            toCEnumZ = un_EnumB;
            declaredValues = \_ -> fromList [(0, singleton "B_FOO"),
-                                            (1, singleton "B_BAR")]}
+                                            (1, singleton "B_BAR")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumB
     where {minDeclaredValue = B_FOO; maxDeclaredValue = B_BAR}
 instance Show EnumB
@@ -188,7 +200,9 @@ instance CEnum EnumC
            fromCEnumZ = EnumC;
            toCEnumZ = un_EnumC;
            declaredValues = \_ -> fromList [(0, singleton "C_FOO"),
-                                            (1, singleton "C_BAR")]}
+                                            (1, singleton "C_BAR")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumC
     where {minDeclaredValue = C_FOO; maxDeclaredValue = C_BAR}
 instance Show EnumC
@@ -212,7 +226,9 @@ instance CEnum EnumD
            fromCEnumZ = EnumD;
            toCEnumZ = un_EnumD;
            declaredValues = \_ -> fromList [(0, singleton "D_FOO"),
-                                            (1, singleton "D_BAR")]}
+                                            (1, singleton "D_BAR")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumD
     where {minDeclaredValue = D_FOO; maxDeclaredValue = D_BAR}
 instance Show EnumD

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -1357,7 +1357,8 @@
         [
           _×_ 0 (NE.fromList ["A"]),
           _×_ 1 (NE.fromList ["B"]),
-          _×_ 2 (NE.fromList ["C"])])),
+          _×_ 2 (NE.fromList ["C"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -216,6 +216,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Index where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "A"), (1, Data.List.NonEmpty.singleton "B"), (2, Data.List.NonEmpty.singleton "C")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Index where
 
   minDeclaredValue = A

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -92,7 +92,9 @@ instance CEnum Index
            toCEnumZ = un_Index;
            declaredValues = \_ -> fromList [(0, singleton "A"),
                                             (1, singleton "B"),
-                                            (2, singleton "C")]}
+                                            (2, singleton "C")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Index
     where {minDeclaredValue = A; maxDeclaredValue = C}
 instance Show Index

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -252,9 +252,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["VALA_1"]),
-          _×_
-            1
-            (NE.fromList ["VALA_2"])])),
+          _×_ 1 (NE.fromList ["VALA_2"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {
@@ -889,9 +888,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["VALB_1"]),
-          _×_
-            1
-            (NE.fromList ["VALB_2"])])),
+          _×_ 1 (NE.fromList ["VALB_2"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/nested_enums.pp.hs
+++ b/hs-bindgen/fixtures/nested_enums.pp.hs
@@ -52,6 +52,10 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "VALA_1"), (1, Data.List.NonEmpty.singleton "VALA_2")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumA where
 
   minDeclaredValue = VALA_1
@@ -131,6 +135,10 @@ instance HsBindgen.Runtime.CEnum.CEnum ExB_fieldB1 where
   declaredValues =
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "VALB_1"), (1, Data.List.NonEmpty.singleton "VALB_2")]
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum ExB_fieldB1 where
 

--- a/hs-bindgen/fixtures/nested_enums.th.txt
+++ b/hs-bindgen/fixtures/nested_enums.th.txt
@@ -14,7 +14,9 @@ instance CEnum EnumA
            fromCEnumZ = EnumA;
            toCEnumZ = un_EnumA;
            declaredValues = \_ -> fromList [(0, singleton "VALA_1"),
-                                            (1, singleton "VALA_2")]}
+                                            (1, singleton "VALA_2")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
     where {minDeclaredValue = VALA_1; maxDeclaredValue = VALA_2}
 instance Show EnumA
@@ -47,7 +49,9 @@ instance CEnum ExB_fieldB1
            fromCEnumZ = ExB_fieldB1;
            toCEnumZ = un_ExB_fieldB1;
            declaredValues = \_ -> fromList [(0, singleton "VALB_1"),
-                                            (1, singleton "VALB_2")]}
+                                            (1, singleton "VALB_2")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum ExB_fieldB1
     where {minDeclaredValue = VALB_1; maxDeclaredValue = VALB_2}
 instance Show ExB_fieldB1

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -231,7 +231,8 @@
       (Map.fromList
         [
           _×_ 0 (NE.fromList ["FOO1"]),
-          _×_ 1 (NE.fromList ["FOO2"])])),
+          _×_ 1 (NE.fromList ["FOO2"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/typenames.pp.hs
+++ b/hs-bindgen/fixtures/typenames.pp.hs
@@ -53,6 +53,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Foo where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FOO1"), (1, Data.List.NonEmpty.singleton "FOO2")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Foo where
 
   minDeclaredValue = FOO1

--- a/hs-bindgen/fixtures/typenames.th.txt
+++ b/hs-bindgen/fixtures/typenames.th.txt
@@ -14,7 +14,9 @@ instance CEnum Foo
            fromCEnumZ = Foo;
            toCEnumZ = un_Foo;
            declaredValues = \_ -> fromList [(0, singleton "FOO1"),
-                                            (1, singleton "FOO2")]}
+                                            (1, singleton "FOO2")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum Foo
     where {minDeclaredValue = FOO1; maxDeclaredValue = FOO2}
 instance Show Foo

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -253,7 +253,8 @@
           _×_
             1
             (NE.fromList
-              ["Say\25308\25308"])])),
+              ["Say\25308\25308"])])
+      True),
   DeclInstance
     (InstanceSequentialCEnum
       Struct {

--- a/hs-bindgen/fixtures/uses_utf8.pp.hs
+++ b/hs-bindgen/fixtures/uses_utf8.pp.hs
@@ -52,6 +52,10 @@ instance HsBindgen.Runtime.CEnum.CEnum MyEnum where
     \_ ->
       Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "Say\20320\22909"), (1, Data.List.NonEmpty.singleton "Say\25308\25308")]
 
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
 instance HsBindgen.Runtime.CEnum.SequentialCEnum MyEnum where
 
   minDeclaredValue = Say你好

--- a/hs-bindgen/fixtures/uses_utf8.th.txt
+++ b/hs-bindgen/fixtures/uses_utf8.th.txt
@@ -14,7 +14,9 @@ instance CEnum MyEnum
            fromCEnumZ = MyEnum;
            toCEnumZ = un_MyEnum;
            declaredValues = \_ -> fromList [(0, singleton "Say\20320\22909"),
-                                            (1, singleton "Say\25308\25308")]}
+                                            (1, singleton "Say\25308\25308")];
+           isDeclared = seqIsDeclared;
+           mkDeclared = seqMkDeclared}
 instance SequentialCEnum MyEnum
     where {minDeclaredValue = Say你好; maxDeclaredValue = Say拜拜}
 instance Show MyEnum

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
@@ -300,10 +300,14 @@ resolveGlobal = \case
     CEnum_fromCEnumZ -> importQ 'HsBindgen.Runtime.CEnum.fromCEnumZ
     CEnum_toCEnumZ -> importQ 'HsBindgen.Runtime.CEnum.toCEnumZ
     CEnum_declaredValues -> importQ 'HsBindgen.Runtime.CEnum.declaredValues
+    CEnum_isDeclared -> importQ 'HsBindgen.Runtime.CEnum.isDeclared
+    CEnum_mkDeclared -> importQ 'HsBindgen.Runtime.CEnum.mkDeclared
     SequentialCEnum_class -> importQ ''HsBindgen.Runtime.CEnum.SequentialCEnum
     SequentialCEnum_minDeclaredValue -> importQ 'HsBindgen.Runtime.CEnum.minDeclaredValue
     SequentialCEnum_maxDeclaredValue -> importQ 'HsBindgen.Runtime.CEnum.maxDeclaredValue
     CEnum_showCEnum -> importQ 'HsBindgen.Runtime.CEnum.showCEnum
+    CEnum_seqIsDeclared -> importQ 'HsBindgen.Runtime.CEnum.seqIsDeclared
+    CEnum_seqMkDeclared -> importQ 'HsBindgen.Runtime.CEnum.seqMkDeclared
     AsCEnum_type -> importQ ''HsBindgen.Runtime.CEnum.AsCEnum
     AsSequentialCEnum_type -> importQ ''HsBindgen.Runtime.CEnum.AsSequentialCEnum
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -163,10 +163,14 @@ mkGlobal = \case
       CEnum_fromCEnumZ -> 'HsBindgen.Runtime.CEnum.fromCEnumZ
       CEnum_toCEnumZ -> 'HsBindgen.Runtime.CEnum.toCEnumZ
       CEnum_declaredValues -> 'HsBindgen.Runtime.CEnum.declaredValues
+      CEnum_isDeclared -> 'HsBindgen.Runtime.CEnum.isDeclared
+      CEnum_mkDeclared -> 'HsBindgen.Runtime.CEnum.mkDeclared
       SequentialCEnum_class -> ''HsBindgen.Runtime.CEnum.SequentialCEnum
       SequentialCEnum_minDeclaredValue -> 'HsBindgen.Runtime.CEnum.minDeclaredValue
       SequentialCEnum_maxDeclaredValue -> 'HsBindgen.Runtime.CEnum.maxDeclaredValue
       CEnum_showCEnum -> 'HsBindgen.Runtime.CEnum.showCEnum
+      CEnum_seqIsDeclared -> 'HsBindgen.Runtime.CEnum.seqIsDeclared
+      CEnum_seqMkDeclared -> 'HsBindgen.Runtime.CEnum.seqMkDeclared
       AsCEnum_type -> ''HsBindgen.Runtime.CEnum.AsCEnum
       AsSequentialCEnum_type -> ''HsBindgen.Runtime.CEnum.AsSequentialCEnum
 
@@ -330,10 +334,14 @@ mkGlobalExpr n = case n of -- in definition order, no wildcards
     CEnum_fromCEnumZ                 -> TH.varE name
     CEnum_toCEnumZ                   -> TH.varE name
     CEnum_declaredValues             -> TH.varE name
+    CEnum_isDeclared                 -> TH.varE name
+    CEnum_mkDeclared                 -> TH.varE name
     SequentialCEnum_class            -> panicPure "class in expression"
     SequentialCEnum_minDeclaredValue -> TH.varE name
     SequentialCEnum_maxDeclaredValue -> TH.varE name
     CEnum_showCEnum                  -> TH.varE name
+    CEnum_seqIsDeclared              -> TH.varE name
+    CEnum_seqMkDeclared              -> TH.varE name
     AsCEnum_type                     -> panicPure "type in expression"
     AsSequentialCEnum_type           -> panicPure "type in expression"
 

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -223,6 +223,7 @@ data InstanceDecl where
          Struct (S Z)
       -> HsType
       -> Map Integer (NonEmpty String)
+      -> Bool  -- is sequential?
       -> InstanceDecl
     InstanceSequentialCEnum ::
          Struct (S Z)

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -149,10 +149,14 @@ data Global =
   | CEnum_fromCEnumZ
   | CEnum_toCEnumZ
   | CEnum_declaredValues
+  | CEnum_isDeclared
+  | CEnum_mkDeclared
   | SequentialCEnum_class
   | SequentialCEnum_minDeclaredValue
   | SequentialCEnum_maxDeclaredValue
   | CEnum_showCEnum
+  | CEnum_seqIsDeclared
+  | CEnum_seqMkDeclared
   | AsCEnum_type
   | AsSequentialCEnum_type
 

--- a/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
@@ -263,8 +263,8 @@ instance ToExpr Hs.InstanceDecl where
       Expr.App "InstanceStorable" [toExpr struct, toExpr inst]
     Hs.InstanceHasFLAM struct fty i ->
       Expr.App "InstanceHasFLAM" [toExpr struct, toExpr fty, toExpr i]
-    Hs.InstanceCEnum struct typ vMap ->
-      Expr.App "InstanceCEnum" [toExpr struct, toExpr typ, toExpr vMap]
+    Hs.InstanceCEnum struct typ vMap isSeq ->
+      Expr.App "InstanceCEnum" [toExpr struct, toExpr typ, toExpr vMap, toExpr isSeq]
     Hs.InstanceSequentialCEnum struct minV maxV ->
       Expr.App "InstanceSequentialCEnum" [toExpr struct, toExpr minV, toExpr maxV]
     Hs.InstanceCEnumShow struct ->


### PR DESCRIPTION
Default implementations are `O(log n)`.  When an enumeration has sequentially declared values, generated instances set these methods to `seqIsDeclared` and `seqMkDeclared`, which are `O(1)`.