### PR TITLE
Add header check

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -261,6 +261,7 @@ test-suite test-internal
   other-modules:
       Test.HsBindgen.C.Parser
       Test.Internal.Misc
+      Test.Internal.C
       Test.Internal.Rust
       Test.Internal.TastyGolden
       Test.Internal.TH

--- a/hs-bindgen/test/internal/Test/Internal/C.hs
+++ b/hs-bindgen/test/internal/Test/Internal/C.hs
@@ -1,0 +1,39 @@
+module Test.Internal.C (
+    cCheck,
+) where
+
+import Test.Tasty (TestTree, TestName)
+import Test.Tasty.HUnit (testCaseSteps)
+import System.IO.Temp (getCanonicalTemporaryDirectory, withTempDirectory)
+import System.FilePath ((</>))
+import System.Process qualified as P
+import System.Exit (ExitCode (..))
+
+cCheck :: FilePath -> TestName -> TestTree
+cCheck packageRoot name = testCaseSteps "header-check" $ \info -> do
+    tmpDir' <- getCanonicalTemporaryDirectory
+    withTempDirectory tmpDir' "header-check" $ \tmpDir -> do
+        writeFile (tmpDir </> "tmp.c") source
+
+        let proc :: P.CreateProcess
+            proc = (P.proc "cc" arguments) { P.cwd = Just tmpDir }
+
+        (ec, out, err) <- P.readCreateProcessWithExitCode proc ""
+        case ec of
+            ExitSuccess    -> info $ unlines [out, err]
+            ExitFailure {} -> info $ unlines [out, err]
+  where
+    header = name ++ ".h"
+
+    source = unlines
+        [ "#include \"" ++ header ++ "\""
+        ]
+
+    arguments :: [String]
+    arguments =
+        [ "-c"
+        , "-Wall"
+        , "-I" ++ (packageRoot </> "examples")
+        , "-o", "tmp.o"
+        , "tmp.c"
+        ]

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -19,6 +19,7 @@ import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 
 import Test.HsBindgen.C.Parser qualified
+import Test.Internal.C
 import Test.Internal.Misc
 import Test.Internal.Rust
 import Test.Internal.TastyGolden (goldenTestSteps)
@@ -105,6 +106,7 @@ tests packageRoot rustBindgen = testGroup "test-internal" [
 #endif
         , goldenPP name
         , goldenExtBindings name
+        , cCheck packageRoot name
         ]
 
     goldenTreeDiff :: TestName -> TestTree


### PR DESCRIPTION
validate with C compiler that headers are valid.

In retrospective we already do this as libclang doesn't accept invalid stuff anyway, but it doesn't hurt to be explicit?