### PR TITLE
Change ext bindings `.yaml` ordering

### DIFF
--- a/hs-bindgen/fixtures/adios.extbindings.yaml
+++ b/hs-bindgen/fixtures/adios.extbindings.yaml
@@ -1,11 +1,11 @@
 types:
-- cname: adiós
-  headers: adios.h
+- headers: adios.h
+  cname: adiós
+  package: example
+  module: Example
   identifier: Adio'0301s
-  module: Example
+- headers: adios.h
+  cname: 数字
   package: example
-- cname: 数字
-  headers: adios.h
+  module: Example
   identifier: C数字
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/anonymous.extbindings.yaml
+++ b/hs-bindgen/fixtures/anonymous.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: struct S1
-  headers: anonymous.h
+- headers: anonymous.h
+  cname: struct S1
+  package: example
+  module: Example
   identifier: S1
-  module: Example
+- headers: anonymous.h
+  cname: struct S2
   package: example
-- cname: struct S2
-  headers: anonymous.h
+  module: Example
   identifier: S2
-  module: Example
+- headers: anonymous.h
+  cname: struct S3
   package: example
-- cname: struct S3
-  headers: anonymous.h
+  module: Example
   identifier: S3
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/bitfields.extbindings.yaml
+++ b/hs-bindgen/fixtures/bitfields.extbindings.yaml
@@ -1,36 +1,36 @@
 types:
-- cname: struct alignA
-  headers: bitfields.h
+- headers: bitfields.h
+  cname: struct alignA
+  package: example
+  module: Example
   identifier: AlignA
-  module: Example
+- headers: bitfields.h
+  cname: struct alignB
   package: example
-- cname: struct alignB
-  headers: bitfields.h
+  module: Example
   identifier: AlignB
-  module: Example
+- headers: bitfields.h
+  cname: struct flags
   package: example
-- cname: struct flags
-  headers: bitfields.h
+  module: Example
   identifier: Flags
-  module: Example
+- headers: bitfields.h
+  cname: struct overflow32
   package: example
-- cname: struct overflow32
-  headers: bitfields.h
+  module: Example
   identifier: Overflow32
-  module: Example
+- headers: bitfields.h
+  cname: struct overflow32b
   package: example
-- cname: struct overflow32b
-  headers: bitfields.h
+  module: Example
   identifier: Overflow32b
-  module: Example
+- headers: bitfields.h
+  cname: struct overflow32c
   package: example
-- cname: struct overflow32c
-  headers: bitfields.h
+  module: Example
   identifier: Overflow32c
-  module: Example
+- headers: bitfields.h
+  cname: struct overflow64
   package: example
-- cname: struct overflow64
-  headers: bitfields.h
+  module: Example
   identifier: Overflow64
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/bool.extbindings.yaml
+++ b/hs-bindgen/fixtures/bool.extbindings.yaml
@@ -1,21 +1,21 @@
 types:
-- cname: BOOL
-  headers: bool.h
+- headers: bool.h
+  cname: BOOL
+  package: example
+  module: Example
   identifier: BOOL
-  module: Example
+- headers: bool.h
+  cname: struct bools1
   package: example
-- cname: struct bools1
-  headers: bool.h
+  module: Example
   identifier: Bools1
-  module: Example
+- headers: bool.h
+  cname: struct bools2
   package: example
-- cname: struct bools2
-  headers: bool.h
+  module: Example
   identifier: Bools2
-  module: Example
+- headers: bool.h
+  cname: struct bools3
   package: example
-- cname: struct bools3
-  headers: bool.h
+  module: Example
   identifier: Bools3
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
+++ b/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
@@ -1,61 +1,61 @@
 types:
-- cname: a_type_t
-  headers: distilled_lib_1.h
+- headers: distilled_lib_1.h
+  cname: a_type_t
+  package: example
+  module: Example
   identifier: A_type_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: a_typedef_enum_e
   package: example
-- cname: a_typedef_enum_e
-  headers: distilled_lib_1.h
+  module: Example
   identifier: A_typedef_enum_e
-  module: Example
+- headers: distilled_lib_1.h
+  cname: a_typedef_struct_t
   package: example
-- cname: a_typedef_struct_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: A_typedef_struct_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: another_typedef_enum_e
   package: example
-- cname: another_typedef_enum_e
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Another_typedef_enum_e
-  module: Example
+- headers: distilled_lib_1.h
+  cname: another_typedef_struct_t
   package: example
-- cname: another_typedef_struct_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Another_typedef_struct_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: callback_t
   package: example
-- cname: callback_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Callback_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: int32_t
   package: example
-- cname: int32_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Int32_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: struct a_typedef_struct
   package: example
-- cname: struct a_typedef_struct
-  headers: distilled_lib_1.h
+  module: Example
   identifier: A_typedef_struct
-  module: Example
+- headers: distilled_lib_1.h
+  cname: uint16_t
   package: example
-- cname: uint16_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Uint16_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: uint32_t
   package: example
-- cname: uint32_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Uint32_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: uint8_t
   package: example
-- cname: uint8_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Uint8_t
-  module: Example
+- headers: distilled_lib_1.h
+  cname: var_t
   package: example
-- cname: var_t
-  headers: distilled_lib_1.h
+  module: Example
   identifier: Var_t
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/enums.extbindings.yaml
@@ -1,61 +1,61 @@
 types:
-- cname: enum enumB
-  headers: enums.h
+- headers: enums.h
+  cname: enum enumB
+  package: example
+  module: Example
   identifier: EnumB
-  module: Example
+- headers: enums.h
+  cname: enum enumC
   package: example
-- cname: enum enumC
-  headers: enums.h
+  module: Example
   identifier: EnumC
-  module: Example
+- headers: enums.h
+  cname: enum enumD
   package: example
-- cname: enum enumD
-  headers: enums.h
+  module: Example
   identifier: EnumD
-  module: Example
+- headers: enums.h
+  cname: enum first
   package: example
-- cname: enum first
-  headers: enums.h
+  module: Example
   identifier: First
-  module: Example
+- headers: enums.h
+  cname: enum nonseq
   package: example
-- cname: enum nonseq
-  headers: enums.h
+  module: Example
   identifier: Nonseq
-  module: Example
+- headers: enums.h
+  cname: enum packad
   package: example
-- cname: enum packad
-  headers: enums.h
+  module: Example
   identifier: Packad
-  module: Example
+- headers: enums.h
+  cname: enum same
   package: example
-- cname: enum same
-  headers: enums.h
+  module: Example
   identifier: Same
-  module: Example
+- headers: enums.h
+  cname: enum second
   package: example
-- cname: enum second
-  headers: enums.h
+  module: Example
   identifier: Second
-  module: Example
+- headers: enums.h
+  cname: enumA
   package: example
-- cname: enumA
-  headers: enums.h
+  module: Example
   identifier: EnumA
-  module: Example
+- headers: enums.h
+  cname: enumB
   package: example
-- cname: enumB
-  headers: enums.h
+  module: Example
   identifier: EnumB
-  module: Example
+- headers: enums.h
+  cname: enumC
   package: example
-- cname: enumC
-  headers: enums.h
+  module: Example
   identifier: EnumC
-  module: Example
+- headers: enums.h
+  cname: enumD_t
   package: example
-- cname: enumD_t
-  headers: enums.h
+  module: Example
   identifier: EnumD_t
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/fixedarray.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedarray.extbindings.yaml
@@ -1,11 +1,11 @@
 types:
-- cname: struct Example
-  headers: fixedarray.h
+- headers: fixedarray.h
+  cname: struct Example
+  package: example
+  module: Example
   identifier: Example
-  module: Example
+- headers: fixedarray.h
+  cname: triple
   package: example
-- cname: triple
-  headers: fixedarray.h
+  module: Example
   identifier: Triple
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: struct foo
-  headers: fixedwidth.h
+- headers: fixedwidth.h
+  cname: struct foo
+  package: example
+  module: Example
   identifier: Foo
-  module: Example
+- headers: fixedwidth.h
+  cname: uint32_t
   package: example
-- cname: uint32_t
-  headers: fixedwidth.h
+  module: Example
   identifier: Uint32_t
-  module: Example
+- headers: fixedwidth.h
+  cname: uint64_t
   package: example
-- cname: uint64_t
-  headers: fixedwidth.h
+  module: Example
   identifier: Uint64_t
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/flam.extbindings.yaml
+++ b/hs-bindgen/fixtures/flam.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: struct diff
-  headers: flam.h
+- headers: flam.h
+  cname: struct diff
+  package: example
+  module: Example
   identifier: Diff
-  module: Example
+- headers: flam.h
+  cname: struct foo
   package: example
-- cname: struct foo
-  headers: flam.h
+  module: Example
   identifier: Foo
-  module: Example
+- headers: flam.h
+  cname: struct pascal
   package: example
-- cname: struct pascal
-  headers: flam.h
+  module: Example
   identifier: Pascal
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: S1_t
-  headers: forward_declaration.h
+- headers: forward_declaration.h
+  cname: S1_t
+  package: example
+  module: Example
   identifier: S1_t
-  module: Example
+- headers: forward_declaration.h
+  cname: struct S1
   package: example
-- cname: struct S1
-  headers: forward_declaration.h
+  module: Example
   identifier: S1
-  module: Example
+- headers: forward_declaration.h
+  cname: struct S2
   package: example
-- cname: struct S2
-  headers: forward_declaration.h
+  module: Example
   identifier: S2
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
@@ -1,26 +1,26 @@
 types:
-- cname: C
-  headers: macro_in_fundecl.h
+- headers: macro_in_fundecl.h
+  cname: C
+  package: example
+  module: Example
   identifier: C
-  module: Example
+- headers: macro_in_fundecl.h
+  cname: F
   package: example
-- cname: F
-  headers: macro_in_fundecl.h
+  module: Example
   identifier: F
-  module: Example
+- headers: macro_in_fundecl.h
+  cname: I
   package: example
-- cname: I
-  headers: macro_in_fundecl.h
+  module: Example
   identifier: I
-  module: Example
+- headers: macro_in_fundecl.h
+  cname: L
   package: example
-- cname: L
-  headers: macro_in_fundecl.h
+  module: Example
   identifier: L
-  module: Example
+- headers: macro_in_fundecl.h
+  cname: S
   package: example
-- cname: S
-  headers: macro_in_fundecl.h
+  module: Example
   identifier: S
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
@@ -1,41 +1,41 @@
 types:
-- cname: MC
-  headers: macro_in_fundecl_vs_typedef.h
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: MC
+  package: example
+  module: Example
   identifier: MC
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: TC
   package: example
-- cname: TC
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: TC
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct struct1
   package: example
-- cname: struct struct1
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct1
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct struct3
   package: example
-- cname: struct struct3
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct3
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct struct4
   package: example
-- cname: struct struct4
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct4
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct2
   package: example
-- cname: struct2
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct2
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct3_t
   package: example
-- cname: struct3_t
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct3_t
-  module: Example
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct4
   package: example
-- cname: struct4
-  headers: macro_in_fundecl_vs_typedef.h
+  module: Example
   identifier: Struct4
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/manual_examples.extbindings.yaml
+++ b/hs-bindgen/fixtures/manual_examples.extbindings.yaml
@@ -1,106 +1,106 @@
 types:
-- cname: DAY
-  headers: manual_examples.h
+- headers: manual_examples.h
+  cname: DAY
+  package: example
+  module: Example
   identifier: DAY
-  module: Example
+- headers: manual_examples.h
+  cname: MONTH
   package: example
-- cname: MONTH
-  headers: manual_examples.h
+  module: Example
   identifier: MONTH
-  module: Example
+- headers: manual_examples.h
+  cname: YEAR
   package: example
-- cname: YEAR
-  headers: manual_examples.h
+  module: Example
   identifier: YEAR
-  module: Example
+- headers: manual_examples.h
+  cname: adiós
   package: example
-- cname: adiós
-  headers: manual_examples.h
+  module: Example
   identifier: Adio'0301s
-  module: Example
+- headers: manual_examples.h
+  cname: average
   package: example
-- cname: average
-  headers: manual_examples.h
+  module: Example
   identifier: Average
-  module: Example
+- headers: manual_examples.h
+  cname: config
   package: example
-- cname: config
-  headers: manual_examples.h
+  module: Example
   identifier: Config
-  module: Example
+- headers: manual_examples.h
+  cname: data
   package: example
-- cname: data
-  headers: manual_examples.h
+  module: Example
   identifier: Data
-  module: Example
+- headers: manual_examples.h
+  cname: date
   package: example
-- cname: date
-  headers: manual_examples.h
+  module: Example
   identifier: Date
-  module: Example
+- headers: manual_examples.h
+  cname: enum index
   package: example
-- cname: enum index
-  headers: manual_examples.h
+  module: Example
   identifier: Index
-  module: Example
+- headers: manual_examples.h
+  cname: index
   package: example
-- cname: index
-  headers: manual_examples.h
+  module: Example
   identifier: Index
-  module: Example
+- headers: manual_examples.h
+  cname: occupation
   package: example
-- cname: occupation
-  headers: manual_examples.h
+  module: Example
   identifier: Occupation
-  module: Example
+- headers: manual_examples.h
+  cname: struct date
   package: example
-- cname: struct date
-  headers: manual_examples.h
+  module: Example
   identifier: Date
-  module: Example
+- headers: manual_examples.h
+  cname: struct employee
   package: example
-- cname: struct employee
-  headers: manual_examples.h
+  module: Example
   identifier: Employee
-  module: Example
+- headers: manual_examples.h
+  cname: struct person
   package: example
-- cname: struct person
-  headers: manual_examples.h
+  module: Example
   identifier: Person
-  module: Example
+- headers: manual_examples.h
+  cname: struct rect
   package: example
-- cname: struct rect
-  headers: manual_examples.h
+  module: Example
   identifier: Rect
-  module: Example
+- headers: manual_examples.h
+  cname: struct student
   package: example
-- cname: struct student
-  headers: manual_examples.h
+  module: Example
   identifier: Student
-  module: Example
+- headers: manual_examples.h
+  cname: struct triple
   package: example
-- cname: struct triple
-  headers: manual_examples.h
+  module: Example
   identifier: Triple
-  module: Example
+- headers: manual_examples.h
+  cname: sum
   package: example
-- cname: sum
-  headers: manual_examples.h
+  module: Example
   identifier: Sum
-  module: Example
+- headers: manual_examples.h
+  cname: triple
   package: example
-- cname: triple
-  headers: manual_examples.h
+  module: Example
   identifier: Triple
-  module: Example
+- headers: manual_examples.h
+  cname: union occupation
   package: example
-- cname: union occupation
-  headers: manual_examples.h
+  module: Example
   identifier: Occupation
-  module: Example
+- headers: manual_examples.h
+  cname: 数字
   package: example
-- cname: 数字
-  headers: manual_examples.h
+  module: Example
   identifier: C数字
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/nested_enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_enums.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: enum enumA
-  headers: nested_enums.h
+- headers: nested_enums.h
+  cname: enum enumA
+  package: example
+  module: Example
   identifier: EnumA
-  module: Example
+- headers: nested_enums.h
+  cname: struct exA
   package: example
-- cname: struct exA
-  headers: nested_enums.h
+  module: Example
   identifier: ExA
-  module: Example
+- headers: nested_enums.h
+  cname: struct exB
   package: example
-- cname: struct exB
-  headers: nested_enums.h
+  module: Example
   identifier: ExB
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/nested_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_types.extbindings.yaml
@@ -1,26 +1,26 @@
 types:
-- cname: struct bar
-  headers: nested_types.h
+- headers: nested_types.h
+  cname: struct bar
+  package: example
+  module: Example
   identifier: Bar
-  module: Example
+- headers: nested_types.h
+  cname: struct ex3
   package: example
-- cname: struct ex3
-  headers: nested_types.h
+  module: Example
   identifier: Ex3
-  module: Example
+- headers: nested_types.h
+  cname: struct ex4_even
   package: example
-- cname: struct ex4_even
-  headers: nested_types.h
+  module: Example
   identifier: Ex4_even
-  module: Example
+- headers: nested_types.h
+  cname: struct ex4_odd
   package: example
-- cname: struct ex4_odd
-  headers: nested_types.h
+  module: Example
   identifier: Ex4_odd
-  module: Example
+- headers: nested_types.h
+  cname: struct foo
   package: example
-- cname: struct foo
-  headers: nested_types.h
+  module: Example
   identifier: Foo
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/nested_unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_unions.extbindings.yaml
@@ -1,16 +1,16 @@
 types:
-- cname: struct exA
-  headers: nested_unions.h
+- headers: nested_unions.h
+  cname: struct exA
+  package: example
+  module: Example
   identifier: ExA
-  module: Example
+- headers: nested_unions.h
+  cname: struct exB
   package: example
-- cname: struct exB
-  headers: nested_unions.h
+  module: Example
   identifier: ExB
-  module: Example
+- headers: nested_unions.h
+  cname: union unionA
   package: example
-- cname: union unionA
-  headers: nested_unions.h
+  module: Example
   identifier: UnionA
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
@@ -1,26 +1,26 @@
 types:
-- cname: enum quu
-  headers: opaque_declaration.h
+- headers: opaque_declaration.h
+  cname: enum quu
+  package: example
+  module: Example
   identifier: Quu
-  module: Example
+- headers: opaque_declaration.h
+  cname: struct bar
   package: example
-- cname: struct bar
-  headers: opaque_declaration.h
+  module: Example
   identifier: Bar
-  module: Example
+- headers: opaque_declaration.h
+  cname: struct baz
   package: example
-- cname: struct baz
-  headers: opaque_declaration.h
+  module: Example
   identifier: Baz
-  module: Example
+- headers: opaque_declaration.h
+  cname: struct foo
   package: example
-- cname: struct foo
-  headers: opaque_declaration.h
+  module: Example
   identifier: Foo
-  module: Example
+- headers: opaque_declaration.h
+  cname: struct opaque_union
   package: example
-- cname: struct opaque_union
-  headers: opaque_declaration.h
+  module: Example
   identifier: Opaque_union
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/primitive_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/primitive_types.extbindings.yaml
@@ -1,6 +1,6 @@
 types:
-- cname: struct primitive
-  headers: primitive_types.h
-  identifier: Primitive
-  module: Example
+- headers: primitive_types.h
+  cname: struct primitive
   package: example
+  module: Example
+  identifier: Primitive

--- a/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
+++ b/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
@@ -1,21 +1,21 @@
 types:
-- cname: linked_list_A_t
-  headers: recursive_struct.h
+- headers: recursive_struct.h
+  cname: linked_list_A_t
+  package: example
+  module: Example
   identifier: Linked_list_A_t
-  module: Example
+- headers: recursive_struct.h
+  cname: linked_list_B_t
   package: example
-- cname: linked_list_B_t
-  headers: recursive_struct.h
+  module: Example
   identifier: Linked_list_B_t
-  module: Example
+- headers: recursive_struct.h
+  cname: struct linked_list_A_s
   package: example
-- cname: struct linked_list_A_s
-  headers: recursive_struct.h
+  module: Example
   identifier: Linked_list_A_s
-  module: Example
+- headers: recursive_struct.h
+  cname: struct linked_list_B_t
   package: example
-- cname: struct linked_list_B_t
-  headers: recursive_struct.h
+  module: Example
   identifier: Linked_list_B_t
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/simple_structs.extbindings.yaml
+++ b/hs-bindgen/fixtures/simple_structs.extbindings.yaml
@@ -1,56 +1,56 @@
 types:
-- cname: S2_t
-  headers: simple_structs.h
+- headers: simple_structs.h
+  cname: S2_t
+  package: example
+  module: Example
   identifier: S2_t
-  module: Example
+- headers: simple_structs.h
+  cname: S3_t
   package: example
-- cname: S3_t
-  headers: simple_structs.h
+  module: Example
   identifier: S3_t
-  module: Example
+- headers: simple_structs.h
+  cname: S5
   package: example
-- cname: S5
-  headers: simple_structs.h
+  module: Example
   identifier: S5
-  module: Example
+- headers: simple_structs.h
+  cname: S6
   package: example
-- cname: S6
-  headers: simple_structs.h
+  module: Example
   identifier: S6
-  module: Example
+- headers: simple_structs.h
+  cname: S7a
   package: example
-- cname: S7a
-  headers: simple_structs.h
+  module: Example
   identifier: S7a
-  module: Example
+- headers: simple_structs.h
+  cname: S7b
   package: example
-- cname: S7b
-  headers: simple_structs.h
+  module: Example
   identifier: S7b
-  module: Example
+- headers: simple_structs.h
+  cname: struct S1
   package: example
-- cname: struct S1
-  headers: simple_structs.h
+  module: Example
   identifier: S1
-  module: Example
+- headers: simple_structs.h
+  cname: struct S2
   package: example
-- cname: struct S2
-  headers: simple_structs.h
+  module: Example
   identifier: S2
-  module: Example
+- headers: simple_structs.h
+  cname: struct S4
   package: example
-- cname: struct S4
-  headers: simple_structs.h
+  module: Example
   identifier: S4
-  module: Example
+- headers: simple_structs.h
+  cname: struct S5
   package: example
-- cname: struct S5
-  headers: simple_structs.h
+  module: Example
   identifier: S5
-  module: Example
+- headers: simple_structs.h
+  cname: struct S6
   package: example
-- cname: struct S6
-  headers: simple_structs.h
+  module: Example
   identifier: S6
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
@@ -1,41 +1,41 @@
 types:
-- cname: M1
-  headers: typedef_vs_macro.h
+- headers: typedef_vs_macro.h
+  cname: M1
+  package: example
+  module: Example
   identifier: M1
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: M2
   package: example
-- cname: M2
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: M2
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: M3
   package: example
-- cname: M3
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: M3
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: T1
   package: example
-- cname: T1
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: T1
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: T2
   package: example
-- cname: T2
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: T2
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: struct ExampleStruct
   package: example
-- cname: struct ExampleStruct
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: ExampleStruct
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: struct foo
   package: example
-- cname: struct foo
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: Foo
-  module: Example
+- headers: typedef_vs_macro.h
+  cname: uint64_t
   package: example
-- cname: uint64_t
-  headers: typedef_vs_macro.h
+  module: Example
   identifier: Uint64_t
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/typedefs.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedefs.extbindings.yaml
@@ -1,11 +1,11 @@
 types:
-- cname: intptr
-  headers: typedefs.h
+- headers: typedefs.h
+  cname: intptr
+  package: example
+  module: Example
   identifier: Intptr
-  module: Example
+- headers: typedefs.h
+  cname: myint
   package: example
-- cname: myint
-  headers: typedefs.h
+  module: Example
   identifier: Myint
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/typenames.extbindings.yaml
+++ b/hs-bindgen/fixtures/typenames.extbindings.yaml
@@ -1,11 +1,11 @@
 types:
-- cname: enum foo
-  headers: typenames.h
-  identifier: Foo
-  module: Example
+- headers: typenames.h
+  cname: enum foo
   package: example
-- cname: foo
-  headers: typenames.h
-  identifier: Foo
   module: Example
+  identifier: Foo
+- headers: typenames.h
+  cname: foo
   package: example
+  module: Example
+  identifier: Foo

--- a/hs-bindgen/fixtures/unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/unions.extbindings.yaml
@@ -1,41 +1,41 @@
 types:
-- cname: DimPayloadB
-  headers: unions.h
-  identifier: DimPayloadB
-  module: Example
+- headers: unions.h
+  cname: DimPayloadB
   package: example
-- cname: struct Dim
-  headers: unions.h
+  module: Example
+  identifier: DimPayloadB
+- headers: unions.h
+  cname: struct Dim
+  package: example
+  module: Example
   identifier: Dim
-  module: Example
+- headers: unions.h
+  cname: struct Dim2
   package: example
-- cname: struct Dim2
-  headers: unions.h
+  module: Example
   identifier: Dim2
-  module: Example
+- headers: unions.h
+  cname: struct Dim3
   package: example
-- cname: struct Dim3
-  headers: unions.h
+  module: Example
   identifier: Dim3
-  module: Example
+- headers: unions.h
+  cname: struct DimB
   package: example
-- cname: struct DimB
-  headers: unions.h
+  module: Example
   identifier: DimB
-  module: Example
+- headers: unions.h
+  cname: union AnonA
   package: example
-- cname: union AnonA
-  headers: unions.h
+  module: Example
   identifier: AnonA
-  module: Example
+- headers: unions.h
+  cname: union DimPayload
   package: example
-- cname: union DimPayload
-  headers: unions.h
+  module: Example
   identifier: DimPayload
-  module: Example
+- headers: unions.h
+  cname: union DimPayloadB
   package: example
-- cname: union DimPayloadB
-  headers: unions.h
+  module: Example
   identifier: DimPayloadB
-  module: Example
-  package: example

--- a/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
+++ b/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
@@ -1,6 +1,6 @@
 types:
-- cname: enum MyEnum
-  headers: uses_utf8.h
-  identifier: MyEnum
-  module: Example
+- headers: uses_utf8.h
+  cname: enum MyEnum
   package: example
+  module: Example
+  identifier: MyEnum

--- a/hs-bindgen/fixtures/weird01.extbindings.yaml
+++ b/hs-bindgen/fixtures/weird01.extbindings.yaml
@@ -1,11 +1,11 @@
 types:
-- cname: struct bar
-  headers: weird01.h
+- headers: weird01.h
+  cname: struct bar
+  package: example
+  module: Example
   identifier: Bar
-  module: Example
+- headers: weird01.h
+  cname: struct foo
   package: example
-- cname: struct foo
-  headers: weird01.h
+  module: Example
   identifier: Foo
-  module: Example
-  package: example


### PR DESCRIPTION
This now matches the Haskell convention `package.module.identifier`.