### PR TITLE
Reparse named structs, unions and enums in function parameters

### DIFF
--- a/hs-bindgen/examples/macro_in_fundecl_vs_typedef.h
+++ b/hs-bindgen/examples/macro_in_fundecl_vs_typedef.h
@@ -24,8 +24,6 @@ void struct_typedef1(struct2   *s, MC x);
 void struct_typedef2(struct3_t *s, MC x);
 void struct_typedef3(struct4   *s, MC x);
 
-// TODO https://github.com/well-typed/hs-bindgen/issues/549
-// Reparser does not understand `struct <name>` syntax yet.
-// void struct_name1(struct struct1 *s, MC x);
-// void struct_name2(struct struct3 *s, MC x);
-// void struct_name3(struct struct4 *s, MC x);
+void struct_name1(struct struct1 *s, MC x);
+void struct_name2(struct struct3 *s, MC x);
+void struct_name3(struct struct4 *s, MC x);

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -315,6 +315,114 @@
           "macro_in_fundecl_vs_typedef.h",
           functionSourceLoc =
           "macro_in_fundecl_vs_typedef.h:25:6"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
+        "struct_name1",
+      foreignImportType = HsFun
+        (HsPtr
+          (HsTypRef
+            (HsName
+              "@NsTypeConstr"
+              "Struct1")))
+        (HsFun
+          (HsTypRef
+            (HsName "@NsTypeConstr" "MC"))
+          (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportOrigName =
+      "struct_name1",
+      foreignImportHeader =
+      "macro_in_fundecl_vs_typedef.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName
+            "struct_name1",
+          functionArgs = [
+            TypePointer
+              (TypeStruct
+                (DeclPathName
+                  (CName "struct1")
+                  DeclPathCtxtTop)),
+            TypeTypedef (CName "MC")],
+          functionRes = TypeVoid,
+          functionHeader =
+          "macro_in_fundecl_vs_typedef.h",
+          functionSourceLoc =
+          "macro_in_fundecl_vs_typedef.h:27:6"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
+        "struct_name2",
+      foreignImportType = HsFun
+        (HsPtr
+          (HsTypRef
+            (HsName
+              "@NsTypeConstr"
+              "Struct3")))
+        (HsFun
+          (HsTypRef
+            (HsName "@NsTypeConstr" "MC"))
+          (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportOrigName =
+      "struct_name2",
+      foreignImportHeader =
+      "macro_in_fundecl_vs_typedef.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName
+            "struct_name2",
+          functionArgs = [
+            TypePointer
+              (TypeStruct
+                (DeclPathName
+                  (CName "struct3")
+                  DeclPathCtxtTop)),
+            TypeTypedef (CName "MC")],
+          functionRes = TypeVoid,
+          functionHeader =
+          "macro_in_fundecl_vs_typedef.h",
+          functionSourceLoc =
+          "macro_in_fundecl_vs_typedef.h:28:6"}},
+  DeclForeignImport
+    ForeignImportDecl {
+      foreignImportName = HsName
+        "@NsVar"
+        "struct_name3",
+      foreignImportType = HsFun
+        (HsPtr
+          (HsTypRef
+            (HsName
+              "@NsTypeConstr"
+              "Struct4")))
+        (HsFun
+          (HsTypRef
+            (HsName "@NsTypeConstr" "MC"))
+          (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportOrigName =
+      "struct_name3",
+      foreignImportHeader =
+      "macro_in_fundecl_vs_typedef.h",
+      foreignImportDeclOrigin =
+      ForeignImportDeclOriginFunction
+        Function {
+          functionName = CName
+            "struct_name3",
+          functionArgs = [
+            TypePointer
+              (TypeStruct
+                (DeclPathName
+                  (CName "struct4")
+                  DeclPathCtxtTop)),
+            TypeTypedef (CName "MC")],
+          functionRes = TypeVoid,
+          functionHeader =
+          "macro_in_fundecl_vs_typedef.h",
+          functionSourceLoc =
+          "macro_in_fundecl_vs_typedef.h:29:6"}},
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
@@ -57,6 +57,12 @@ foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef2" struct_
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef3" struct_typedef3 :: (F.Ptr Struct4) -> MC -> IO ()
 
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name1" struct_name1 :: (F.Ptr Struct1) -> MC -> IO ()
+
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name2" struct_name2 :: (F.Ptr Struct3) -> MC -> IO ()
+
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name3" struct_name3 :: (F.Ptr Struct4) -> MC -> IO ()
+
 newtype TC = TC
   { un_TC :: FC.CChar
   }

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.rs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.rs
@@ -67,3 +67,12 @@ extern "C" {
 extern "C" {
     pub fn struct_typedef3(s: *mut struct4, x: ::std::os::raw::c_char);
 }
+extern "C" {
+    pub fn struct_name1(s: *mut struct1, x: ::std::os::raw::c_char);
+}
+extern "C" {
+    pub fn struct_name2(s: *mut struct3, x: ::std::os::raw::c_char);
+}
+extern "C" {
+    pub fn struct_name3(s: *mut struct4, x: ::std::os::raw::c_char);
+}

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
@@ -30,6 +30,12 @@ foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef2" struct_
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef3" struct_typedef3 :: Ptr Struct4 ->
                                                                                             MC ->
                                                                                             IO Unit
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name1" struct_name1 :: Ptr Struct1 ->
+                                                                                      MC -> IO Unit
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name2" struct_name2 :: Ptr Struct3 ->
+                                                                                      MC -> IO Unit
+foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name3" struct_name3 :: Ptr Struct4 ->
+                                                                                      MC -> IO Unit
 newtype TC = TC {un_TC :: CChar}
 deriving newtype instance Storable TC
 deriving stock instance Eq TC

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
@@ -114,6 +114,54 @@ Header
         "macro_in_fundecl_vs_typedef.h",
         functionSourceLoc =
         "macro_in_fundecl_vs_typedef.h:25:6"},
+    DeclFunction
+      Function {
+        functionName = CName
+          "struct_name1",
+        functionArgs = [
+          TypePointer
+            (TypeStruct
+              (DeclPathName
+                (CName "struct1")
+                DeclPathCtxtTop)),
+          TypeTypedef (CName "MC")],
+        functionRes = TypeVoid,
+        functionHeader =
+        "macro_in_fundecl_vs_typedef.h",
+        functionSourceLoc =
+        "macro_in_fundecl_vs_typedef.h:27:6"},
+    DeclFunction
+      Function {
+        functionName = CName
+          "struct_name2",
+        functionArgs = [
+          TypePointer
+            (TypeStruct
+              (DeclPathName
+                (CName "struct3")
+                DeclPathCtxtTop)),
+          TypeTypedef (CName "MC")],
+        functionRes = TypeVoid,
+        functionHeader =
+        "macro_in_fundecl_vs_typedef.h",
+        functionSourceLoc =
+        "macro_in_fundecl_vs_typedef.h:28:6"},
+    DeclFunction
+      Function {
+        functionName = CName
+          "struct_name3",
+        functionArgs = [
+          TypePointer
+            (TypeStruct
+              (DeclPathName
+                (CName "struct4")
+                DeclPathCtxtTop)),
+          TypeTypedef (CName "MC")],
+        functionRes = TypeVoid,
+        functionHeader =
+        "macro_in_fundecl_vs_typedef.h",
+        functionSourceLoc =
+        "macro_in_fundecl_vs_typedef.h:29:6"},
     DeclTypedef
       Typedef {
         typedefName = CName "TC",

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Common.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Common.hs
@@ -43,7 +43,7 @@ reparseLocName = token $ \t -> do
 reparseAttribute :: Reparse Attribute
 reparseAttribute = fmap Attribute $ do
     exact CXToken_Keyword "__attribute__"
-    doubleOpenParens *> anythingMatchingBrackets <* doubleCloseParens
+    doubleOpenParens *> anythingMatchingBrackets [("(",")")] <* doubleCloseParens
   where
     doubleOpenParens, doubleCloseParens :: Reparse ()
     doubleOpenParens  = (punctuation "(" >> punctuation "(") <?> "(("

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
@@ -29,6 +29,12 @@ primTypeKeyword = choice [
     -- TODO: check that "#define bool" is actually defined to _Bool
     -- it would be better to not special-case this
     , keyword "bool", identifier "bool" -- newer LLVM treat "bool" as keyword, older as identifier
+
+    -- The following are unsupported
+    , keyword "_Complex"
+    , keyword "_Decimal32"
+    , keyword "_Decimal64"
+    , keyword "_Decimal128"
     ]
 
 reparsePrimType :: Reparse Type


### PR DESCRIPTION
This commit extends reparsing to support a few missing cases, specifically with what the C specification calls "type specifiers".

The following type specifiers are now handled by the reparser:

  - structs and unions, although those with explicit (in-line) member
    declaration lists are reported as unsupported;
  - enums, although those with explicit (in-line) enumerator lists are
    reported as unsupported;
  - the following type specifiers, all reported as currently unsupported:
     - `_Complex`, `_Decimal32`, `_Decimal64`, `_Decimal128`
     - `_BitInt ( constant-expression )`
     - `_Atomic ( type-name )`
     - `typeof ( expression | type-name )`, and `typeof_unqual`

With these changes, the reparser handles all type specifiers that are defined in the [C23 specification](https://open-std.org/JTC1/SC22/WG14/www/docs/n3467.pdf) (see §6.7.3 "Type specifiers").