### PR TITLE
Deal with `CXType_Char_U`

### DIFF
--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -21,7 +21,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "bitfields.h:2:10"}},
         Field {
@@ -85,7 +87,9 @@
               fieldOffset = 16,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "bitfields.h:6:10"}},
         Field {
@@ -119,7 +123,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "bitfields.h:2:10"},
             StructField {
@@ -151,7 +157,9 @@
               fieldOffset = 16,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "bitfields.h:6:10"},
             StructField {
@@ -188,7 +196,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "bitfields.h:2:10"}},
           Field {
@@ -252,7 +262,9 @@
                 fieldOffset = 16,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "bitfields.h:6:10"}},
           Field {
@@ -286,7 +298,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "bitfields.h:2:10"},
               StructField {
@@ -318,7 +332,9 @@
                 fieldOffset = 16,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "bitfields.h:6:10"},
               StructField {
@@ -360,7 +376,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:2:10"}},
                   Field {
@@ -424,7 +442,9 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:6:10"}},
                   Field {
@@ -458,7 +478,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:2:10"},
                       StructField {
@@ -490,7 +512,9 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:6:10"},
                       StructField {
@@ -538,7 +562,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:2:10"}},
                   Field {
@@ -602,7 +628,9 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:6:10"}},
                   Field {
@@ -636,7 +664,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:2:10"},
                       StructField {
@@ -668,7 +698,9 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "bitfields.h:6:10"},
                       StructField {
@@ -2327,7 +2359,8 @@
               fieldOffset = 0,
               fieldWidth = Just 1,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "bitfields.h:37:16"}},
         Field {
@@ -2361,7 +2394,8 @@
               fieldOffset = 0,
               fieldWidth = Just 1,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "bitfields.h:37:16"},
             StructField {
@@ -2398,7 +2432,8 @@
                 fieldOffset = 0,
                 fieldWidth = Just 1,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "bitfields.h:37:16"}},
           Field {
@@ -2432,7 +2467,8 @@
                 fieldOffset = 0,
                 fieldWidth = Just 1,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "bitfields.h:37:16"},
               StructField {
@@ -2474,7 +2510,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 1,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:37:16"}},
                   Field {
@@ -2508,7 +2545,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 1,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:37:16"},
                       StructField {
@@ -2552,7 +2590,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 1,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:37:16"}},
                   Field {
@@ -2586,7 +2625,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 1,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:37:16"},
                       StructField {
@@ -2647,7 +2687,8 @@
               fieldOffset = 0,
               fieldWidth = Just 7,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "bitfields.h:42:16"}},
         Field {
@@ -2681,7 +2722,8 @@
               fieldOffset = 0,
               fieldWidth = Just 7,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "bitfields.h:42:16"},
             StructField {
@@ -2718,7 +2760,8 @@
                 fieldOffset = 0,
                 fieldWidth = Just 7,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "bitfields.h:42:16"}},
           Field {
@@ -2752,7 +2795,8 @@
                 fieldOffset = 0,
                 fieldWidth = Just 7,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "bitfields.h:42:16"},
               StructField {
@@ -2794,7 +2838,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 7,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:42:16"}},
                   Field {
@@ -2828,7 +2873,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 7,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:42:16"},
                       StructField {
@@ -2872,7 +2918,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 7,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:42:16"}},
                   Field {
@@ -2906,7 +2953,8 @@
                         fieldOffset = 0,
                         fieldWidth = Just 7,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "bitfields.h:42:16"},
                       StructField {

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -14,7 +14,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "bitfields.h:2:10"},
           StructField {
@@ -46,7 +48,9 @@ Header
             fieldOffset = 16,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "bitfields.h:6:10"},
           StructField {
@@ -210,7 +214,8 @@ Header
             fieldOffset = 0,
             fieldWidth = Just 1,
             fieldType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             fieldSourceLoc =
             "bitfields.h:37:16"},
           StructField {
@@ -238,7 +243,8 @@ Header
             fieldOffset = 0,
             fieldWidth = Just 7,
             fieldType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             fieldSourceLoc =
             "bitfields.h:42:16"},
           StructField {

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -285,7 +285,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "distilled_lib_1.h:8:32"}}],
       structOrigin =
@@ -312,7 +314,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "distilled_lib_1.h:8:32"}],
           structFlam = Nothing,
@@ -357,7 +361,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:8:32"}}],
         structOrigin =
@@ -384,7 +390,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "distilled_lib_1.h:8:32"}],
             structFlam = Nothing,
@@ -434,7 +442,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:8:32"}}],
                 structOrigin =
@@ -461,7 +471,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
@@ -513,7 +525,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:8:32"}}],
                 structOrigin =
@@ -540,7 +554,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
@@ -1154,7 +1170,8 @@
         Typedef {
           typedefName = CName "uint8_t",
           typedefType = TypePrim
-            (PrimChar (Just Unsigned)),
+            (PrimChar
+              (PrimSignExplicit Unsigned)),
           typedefSourceLoc =
           "alltypes.h:121:25"}},
   DeclNewtypeInstance
@@ -2985,7 +3002,8 @@
               (CName "a_typedef_enum_e")),
           enumAliases = [],
           enumType = TypePrim
-            (PrimChar (Just Unsigned)),
+            (PrimChar
+              (PrimSignExplicit Unsigned)),
           enumSizeof = 1,
           enumAlignment = 1,
           enumValues = [
@@ -3035,7 +3053,8 @@
                 (CName "a_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -3090,7 +3109,8 @@
                         (CName "a_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
-                      (PrimChar (Just Unsigned)),
+                      (PrimChar
+                        (PrimSignExplicit Unsigned)),
                     enumSizeof = 1,
                     enumAlignment = 1,
                     enumValues = [
@@ -3145,7 +3165,8 @@
                         (CName "a_typedef_enum_e")),
                     enumAliases = [],
                     enumType = TypePrim
-                      (PrimChar (Just Unsigned)),
+                      (PrimChar
+                        (PrimSignExplicit Unsigned)),
                     enumSizeof = 1,
                     enumAlignment = 1,
                     enumValues = [
@@ -3220,7 +3241,8 @@
                 (CName "a_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -3286,7 +3308,8 @@
                 (CName "a_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -3342,7 +3365,8 @@
                 (CName "a_typedef_enum_e")),
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -347,7 +347,9 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "distilled_lib_1.h:8:32"}],
         structFlam = Nothing,
@@ -395,7 +397,8 @@ Header
       Typedef {
         typedefName = CName "uint8_t",
         typedefType = TypePrim
-          (PrimChar (Just Unsigned)),
+          (PrimChar
+            (PrimSignExplicit Unsigned)),
         typedefSourceLoc =
         "alltypes.h:121:25"},
     DeclTypedef
@@ -554,7 +557,8 @@ Header
             (CName "a_typedef_enum_e")),
         enumAliases = [],
         enumType = TypePrim
-          (PrimChar (Just Unsigned)),
+          (PrimChar
+            (PrimSignExplicit Unsigned)),
         enumSizeof = 1,
         enumAlignment = 1,
         enumValues = [

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -1507,7 +1507,8 @@
             DeclPathCtxtTop,
           enumAliases = [],
           enumType = TypePrim
-            (PrimChar (Just Unsigned)),
+            (PrimChar
+              (PrimSignExplicit Unsigned)),
           enumSizeof = 1,
           enumAlignment = 1,
           enumValues = [
@@ -1552,7 +1553,8 @@
               DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -1601,7 +1603,8 @@
                       DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
-                      (PrimChar (Just Unsigned)),
+                      (PrimChar
+                        (PrimSignExplicit Unsigned)),
                     enumSizeof = 1,
                     enumAlignment = 1,
                     enumValues = [
@@ -1651,7 +1654,8 @@
                       DeclPathCtxtTop,
                     enumAliases = [],
                     enumType = TypePrim
-                      (PrimChar (Just Unsigned)),
+                      (PrimChar
+                        (PrimSignExplicit Unsigned)),
                     enumSizeof = 1,
                     enumAlignment = 1,
                     enumValues = [
@@ -1720,7 +1724,8 @@
               DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -1776,7 +1781,8 @@
               DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [
@@ -1824,7 +1830,8 @@
               DeclPathCtxtTop,
             enumAliases = [],
             enumType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             enumSizeof = 1,
             enumAlignment = 1,
             enumValues = [

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -119,7 +119,8 @@ Header
           DeclPathCtxtTop,
         enumAliases = [],
         enumType = TypePrim
-          (PrimChar (Just Unsigned)),
+          (PrimChar
+            (PrimSignExplicit Unsigned)),
         enumSizeof = 1,
         enumAlignment = 1,
         enumValues = [

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -47,7 +47,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc = "flam.h:4:10"},
           structSourceLoc =
           "flam.h:2:8"}},
@@ -100,7 +102,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc = "flam.h:4:10"},
             structSourceLoc = "flam.h:2:8"}}
       StorableInstance {
@@ -157,7 +161,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc = "flam.h:4:10"},
                     structSourceLoc =
                     "flam.h:2:8"}})
@@ -215,7 +221,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc = "flam.h:4:10"},
                     structSourceLoc = "flam.h:2:8"}}
               (Add 1)
@@ -286,7 +294,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc = "flam.h:4:10"},
             structSourceLoc = "flam.h:2:8"}}
       (HsPrimType HsPrimCChar)
@@ -959,7 +969,9 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "flam.h:19:7"}}],
       structOrigin =
@@ -984,7 +996,9 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "flam.h:19:7"}],
           structFlam = Just
@@ -993,7 +1007,9 @@
               fieldOffset = 72,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc = "flam.h:20:7"},
           structSourceLoc =
           "flam.h:17:8"}},
@@ -1036,7 +1052,9 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "flam.h:19:7"}}],
         structOrigin =
@@ -1061,7 +1079,9 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "flam.h:19:7"}],
             structFlam = Just
@@ -1070,7 +1090,9 @@
                 fieldOffset = 72,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc = "flam.h:20:7"},
             structSourceLoc =
             "flam.h:17:8"}}
@@ -1118,7 +1140,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "flam.h:19:7"}}],
                 structOrigin =
@@ -1143,7 +1167,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "flam.h:19:7"}],
                     structFlam = Just
@@ -1152,7 +1178,9 @@
                         fieldOffset = 72,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc = "flam.h:20:7"},
                     structSourceLoc =
                     "flam.h:17:8"}})
@@ -1202,7 +1230,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "flam.h:19:7"}}],
                 structOrigin =
@@ -1227,7 +1257,9 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "flam.h:19:7"}],
                     structFlam = Just
@@ -1236,7 +1268,9 @@
                         fieldOffset = 72,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc = "flam.h:20:7"},
                     structSourceLoc =
                     "flam.h:17:8"}}
@@ -1295,7 +1329,9 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "flam.h:19:7"}}],
         structOrigin =
@@ -1320,7 +1356,9 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "flam.h:19:7"}],
             structFlam = Just
@@ -1329,7 +1367,9 @@
                 fieldOffset = 72,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc = "flam.h:20:7"},
             structSourceLoc =
             "flam.h:17:8"}}

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -22,7 +22,9 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc = "flam.h:4:10"},
         structSourceLoc = "flam.h:2:8"},
     DeclStruct
@@ -104,7 +106,9 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "flam.h:19:7"}],
         structFlam = Just
@@ -113,7 +117,9 @@ Header
             fieldOffset = 72,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc = "flam.h:20:7"},
         structSourceLoc =
         "flam.h:17:8"}]

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -112,7 +112,8 @@
           macroBody = MTerm
             (MType
               (TypePrim
-                (PrimChar Nothing)))}},
+                (PrimChar
+                  (PrimSignImplicit Nothing))))}},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -432,9 +433,12 @@
           functionName = CName "quux",
           functionArgs = [
             TypeTypedef (CName "F"),
-            TypePrim (PrimChar Nothing)],
+            TypePrim
+              (PrimChar
+                (PrimSignImplicit Nothing))],
           functionRes = TypePrim
-            (PrimChar Nothing),
+            (PrimChar
+              (PrimSignImplicit Nothing)),
           functionHeader =
           "macro_in_fundecl.h",
           functionSourceLoc =
@@ -509,7 +513,10 @@
                     PrimInt
                     Signed)))],
           functionRes = TypePointer
-            (TypePrim (PrimChar Nothing)),
+            (TypePrim
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed)))),
           functionHeader =
           "macro_in_fundecl.h",
           functionSourceLoc =
@@ -549,7 +556,9 @@
                     PrimInt
                     Signed)))],
           functionRes = TypePointer
-            (TypePrim (PrimChar Nothing)),
+            (TypePrim
+              (PrimChar
+                (PrimSignImplicit Nothing))),
           functionHeader =
           "macro_in_fundecl.h",
           functionSourceLoc =

--- a/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
@@ -33,7 +33,9 @@ Header
           macroArgs = [],
           macroBody = MTerm
             (MType
-              (TypePrim (PrimChar Nothing)))},
+              (TypePrim
+                (PrimChar
+                  (PrimSignImplicit Nothing))))},
         macroDeclMacroTy = "PrimTy",
         macroDeclSourceLoc =
         "macro_in_fundecl.h:6:9"},
@@ -100,9 +102,12 @@ Header
         functionName = CName "quux",
         functionArgs = [
           TypeTypedef (CName "F"),
-          TypePrim (PrimChar Nothing)],
+          TypePrim
+            (PrimChar
+              (PrimSignImplicit Nothing))],
         functionRes = TypePrim
-          (PrimChar Nothing),
+          (PrimChar
+            (PrimSignImplicit Nothing)),
         functionHeader =
         "macro_in_fundecl.h",
         functionSourceLoc =
@@ -137,7 +142,10 @@ Header
                   PrimInt
                   Signed)))],
         functionRes = TypePointer
-          (TypePrim (PrimChar Nothing)),
+          (TypePrim
+            (PrimChar
+              (PrimSignImplicit
+                (Just Signed)))),
         functionHeader =
         "macro_in_fundecl.h",
         functionSourceLoc =
@@ -157,7 +165,9 @@ Header
                   PrimInt
                   Signed)))],
         functionRes = TypePointer
-          (TypePrim (PrimChar Nothing)),
+          (TypePrim
+            (PrimChar
+              (PrimSignImplicit Nothing))),
         functionHeader =
         "macro_in_fundecl.h",
         functionSourceLoc =

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -28,7 +28,8 @@
           macroBody = MTerm
             (MType
               (TypePrim
-                (PrimChar Nothing)))}},
+                (PrimChar
+                  (PrimSignImplicit Nothing))))}},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -105,7 +106,8 @@
             TypeTypedef (CName "MC"),
             TypeTypedef (CName "TC")],
           functionRes = TypePrim
-            (PrimChar Nothing),
+            (PrimChar
+              (PrimSignImplicit Nothing)),
           functionHeader =
           "macro_in_fundecl_vs_typedef.h",
           functionSourceLoc =
@@ -134,7 +136,9 @@
           functionName = CName "quux2",
           functionArgs = [
             TypeTypedef (CName "MC"),
-            TypePrim (PrimChar Nothing)],
+            TypePrim
+              (PrimChar
+                (PrimSignImplicit Nothing))],
           functionRes = TypeTypedef
             (CName "TC"),
           functionHeader =
@@ -331,7 +335,9 @@
         Typedef {
           typedefName = CName "TC",
           typedefType = TypePrim
-            (PrimChar Nothing),
+            (PrimChar
+              (PrimSignImplicit
+                (Just Signed))),
           typedefSourceLoc =
           "macro_in_fundecl_vs_typedef.h:5:14"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
@@ -13,7 +13,9 @@ Header
           macroArgs = [],
           macroBody = MTerm
             (MType
-              (TypePrim (PrimChar Nothing)))},
+              (TypePrim
+                (PrimChar
+                  (PrimSignImplicit Nothing))))},
         macroDeclMacroTy = "PrimTy",
         macroDeclSourceLoc =
         "macro_in_fundecl_vs_typedef.h:4:9"},
@@ -24,7 +26,8 @@ Header
           TypeTypedef (CName "MC"),
           TypeTypedef (CName "TC")],
         functionRes = TypePrim
-          (PrimChar Nothing),
+          (PrimChar
+            (PrimSignImplicit Nothing)),
         functionHeader =
         "macro_in_fundecl_vs_typedef.h",
         functionSourceLoc =
@@ -34,7 +37,9 @@ Header
         functionName = CName "quux2",
         functionArgs = [
           TypeTypedef (CName "MC"),
-          TypePrim (PrimChar Nothing)],
+          TypePrim
+            (PrimChar
+              (PrimSignImplicit Nothing))],
         functionRes = TypeTypedef
           (CName "TC"),
         functionHeader =
@@ -113,7 +118,9 @@ Header
       Typedef {
         typedefName = CName "TC",
         typedefType = TypePrim
-          (PrimChar Nothing),
+          (PrimChar
+            (PrimSignImplicit
+              (Just Signed))),
         typedefSourceLoc =
         "macro_in_fundecl_vs_typedef.h:5:14"},
     DeclStruct

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -2116,7 +2116,10 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePointer
-                (TypePrim (PrimChar Nothing)),
+                (TypePrim
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed)))),
               fieldSourceLoc =
               "manual_examples.h:71:11"}},
         Field {
@@ -2153,7 +2156,10 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePointer
-                (TypePrim (PrimChar Nothing)),
+                (TypePrim
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed)))),
               fieldSourceLoc =
               "manual_examples.h:71:11"},
             StructField {
@@ -2190,7 +2196,10 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePointer
-                  (TypePrim (PrimChar Nothing)),
+                  (TypePrim
+                    (PrimChar
+                      (PrimSignImplicit
+                        (Just Signed)))),
                 fieldSourceLoc =
                 "manual_examples.h:71:11"}},
           Field {
@@ -2227,7 +2236,10 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePointer
-                  (TypePrim (PrimChar Nothing)),
+                  (TypePrim
+                    (PrimChar
+                      (PrimSignImplicit
+                        (Just Signed)))),
                 fieldSourceLoc =
                 "manual_examples.h:71:11"},
               StructField {
@@ -2269,7 +2281,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:71:11"}},
                   Field {
@@ -2306,7 +2321,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:71:11"},
                       StructField {
@@ -2350,7 +2368,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:71:11"}},
                   Field {
@@ -2387,7 +2408,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:71:11"},
                       StructField {
@@ -2456,7 +2480,10 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePointer
-                (TypePrim (PrimChar Nothing)),
+                (TypePrim
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed)))),
               fieldSourceLoc =
               "manual_examples.h:76:11"}},
         Field {
@@ -2522,7 +2549,10 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePointer
-                (TypePrim (PrimChar Nothing)),
+                (TypePrim
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed)))),
               fieldSourceLoc =
               "manual_examples.h:76:11"},
             StructField {
@@ -2577,7 +2607,10 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePointer
-                  (TypePrim (PrimChar Nothing)),
+                  (TypePrim
+                    (PrimChar
+                      (PrimSignImplicit
+                        (Just Signed)))),
                 fieldSourceLoc =
                 "manual_examples.h:76:11"}},
           Field {
@@ -2643,7 +2676,10 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePointer
-                  (TypePrim (PrimChar Nothing)),
+                  (TypePrim
+                    (PrimChar
+                      (PrimSignImplicit
+                        (Just Signed)))),
                 fieldSourceLoc =
                 "manual_examples.h:76:11"},
               StructField {
@@ -2703,7 +2739,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:76:11"}},
                   Field {
@@ -2769,7 +2808,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:76:11"},
                       StructField {
@@ -2832,7 +2874,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:76:11"}},
                   Field {
@@ -2898,7 +2943,10 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePointer
-                          (TypePrim (PrimChar Nothing)),
+                          (TypePrim
+                            (PrimChar
+                              (PrimSignImplicit
+                                (Just Signed)))),
                         fieldSourceLoc =
                         "manual_examples.h:76:11"},
                       StructField {

--- a/hs-bindgen/fixtures/manual_examples.tree-diff.txt
+++ b/hs-bindgen/fixtures/manual_examples.tree-diff.txt
@@ -396,7 +396,10 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePointer
-              (TypePrim (PrimChar Nothing)),
+              (TypePrim
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed)))),
             fieldSourceLoc =
             "manual_examples.h:71:11"},
           StructField {
@@ -434,7 +437,10 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePointer
-              (TypePrim (PrimChar Nothing)),
+              (TypePrim
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed)))),
             fieldSourceLoc =
             "manual_examples.h:76:11"},
           StructField {

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -37,7 +37,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "nested_types.h:3:10"}}],
       structOrigin =
@@ -63,7 +65,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "nested_types.h:3:10"}],
           structFlam = Nothing,
@@ -108,7 +112,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "nested_types.h:3:10"}}],
         structOrigin =
@@ -134,7 +140,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "nested_types.h:3:10"}],
             structFlam = Nothing,
@@ -184,7 +192,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "nested_types.h:3:10"}}],
                 structOrigin =
@@ -210,7 +220,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "nested_types.h:3:10"}],
                     structFlam = Nothing,
@@ -262,7 +274,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "nested_types.h:3:10"}}],
                 structOrigin =
@@ -288,7 +302,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "nested_types.h:3:10"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -22,7 +22,9 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "nested_types.h:3:10"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/nested_unions.hs
+++ b/hs-bindgen/fixtures/nested_unions.hs
@@ -35,7 +35,9 @@
             UnionField {
               ufieldName = CName "b",
               ufieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               ufieldSourceLoc =
               "nested_unions.h:4:22"}],
           unionSourceLoc =
@@ -374,7 +376,9 @@
             UnionField {
               ufieldName = CName "b",
               ufieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               ufieldSourceLoc =
               "nested_unions.h:11:22"}],
           unionSourceLoc =

--- a/hs-bindgen/fixtures/nested_unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_unions.tree-diff.txt
@@ -21,7 +21,9 @@ Header
           UnionField {
             ufieldName = CName "b",
             ufieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             ufieldSourceLoc =
             "nested_unions.h:4:22"}],
         unionSourceLoc =
@@ -71,7 +73,9 @@ Header
           UnionField {
             ufieldName = CName "b",
             ufieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             ufieldSourceLoc =
             "nested_unions.h:11:22"}],
         unionSourceLoc =

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -21,7 +21,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "primitive_types.h:2:10"}},
         Field {
@@ -37,7 +39,8 @@
               fieldOffset = 8,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar (Just Signed)),
+                (PrimChar
+                  (PrimSignExplicit Signed)),
               fieldSourceLoc =
               "primitive_types.h:3:17"}},
         Field {
@@ -53,7 +56,8 @@
               fieldOffset = 16,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "primitive_types.h:4:19"}},
         Field {
@@ -491,7 +495,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "primitive_types.h:2:10"},
             StructField {
@@ -499,7 +505,8 @@
               fieldOffset = 8,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar (Just Signed)),
+                (PrimChar
+                  (PrimSignExplicit Signed)),
               fieldSourceLoc =
               "primitive_types.h:3:17"},
             StructField {
@@ -507,7 +514,8 @@
               fieldOffset = 16,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar (Just Unsigned)),
+                (PrimChar
+                  (PrimSignExplicit Unsigned)),
               fieldSourceLoc =
               "primitive_types.h:4:19"},
             StructField {
@@ -756,7 +764,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "primitive_types.h:2:10"}},
           Field {
@@ -772,7 +782,8 @@
                 fieldOffset = 8,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar (Just Signed)),
+                  (PrimChar
+                    (PrimSignExplicit Signed)),
                 fieldSourceLoc =
                 "primitive_types.h:3:17"}},
           Field {
@@ -788,7 +799,8 @@
                 fieldOffset = 16,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "primitive_types.h:4:19"}},
           Field {
@@ -1226,7 +1238,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "primitive_types.h:2:10"},
               StructField {
@@ -1234,7 +1248,8 @@
                 fieldOffset = 8,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar (Just Signed)),
+                  (PrimChar
+                    (PrimSignExplicit Signed)),
                 fieldSourceLoc =
                 "primitive_types.h:3:17"},
               StructField {
@@ -1242,7 +1257,8 @@
                 fieldOffset = 16,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar (Just Unsigned)),
+                  (PrimChar
+                    (PrimSignExplicit Unsigned)),
                 fieldSourceLoc =
                 "primitive_types.h:4:19"},
               StructField {
@@ -1496,7 +1512,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "primitive_types.h:2:10"}},
                   Field {
@@ -1512,7 +1530,8 @@
                         fieldOffset = 8,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Signed)),
+                          (PrimChar
+                            (PrimSignExplicit Signed)),
                         fieldSourceLoc =
                         "primitive_types.h:3:17"}},
                   Field {
@@ -1528,7 +1547,8 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "primitive_types.h:4:19"}},
                   Field {
@@ -1966,7 +1986,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "primitive_types.h:2:10"},
                       StructField {
@@ -1974,7 +1996,8 @@
                         fieldOffset = 8,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Signed)),
+                          (PrimChar
+                            (PrimSignExplicit Signed)),
                         fieldSourceLoc =
                         "primitive_types.h:3:17"},
                       StructField {
@@ -1982,7 +2005,8 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "primitive_types.h:4:19"},
                       StructField {
@@ -2264,7 +2288,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "primitive_types.h:2:10"}},
                   Field {
@@ -2280,7 +2306,8 @@
                         fieldOffset = 8,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Signed)),
+                          (PrimChar
+                            (PrimSignExplicit Signed)),
                         fieldSourceLoc =
                         "primitive_types.h:3:17"}},
                   Field {
@@ -2296,7 +2323,8 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "primitive_types.h:4:19"}},
                   Field {
@@ -2734,7 +2762,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "primitive_types.h:2:10"},
                       StructField {
@@ -2742,7 +2772,8 @@
                         fieldOffset = 8,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Signed)),
+                          (PrimChar
+                            (PrimSignExplicit Signed)),
                         fieldSourceLoc =
                         "primitive_types.h:3:17"},
                       StructField {
@@ -2750,7 +2781,8 @@
                         fieldOffset = 16,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar (Just Unsigned)),
+                          (PrimChar
+                            (PrimSignExplicit Unsigned)),
                         fieldSourceLoc =
                         "primitive_types.h:4:19"},
                       StructField {

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -14,7 +14,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "primitive_types.h:2:10"},
           StructField {
@@ -22,7 +24,8 @@ Header
             fieldOffset = 8,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar (Just Signed)),
+              (PrimChar
+                (PrimSignExplicit Signed)),
             fieldSourceLoc =
             "primitive_types.h:3:17"},
           StructField {
@@ -30,7 +33,8 @@ Header
             fieldOffset = 16,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar (Just Unsigned)),
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
             fieldSourceLoc =
             "primitive_types.h:4:19"},
           StructField {

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -119,7 +119,10 @@
         Function {
           functionName = CName "fun",
           functionArgs = [
-            TypePrim (PrimChar Nothing),
+            TypePrim
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -51,7 +51,10 @@ Header
       Function {
         functionName = CName "fun",
         functionArgs = [
-          TypePrim (PrimChar Nothing),
+          TypePrim
+            (PrimChar
+              (PrimSignImplicit
+                (Just Signed))),
           TypePrim
             (PrimFloating PrimDouble)],
         functionRes = TypePrim

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -37,7 +37,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:4:10"}}],
       structOrigin =
@@ -63,7 +65,9 @@
               fieldOffset = 32,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:4:10"}],
           structFlam = Nothing,
@@ -108,7 +112,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:4:10"}}],
         structOrigin =
@@ -134,7 +140,9 @@
                 fieldOffset = 32,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:4:10"}],
             structFlam = Nothing,
@@ -184,7 +192,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:4:10"}}],
                 structOrigin =
@@ -210,7 +220,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:4:10"}],
                     structFlam = Nothing,
@@ -262,7 +274,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:4:10"}}],
                 structOrigin =
@@ -288,7 +302,9 @@
                         fieldOffset = 32,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:4:10"}],
                     structFlam = Nothing,
@@ -332,7 +348,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:9:10"}},
         Field {
@@ -382,7 +400,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:9:10"},
             StructField {
@@ -427,7 +447,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:9:10"}},
           Field {
@@ -477,7 +499,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:9:10"},
               StructField {
@@ -527,7 +551,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:9:10"}},
                   Field {
@@ -577,7 +603,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:9:10"},
                       StructField {
@@ -630,7 +658,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:9:10"}},
                   Field {
@@ -680,7 +710,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:9:10"},
                       StructField {
@@ -770,7 +802,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:16:10"}}],
       structOrigin =
@@ -788,7 +822,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:16:10"}],
           structFlam = Nothing,
@@ -817,7 +853,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:16:10"}}],
         structOrigin =
@@ -835,7 +873,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:16:10"}],
             structFlam = Nothing,
@@ -869,7 +909,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:16:10"}}],
                 structOrigin =
@@ -887,7 +929,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:16:10"}],
                     structFlam = Nothing,
@@ -921,7 +965,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:16:10"}}],
                 structOrigin =
@@ -939,7 +985,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:16:10"}],
                     structFlam = Nothing,
@@ -982,7 +1030,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:20:10"}},
         Field {
@@ -1033,7 +1083,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:20:10"},
             StructField {
@@ -1079,7 +1131,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:20:10"}},
           Field {
@@ -1130,7 +1184,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:20:10"},
               StructField {
@@ -1181,7 +1237,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:20:10"}},
                   Field {
@@ -1232,7 +1290,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:20:10"},
                       StructField {
@@ -1286,7 +1346,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:20:10"}},
                   Field {
@@ -1337,7 +1399,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:20:10"},
                       StructField {
@@ -1399,7 +1463,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:27:10"}},
         Field {
@@ -1433,7 +1499,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:27:10"},
             StructField {
@@ -1470,7 +1538,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:27:10"}},
           Field {
@@ -1504,7 +1574,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:27:10"},
               StructField {
@@ -1546,7 +1618,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:27:10"}},
                   Field {
@@ -1580,7 +1654,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:27:10"},
                       StructField {
@@ -1624,7 +1700,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:27:10"}},
                   Field {
@@ -1658,7 +1736,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:27:10"},
                       StructField {
@@ -1710,7 +1790,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:31:18"}},
         Field {
@@ -1744,7 +1826,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:31:18"},
             StructField {
@@ -1781,7 +1865,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:31:18"}},
           Field {
@@ -1815,7 +1901,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:31:18"},
               StructField {
@@ -1857,7 +1945,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:31:18"}},
                   Field {
@@ -1891,7 +1981,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:31:18"},
                       StructField {
@@ -1935,7 +2027,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:31:18"}},
                   Field {
@@ -1969,7 +2063,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:31:18"},
                       StructField {
@@ -2021,7 +2117,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:34:23"}},
         Field {
@@ -2056,7 +2154,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:34:23"},
             StructField {
@@ -2093,7 +2193,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:34:23"}},
           Field {
@@ -2128,7 +2230,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:34:23"},
               StructField {
@@ -2170,7 +2274,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:34:23"}},
                   Field {
@@ -2205,7 +2311,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:34:23"},
                       StructField {
@@ -2249,7 +2357,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:34:23"}},
                   Field {
@@ -2284,7 +2394,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:34:23"},
                       StructField {
@@ -2374,7 +2486,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:35:23"}},
         Field {
@@ -2411,7 +2525,9 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypePrim
-                (PrimChar Nothing),
+                (PrimChar
+                  (PrimSignImplicit
+                    (Just Signed))),
               fieldSourceLoc =
               "simple_structs.h:35:23"},
             StructField {
@@ -2448,7 +2564,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:35:23"}},
           Field {
@@ -2485,7 +2603,9 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypePrim
-                  (PrimChar Nothing),
+                  (PrimChar
+                    (PrimSignImplicit
+                      (Just Signed))),
                 fieldSourceLoc =
                 "simple_structs.h:35:23"},
               StructField {
@@ -2527,7 +2647,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:35:23"}},
                   Field {
@@ -2564,7 +2686,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:35:23"},
                       StructField {
@@ -2608,7 +2732,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:35:23"}},
                   Field {
@@ -2645,7 +2771,9 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypePrim
-                          (PrimChar Nothing),
+                          (PrimChar
+                            (PrimSignImplicit
+                              (Just Signed))),
                         fieldSourceLoc =
                         "simple_structs.h:35:23"},
                       StructField {

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -22,7 +22,9 @@ Header
             fieldOffset = 32,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:4:10"}],
         structFlam = Nothing,
@@ -42,7 +44,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:9:10"},
           StructField {
@@ -87,7 +91,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:16:10"}],
         structFlam = Nothing,
@@ -107,7 +113,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:20:10"},
           StructField {
@@ -144,7 +152,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:27:10"},
           StructField {
@@ -172,7 +182,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:31:18"},
           StructField {
@@ -201,7 +213,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:34:23"},
           StructField {
@@ -243,7 +257,9 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypePrim
-              (PrimChar Nothing),
+              (PrimChar
+                (PrimSignImplicit
+                  (Just Signed))),
             fieldSourceLoc =
             "simple_structs.h:35:23"},
           StructField {

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -112,7 +112,8 @@
           macroBody = MTerm
             (MType
               (TypePrim
-                (PrimChar Nothing)))}},
+                (PrimChar
+                  (PrimSignImplicit Nothing))))}},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -409,7 +410,9 @@
         Typedef {
           typedefName = CName "T2",
           typedefType = TypePrim
-            (PrimChar Nothing),
+            (PrimChar
+              (PrimSignImplicit
+                (Just Signed))),
           typedefSourceLoc =
           "typedef_vs_macro.h:2:14"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -33,7 +33,9 @@ Header
           macroArgs = [],
           macroBody = MTerm
             (MType
-              (TypePrim (PrimChar Nothing)))},
+              (TypePrim
+                (PrimChar
+                  (PrimSignImplicit Nothing))))},
         macroDeclMacroTy = "PrimTy",
         macroDeclSourceLoc =
         "typedef_vs_macro.h:5:9"},
@@ -156,7 +158,9 @@ Header
       Typedef {
         typedefName = CName "T2",
         typedefType = TypePrim
-          (PrimChar Nothing),
+          (PrimChar
+            (PrimSignImplicit
+              (Just Signed))),
         typedefSourceLoc =
         "typedef_vs_macro.h:2:14"},
     DeclStruct

--- a/hs-bindgen/src-internal/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST.hs
@@ -19,6 +19,7 @@ module HsBindgen.C.AST (
   , PrimIntType(..)
   , PrimFloatType(..)
   , PrimSign(..)
+  , PrimSignChar(..)
     -- ** Structs
   , Struct(..)
   , StructField(..)

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -782,9 +782,10 @@ primType :: Either CInt CXTypeKind -> Maybe PrimType
 primType (Left _)     = Nothing
 primType (Right kind) =
     case kind of
-      CXType_Char_S     -> Just $ PrimChar     Nothing
-      CXType_SChar      -> Just $ PrimChar     (Just Signed)
-      CXType_UChar      -> Just $ PrimChar     (Just Unsigned)
+      CXType_Char_S     -> Just $ PrimChar $ PrimSignImplicit (Just Signed)
+      CXType_Char_U     -> Just $ PrimChar $ PrimSignImplicit (Just Unsigned)
+      CXType_SChar      -> Just $ PrimChar $ PrimSignExplicit Signed
+      CXType_UChar      -> Just $ PrimChar $ PrimSignExplicit Unsigned
       CXType_Short      -> Just $ PrimIntegral PrimShort    Signed
       CXType_UShort     -> Just $ PrimIntegral PrimShort    Unsigned
       CXType_Int        -> Just $ PrimIntegral PrimInt      Signed

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
@@ -36,9 +36,9 @@ reparsePrimType = do
     kws <- many1 primTypeKeyword
     case kws of
       -- char
-      [             "char"] -> return $ TypePrim $ PrimChar Nothing
-      ["signed"   , "char"] -> return $ TypePrim $ PrimChar (Just Signed)
-      ["unsigned" , "char"] -> return $ TypePrim $ PrimChar (Just Unsigned)
+      [             "char"] -> return $ TypePrim $ PrimChar (PrimSignImplicit Nothing)
+      ["signed"   , "char"] -> return $ TypePrim $ PrimChar (PrimSignExplicit Signed)
+      ["unsigned" , "char"] -> return $ TypePrim $ PrimChar (PrimSignExplicit Unsigned)
       -- short
       [             "short"        ] -> return $ TypePrim $ PrimIntegral PrimShort Signed
       ["signed"   , "short"        ] -> return $ TypePrim $ PrimIntegral PrimShort Signed

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -495,13 +495,15 @@ typ' ctx nm = go ctx
         Hs.HsExtBinding extId
 
     goPrim :: C.PrimType -> HsPrimType
-    goPrim C.PrimBool                     = HsPrimCBool
-    goPrim (C.PrimChar Nothing)           = HsPrimCChar
-    goPrim (C.PrimChar (Just C.Signed))   = HsPrimCSChar
-    goPrim (C.PrimChar (Just C.Unsigned)) = HsPrimCSChar
-    goPrim (C.PrimIntegral i s)           = integralType i s
-    goPrim (C.PrimFloating f)             = floatingType f
-    goPrim C.PrimPtrDiff                  = HsPrimCPtrDiff
+    goPrim C.PrimBool           = HsPrimCBool
+    goPrim (C.PrimIntegral i s) = integralType i s
+    goPrim (C.PrimFloating f)   = floatingType f
+    goPrim C.PrimPtrDiff        = HsPrimCPtrDiff
+    goPrim (C.PrimChar sign)    =
+        case sign of
+          C.PrimSignImplicit _          -> HsPrimCChar
+          C.PrimSignExplicit C.Signed   -> HsPrimCSChar
+          C.PrimSignExplicit C.Unsigned -> HsPrimCSChar
 
     goVoid :: TypeContext -> HsPrimType
     goVoid CFunRes = HsPrimUnit

--- a/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
@@ -59,6 +59,7 @@ instance ToExpr C.OpaqueStruct
 instance ToExpr C.PrimFloatType
 instance ToExpr C.PrimIntType
 instance ToExpr C.PrimSign
+instance ToExpr C.PrimSignChar
 instance ToExpr C.PrimType
 instance ToExpr C.Struct
 instance ToExpr C.StructField


### PR DESCRIPTION
When the user does not specify the sign for `char`, the compiler picks one (this is different from `int`, where the absence of a sign means `signed`, rather than "implementation defined"). We dealt with the `CXType_Char_S` case, which is where the inferred sign is `signed`, but didn't deal with the case where the inferred sign is `CXType_Char_U`, or unsigned. Unfortunately I'm not sure under which circumstances this happens so this commit is lacking a test currently (but the client has one).