### PR TITLE
Preserve source order for `Enum` names

### DIFF
--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -994,7 +994,7 @@
           _×_
             1
             (NE.fromList
-              ["SAME_B", "SAME_A"])])
+              ["SAME_A", "SAME_B"])])
       True),
   DeclInstance
     (InstanceSequentialCEnum
@@ -1035,8 +1035,8 @@
                 valueSourceLoc =
                 "enums.h:17:5"}],
             enumSourceLoc = "enums.h:15:6"}}
-      (HsName "@NsConstr" "SAME_B")
-      (HsName "@NsConstr" "SAME_B")),
+      (HsName "@NsConstr" "SAME_A")
+      (HsName "@NsConstr" "SAME_A")),
   DeclInstance
     (InstanceCEnumShow
       Struct {

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -174,7 +174,7 @@ instance HsBindgen.Runtime.CEnum.CEnum Same where
 
   declaredValues =
     \_ ->
-      HsBindgen.Runtime.CEnum.declaredValuesFromList [(1, ("SAME_B" Data.List.NonEmpty.:| ["SAME_A"]))]
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [(1, ("SAME_A" Data.List.NonEmpty.:| ["SAME_B"]))]
 
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
@@ -182,9 +182,9 @@ instance HsBindgen.Runtime.CEnum.CEnum Same where
 
 instance HsBindgen.Runtime.CEnum.SequentialCEnum Same where
 
-  minDeclaredValue = SAME_B
+  minDeclaredValue = SAME_A
 
-  maxDeclaredValue = SAME_B
+  maxDeclaredValue = SAME_A
 
 instance Show Same where
 

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -71,11 +71,11 @@ instance CEnum Same
            fromCEnumZ = Same;
            toCEnumZ = un_Same;
            declaredValues = \_ -> declaredValuesFromList [(1,
-                                                           "SAME_B" :| ["SAME_A"])];
+                                                           "SAME_A" :| ["SAME_B"])];
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Same
-    where {minDeclaredValue = SAME_B; maxDeclaredValue = SAME_B}
+    where {minDeclaredValue = SAME_A; maxDeclaredValue = SAME_A}
 instance Show Same
     where {show = showCEnum "Same"}
 pattern SAME_A :: Same

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -328,7 +328,7 @@ enumDecs opts nm e = concat [
 
     cEnumInstanceDecls :: [Hs.Decl]
     cEnumInstanceDecls =
-      let vNames = Map.fromListWith (<>) [
+      let vNames = Map.fromListWith (flip (<>)) [ -- preserve source order
               ( Hs.patSynValue pat
               , NonEmpty.singleton (Hs.patSynName pat)
               )


### PR DESCRIPTION
The first name declared in the enum is now the first name in the list. This is not always the right choice (in some cases this will result in a suboptimal `Show` instance) but it's probably the less surprising choice.