### PR TITLE
test-pp.hs: don't use a symlink

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -321,7 +321,7 @@ test-suite test-th
 
 test-suite test-pp
   type:           exitcode-stdio-1.0
-  main-is:        test-pp.hs
+  main-is:        ../th/test-th.hs
   hs-source-dirs: test/pp
   include-dirs:   examples
 

--- a/hs-bindgen/test/pp/test-pp.hs
+++ b/hs-bindgen/test/pp/test-pp.hs
@@ -1,1 +1,0 @@
-../th/test-th.hs


### PR DESCRIPTION
This avoids usage of symlinks in `test-pp.hs`. The workaround in the cabal file is perhaps a bit unsavoury but it seems to work.