### PR TITLE
Remove package from external bindings

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cli.hs
@@ -44,7 +44,6 @@ data Mode =
     ModePreprocess {
         preprocessInput           :: CHeaderIncludePath
       , preprocessTranslationOpts :: TranslationOpts
-      , preprocessPackageName     :: Maybe HsPackageName
       , preprocessModuleOpts      :: HsModuleOpts
       , preprocessRenderOpts      :: HsRenderOpts
       , preprocessOutput          :: Maybe FilePath
@@ -102,7 +101,6 @@ parseModePreprocess =
     ModePreprocess
       <$> parseInput
       <*> parseTranslationOpts
-      <*> optional parseHsPackageName
       <*> parseHsModuleOpts
       <*> parseHsRenderOpts
       <*> parseOutput
@@ -130,15 +128,6 @@ parseModeLiterate = do
 
 parseTranslationOpts :: Parser TranslationOpts
 parseTranslationOpts = pure defaultTranslationOpts
-
-parseHsPackageName :: Parser HsPackageName
-parseHsPackageName =
-    HsPackageName
-      <$> strOption (mconcat [
-              help "Package name for generated external bindings"
-            , metavar "NAME"
-            , long "package"
-            ])
 
 parseHsModuleOpts :: Parser HsModuleOpts
 parseHsModuleOpts =

--- a/hs-bindgen/bindings/Mapping.dhall
+++ b/hs-bindgen/bindings/Mapping.dhall
@@ -4,6 +4,5 @@ let Mapping
       , headers : List Text
       , identifier : Text
       , module : Text
-      , package : Text
       }
 in  Mapping

--- a/hs-bindgen/bindings/base.dhall
+++ b/hs-bindgen/bindings/base.dhall
@@ -15,7 +15,6 @@ let mkM =
         , headers = map Text Text systemHeader headers
         , identifier
         , module
-        , package = "base"
         }
 
 let intTypesH = [ "inttypes.h", "stdint.h" ]

--- a/hs-bindgen/bindings/base.yaml
+++ b/hs-bindgen/bindings/base.yaml
@@ -6,196 +6,168 @@ types:
       - system:stdint.h
     identifier: Int8
     module: Data.Int
-    package: base
   - cname: int16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
     module: Data.Int
-    package: base
   - cname: int32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
     module: Data.Int
-    package: base
   - cname: int64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
     module: Data.Int
-    package: base
   - cname: uint8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
     module: Data.Word
-    package: base
   - cname: uint16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
     module: Data.Word
-    package: base
   - cname: uint32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
     module: Data.Word
-    package: base
   - cname: uint64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
     module: Data.Word
-    package: base
   - cname: int_least8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int8
     module: Data.Int
-    package: base
   - cname: int_least16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
     module: Data.Int
-    package: base
   - cname: int_least32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
     module: Data.Int
-    package: base
   - cname: int_least64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
     module: Data.Int
-    package: base
   - cname: uint_least8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
     module: Data.Word
-    package: base
   - cname: uint_least16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
     module: Data.Word
-    package: base
   - cname: uint_least32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
     module: Data.Word
-    package: base
   - cname: uint_least64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
     module: Data.Word
-    package: base
   - cname: int_fast8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int8
     module: Data.Int
-    package: base
   - cname: int_fast16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
     module: Data.Int
-    package: base
   - cname: int_fast32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
     module: Data.Int
-    package: base
   - cname: int_fast64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
     module: Data.Int
-    package: base
   - cname: uint_fast8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
     module: Data.Word
-    package: base
   - cname: uint_fast16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
     module: Data.Word
-    package: base
   - cname: uint_fast32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
     module: Data.Word
-    package: base
   - cname: uint_fast64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
     module: Data.Word
-    package: base
   - cname: intmax_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CIntMax
     module: Foreign.C.Types
-    package: base
   - cname: uintmax_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CUIntMax
     module: Foreign.C.Types
-    package: base
   - cname: intptr_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CIntPtr
     module: Foreign.C.Types
-    package: base
   - cname: uintptr_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CUIntPtr
     module: Foreign.C.Types
-    package: base
   - cname: size_t
     headers:
       - system:signal.h
@@ -208,19 +180,16 @@ types:
       - system:wchar.h
     identifier: CSize
     module: Foreign.C.Types
-    package: base
   - cname: ptrdiff_t
     headers:
       - system:stddef.h
     identifier: CPtrdiff
     module: Foreign.C.Types
-    package: base
   - cname: jmp_buf
     headers:
       - system:setjmp.h
     identifier: CJmpBuf
     module: Foreign.C.Types
-    package: base
   - cname: wchar_t
     headers:
       - system:inttypes.h
@@ -229,37 +198,31 @@ types:
       - system:wchar.h
     identifier: CWchar
     module: Foreign.C.Types
-    package: base
   - cname: time_t
     headers:
       - system:signal.h
       - system:time.h
     identifier: CTime
     module: Foreign.C.Types
-    package: base
   - cname: clock_t
     headers:
       - system:signal.h
       - system:time.h
     identifier: CClock
     module: Foreign.C.Types
-    package: base
   - cname: FILE
     headers:
       - system:stdio.h
       - system:wchar.h
     identifier: CFile
     module: Foreign.C.Types
-    package: base
   - cname: fpos_t
     headers:
       - system:stdio.h
     identifier: CFpos
     module: Foreign.C.Types
-    package: base
   - cname: sig_atomic_t
     headers:
       - system:signal.h
     identifier: CSigAtomic
     module: Foreign.C.Types
-    package: base

--- a/hs-bindgen/bindings/hs-bindgen-runtime.dhall
+++ b/hs-bindgen/bindings/hs-bindgen-runtime.dhall
@@ -14,7 +14,6 @@ let mkM =
         , headers = map Text Text systemHeader headers
         , identifier
         , module = "HsBindgen.Runtime.LibC"
-        , package = "hs-bindgen-runtime"
         }
 
 let types

--- a/hs-bindgen/bindings/hs-bindgen-runtime.yaml
+++ b/hs-bindgen/bindings/hs-bindgen-runtime.yaml
@@ -5,79 +5,66 @@ types:
       - system:fenv.h
     identifier: CFenvT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: fexcept_t
     headers:
       - system:fenv.h
     identifier: CFexceptT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: div_t
     headers:
       - system:stdlib.h
     identifier: CDivT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: ldiv_t
     headers:
       - system:stdlib.h
     identifier: CLdivT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: lldiv_t
     headers:
       - system:stdlib.h
     identifier: CLldivT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: imaxdiv_t
     headers:
       - system:inttypes.h
     identifier: CImaxdivT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: wint_t
     headers:
       - system:wchar.h
       - system:wctype.h
     identifier: CWintT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: mbstate_t
     headers:
       - system:uchar.h
       - system:wchar.h
     identifier: CMbstateT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: wctrans_t
     headers:
       - system:wctype.h
     identifier: CWctransT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: wctype_t
     headers:
       - system:wchar.h
       - system:wctype.h
     identifier: CWctypeT
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: char16_t
     headers:
       - system:uchar.h
     identifier: CChar16T
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: char32_t
     headers:
       - system:uchar.h
     identifier: CChar32T
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime
   - cname: struct tm
     headers:
       - system:time.h
     identifier: CTm
     module: HsBindgen.Runtime.LibC
-    package: hs-bindgen-runtime

--- a/hs-bindgen/fixtures/adios.extbindings.yaml
+++ b/hs-bindgen/fixtures/adios.extbindings.yaml
@@ -1,11 +1,9 @@
 types:
 - headers: adios.h
   cname: adiós
-  package: example
   module: Example
   identifier: Adio'0301s
 - headers: adios.h
   cname: 数字
-  package: example
   module: Example
   identifier: C数字

--- a/hs-bindgen/fixtures/anonymous.extbindings.yaml
+++ b/hs-bindgen/fixtures/anonymous.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: anonymous.h
   cname: struct S1
-  package: example
   module: Example
   identifier: S1
 - headers: anonymous.h
   cname: struct S2
-  package: example
   module: Example
   identifier: S2
 - headers: anonymous.h
   cname: struct S3
-  package: example
   module: Example
   identifier: S3

--- a/hs-bindgen/fixtures/bitfields.extbindings.yaml
+++ b/hs-bindgen/fixtures/bitfields.extbindings.yaml
@@ -1,36 +1,29 @@
 types:
 - headers: bitfields.h
   cname: struct alignA
-  package: example
   module: Example
   identifier: AlignA
 - headers: bitfields.h
   cname: struct alignB
-  package: example
   module: Example
   identifier: AlignB
 - headers: bitfields.h
   cname: struct flags
-  package: example
   module: Example
   identifier: Flags
 - headers: bitfields.h
   cname: struct overflow32
-  package: example
   module: Example
   identifier: Overflow32
 - headers: bitfields.h
   cname: struct overflow32b
-  package: example
   module: Example
   identifier: Overflow32b
 - headers: bitfields.h
   cname: struct overflow32c
-  package: example
   module: Example
   identifier: Overflow32c
 - headers: bitfields.h
   cname: struct overflow64
-  package: example
   module: Example
   identifier: Overflow64

--- a/hs-bindgen/fixtures/bool.extbindings.yaml
+++ b/hs-bindgen/fixtures/bool.extbindings.yaml
@@ -1,21 +1,17 @@
 types:
 - headers: bool.h
   cname: BOOL
-  package: example
   module: Example
   identifier: BOOL
 - headers: bool.h
   cname: struct bools1
-  package: example
   module: Example
   identifier: Bools1
 - headers: bool.h
   cname: struct bools2
-  package: example
   module: Example
   identifier: Bools2
 - headers: bool.h
   cname: struct bools3
-  package: example
   module: Example
   identifier: Bools3

--- a/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
+++ b/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
@@ -1,61 +1,49 @@
 types:
 - headers: distilled_lib_1.h
   cname: a_type_t
-  package: example
   module: Example
   identifier: A_type_t
 - headers: distilled_lib_1.h
   cname: a_typedef_enum_e
-  package: example
   module: Example
   identifier: A_typedef_enum_e
 - headers: distilled_lib_1.h
   cname: a_typedef_struct_t
-  package: example
   module: Example
   identifier: A_typedef_struct_t
 - headers: distilled_lib_1.h
   cname: another_typedef_enum_e
-  package: example
   module: Example
   identifier: Another_typedef_enum_e
 - headers: distilled_lib_1.h
   cname: another_typedef_struct_t
-  package: example
   module: Example
   identifier: Another_typedef_struct_t
 - headers: distilled_lib_1.h
   cname: callback_t
-  package: example
   module: Example
   identifier: Callback_t
 - headers: distilled_lib_1.h
   cname: int32_t
-  package: example
   module: Example
   identifier: Int32_t
 - headers: distilled_lib_1.h
   cname: struct a_typedef_struct
-  package: example
   module: Example
   identifier: A_typedef_struct
 - headers: distilled_lib_1.h
   cname: uint16_t
-  package: example
   module: Example
   identifier: Uint16_t
 - headers: distilled_lib_1.h
   cname: uint32_t
-  package: example
   module: Example
   identifier: Uint32_t
 - headers: distilled_lib_1.h
   cname: uint8_t
-  package: example
   module: Example
   identifier: Uint8_t
 - headers: distilled_lib_1.h
   cname: var_t
-  package: example
   module: Example
   identifier: Var_t

--- a/hs-bindgen/fixtures/enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/enums.extbindings.yaml
@@ -1,61 +1,49 @@
 types:
 - headers: enums.h
   cname: enum enumB
-  package: example
   module: Example
   identifier: EnumB
 - headers: enums.h
   cname: enum enumC
-  package: example
   module: Example
   identifier: EnumC
 - headers: enums.h
   cname: enum enumD
-  package: example
   module: Example
   identifier: EnumD
 - headers: enums.h
   cname: enum first
-  package: example
   module: Example
   identifier: First
 - headers: enums.h
   cname: enum nonseq
-  package: example
   module: Example
   identifier: Nonseq
 - headers: enums.h
   cname: enum packad
-  package: example
   module: Example
   identifier: Packad
 - headers: enums.h
   cname: enum same
-  package: example
   module: Example
   identifier: Same
 - headers: enums.h
   cname: enum second
-  package: example
   module: Example
   identifier: Second
 - headers: enums.h
   cname: enumA
-  package: example
   module: Example
   identifier: EnumA
 - headers: enums.h
   cname: enumB
-  package: example
   module: Example
   identifier: EnumB
 - headers: enums.h
   cname: enumC
-  package: example
   module: Example
   identifier: EnumC
 - headers: enums.h
   cname: enumD_t
-  package: example
   module: Example
   identifier: EnumD_t

--- a/hs-bindgen/fixtures/fixedarray.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedarray.extbindings.yaml
@@ -1,11 +1,9 @@
 types:
 - headers: fixedarray.h
   cname: struct Example
-  package: example
   module: Example
   identifier: Example
 - headers: fixedarray.h
   cname: triple
-  package: example
   module: Example
   identifier: Triple

--- a/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: fixedwidth.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo
 - headers: fixedwidth.h
   cname: uint32_t
-  package: example
   module: Example
   identifier: Uint32_t
 - headers: fixedwidth.h
   cname: uint64_t
-  package: example
   module: Example
   identifier: Uint64_t

--- a/hs-bindgen/fixtures/flam.extbindings.yaml
+++ b/hs-bindgen/fixtures/flam.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: flam.h
   cname: struct diff
-  package: example
   module: Example
   identifier: Diff
 - headers: flam.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo
 - headers: flam.h
   cname: struct pascal
-  package: example
   module: Example
   identifier: Pascal

--- a/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: forward_declaration.h
   cname: S1_t
-  package: example
   module: Example
   identifier: S1_t
 - headers: forward_declaration.h
   cname: struct S1
-  package: example
   module: Example
   identifier: S1
 - headers: forward_declaration.h
   cname: struct S2
-  package: example
   module: Example
   identifier: S2

--- a/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
@@ -1,26 +1,21 @@
 types:
 - headers: macro_in_fundecl.h
   cname: C
-  package: example
   module: Example
   identifier: C
 - headers: macro_in_fundecl.h
   cname: F
-  package: example
   module: Example
   identifier: F
 - headers: macro_in_fundecl.h
   cname: I
-  package: example
   module: Example
   identifier: I
 - headers: macro_in_fundecl.h
   cname: L
-  package: example
   module: Example
   identifier: L
 - headers: macro_in_fundecl.h
   cname: S
-  package: example
   module: Example
   identifier: S

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
@@ -1,41 +1,33 @@
 types:
 - headers: macro_in_fundecl_vs_typedef.h
   cname: MC
-  package: example
   module: Example
   identifier: MC
 - headers: macro_in_fundecl_vs_typedef.h
   cname: TC
-  package: example
   module: Example
   identifier: TC
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct1
-  package: example
   module: Example
   identifier: Struct1
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct3
-  package: example
   module: Example
   identifier: Struct3
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct4
-  package: example
   module: Example
   identifier: Struct4
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct2
-  package: example
   module: Example
   identifier: Struct2
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct3_t
-  package: example
   module: Example
   identifier: Struct3_t
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct4
-  package: example
   module: Example
   identifier: Struct4

--- a/hs-bindgen/fixtures/manual_examples.extbindings.yaml
+++ b/hs-bindgen/fixtures/manual_examples.extbindings.yaml
@@ -1,131 +1,105 @@
 types:
 - headers: manual_examples.h
   cname: DAY
-  package: example
   module: Example
   identifier: DAY
 - headers: manual_examples.h
   cname: MONTH
-  package: example
   module: Example
   identifier: MONTH
 - headers: manual_examples.h
   cname: YEAR
-  package: example
   module: Example
   identifier: YEAR
 - headers: manual_examples.h
   cname: adiós
-  package: example
   module: Example
   identifier: Adio'0301s
 - headers: manual_examples.h
   cname: average
-  package: example
   module: Example
   identifier: Average
 - headers: manual_examples.h
   cname: config
-  package: example
   module: Example
   identifier: Config
 - headers: manual_examples.h
   cname: data
-  package: example
   module: Example
   identifier: Data
 - headers: manual_examples.h
   cname: date
-  package: example
   module: Example
   identifier: Date
 - headers: manual_examples.h
   cname: enum CXCursorKind
-  package: example
   module: Example
   identifier: CXCursorKind
 - headers: manual_examples.h
   cname: enum HTTP_status
-  package: example
   module: Example
   identifier: HTTP_status
 - headers: manual_examples.h
   cname: enum index
-  package: example
   module: Example
   identifier: Index
 - headers: manual_examples.h
   cname: enum result
-  package: example
   module: Example
   identifier: Result
 - headers: manual_examples.h
   cname: enum signal
-  package: example
   module: Example
   identifier: Signal
 - headers: manual_examples.h
   cname: enum vote
-  package: example
   module: Example
   identifier: Vote
 - headers: manual_examples.h
   cname: index
-  package: example
   module: Example
   identifier: Index
 - headers: manual_examples.h
   cname: occupation
-  package: example
   module: Example
   identifier: Occupation
 - headers: manual_examples.h
   cname: struct date
-  package: example
   module: Example
   identifier: Date
 - headers: manual_examples.h
   cname: struct employee
-  package: example
   module: Example
   identifier: Employee
 - headers: manual_examples.h
   cname: struct person
-  package: example
   module: Example
   identifier: Person
 - headers: manual_examples.h
   cname: struct rect
-  package: example
   module: Example
   identifier: Rect
 - headers: manual_examples.h
   cname: struct student
-  package: example
   module: Example
   identifier: Student
 - headers: manual_examples.h
   cname: struct triple
-  package: example
   module: Example
   identifier: Triple
 - headers: manual_examples.h
   cname: sum
-  package: example
   module: Example
   identifier: Sum
 - headers: manual_examples.h
   cname: triple
-  package: example
   module: Example
   identifier: Triple
 - headers: manual_examples.h
   cname: union occupation
-  package: example
   module: Example
   identifier: Occupation
 - headers: manual_examples.h
   cname: 数字
-  package: example
   module: Example
   identifier: C数字

--- a/hs-bindgen/fixtures/nested_enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_enums.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: nested_enums.h
   cname: enum enumA
-  package: example
   module: Example
   identifier: EnumA
 - headers: nested_enums.h
   cname: struct exA
-  package: example
   module: Example
   identifier: ExA
 - headers: nested_enums.h
   cname: struct exB
-  package: example
   module: Example
   identifier: ExB

--- a/hs-bindgen/fixtures/nested_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_types.extbindings.yaml
@@ -1,26 +1,21 @@
 types:
 - headers: nested_types.h
   cname: struct bar
-  package: example
   module: Example
   identifier: Bar
 - headers: nested_types.h
   cname: struct ex3
-  package: example
   module: Example
   identifier: Ex3
 - headers: nested_types.h
   cname: struct ex4_even
-  package: example
   module: Example
   identifier: Ex4_even
 - headers: nested_types.h
   cname: struct ex4_odd
-  package: example
   module: Example
   identifier: Ex4_odd
 - headers: nested_types.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo

--- a/hs-bindgen/fixtures/nested_unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_unions.extbindings.yaml
@@ -1,16 +1,13 @@
 types:
 - headers: nested_unions.h
   cname: struct exA
-  package: example
   module: Example
   identifier: ExA
 - headers: nested_unions.h
   cname: struct exB
-  package: example
   module: Example
   identifier: ExB
 - headers: nested_unions.h
   cname: union unionA
-  package: example
   module: Example
   identifier: UnionA

--- a/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
@@ -1,26 +1,21 @@
 types:
 - headers: opaque_declaration.h
   cname: enum quu
-  package: example
   module: Example
   identifier: Quu
 - headers: opaque_declaration.h
   cname: struct bar
-  package: example
   module: Example
   identifier: Bar
 - headers: opaque_declaration.h
   cname: struct baz
-  package: example
   module: Example
   identifier: Baz
 - headers: opaque_declaration.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo
 - headers: opaque_declaration.h
   cname: struct opaque_union
-  package: example
   module: Example
   identifier: Opaque_union

--- a/hs-bindgen/fixtures/primitive_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/primitive_types.extbindings.yaml
@@ -1,6 +1,5 @@
 types:
 - headers: primitive_types.h
   cname: struct primitive
-  package: example
   module: Example
   identifier: Primitive

--- a/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
+++ b/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
@@ -1,21 +1,17 @@
 types:
 - headers: recursive_struct.h
   cname: linked_list_A_t
-  package: example
   module: Example
   identifier: Linked_list_A_t
 - headers: recursive_struct.h
   cname: linked_list_B_t
-  package: example
   module: Example
   identifier: Linked_list_B_t
 - headers: recursive_struct.h
   cname: struct linked_list_A_s
-  package: example
   module: Example
   identifier: Linked_list_A_s
 - headers: recursive_struct.h
   cname: struct linked_list_B_t
-  package: example
   module: Example
   identifier: Linked_list_B_t

--- a/hs-bindgen/fixtures/simple_structs.extbindings.yaml
+++ b/hs-bindgen/fixtures/simple_structs.extbindings.yaml
@@ -1,56 +1,45 @@
 types:
 - headers: simple_structs.h
   cname: S2_t
-  package: example
   module: Example
   identifier: S2_t
 - headers: simple_structs.h
   cname: S3_t
-  package: example
   module: Example
   identifier: S3_t
 - headers: simple_structs.h
   cname: S5
-  package: example
   module: Example
   identifier: S5
 - headers: simple_structs.h
   cname: S6
-  package: example
   module: Example
   identifier: S6
 - headers: simple_structs.h
   cname: S7a
-  package: example
   module: Example
   identifier: S7a
 - headers: simple_structs.h
   cname: S7b
-  package: example
   module: Example
   identifier: S7b
 - headers: simple_structs.h
   cname: struct S1
-  package: example
   module: Example
   identifier: S1
 - headers: simple_structs.h
   cname: struct S2
-  package: example
   module: Example
   identifier: S2
 - headers: simple_structs.h
   cname: struct S4
-  package: example
   module: Example
   identifier: S4
 - headers: simple_structs.h
   cname: struct S5
-  package: example
   module: Example
   identifier: S5
 - headers: simple_structs.h
   cname: struct S6
-  package: example
   module: Example
   identifier: S6

--- a/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
@@ -1,41 +1,33 @@
 types:
 - headers: typedef_vs_macro.h
   cname: M1
-  package: example
   module: Example
   identifier: M1
 - headers: typedef_vs_macro.h
   cname: M2
-  package: example
   module: Example
   identifier: M2
 - headers: typedef_vs_macro.h
   cname: M3
-  package: example
   module: Example
   identifier: M3
 - headers: typedef_vs_macro.h
   cname: T1
-  package: example
   module: Example
   identifier: T1
 - headers: typedef_vs_macro.h
   cname: T2
-  package: example
   module: Example
   identifier: T2
 - headers: typedef_vs_macro.h
   cname: struct ExampleStruct
-  package: example
   module: Example
   identifier: ExampleStruct
 - headers: typedef_vs_macro.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo
 - headers: typedef_vs_macro.h
   cname: uint64_t
-  package: example
   module: Example
   identifier: Uint64_t

--- a/hs-bindgen/fixtures/typedefs.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedefs.extbindings.yaml
@@ -1,11 +1,9 @@
 types:
 - headers: typedefs.h
   cname: intptr
-  package: example
   module: Example
   identifier: Intptr
 - headers: typedefs.h
   cname: myint
-  package: example
   module: Example
   identifier: Myint

--- a/hs-bindgen/fixtures/typenames.extbindings.yaml
+++ b/hs-bindgen/fixtures/typenames.extbindings.yaml
@@ -1,11 +1,9 @@
 types:
 - headers: typenames.h
   cname: enum foo
-  package: example
   module: Example
   identifier: Foo
 - headers: typenames.h
   cname: foo
-  package: example
   module: Example
   identifier: Foo

--- a/hs-bindgen/fixtures/unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/unions.extbindings.yaml
@@ -1,41 +1,33 @@
 types:
 - headers: unions.h
   cname: DimPayloadB
-  package: example
   module: Example
   identifier: DimPayloadB
 - headers: unions.h
   cname: struct Dim
-  package: example
   module: Example
   identifier: Dim
 - headers: unions.h
   cname: struct Dim2
-  package: example
   module: Example
   identifier: Dim2
 - headers: unions.h
   cname: struct Dim3
-  package: example
   module: Example
   identifier: Dim3
 - headers: unions.h
   cname: struct DimB
-  package: example
   module: Example
   identifier: DimB
 - headers: unions.h
   cname: union AnonA
-  package: example
   module: Example
   identifier: AnonA
 - headers: unions.h
   cname: union DimPayload
-  package: example
   module: Example
   identifier: DimPayload
 - headers: unions.h
   cname: union DimPayloadB
-  package: example
   module: Example
   identifier: DimPayloadB

--- a/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
+++ b/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
@@ -1,6 +1,5 @@
 types:
 - headers: uses_utf8.h
   cname: enum MyEnum
-  package: example
   module: Example
   identifier: MyEnum

--- a/hs-bindgen/fixtures/weird01.extbindings.yaml
+++ b/hs-bindgen/fixtures/weird01.extbindings.yaml
@@ -1,11 +1,9 @@
 types:
 - headers: weird01.h
   cname: struct bar
-  package: example
   module: Example
   identifier: Bar
 - headers: weird01.h
   cname: struct foo
-  package: example
   module: Example
   identifier: Foo

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -22,11 +22,10 @@ import HsBindgen.Imports
 
 genExtBindings ::
      CHeaderIncludePath
-  -> HsPackageName
   -> HsModuleName
   -> [Hs.Decl]
   -> UnresolvedExtBindings
-genExtBindings headerIncludePath extIdentifierPackage extIdentifierModule =
+genExtBindings headerIncludePath extIdentifierModule =
     foldr aux emptyUnresolvedExtBindings
   where
     aux :: Hs.Decl -> UnresolvedExtBindings -> UnresolvedExtBindings

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -237,14 +237,13 @@ genBindings' quoteIncPathDirs = genBindings defaultOpts {
 genExtBindings ::
      PPOpts
   -> CHeaderIncludePath
-  -> HsPackageName
   -> FilePath
   -> [Hs.Decl]
   -> IO ()
-genExtBindings PPOpts{..} headerIncludePath packageName path =
+genExtBindings PPOpts{..} headerIncludePath path =
         either (throwIO . HsBindgenException) return
     <=< writeUnresolvedExtBindings path
-    .   GenExtBindings.genExtBindings headerIncludePath packageName moduleName
+    .   GenExtBindings.genExtBindings headerIncludePath moduleName
   where
     moduleName :: HsModuleName
     moduleName = HsModuleName $ Text.pack (hsModuleOptsName ppOptsModule)

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -31,7 +31,6 @@ module HsBindgen.Lib (
   , Args.CStandard(..)
 
     -- ** External bindings
-  , ExtBindings.HsPackageName(..)
   , ExtBindings.ExtBindings
   , ExtBindings.emptyExtBindings
   , ExtBindings.loadExtBindings
@@ -121,13 +120,11 @@ preprocessIO ppOpts fp = Pipeline.preprocessIO ppOpts fp . unwrapHsDecls
 genExtBindings ::
      Pipeline.PPOpts
   -> Paths.CHeaderIncludePath
-  -> ExtBindings.HsPackageName
   -> FilePath
   -> HsDecls
   -> IO ()
-genExtBindings ppOpts headerIncludePath packageName fp =
-      Pipeline.genExtBindings ppOpts headerIncludePath packageName fp
-    . unwrapHsDecls
+genExtBindings ppOpts headerIncludePath fp =
+    Pipeline.genExtBindings ppOpts headerIncludePath fp . unwrapHsDecls
 
 {-------------------------------------------------------------------------------
   Test generation

--- a/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
@@ -116,7 +116,6 @@ instance ToExpr C.ReparseError where
             ++ '>' : '"' : normalizePaths sR
         _otherwise -> '"' : '<' : s -- unexpected
 
-instance ToExpr HsPackageName
 instance ToExpr HsModuleName
 instance ToExpr HsIdentifier
 instance ToExpr ExtIdentifier

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -150,7 +150,6 @@ tests packageRoot rustBindgen = testGroup "test-internal" [
         return . UTF8.toString . ExtBindings.encodeUnresolvedExtBindingsYaml $
           ExtBindings.genExtBindings
             headerIncludePath
-            (ExtBindings.HsPackageName "example")
             (ExtBindings.HsModuleName "Example")
             decls
 


### PR DESCRIPTION
The package was not used yet.  The only foreseeable usage was to provide dependency information to users.

We discussed how we might use external bindings configuration (renamed "bindings specifications") as a way for users to configure bindings generation, and we decided that `package` should go.