### PR TITLE
Make `CEnum` `declaredValues` `Map` opaque

### DIFF
--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -72,9 +72,6 @@ test-suite test-runtime
       -- Internal dependencies
     , hs-bindgen-runtime
   build-depends:
-      -- Inherited dependencies
-    , containers
-  build-depends:
       -- External dependencies
     , QuickCheck        ^>=2.15.0.1
     , tasty             ^>=1.5

--- a/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnum.hs
+++ b/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnum.hs
@@ -5,7 +5,6 @@ module Test.HsBindgen.Runtime.CEnum (tests) where
 import Control.Monad (forM_)
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Map.Strict qualified as Map
 import Foreign.C qualified as FC
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@=?), testCase)
@@ -52,7 +51,7 @@ instance CEnum NoValue where
 
   fromCEnumZ       = NoValue
   toCEnumZ         = un_NoValue
-  declaredValues _ = Map.empty
+  declaredValues _ = CEnum.declaredValuesFromList []
 
 deriving via AsCEnum NoValue instance Bounded NoValue
 
@@ -109,7 +108,7 @@ instance CEnum GenSingleValue where
 
   fromCEnumZ       = GenSingleValue
   toCEnumZ         = un_GenSingleValue
-  declaredValues _ = Map.singleton 1 ("OK" :| ["SUCCESS"])
+  declaredValues _ = CEnum.declaredValuesFromList [(1, "OK" :| ["SUCCESS"])]
 
 deriving via AsCEnum GenSingleValue instance Bounded GenSingleValue
 
@@ -205,7 +204,7 @@ instance CEnum GenPosValue where
 
   fromCEnumZ       = GenPosValue
   toCEnumZ         = un_GenPosValue
-  declaredValues _ = Map.fromList [
+  declaredValues _ = CEnum.declaredValuesFromList [
       (100, NonEmpty.singleton "CONTINUE")
     , (101, NonEmpty.singleton "SWITCHING_PROTOCOLS")
     , (200, NonEmpty.singleton "OK")
@@ -354,7 +353,7 @@ instance CEnum GenNegValue where
 
   fromCEnumZ       = GenNegValue
   toCEnumZ         = un_GenNegValue
-  declaredValues _ = Map.fromList [
+  declaredValues _ = CEnum.declaredValuesFromList [
       (-201, NonEmpty.singleton "REALLY_TERRIBLE")
     , (-200, NonEmpty.singleton "TERRIBLE")
     , (-101, NonEmpty.singleton "REALLY_BAD")
@@ -503,7 +502,7 @@ instance CEnum SeqSingleValue where
 
   fromCEnumZ       = SeqSingleValue
   toCEnumZ         = un_SeqSingleValue
-  declaredValues _ = Map.singleton 1 ("OK" :| ["SUCCESS"])
+  declaredValues _ = CEnum.declaredValuesFromList [(1, "OK" :| ["SUCCESS"])]
 
 instance SequentialCEnum SeqSingleValue where
   minDeclaredValue = SeqSingleValue 1
@@ -603,7 +602,7 @@ instance CEnum SeqPosValue where
 
   fromCEnumZ       = SeqPosValue
   toCEnumZ         = un_SeqPosValue
-  declaredValues _ = Map.fromList [
+  declaredValues _ = CEnum.declaredValuesFromList [
       (1,  "A" :| ["ALPHA"])
     , (2,  "B" :| ["BETA"])
     , (3,  NonEmpty.singleton "C")
@@ -747,7 +746,7 @@ instance CEnum SeqNegValue where
 
   fromCEnumZ       = SeqNegValue
   toCEnumZ         = un_SeqNegValue
-  declaredValues _ = Map.fromList [
+  declaredValues _ = CEnum.declaredValuesFromList [
       (-5, NonEmpty.singleton "GARBAGE")
     , (-4, NonEmpty.singleton "TERRIBLE")
     , (-3, NonEmpty.singleton "BAD")

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -14,7 +14,6 @@ import Data.Bits (FiniteBits)
 import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
@@ -112,7 +111,7 @@ instance HsBindgen.Runtime.CEnum.CEnum Another_typedef_enum_e where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FOO"), (1, Data.List.NonEmpty.singleton "BAR")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "FOO"), (1, Data.List.NonEmpty.singleton "BAR")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -395,11 +394,11 @@ instance HsBindgen.Runtime.CEnum.CEnum A_typedef_enum_e where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [ (0, Data.List.NonEmpty.singleton "ENUM_CASE_0")
-                               , (1, Data.List.NonEmpty.singleton "ENUM_CASE_1")
-                               , (2, Data.List.NonEmpty.singleton "ENUM_CASE_2")
-                               , (3, Data.List.NonEmpty.singleton "ENUM_CASE_3")
-                               ]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [ (0, Data.List.NonEmpty.singleton "ENUM_CASE_0")
+                                                     , (1, Data.List.NonEmpty.singleton "ENUM_CASE_1")
+                                                     , (2, Data.List.NonEmpty.singleton "ENUM_CASE_2")
+                                                     , (3, Data.List.NonEmpty.singleton "ENUM_CASE_3")
+                                                     ]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -47,8 +47,9 @@ instance CEnum Another_typedef_enum_e
     where {type CEnumZ Another_typedef_enum_e = CUInt;
            fromCEnumZ = Another_typedef_enum_e;
            toCEnumZ = un_Another_typedef_enum_e;
-           declaredValues = \_ -> fromList [(0, singleton "FOO"),
-                                            (1, singleton "BAR")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "FOO"),
+                                                          (1, singleton "BAR")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Another_typedef_enum_e
@@ -180,10 +181,11 @@ instance CEnum A_typedef_enum_e
     where {type CEnumZ A_typedef_enum_e = CSChar;
            fromCEnumZ = A_typedef_enum_e;
            toCEnumZ = un_A_typedef_enum_e;
-           declaredValues = \_ -> fromList [(0, singleton "ENUM_CASE_0"),
-                                            (1, singleton "ENUM_CASE_1"),
-                                            (2, singleton "ENUM_CASE_2"),
-                                            (3, singleton "ENUM_CASE_3")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "ENUM_CASE_0"),
+                                                          (1, singleton "ENUM_CASE_1"),
+                                                          (2, singleton "ENUM_CASE_2"),
+                                                          (3, singleton "ENUM_CASE_3")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum A_typedef_enum_e

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -8,7 +8,6 @@
 module Example where
 
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
@@ -51,7 +50,7 @@ instance HsBindgen.Runtime.CEnum.CEnum First where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FIRST1"), (1, Data.List.NonEmpty.singleton "FIRST2")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "FIRST1"), (1, Data.List.NonEmpty.singleton "FIRST2")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -110,10 +109,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Second where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [ (-1, Data.List.NonEmpty.singleton "SECOND_A")
-                               , (0, Data.List.NonEmpty.singleton "SECOND_B")
-                               , (1, Data.List.NonEmpty.singleton "SECOND_C")
-                               ]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [ (-1, Data.List.NonEmpty.singleton "SECOND_A")
+                                                     , (0, Data.List.NonEmpty.singleton "SECOND_B")
+                                                     , (1, Data.List.NonEmpty.singleton "SECOND_C")
+                                                     ]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -175,7 +174,7 @@ instance HsBindgen.Runtime.CEnum.CEnum Same where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(1, ("SAME_B" Data.List.NonEmpty.:| ["SAME_A"]))]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(1, ("SAME_B" Data.List.NonEmpty.:| ["SAME_A"]))]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -234,10 +233,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Nonseq where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [ (200, Data.List.NonEmpty.singleton "NONSEQ_A")
-                               , (301, Data.List.NonEmpty.singleton "NONSEQ_B")
-                               , (404, Data.List.NonEmpty.singleton "NONSEQ_C")
-                               ]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [ (200, Data.List.NonEmpty.singleton "NONSEQ_A")
+                                                     , (301, Data.List.NonEmpty.singleton "NONSEQ_B")
+                                                     , (404, Data.List.NonEmpty.singleton "NONSEQ_C")
+                                                     ]
 
 instance Show Nonseq where
 
@@ -289,10 +288,10 @@ instance HsBindgen.Runtime.CEnum.CEnum Packad where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [ (0, Data.List.NonEmpty.singleton "PACKED_A")
-                               , (1, Data.List.NonEmpty.singleton "PACKED_B")
-                               , (2, Data.List.NonEmpty.singleton "PACKED_C")
-                               ]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [ (0, Data.List.NonEmpty.singleton "PACKED_A")
+                                                     , (1, Data.List.NonEmpty.singleton "PACKED_B")
+                                                     , (2, Data.List.NonEmpty.singleton "PACKED_C")
+                                                     ]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -354,7 +353,7 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "A_FOO"), (1, Data.List.NonEmpty.singleton "A_BAR")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "A_FOO"), (1, Data.List.NonEmpty.singleton "A_BAR")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -413,7 +412,7 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumB where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "B_FOO"), (1, Data.List.NonEmpty.singleton "B_BAR")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "B_FOO"), (1, Data.List.NonEmpty.singleton "B_BAR")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -472,7 +471,7 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumC where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "C_FOO"), (1, Data.List.NonEmpty.singleton "C_BAR")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "C_FOO"), (1, Data.List.NonEmpty.singleton "C_BAR")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -531,7 +530,7 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumD where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "D_FOO"), (1, Data.List.NonEmpty.singleton "D_BAR")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "D_FOO"), (1, Data.List.NonEmpty.singleton "D_BAR")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -13,8 +13,9 @@ instance CEnum First
     where {type CEnumZ First = CUInt;
            fromCEnumZ = First;
            toCEnumZ = un_First;
-           declaredValues = \_ -> fromList [(0, singleton "FIRST1"),
-                                            (1, singleton "FIRST2")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "FIRST1"),
+                                                          (1, singleton "FIRST2")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum First
@@ -39,9 +40,10 @@ instance CEnum Second
     where {type CEnumZ Second = CInt;
            fromCEnumZ = Second;
            toCEnumZ = un_Second;
-           declaredValues = \_ -> fromList [(-1, singleton "SECOND_A"),
-                                            (0, singleton "SECOND_B"),
-                                            (1, singleton "SECOND_C")];
+           declaredValues = \_ -> declaredValuesFromList [(-1,
+                                                           singleton "SECOND_A"),
+                                                          (0, singleton "SECOND_B"),
+                                                          (1, singleton "SECOND_C")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Second
@@ -68,7 +70,8 @@ instance CEnum Same
     where {type CEnumZ Same = CUInt;
            fromCEnumZ = Same;
            toCEnumZ = un_Same;
-           declaredValues = \_ -> fromList [(1, "SAME_B" :| ["SAME_A"])];
+           declaredValues = \_ -> declaredValuesFromList [(1,
+                                                           "SAME_B" :| ["SAME_A"])];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Same
@@ -93,9 +96,10 @@ instance CEnum Nonseq
     where {type CEnumZ Nonseq = CUInt;
            fromCEnumZ = Nonseq;
            toCEnumZ = un_Nonseq;
-           declaredValues = \_ -> fromList [(200, singleton "NONSEQ_A"),
-                                            (301, singleton "NONSEQ_B"),
-                                            (404, singleton "NONSEQ_C")]}
+           declaredValues = \_ -> declaredValuesFromList [(200,
+                                                           singleton "NONSEQ_A"),
+                                                          (301, singleton "NONSEQ_B"),
+                                                          (404, singleton "NONSEQ_C")]}
 instance Show Nonseq
     where {show = showCEnum "Nonseq"}
 pattern NONSEQ_A :: Nonseq
@@ -118,9 +122,10 @@ instance CEnum Packad
     where {type CEnumZ Packad = CSChar;
            fromCEnumZ = Packad;
            toCEnumZ = un_Packad;
-           declaredValues = \_ -> fromList [(0, singleton "PACKED_A"),
-                                            (1, singleton "PACKED_B"),
-                                            (2, singleton "PACKED_C")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "PACKED_A"),
+                                                          (1, singleton "PACKED_B"),
+                                                          (2, singleton "PACKED_C")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Packad
@@ -147,8 +152,9 @@ instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            fromCEnumZ = EnumA;
            toCEnumZ = un_EnumA;
-           declaredValues = \_ -> fromList [(0, singleton "A_FOO"),
-                                            (1, singleton "A_BAR")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "A_FOO"),
+                                                          (1, singleton "A_BAR")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
@@ -173,8 +179,9 @@ instance CEnum EnumB
     where {type CEnumZ EnumB = CUInt;
            fromCEnumZ = EnumB;
            toCEnumZ = un_EnumB;
-           declaredValues = \_ -> fromList [(0, singleton "B_FOO"),
-                                            (1, singleton "B_BAR")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "B_FOO"),
+                                                          (1, singleton "B_BAR")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumB
@@ -199,8 +206,9 @@ instance CEnum EnumC
     where {type CEnumZ EnumC = CUInt;
            fromCEnumZ = EnumC;
            toCEnumZ = un_EnumC;
-           declaredValues = \_ -> fromList [(0, singleton "C_FOO"),
-                                            (1, singleton "C_BAR")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "C_FOO"),
+                                                          (1, singleton "C_BAR")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumC
@@ -225,8 +233,9 @@ instance CEnum EnumD
     where {type CEnumZ EnumD = CUInt;
            fromCEnumZ = EnumD;
            toCEnumZ = un_EnumD;
-           declaredValues = \_ -> fromList [(0, singleton "D_FOO"),
-                                            (1, singleton "D_BAR")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "D_FOO"),
+                                                          (1, singleton "D_BAR")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumD

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -20,7 +20,6 @@ import Data.Bits (FiniteBits)
 import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.ByteArray
@@ -214,7 +213,7 @@ instance HsBindgen.Runtime.CEnum.CEnum Index where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "A"), (1, Data.List.NonEmpty.singleton "B"), (2, Data.List.NonEmpty.singleton "C")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "A"), (1, Data.List.NonEmpty.singleton "B"), (2, Data.List.NonEmpty.singleton "C")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -90,9 +90,9 @@ instance CEnum Index
     where {type CEnumZ Index = CUInt;
            fromCEnumZ = Index;
            toCEnumZ = un_Index;
-           declaredValues = \_ -> fromList [(0, singleton "A"),
-                                            (1, singleton "B"),
-                                            (2, singleton "C")];
+           declaredValues = \_ -> declaredValuesFromList [(0, singleton "A"),
+                                                          (1, singleton "B"),
+                                                          (2, singleton "C")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Index

--- a/hs-bindgen/fixtures/nested_enums.pp.hs
+++ b/hs-bindgen/fixtures/nested_enums.pp.hs
@@ -7,7 +7,6 @@
 module Example where
 
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
@@ -50,7 +49,7 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "VALA_1"), (1, Data.List.NonEmpty.singleton "VALA_2")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "VALA_1"), (1, Data.List.NonEmpty.singleton "VALA_2")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -134,7 +133,7 @@ instance HsBindgen.Runtime.CEnum.CEnum ExB_fieldB1 where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "VALB_1"), (1, Data.List.NonEmpty.singleton "VALB_2")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "VALB_1"), (1, Data.List.NonEmpty.singleton "VALB_2")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/nested_enums.th.txt
+++ b/hs-bindgen/fixtures/nested_enums.th.txt
@@ -13,8 +13,9 @@ instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            fromCEnumZ = EnumA;
            toCEnumZ = un_EnumA;
-           declaredValues = \_ -> fromList [(0, singleton "VALA_1"),
-                                            (1, singleton "VALA_2")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "VALA_1"),
+                                                          (1, singleton "VALA_2")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
@@ -48,8 +49,9 @@ instance CEnum ExB_fieldB1
     where {type CEnumZ ExB_fieldB1 = CUInt;
            fromCEnumZ = ExB_fieldB1;
            toCEnumZ = un_ExB_fieldB1;
-           declaredValues = \_ -> fromList [(0, singleton "VALB_1"),
-                                            (1, singleton "VALB_2")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "VALB_1"),
+                                                          (1, singleton "VALB_2")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum ExB_fieldB1

--- a/hs-bindgen/fixtures/typenames.pp.hs
+++ b/hs-bindgen/fixtures/typenames.pp.hs
@@ -8,7 +8,6 @@
 module Example where
 
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
@@ -51,7 +50,7 @@ instance HsBindgen.Runtime.CEnum.CEnum Foo where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "FOO1"), (1, Data.List.NonEmpty.singleton "FOO2")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "FOO1"), (1, Data.List.NonEmpty.singleton "FOO2")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/typenames.th.txt
+++ b/hs-bindgen/fixtures/typenames.th.txt
@@ -13,8 +13,9 @@ instance CEnum Foo
     where {type CEnumZ Foo = CUInt;
            fromCEnumZ = Foo;
            toCEnumZ = un_Foo;
-           declaredValues = \_ -> fromList [(0, singleton "FOO1"),
-                                            (1, singleton "FOO2")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "FOO1"),
+                                                          (1, singleton "FOO2")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Foo

--- a/hs-bindgen/fixtures/uses_utf8.pp.hs
+++ b/hs-bindgen/fixtures/uses_utf8.pp.hs
@@ -7,7 +7,6 @@
 module Example where
 
 import qualified Data.List.NonEmpty
-import qualified Data.Map.Strict
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
@@ -50,7 +49,7 @@ instance HsBindgen.Runtime.CEnum.CEnum MyEnum where
 
   declaredValues =
     \_ ->
-      Data.Map.Strict.fromList [(0, Data.List.NonEmpty.singleton "Say\20320\22909"), (1, Data.List.NonEmpty.singleton "Say\25308\25308")]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(0, Data.List.NonEmpty.singleton "Say\20320\22909"), (1, Data.List.NonEmpty.singleton "Say\25308\25308")]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 

--- a/hs-bindgen/fixtures/uses_utf8.th.txt
+++ b/hs-bindgen/fixtures/uses_utf8.th.txt
@@ -13,8 +13,9 @@ instance CEnum MyEnum
     where {type CEnumZ MyEnum = CUInt;
            fromCEnumZ = MyEnum;
            toCEnumZ = un_MyEnum;
-           declaredValues = \_ -> fromList [(0, singleton "Say\20320\22909"),
-                                            (1, singleton "Say\25308\25308")];
+           declaredValues = \_ -> declaredValuesFromList [(0,
+                                                           singleton "Say\20320\22909"),
+                                                          (1, singleton "Say\25308\25308")];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum MyEnum

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
@@ -305,6 +305,7 @@ resolveGlobal = \case
     SequentialCEnum_class -> importQ ''HsBindgen.Runtime.CEnum.SequentialCEnum
     SequentialCEnum_minDeclaredValue -> importQ 'HsBindgen.Runtime.CEnum.minDeclaredValue
     SequentialCEnum_maxDeclaredValue -> importQ 'HsBindgen.Runtime.CEnum.maxDeclaredValue
+    CEnum_declaredValuesFromList -> importQ 'HsBindgen.Runtime.CEnum.declaredValuesFromList
     CEnum_showCEnum -> importQ 'HsBindgen.Runtime.CEnum.showCEnum
     CEnum_seqIsDeclared -> importQ 'HsBindgen.Runtime.CEnum.seqIsDeclared
     CEnum_seqMkDeclared -> importQ 'HsBindgen.Runtime.CEnum.seqMkDeclared

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -168,6 +168,7 @@ mkGlobal = \case
       SequentialCEnum_class -> ''HsBindgen.Runtime.CEnum.SequentialCEnum
       SequentialCEnum_minDeclaredValue -> 'HsBindgen.Runtime.CEnum.minDeclaredValue
       SequentialCEnum_maxDeclaredValue -> 'HsBindgen.Runtime.CEnum.maxDeclaredValue
+      CEnum_declaredValuesFromList -> 'HsBindgen.Runtime.CEnum.declaredValuesFromList
       CEnum_showCEnum -> 'HsBindgen.Runtime.CEnum.showCEnum
       CEnum_seqIsDeclared -> 'HsBindgen.Runtime.CEnum.seqIsDeclared
       CEnum_seqMkDeclared -> 'HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -339,6 +340,7 @@ mkGlobalExpr n = case n of -- in definition order, no wildcards
     SequentialCEnum_class            -> panicPure "class in expression"
     SequentialCEnum_minDeclaredValue -> TH.varE name
     SequentialCEnum_maxDeclaredValue -> TH.varE name
+    CEnum_declaredValuesFromList     -> TH.varE name
     CEnum_showCEnum                  -> TH.varE name
     CEnum_seqIsDeclared              -> TH.varE name
     CEnum_seqMkDeclared              -> TH.varE name

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -154,6 +154,7 @@ data Global =
   | SequentialCEnum_class
   | SequentialCEnum_minDeclaredValue
   | SequentialCEnum_maxDeclaredValue
+  | CEnum_declaredValuesFromList
   | CEnum_showCEnum
   | CEnum_seqIsDeclared
   | CEnum_seqMkDeclared

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -408,7 +408,7 @@ translateCEnumInstance struct fTyp vMap isSequential = Instance {
     , instanceDecs  = [
           (CEnum_fromCEnumZ, ECon (Hs.structConstr struct))
         , (CEnum_toCEnumZ, EFree fname)
-        , (CEnum_declaredValues, EUnusedLam vMapE)
+        , (CEnum_declaredValues, EUnusedLam declaredValuesE)
         ] ++ seqDecs
     }
   where
@@ -419,8 +419,8 @@ translateCEnumInstance struct fTyp vMap isSequential = Instance {
     fname = Hs.fieldName $
       NonEmpty.head (Vec.toNonEmpty (Hs.structFields struct))
 
-    vMapE :: SExpr ctx
-    vMapE = EApp (EGlobal Map_fromList) $ EList [
+    declaredValuesE :: SExpr ctx
+    declaredValuesE = EApp (EGlobal CEnum_declaredValuesFromList) $ EList [
         ETup [
             EIntegral v Nothing
           , if null names


### PR DESCRIPTION
In addition, `containers` is no longer an immediate dependency of generated code. (#587)