### PR TITLE
Track available instances

### DIFF
--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/ConstantArray.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/ConstantArray.hs
@@ -12,8 +12,11 @@ import Foreign.Storable (Storable (..))
 import Foreign.Marshal.Utils (copyBytes)
 import Data.Vector.Storable qualified as VS
 
+import HsBindgen.Runtime.Marshal (ReadRaw, StaticSize, WriteRaw)
+
 newtype ConstantArray (n :: Nat) a = CA (VS.Vector a)
   deriving (Eq, Show)
+  deriving anyclass (ReadRaw, StaticSize, WriteRaw)
 
 type role ConstantArray nominal nominal
 

--- a/hs-bindgen/bindings/Makefile
+++ b/hs-bindgen/bindings/Makefile
@@ -1,0 +1,5 @@
+all: base.yaml hs-bindgen-runtime.yaml
+.PHONY: all
+
+%.yaml: %.dhall
+	dhall-to-yaml --generated-comment --omit-empty --file $< --output $@

--- a/hs-bindgen/bindings/Mapping.dhall
+++ b/hs-bindgen/bindings/Mapping.dhall
@@ -3,6 +3,7 @@ let Mapping
     = { cname : Text
       , headers : List Text
       , identifier : Text
+      , instances : List Text
       , module : Text
       }
 in  Mapping

--- a/hs-bindgen/bindings/base.dhall
+++ b/hs-bindgen/bindings/base.dhall
@@ -11,45 +11,80 @@ let mkM =
       \(identifier : Text) ->
       \(module : Text) ->
       \(headers : List Text) ->
+      \(instances : List Text) ->
         { cname
         , headers = map Text Text systemHeader headers
         , identifier
+        , instances
         , module
         }
 
 let intTypesH = [ "inttypes.h", "stdint.h" ]
 
+let noI   = [] : List Text
+let intI  =
+      [ "Bits"
+      , "Bounded"
+      , "Enum"
+      , "Eq"
+      , "FiniteBits"
+      , "Integral"
+      , "Ix"
+      , "Num"
+      , "Ord"
+      , "Read"
+      , "ReadRaw"
+      , "Real"
+      , "Show"
+      , "StaticSize"
+      , "Storable"
+      , "WriteRaw"
+      ]
+let timeI =
+      [ "Enum"
+      , "Eq"
+      , "Num"
+      , "Ord"
+      , "Read"
+      , "ReadRaw"
+      , "Real"
+      , "Show"
+      , "StaticSize"
+      , "Storable"
+      , "WriteRaw"
+      ]
+
 let types
     : List ./Mapping.dhall
         -- Integral Types
-    = [ mkM "int8_t"         "Int8"     "Data.Int"        intTypesH
-      , mkM "int16_t"        "Int16"    "Data.Int"        intTypesH
-      , mkM "int32_t"        "Int32"    "Data.Int"        intTypesH
-      , mkM "int64_t"        "Int64"    "Data.Int"        intTypesH
-      , mkM "uint8_t"        "Word8"    "Data.Word"       intTypesH
-      , mkM "uint16_t"       "Word16"   "Data.Word"       intTypesH
-      , mkM "uint32_t"       "Word32"   "Data.Word"       intTypesH
-      , mkM "uint64_t"       "Word64"   "Data.Word"       intTypesH
-      , mkM "int_least8_t"   "Int8"     "Data.Int"        intTypesH
-      , mkM "int_least16_t"  "Int16"    "Data.Int"        intTypesH
-      , mkM "int_least32_t"  "Int32"    "Data.Int"        intTypesH
-      , mkM "int_least64_t"  "Int64"    "Data.Int"        intTypesH
-      , mkM "uint_least8_t"  "Word8"    "Data.Word"       intTypesH
-      , mkM "uint_least16_t" "Word16"   "Data.Word"       intTypesH
-      , mkM "uint_least32_t" "Word32"   "Data.Word"       intTypesH
-      , mkM "uint_least64_t" "Word64"   "Data.Word"       intTypesH
-      , mkM "int_fast8_t"    "Int8"     "Data.Int"        intTypesH
-      , mkM "int_fast16_t"   "Int16"    "Data.Int"        intTypesH
-      , mkM "int_fast32_t"   "Int32"    "Data.Int"        intTypesH
-      , mkM "int_fast64_t"   "Int64"    "Data.Int"        intTypesH
-      , mkM "uint_fast8_t"   "Word8"    "Data.Word"       intTypesH
-      , mkM "uint_fast16_t"  "Word16"   "Data.Word"       intTypesH
-      , mkM "uint_fast32_t"  "Word32"   "Data.Word"       intTypesH
-      , mkM "uint_fast64_t"  "Word64"   "Data.Word"       intTypesH
-      , mkM "intmax_t"       "CIntMax"  "Foreign.C.Types" intTypesH
-      , mkM "uintmax_t"      "CUIntMax" "Foreign.C.Types" intTypesH
-      , mkM "intptr_t"       "CIntPtr"  "Foreign.C.Types" intTypesH
-      , mkM "uintptr_t"      "CUIntPtr" "Foreign.C.Types" intTypesH
+    = [ mkM "int8_t"         "Int8"     "Data.Int"        intTypesH intI
+      , mkM "int16_t"        "Int16"    "Data.Int"        intTypesH intI
+      , mkM "int32_t"        "Int32"    "Data.Int"        intTypesH intI
+      , mkM "int64_t"        "Int64"    "Data.Int"        intTypesH intI
+      , mkM "uint8_t"        "Word8"    "Data.Word"       intTypesH intI
+      , mkM "uint16_t"       "Word16"   "Data.Word"       intTypesH intI
+      , mkM "uint32_t"       "Word32"   "Data.Word"       intTypesH intI
+      , mkM "uint64_t"       "Word64"   "Data.Word"       intTypesH intI
+      , mkM "int_least8_t"   "Int8"     "Data.Int"        intTypesH intI
+      , mkM "int_least16_t"  "Int16"    "Data.Int"        intTypesH intI
+      , mkM "int_least32_t"  "Int32"    "Data.Int"        intTypesH intI
+      , mkM "int_least64_t"  "Int64"    "Data.Int"        intTypesH intI
+      , mkM "uint_least8_t"  "Word8"    "Data.Word"       intTypesH intI
+      , mkM "uint_least16_t" "Word16"   "Data.Word"       intTypesH intI
+      , mkM "uint_least32_t" "Word32"   "Data.Word"       intTypesH intI
+      , mkM "uint_least64_t" "Word64"   "Data.Word"       intTypesH intI
+      , mkM "int_fast8_t"    "Int8"     "Data.Int"        intTypesH intI
+      , mkM "int_fast16_t"   "Int16"    "Data.Int"        intTypesH intI
+      , mkM "int_fast32_t"   "Int32"    "Data.Int"        intTypesH intI
+      , mkM "int_fast64_t"   "Int64"    "Data.Int"        intTypesH intI
+      , mkM "uint_fast8_t"   "Word8"    "Data.Word"       intTypesH intI
+      , mkM "uint_fast16_t"  "Word16"   "Data.Word"       intTypesH intI
+      , mkM "uint_fast32_t"  "Word32"   "Data.Word"       intTypesH intI
+      , mkM "uint_fast64_t"  "Word64"   "Data.Word"       intTypesH intI
+      , mkM "intmax_t"       "CIntMax"  "Foreign.C.Types" intTypesH intI
+      , mkM "uintmax_t"      "CUIntMax" "Foreign.C.Types" intTypesH intI
+      , mkM "intptr_t"       "CIntPtr"  "Foreign.C.Types" intTypesH intI
+      , mkM "uintptr_t"      "CUIntPtr" "Foreign.C.Types" intTypesH intI
         -- Standard Definitions
       , mkM "size_t" "CSize" "Foreign.C.Types"
           [ "signal.h"
@@ -61,20 +96,21 @@ let types
           , "uchar.h"
           , "wchar.h"
           ]
-      , mkM "ptrdiff_t" "CPtrdiff" "Foreign.C.Types" [ "stddef.h" ]
+          intI
+      , mkM "ptrdiff_t" "CPtrdiff" "Foreign.C.Types" [ "stddef.h" ] intI
         -- Non-Local Jump Types
-      , mkM "jmp_buf" "CJmpBuf" "Foreign.C.Types" [ "setjmp.h" ]
+      , mkM "jmp_buf" "CJmpBuf" "Foreign.C.Types" [ "setjmp.h" ] noI
         -- Wide Character Types
       , mkM "wchar_t" "CWchar" "Foreign.C.Types"
-          [ "inttypes.h", "stddef.h", "stdlib.h", "wchar.h" ]
+          [ "inttypes.h", "stddef.h", "stdlib.h", "wchar.h" ] intI
         -- Time Types
-      , mkM "time_t"  "CTime"  "Foreign.C.Types" [ "signal.h", "time.h" ]
-      , mkM "clock_t" "CClock" "Foreign.C.Types" [ "signal.h", "time.h" ]
+      , mkM "time_t"  "CTime"  "Foreign.C.Types" [ "signal.h", "time.h" ] timeI
+      , mkM "clock_t" "CClock" "Foreign.C.Types" [ "signal.h", "time.h" ] timeI
         -- File Types
-      , mkM "FILE"   "CFile" "Foreign.C.Types" [ "stdio.h", "wchar.h" ]
-      , mkM "fpos_t" "CFpos" "Foreign.C.Types" [ "stdio.h" ]
+      , mkM "FILE"   "CFile" "Foreign.C.Types" [ "stdio.h", "wchar.h" ] noI
+      , mkM "fpos_t" "CFpos" "Foreign.C.Types" [ "stdio.h" ]            noI
         -- Signal Types
-      , mkM "sig_atomic_t" "CSigAtomic" "Foreign.C.Types" [ "signal.h" ]
+      , mkM "sig_atomic_t" "CSigAtomic" "Foreign.C.Types" [ "signal.h" ] intI
       ]
 
 in  { types }

--- a/hs-bindgen/bindings/base.yaml
+++ b/hs-bindgen/bindings/base.yaml
@@ -5,168 +5,644 @@ types:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: uint8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: int_least8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_least16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_least32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_least64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: uint_least8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_least16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_least32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_least64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: int_fast8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_fast16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_fast32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: int_fast64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Int64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Int
   - cname: uint_fast8_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word8
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_fast16_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word16
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_fast32_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word32
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: uint_fast64_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: Word64
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Data.Word
   - cname: intmax_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CIntMax
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: uintmax_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CUIntMax
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: intptr_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CIntPtr
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: uintptr_t
     headers:
       - system:inttypes.h
       - system:stdint.h
     identifier: CUIntPtr
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: size_t
     headers:
@@ -179,11 +655,45 @@ types:
       - system:uchar.h
       - system:wchar.h
     identifier: CSize
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: ptrdiff_t
     headers:
       - system:stddef.h
     identifier: CPtrdiff
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: jmp_buf
     headers:
@@ -197,18 +707,59 @@ types:
       - system:stdlib.h
       - system:wchar.h
     identifier: CWchar
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: time_t
     headers:
       - system:signal.h
       - system:time.h
     identifier: CTime
+    instances:
+      - Enum
+      - Eq
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: clock_t
     headers:
       - system:signal.h
       - system:time.h
     identifier: CClock
+    instances:
+      - Enum
+      - Eq
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types
   - cname: FILE
     headers:
@@ -225,4 +776,21 @@ types:
     headers:
       - system:signal.h
     identifier: CSigAtomic
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: Foreign.C.Types

--- a/hs-bindgen/bindings/hs-bindgen-runtime.dhall
+++ b/hs-bindgen/bindings/hs-bindgen-runtime.dhall
@@ -10,31 +10,55 @@ let mkM =
       \(cname : Text) ->
       \(identifier : Text) ->
       \(headers : List Text) ->
+      \(instances : List Text) ->
         { cname
         , headers = map Text Text systemHeader headers
         , identifier
+        , instances
         , module = "HsBindgen.Runtime.LibC"
         }
+
+let noI  = [] : List Text
+let eqI  = [ "Eq", "ReadRaw", "Show", "StaticSize", "Storable", "WriteRaw" ]
+let divI = [ "Eq", "Ord", "ReadRaw", "Show" ]
+let intI =
+      [ "Bits"
+      , "Bounded"
+      , "Enum"
+      , "Eq"
+      , "FiniteBits"
+      , "Integral"
+      , "Ix"
+      , "Num"
+      , "Ord"
+      , "Read"
+      , "ReadRaw"
+      , "Real"
+      , "Show"
+      , "StaticSize"
+      , "Storable"
+      , "WriteRaw"
+      ]
 
 let types
     : List ./Mapping.dhall
         -- Floating Types
-    = [ mkM "fenv_t"       "CFenvT"    [ "fenv.h" ]
-      , mkM "fexcept_t"    "CFexceptT" [ "fenv.h" ]
+    = [ mkM "fenv_t"       "CFenvT"    [ "fenv.h" ]              noI
+      , mkM "fexcept_t"    "CFexceptT" [ "fenv.h" ]              noI
         -- Mathematical Types
-      , mkM "div_t"        "CDivT"     [ "stdlib.h" ]
-      , mkM "ldiv_t"       "CLdivT"    [ "stdlib.h" ]
-      , mkM "lldiv_t"      "CLldivT"   [ "stdlib.h" ]
-      , mkM "imaxdiv_t"    "CImaxdivT" [ "inttypes.h" ]
+      , mkM "div_t"        "CDivT"     [ "stdlib.h" ]            divI
+      , mkM "ldiv_t"       "CLdivT"    [ "stdlib.h" ]            divI
+      , mkM "lldiv_t"      "CLldivT"   [ "stdlib.h" ]            divI
+      , mkM "imaxdiv_t"    "CImaxdivT" [ "inttypes.h" ]          divI
         -- Wide Character Types
-      , mkM "wint_t"       "CWintT"    [ "wchar.h", "wctype.h" ]
-      , mkM "mbstate_t"    "CMbstateT" [ "uchar.h", "wchar.h" ]
-      , mkM "wctrans_t"    "CWctransT" [ "wctype.h" ]
-      , mkM "wctype_t"     "CWctypeT"  [ "wchar.h", "wctype.h" ]
-      , mkM "char16_t"     "CChar16T"  [ "uchar.h" ]
-      , mkM "char32_t"     "CChar32T"  [ "uchar.h" ]
+      , mkM "wint_t"       "CWintT"    [ "wchar.h", "wctype.h" ] intI
+      , mkM "mbstate_t"    "CMbstateT" [ "uchar.h", "wchar.h" ]  noI
+      , mkM "wctrans_t"    "CWctransT" [ "wctype.h" ]            eqI
+      , mkM "wctype_t"     "CWctypeT"  [ "wchar.h", "wctype.h" ] eqI
+      , mkM "char16_t"     "CChar16T"  [ "uchar.h" ]             intI
+      , mkM "char32_t"     "CChar32T"  [ "uchar.h" ]             intI
         -- Time Types
-      , mkM "struct tm"    "CTm"       [ "time.h" ]
+      , mkM "struct tm"    "CTm"       [ "time.h" ]              eqI
       ]
 
 in  { types }

--- a/hs-bindgen/bindings/hs-bindgen-runtime.yaml
+++ b/hs-bindgen/bindings/hs-bindgen-runtime.yaml
@@ -14,27 +14,64 @@ types:
     headers:
       - system:stdlib.h
     identifier: CDivT
+    instances:
+      - Eq
+      - Ord
+      - ReadRaw
+      - Show
     module: HsBindgen.Runtime.LibC
   - cname: ldiv_t
     headers:
       - system:stdlib.h
     identifier: CLdivT
+    instances:
+      - Eq
+      - Ord
+      - ReadRaw
+      - Show
     module: HsBindgen.Runtime.LibC
   - cname: lldiv_t
     headers:
       - system:stdlib.h
     identifier: CLldivT
+    instances:
+      - Eq
+      - Ord
+      - ReadRaw
+      - Show
     module: HsBindgen.Runtime.LibC
   - cname: imaxdiv_t
     headers:
       - system:inttypes.h
     identifier: CImaxdivT
+    instances:
+      - Eq
+      - Ord
+      - ReadRaw
+      - Show
     module: HsBindgen.Runtime.LibC
   - cname: wint_t
     headers:
       - system:wchar.h
       - system:wctype.h
     identifier: CWintT
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC
   - cname: mbstate_t
     headers:
@@ -46,25 +83,80 @@ types:
     headers:
       - system:wctype.h
     identifier: CWctransT
+    instances:
+      - Eq
+      - ReadRaw
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC
   - cname: wctype_t
     headers:
       - system:wchar.h
       - system:wctype.h
     identifier: CWctypeT
+    instances:
+      - Eq
+      - ReadRaw
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC
   - cname: char16_t
     headers:
       - system:uchar.h
     identifier: CChar16T
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC
   - cname: char32_t
     headers:
       - system:uchar.h
     identifier: CChar32T
+    instances:
+      - Bits
+      - Bounded
+      - Enum
+      - Eq
+      - FiniteBits
+      - Integral
+      - Ix
+      - Num
+      - Ord
+      - Read
+      - ReadRaw
+      - Real
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC
   - cname: struct tm
     headers:
       - system:time.h
     identifier: CTm
+    instances:
+      - Eq
+      - ReadRaw
+      - Show
+      - StaticSize
+      - Storable
+      - WriteRaw
     module: HsBindgen.Runtime.LibC

--- a/hs-bindgen/fixtures/adios.extbindings.yaml
+++ b/hs-bindgen/fixtures/adios.extbindings.yaml
@@ -3,7 +3,35 @@ types:
   cname: adiós
   module: Example
   identifier: Adio'0301s
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: adios.h
   cname: 数字
   module: Example
   identifier: C数字
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -21,7 +21,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "adios.h:7:13"}},
+          "adios.h:7:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -123,7 +125,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "adios.h:12:13"}},
+          "adios.h:12:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -23,7 +23,20 @@
           typedefSourceLoc =
           "adios.h:7:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -127,7 +140,20 @@
           typedefSourceLoc =
           "adios.h:12:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/anonymous.extbindings.yaml
+++ b/hs-bindgen/fixtures/anonymous.extbindings.yaml
@@ -3,11 +3,23 @@ types:
   cname: struct S1
   module: Example
   identifier: S1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: anonymous.h
   cname: struct S2
   module: Example
   identifier: S2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: anonymous.h
   cname: struct S3
   module: Example
   identifier: S3
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -72,7 +72,7 @@
           structSourceLoc =
           "anonymous.h:3:3"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -147,7 +147,7 @@
             structSourceLoc =
             "anonymous.h:3:3"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -227,7 +227,7 @@
                     structSourceLoc =
                     "anonymous.h:3:3"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -309,7 +309,7 @@
                     structSourceLoc =
                     "anonymous.h:3:3"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -404,7 +404,7 @@
           structSourceLoc =
           "anonymous.h:2:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -484,7 +484,7 @@
             structSourceLoc =
             "anonymous.h:2:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -569,7 +569,7 @@
                     structSourceLoc =
                     "anonymous.h:2:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -656,7 +656,7 @@
                     structSourceLoc =
                     "anonymous.h:2:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -725,7 +725,7 @@
           structSourceLoc =
           "anonymous.h:15:5"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -779,7 +779,7 @@
             structSourceLoc =
             "anonymous.h:15:5"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -838,7 +838,7 @@
                     structSourceLoc =
                     "anonymous.h:15:5"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -897,7 +897,7 @@
                     structSourceLoc =
                     "anonymous.h:15:5"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1006,7 +1006,7 @@
           structSourceLoc =
           "anonymous.h:13:3"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1097,7 +1097,7 @@
             structSourceLoc =
             "anonymous.h:13:3"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1193,7 +1193,7 @@
                     structSourceLoc =
                     "anonymous.h:13:3"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1291,7 +1291,7 @@
                     structSourceLoc =
                     "anonymous.h:13:3"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1392,7 +1392,7 @@
           structSourceLoc =
           "anonymous.h:12:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1474,7 +1474,7 @@
             structSourceLoc =
             "anonymous.h:12:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1561,7 +1561,7 @@
                     structSourceLoc =
                     "anonymous.h:12:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1650,7 +1650,7 @@
                     structSourceLoc =
                     "anonymous.h:12:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1757,7 +1757,7 @@
           structSourceLoc =
           "anonymous.h:24:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1849,7 +1849,7 @@
             structSourceLoc =
             "anonymous.h:24:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1946,7 +1946,7 @@
                     structSourceLoc =
                     "anonymous.h:24:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -2045,7 +2045,7 @@
                     structSourceLoc =
                     "anonymous.h:24:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2137,7 +2137,7 @@
           structSourceLoc =
           "anonymous.h:25:3"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2214,7 +2214,7 @@
             structSourceLoc =
             "anonymous.h:25:3"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2296,7 +2296,7 @@
                     structSourceLoc =
                     "anonymous.h:25:3"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2380,7 +2380,7 @@
                     structSourceLoc =
                     "anonymous.h:25:3"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -70,7 +70,9 @@
               "anonymous.h:5:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:3:3"}},
+          "anonymous.h:3:3"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -143,7 +145,9 @@
                 "anonymous.h:5:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:3:3"}}
+            "anonymous.h:3:3"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -221,7 +225,9 @@
                         "anonymous.h:5:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:3:3"}})
+                    "anonymous.h:3:3"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -301,7 +307,9 @@
                         "anonymous.h:5:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:3:3"}}
+                    "anonymous.h:3:3"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -394,7 +402,9 @@
               "anonymous.h:8:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:2:8"}},
+          "anonymous.h:2:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -472,7 +482,9 @@
                 "anonymous.h:8:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:2:8"}}
+            "anonymous.h:2:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -555,7 +567,9 @@
                         "anonymous.h:8:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:2:8"}})
+                    "anonymous.h:2:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -640,7 +654,9 @@
                         "anonymous.h:8:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:2:8"}}
+                    "anonymous.h:2:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -707,7 +723,9 @@
               "anonymous.h:16:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:15:5"}},
+          "anonymous.h:15:5"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -759,7 +777,9 @@
                 "anonymous.h:16:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:15:5"}}
+            "anonymous.h:15:5"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -816,7 +836,9 @@
                         "anonymous.h:16:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:15:5"}})
+                    "anonymous.h:15:5"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -873,7 +895,9 @@
                         "anonymous.h:16:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:15:5"}}
+                    "anonymous.h:15:5"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -980,7 +1004,9 @@
               "anonymous.h:17:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:13:3"}},
+          "anonymous.h:13:3"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1069,7 +1095,9 @@
                 "anonymous.h:17:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:13:3"}}
+            "anonymous.h:13:3"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1163,7 +1191,9 @@
                         "anonymous.h:17:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:13:3"}})
+                    "anonymous.h:13:3"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1259,7 +1289,9 @@
                         "anonymous.h:17:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:13:3"}}
+                    "anonymous.h:13:3"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1358,7 +1390,9 @@
               "anonymous.h:20:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:12:8"}},
+          "anonymous.h:12:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1438,7 +1472,9 @@
                 "anonymous.h:20:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:12:8"}}
+            "anonymous.h:12:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1523,7 +1559,9 @@
                         "anonymous.h:20:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:12:8"}})
+                    "anonymous.h:12:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1610,7 +1648,9 @@
                         "anonymous.h:20:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:12:8"}}
+                    "anonymous.h:12:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1715,7 +1755,9 @@
               "anonymous.h:30:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:24:8"}},
+          "anonymous.h:24:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1805,7 +1847,9 @@
                 "anonymous.h:30:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:24:8"}}
+            "anonymous.h:24:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1900,7 +1944,9 @@
                         "anonymous.h:30:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:24:8"}})
+                    "anonymous.h:24:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1997,7 +2043,9 @@
                         "anonymous.h:30:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:24:8"}}
+                    "anonymous.h:24:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2087,7 +2135,9 @@
               "anonymous.h:27:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "anonymous.h:25:3"}},
+          "anonymous.h:25:3"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2162,7 +2212,9 @@
                 "anonymous.h:27:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "anonymous.h:25:3"}}
+            "anonymous.h:25:3"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2242,7 +2294,9 @@
                         "anonymous.h:27:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:25:3"}})
+                    "anonymous.h:25:3"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2324,7 +2378,9 @@
                         "anonymous.h:27:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "anonymous.h:25:3"}}
+                    "anonymous.h:25:3"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/attributes.extbindings.yaml
+++ b/hs-bindgen/fixtures/attributes.extbindings.yaml
@@ -3,7 +3,15 @@ types:
   cname: FILE
   module: Example
   identifier: FILE
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: attributes.h
   cname: struct __sFILE
   module: Example
   identifier: C__SFILE
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/attributes.hs
+++ b/hs-bindgen/fixtures/attributes.hs
@@ -99,7 +99,9 @@
               "attributes.h:11:19"}],
           structFlam = Nothing,
           structSourceLoc =
-          "attributes.h:8:16"}},
+          "attributes.h:8:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -201,7 +203,9 @@
                 "attributes.h:11:19"}],
             structFlam = Nothing,
             structSourceLoc =
-            "attributes.h:8:16"}}
+            "attributes.h:8:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -308,7 +312,9 @@
                         "attributes.h:11:19"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "attributes.h:8:16"}})
+                    "attributes.h:8:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -418,7 +424,9 @@
                         "attributes.h:11:19"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "attributes.h:8:16"}}
+                    "attributes.h:8:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -465,7 +473,9 @@
             (DeclPathName
               (CName "__sFILE")),
           typedefSourceLoc =
-          "attributes.h:12:3"}},
+          "attributes.h:12:3"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/attributes.hs
+++ b/hs-bindgen/fixtures/attributes.hs
@@ -101,7 +101,7 @@
           structSourceLoc =
           "attributes.h:8:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -205,7 +205,7 @@
             structSourceLoc =
             "attributes.h:8:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -314,7 +314,7 @@
                     structSourceLoc =
                     "attributes.h:8:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -426,7 +426,7 @@
                     structSourceLoc =
                     "attributes.h:8:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -475,8 +475,16 @@
           typedefSourceLoc =
           "attributes.h:12:3"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "FILE"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "FILE"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "FILE")]

--- a/hs-bindgen/fixtures/attributes.pp.hs
+++ b/hs-bindgen/fixtures/attributes.pp.hs
@@ -48,3 +48,7 @@ newtype FILE = FILE
   }
 
 deriving newtype instance F.Storable FILE
+
+deriving stock instance Eq FILE
+
+deriving stock instance Show FILE

--- a/hs-bindgen/fixtures/attributes.th.txt
+++ b/hs-bindgen/fixtures/attributes.th.txt
@@ -15,3 +15,5 @@ deriving stock instance Show C__SFILE
 deriving stock instance Eq C__SFILE
 newtype FILE = FILE {un_FILE :: C__SFILE}
 deriving newtype instance Storable FILE
+deriving stock instance Eq FILE
+deriving stock instance Show FILE

--- a/hs-bindgen/fixtures/bitfields.extbindings.yaml
+++ b/hs-bindgen/fixtures/bitfields.extbindings.yaml
@@ -3,27 +3,55 @@ types:
   cname: struct alignA
   module: Example
   identifier: AlignA
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct alignB
   module: Example
   identifier: AlignB
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct flags
   module: Example
   identifier: Flags
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct overflow32
   module: Example
   identifier: Overflow32
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct overflow32b
   module: Example
   identifier: Overflow32b
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct overflow32c
   module: Example
   identifier: Overflow32c
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bitfields.h
   cname: struct overflow64
   module: Example
   identifier: Overflow64
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -171,7 +171,9 @@
               "bitfields.h:7:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:1:8"}},
+          "bitfields.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -345,7 +347,9 @@
                 "bitfields.h:7:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:1:8"}}
+            "bitfields.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -524,7 +528,9 @@
                         "bitfields.h:7:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:1:8"}})
+                    "bitfields.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekBitOffWidth (Idx 0) 8 1,
@@ -709,7 +715,9 @@
                         "bitfields.h:7:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:1:8"}}
+                    "bitfields.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 6)
               (Seq
                 [
@@ -839,7 +847,9 @@
               "bitfields.h:15:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:12:8"}},
+          "bitfields.h:12:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -933,7 +943,9 @@
                 "bitfields.h:15:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:12:8"}}
+            "bitfields.h:12:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1032,7 +1044,9 @@
                         "bitfields.h:15:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:12:8"}})
+                    "bitfields.h:12:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 32 17,
@@ -1134,7 +1148,9 @@
                         "bitfields.h:15:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:12:8"}}
+                    "bitfields.h:12:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -1257,7 +1273,9 @@
               "bitfields.h:21:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:18:8"}},
+          "bitfields.h:18:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1351,7 +1369,9 @@
                 "bitfields.h:21:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:18:8"}}
+            "bitfields.h:18:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 8,
@@ -1450,7 +1470,9 @@
                         "bitfields.h:21:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:18:8"}})
+                    "bitfields.h:18:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 17 17,
@@ -1552,7 +1574,9 @@
                         "bitfields.h:21:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:18:8"}}
+                    "bitfields.h:18:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -1675,7 +1699,9 @@
               "bitfields.h:27:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:24:8"}},
+          "bitfields.h:24:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1769,7 +1795,9 @@
                 "bitfields.h:27:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:24:8"}}
+            "bitfields.h:24:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1868,7 +1896,9 @@
                         "bitfields.h:27:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:24:8"}})
+                    "bitfields.h:24:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 32 17,
@@ -1970,7 +2000,9 @@
                         "bitfields.h:27:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:24:8"}}
+                    "bitfields.h:24:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -2069,7 +2101,9 @@
               "bitfields.h:32:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:30:8"}},
+          "bitfields.h:30:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2139,7 +2173,9 @@
                 "bitfields.h:32:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:30:8"}}
+            "bitfields.h:30:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2214,7 +2250,9 @@
                         "bitfields.h:32:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:30:8"}})
+                    "bitfields.h:30:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 33,
               PeekBitOffWidth (Idx 0) 64 33]),
@@ -2291,7 +2329,9 @@
                         "bitfields.h:32:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:30:8"}}
+                    "bitfields.h:30:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2387,7 +2427,9 @@
               "bitfields.h:38:6"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:36:8"}},
+          "bitfields.h:36:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2459,7 +2501,9 @@
                 "bitfields.h:38:6"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:36:8"}}
+            "bitfields.h:36:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2536,7 +2580,9 @@
                         "bitfields.h:38:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:36:8"}})
+                    "bitfields.h:36:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 1,
               PeekBitOffWidth (Idx 0) 1 10]),
@@ -2615,7 +2661,9 @@
                         "bitfields.h:38:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:36:8"}}
+                    "bitfields.h:36:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2711,7 +2759,9 @@
               "bitfields.h:43:6"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bitfields.h:41:8"}},
+          "bitfields.h:41:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2783,7 +2833,9 @@
                 "bitfields.h:43:6"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bitfields.h:41:8"}}
+            "bitfields.h:41:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2860,7 +2912,9 @@
                         "bitfields.h:43:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:41:8"}})
+                    "bitfields.h:41:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekBitOffWidth (Idx 0) 0 7,
               PeekBitOffWidth (Idx 0) 32 31]),
@@ -2939,7 +2993,9 @@
                         "bitfields.h:43:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bitfields.h:41:8"}}
+                    "bitfields.h:41:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -173,7 +173,7 @@
           structSourceLoc =
           "bitfields.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -349,7 +349,7 @@
             structSourceLoc =
             "bitfields.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -530,7 +530,7 @@
                     structSourceLoc =
                     "bitfields.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekBitOffWidth (Idx 0) 8 1,
@@ -717,7 +717,7 @@
                     structSourceLoc =
                     "bitfields.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 6)
               (Seq
                 [
@@ -849,7 +849,7 @@
           structSourceLoc =
           "bitfields.h:12:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -945,7 +945,7 @@
             structSourceLoc =
             "bitfields.h:12:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1046,7 +1046,7 @@
                     structSourceLoc =
                     "bitfields.h:12:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 32 17,
@@ -1150,7 +1150,7 @@
                     structSourceLoc =
                     "bitfields.h:12:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -1275,7 +1275,7 @@
           structSourceLoc =
           "bitfields.h:18:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1371,7 +1371,7 @@
             structSourceLoc =
             "bitfields.h:18:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 8,
@@ -1472,7 +1472,7 @@
                     structSourceLoc =
                     "bitfields.h:18:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 17 17,
@@ -1576,7 +1576,7 @@
                     structSourceLoc =
                     "bitfields.h:18:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -1701,7 +1701,7 @@
           structSourceLoc =
           "bitfields.h:24:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1797,7 +1797,7 @@
             structSourceLoc =
             "bitfields.h:24:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1898,7 +1898,7 @@
                     structSourceLoc =
                     "bitfields.h:24:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 17,
               PeekBitOffWidth (Idx 0) 32 17,
@@ -2002,7 +2002,7 @@
                     structSourceLoc =
                     "bitfields.h:24:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -2103,7 +2103,7 @@
           structSourceLoc =
           "bitfields.h:30:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2175,7 +2175,7 @@
             structSourceLoc =
             "bitfields.h:30:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2252,7 +2252,7 @@
                     structSourceLoc =
                     "bitfields.h:30:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 33,
               PeekBitOffWidth (Idx 0) 64 33]),
@@ -2331,7 +2331,7 @@
                     structSourceLoc =
                     "bitfields.h:30:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2429,7 +2429,7 @@
           structSourceLoc =
           "bitfields.h:36:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2503,7 +2503,7 @@
             structSourceLoc =
             "bitfields.h:36:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2582,7 +2582,7 @@
                     structSourceLoc =
                     "bitfields.h:36:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 1,
               PeekBitOffWidth (Idx 0) 1 10]),
@@ -2663,7 +2663,7 @@
                     structSourceLoc =
                     "bitfields.h:36:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2761,7 +2761,7 @@
           structSourceLoc =
           "bitfields.h:41:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2835,7 +2835,7 @@
             structSourceLoc =
             "bitfields.h:41:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2914,7 +2914,7 @@
                     structSourceLoc =
                     "bitfields.h:41:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekBitOffWidth (Idx 0) 0 7,
               PeekBitOffWidth (Idx 0) 32 31]),
@@ -2995,7 +2995,7 @@
                     structSourceLoc =
                     "bitfields.h:41:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/bool.extbindings.yaml
+++ b/hs-bindgen/fixtures/bool.extbindings.yaml
@@ -3,15 +3,41 @@ types:
   cname: BOOL
   module: Example
   identifier: BOOL
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: bool.h
   cname: struct bools1
   module: Example
   identifier: Bools1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bool.h
   cname: struct bools2
   module: Example
   identifier: Bools2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: bool.h
   cname: struct bools3
   module: Example
   identifier: Bools3
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -63,7 +63,7 @@
           structFlam = Nothing,
           structSourceLoc = "bool.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -129,7 +129,7 @@
             structFlam = Nothing,
             structSourceLoc = "bool.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -200,7 +200,7 @@
                     structFlam = Nothing,
                     structSourceLoc = "bool.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -273,7 +273,7 @@
                     structFlam = Nothing,
                     structSourceLoc = "bool.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -358,7 +358,7 @@
           structFlam = Nothing,
           structSourceLoc = "bool.h:8:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -424,7 +424,7 @@
             structFlam = Nothing,
             structSourceLoc = "bool.h:8:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -495,7 +495,7 @@
                     structFlam = Nothing,
                     structSourceLoc = "bool.h:8:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -568,7 +568,7 @@
                     structFlam = Nothing,
                     structSourceLoc = "bool.h:8:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -627,7 +627,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -750,7 +763,7 @@
           structSourceLoc =
           "bool.h:15:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -822,7 +835,7 @@
             structSourceLoc =
             "bool.h:15:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -899,7 +912,7 @@
                     structSourceLoc =
                     "bool.h:15:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -978,7 +991,7 @@
                     structSourceLoc =
                     "bool.h:15:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -61,8 +61,9 @@
               fieldSourceLoc =
               "bool.h:3:11"}],
           structFlam = Nothing,
-          structSourceLoc =
-          "bool.h:1:8"}},
+          structSourceLoc = "bool.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -126,7 +127,9 @@
                 fieldSourceLoc =
                 "bool.h:3:11"}],
             structFlam = Nothing,
-            structSourceLoc = "bool.h:1:8"}}
+            structSourceLoc = "bool.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -195,8 +198,9 @@
                         fieldSourceLoc =
                         "bool.h:3:11"}],
                     structFlam = Nothing,
-                    structSourceLoc =
-                    "bool.h:1:8"}})
+                    structSourceLoc = "bool.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -267,7 +271,9 @@
                         fieldSourceLoc =
                         "bool.h:3:11"}],
                     structFlam = Nothing,
-                    structSourceLoc = "bool.h:1:8"}}
+                    structSourceLoc = "bool.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -350,8 +356,9 @@
               fieldSourceLoc =
               "bool.h:10:10"}],
           structFlam = Nothing,
-          structSourceLoc =
-          "bool.h:8:8"}},
+          structSourceLoc = "bool.h:8:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -415,7 +422,9 @@
                 fieldSourceLoc =
                 "bool.h:10:10"}],
             structFlam = Nothing,
-            structSourceLoc = "bool.h:8:8"}}
+            structSourceLoc = "bool.h:8:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -484,8 +493,9 @@
                         fieldSourceLoc =
                         "bool.h:10:10"}],
                     structFlam = Nothing,
-                    structSourceLoc =
-                    "bool.h:8:8"}})
+                    structSourceLoc = "bool.h:8:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -556,7 +566,9 @@
                         fieldSourceLoc =
                         "bool.h:10:10"}],
                     structFlam = Nothing,
-                    structSourceLoc = "bool.h:8:8"}}
+                    structSourceLoc = "bool.h:8:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -613,7 +625,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -734,7 +748,9 @@
               "bool.h:17:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "bool.h:15:8"}},
+          "bool.h:15:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -804,7 +820,9 @@
                 "bool.h:17:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "bool.h:15:8"}}
+            "bool.h:15:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 2,
         storableAlignment = 1,
@@ -879,7 +897,9 @@
                         "bool.h:17:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bool.h:15:8"}})
+                    "bool.h:15:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1]),
@@ -956,7 +976,9 @@
                         "bool.h:17:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "bool.h:15:8"}}
+                    "bool.h:15:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
+++ b/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
@@ -3,47 +3,160 @@ types:
   cname: a_type_t
   module: Example
   identifier: A_type_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: distilled_lib_1.h
   cname: a_typedef_enum_e
   module: Example
   identifier: A_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: a_typedef_struct_t
   module: Example
   identifier: A_typedef_struct_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: another_typedef_enum_e
   module: Example
   identifier: Another_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: another_typedef_struct_t
   module: Example
   identifier: Another_typedef_struct_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: callback_t
   module: Example
   identifier: Callback_t
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: int32_t
   module: Example
   identifier: Int32_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: distilled_lib_1.h
   cname: struct a_typedef_struct
   module: Example
   identifier: A_typedef_struct
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: distilled_lib_1.h
   cname: uint16_t
   module: Example
   identifier: Uint16_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: distilled_lib_1.h
   cname: uint32_t
   module: Example
   identifier: Uint32_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: distilled_lib_1.h
   cname: uint8_t
   module: Example
   identifier: Uint8_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: distilled_lib_1.h
   cname: var_t
   module: Example
   identifier: Var_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -21,7 +21,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "alltypes.h:106:25"}},
+          "alltypes.h:106:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -123,7 +125,9 @@
             (PrimChar
               (PrimSignExplicit Unsigned)),
           typedefSourceLoc =
-          "alltypes.h:121:25"}},
+          "alltypes.h:121:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -226,7 +230,9 @@
               PrimShort
               Unsigned),
           typedefSourceLoc =
-          "alltypes.h:126:25"}},
+          "alltypes.h:126:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -327,7 +333,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           typedefSourceLoc =
-          "alltypes.h:131:25"}},
+          "alltypes.h:131:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -480,7 +488,9 @@
               "distilled_lib_1.h:8:32"}],
           structFlam = Nothing,
           structSourceLoc =
-          "distilled_lib_1.h:8:9"}},
+          "distilled_lib_1.h:8:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -556,7 +566,9 @@
                 "distilled_lib_1.h:8:32"}],
             structFlam = Nothing,
             structSourceLoc =
-            "distilled_lib_1.h:8:9"}}
+            "distilled_lib_1.h:8:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -637,7 +649,9 @@
                         "distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "distilled_lib_1.h:8:9"}})
+                    "distilled_lib_1.h:8:9"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -720,7 +734,9 @@
                         "distilled_lib_1.h:8:32"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "distilled_lib_1.h:8:9"}}
+                    "distilled_lib_1.h:8:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -780,7 +796,9 @@
               valueSourceLoc =
               "distilled_lib_1.h:9:21"}],
           enumSourceLoc =
-          "distilled_lib_1.h:9:9"}},
+          "distilled_lib_1.h:9:9"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -821,7 +839,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:9:21"}],
             enumSourceLoc =
-            "distilled_lib_1.h:9:9"}}
+            "distilled_lib_1.h:9:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -867,7 +887,9 @@
                         valueSourceLoc =
                         "distilled_lib_1.h:9:21"}],
                     enumSourceLoc =
-                    "distilled_lib_1.h:9:9"}})
+                    "distilled_lib_1.h:9:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -913,7 +935,9 @@
                         valueSourceLoc =
                         "distilled_lib_1.h:9:21"}],
                     enumSourceLoc =
-                    "distilled_lib_1.h:9:9"}}
+                    "distilled_lib_1.h:9:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -979,7 +1003,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:9:21"}],
             enumSourceLoc =
-            "distilled_lib_1.h:9:9"}}
+            "distilled_lib_1.h:9:9"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1026,7 +1052,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:9:21"}],
             enumSourceLoc =
-            "distilled_lib_1.h:9:9"}}
+            "distilled_lib_1.h:9:9"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "FOO")
       (HsName "@NsConstr" "BAR")),
   DeclInstance
@@ -1069,7 +1097,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:9:21"}],
             enumSourceLoc =
-            "distilled_lib_1.h:9:9"}}),
+            "distilled_lib_1.h:9:9"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1205,7 +1235,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "distilled_lib_1.h:13:13"}},
+          "distilled_lib_1.h:13:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1306,7 +1338,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "distilled_lib_1.h:14:13"}},
+          "distilled_lib_1.h:14:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1742,7 +1776,9 @@
               "distilled_lib_1.h:46:31"}],
           structFlam = Nothing,
           structSourceLoc =
-          "distilled_lib_1.h:34:16"}},
+          "distilled_lib_1.h:34:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2101,7 +2137,9 @@
                 "distilled_lib_1.h:46:31"}],
             structFlam = Nothing,
             structSourceLoc =
-            "distilled_lib_1.h:34:16"}}
+            "distilled_lib_1.h:34:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 140,
         storableAlignment = 1,
@@ -2465,7 +2503,9 @@
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "distilled_lib_1.h:34:16"}})
+                    "distilled_lib_1.h:34:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -2840,7 +2880,9 @@
                         "distilled_lib_1.h:46:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "distilled_lib_1.h:34:16"}}
+                    "distilled_lib_1.h:34:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 11)
               (Seq
                 [
@@ -2896,7 +2938,9 @@
             (DeclPathName
               (CName "a_typedef_struct")),
           typedefSourceLoc =
-          "distilled_lib_1.h:47:3"}},
+          "distilled_lib_1.h:47:3"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -3076,7 +3120,9 @@
               valueSourceLoc =
               "distilled_lib_1.h:65:3"}],
           enumSourceLoc =
-          "distilled_lib_1.h:60:9"}},
+          "distilled_lib_1.h:60:9"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3127,7 +3173,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:65:3"}],
             enumSourceLoc =
-            "distilled_lib_1.h:60:9"}}
+            "distilled_lib_1.h:60:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -3183,7 +3231,9 @@
                         valueSourceLoc =
                         "distilled_lib_1.h:65:3"}],
                     enumSourceLoc =
-                    "distilled_lib_1.h:60:9"}})
+                    "distilled_lib_1.h:60:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -3239,7 +3289,9 @@
                         valueSourceLoc =
                         "distilled_lib_1.h:65:3"}],
                     enumSourceLoc =
-                    "distilled_lib_1.h:60:9"}}
+                    "distilled_lib_1.h:60:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -3315,7 +3367,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:65:3"}],
             enumSourceLoc =
-            "distilled_lib_1.h:60:9"}}
+            "distilled_lib_1.h:60:9"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -3382,7 +3436,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:65:3"}],
             enumSourceLoc =
-            "distilled_lib_1.h:60:9"}}
+            "distilled_lib_1.h:60:9"},
+        structInstances = Set.fromList
+          []}
       (HsName
         "@NsConstr"
         "ENUM_CASE_0")
@@ -3439,7 +3495,9 @@
                 valueSourceLoc =
                 "distilled_lib_1.h:65:3"}],
             enumSourceLoc =
-            "distilled_lib_1.h:60:9"}}),
+            "distilled_lib_1.h:60:9"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3614,7 +3672,9 @@
               (TypeTypedef
                 (CName "uint32_t"))),
           typedefSourceLoc =
-          "distilled_lib_1.h:76:19"}},
+          "distilled_lib_1.h:76:19"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -23,7 +23,20 @@
           typedefSourceLoc =
           "alltypes.h:106:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -127,7 +140,20 @@
           typedefSourceLoc =
           "alltypes.h:121:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -232,7 +258,20 @@
           typedefSourceLoc =
           "alltypes.h:126:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -335,7 +374,20 @@
           typedefSourceLoc =
           "alltypes.h:131:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -490,7 +542,7 @@
           structSourceLoc =
           "distilled_lib_1.h:8:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -568,7 +620,7 @@
             structSourceLoc =
             "distilled_lib_1.h:8:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -651,7 +703,7 @@
                     structSourceLoc =
                     "distilled_lib_1.h:8:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -736,7 +788,7 @@
                     structSourceLoc =
                     "distilled_lib_1.h:8:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -798,7 +850,12 @@
           enumSourceLoc =
           "distilled_lib_1.h:9:9"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -841,7 +898,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -889,7 +946,12 @@
                     enumSourceLoc =
                     "distilled_lib_1.h:9:9"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -937,7 +999,7 @@
                     enumSourceLoc =
                     "distilled_lib_1.h:9:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1005,7 +1067,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1054,7 +1116,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "FOO")
       (HsName "@NsConstr" "BAR")),
   DeclInstance
@@ -1099,7 +1161,12 @@
             enumSourceLoc =
             "distilled_lib_1.h:9:9"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1237,7 +1304,20 @@
           typedefSourceLoc =
           "distilled_lib_1.h:13:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1340,7 +1420,20 @@
           typedefSourceLoc =
           "distilled_lib_1.h:14:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1778,7 +1871,7 @@
           structSourceLoc =
           "distilled_lib_1.h:34:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2139,7 +2232,7 @@
             structSourceLoc =
             "distilled_lib_1.h:34:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 140,
         storableAlignment = 1,
@@ -2505,7 +2598,7 @@
                     structSourceLoc =
                     "distilled_lib_1.h:34:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -2882,7 +2975,7 @@
                     structSourceLoc =
                     "distilled_lib_1.h:34:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 11)
               (Seq
                 [
@@ -2940,10 +3033,22 @@
           typedefSourceLoc =
           "distilled_lib_1.h:47:3"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "A_typedef_struct_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "A_typedef_struct_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "A_typedef_struct_t"),
@@ -3122,7 +3227,12 @@
           enumSourceLoc =
           "distilled_lib_1.h:60:9"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3175,7 +3285,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:60:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -3233,7 +3343,12 @@
                     enumSourceLoc =
                     "distilled_lib_1.h:60:9"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -3291,7 +3406,7 @@
                     enumSourceLoc =
                     "distilled_lib_1.h:60:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -3369,7 +3484,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:60:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -3438,7 +3553,7 @@
             enumSourceLoc =
             "distilled_lib_1.h:60:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName
         "@NsConstr"
         "ENUM_CASE_0")
@@ -3497,7 +3612,12 @@
             enumSourceLoc =
             "distilled_lib_1.h:60:9"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3674,10 +3794,28 @@
           typedefSourceLoc =
           "distilled_lib_1.h:76:19"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Callback_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Callback_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "Callback_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Callback_t")]

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -378,6 +378,10 @@ newtype A_typedef_struct_t = A_typedef_struct_t
 
 deriving newtype instance F.Storable A_typedef_struct_t
 
+deriving stock instance Eq A_typedef_struct_t
+
+deriving stock instance Show A_typedef_struct_t
+
 a_DEFINE_0 :: FC.CInt
 a_DEFINE_0 = (0 :: FC.CInt)
 
@@ -472,3 +476,9 @@ newtype Callback_t = Callback_t
   }
 
 deriving newtype instance F.Storable Callback_t
+
+deriving stock instance Eq Callback_t
+
+deriving stock instance Ord Callback_t
+
+deriving stock instance Show Callback_t

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -171,6 +171,8 @@ deriving stock instance Eq A_typedef_struct
 newtype A_typedef_struct_t
     = A_typedef_struct_t {un_A_typedef_struct_t :: A_typedef_struct}
 deriving newtype instance Storable A_typedef_struct_t
+deriving stock instance Eq A_typedef_struct_t
+deriving stock instance Show A_typedef_struct_t
 a_DEFINE_0 :: CInt
 a_DEFINE_0 = 0 :: CInt
 a_DEFINE_1 :: CUInt
@@ -222,3 +224,6 @@ newtype Callback_t
     = Callback_t {un_Callback_t :: (FunPtr (Ptr Void ->
                                             Uint32_t -> IO Uint32_t))}
 deriving newtype instance Storable Callback_t
+deriving stock instance Eq Callback_t
+deriving stock instance Ord Callback_t
+deriving stock instance Show Callback_t

--- a/hs-bindgen/fixtures/enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/enums.extbindings.yaml
@@ -3,47 +3,119 @@ types:
   cname: enum enumB
   module: Example
   identifier: EnumB
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum enumC
   module: Example
   identifier: EnumC
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum enumD
   module: Example
   identifier: EnumD
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum first
   module: Example
   identifier: First
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum nonseq
   module: Example
   identifier: Nonseq
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum packad
   module: Example
   identifier: Packad
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum same
   module: Example
   identifier: Same
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enum second
   module: Example
   identifier: Second
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enumA
   module: Example
   identifier: EnumA
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enumB
   module: Example
   identifier: EnumB
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enumC
   module: Example
   identifier: EnumC
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: enums.h
   cname: enumD_t
   module: Example
   identifier: EnumD_t
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -34,7 +34,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:6:5"}],
-          enumSourceLoc = "enums.h:4:6"}},
+          enumSourceLoc = "enums.h:4:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -71,7 +73,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:6:5"}],
-            enumSourceLoc = "enums.h:4:6"}}
+            enumSourceLoc = "enums.h:4:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -113,7 +117,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:6:5"}],
-                    enumSourceLoc = "enums.h:4:6"}})
+                    enumSourceLoc = "enums.h:4:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -155,7 +161,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:6:5"}],
-                    enumSourceLoc = "enums.h:4:6"}}
+                    enumSourceLoc = "enums.h:4:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -217,7 +225,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:6:5"}],
-            enumSourceLoc = "enums.h:4:6"}}
+            enumSourceLoc = "enums.h:4:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -260,7 +270,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:6:5"}],
-            enumSourceLoc = "enums.h:4:6"}}
+            enumSourceLoc = "enums.h:4:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "FIRST1")
       (HsName "@NsConstr" "FIRST2")),
   DeclInstance
@@ -299,8 +311,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:6:5"}],
-            enumSourceLoc =
-            "enums.h:4:6"}}),
+            enumSourceLoc = "enums.h:4:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -380,7 +393,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:12:5"}],
-          enumSourceLoc = "enums.h:9:6"}},
+          enumSourceLoc = "enums.h:9:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -423,7 +438,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:12:5"}],
-            enumSourceLoc = "enums.h:9:6"}}
+            enumSourceLoc = "enums.h:9:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -471,7 +488,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:12:5"}],
-                    enumSourceLoc = "enums.h:9:6"}})
+                    enumSourceLoc = "enums.h:9:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -519,7 +538,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:12:5"}],
-                    enumSourceLoc = "enums.h:9:6"}}
+                    enumSourceLoc = "enums.h:9:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -587,7 +608,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:12:5"}],
-            enumSourceLoc = "enums.h:9:6"}}
+            enumSourceLoc = "enums.h:9:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCInt)
       (Map.fromList
         [
@@ -643,7 +666,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:12:5"}],
-            enumSourceLoc = "enums.h:9:6"}}
+            enumSourceLoc = "enums.h:9:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "SECOND_A")
       (HsName
         "@NsConstr"
@@ -690,8 +715,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:12:5"}],
-            enumSourceLoc =
-            "enums.h:9:6"}}),
+            enumSourceLoc = "enums.h:9:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -785,8 +811,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:17:5"}],
-          enumSourceLoc =
-          "enums.h:15:6"}},
+          enumSourceLoc = "enums.h:15:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -824,7 +851,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:17:5"}],
-            enumSourceLoc = "enums.h:15:6"}}
+            enumSourceLoc = "enums.h:15:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -867,8 +896,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:17:5"}],
-                    enumSourceLoc =
-                    "enums.h:15:6"}})
+                    enumSourceLoc = "enums.h:15:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -911,7 +941,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:17:5"}],
-                    enumSourceLoc = "enums.h:15:6"}}
+                    enumSourceLoc = "enums.h:15:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -968,7 +1000,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:17:5"}],
-            enumSourceLoc = "enums.h:15:6"}}
+            enumSourceLoc = "enums.h:15:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1014,7 +1048,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:17:5"}],
-            enumSourceLoc = "enums.h:15:6"}}
+            enumSourceLoc = "enums.h:15:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "SAME_A")
       (HsName "@NsConstr" "SAME_A")),
   DeclInstance
@@ -1054,8 +1090,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:17:5"}],
-            enumSourceLoc =
-            "enums.h:15:6"}}),
+            enumSourceLoc = "enums.h:15:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1135,8 +1172,9 @@
               valueValue = 404,
               valueSourceLoc =
               "enums.h:23:5"}],
-          enumSourceLoc =
-          "enums.h:20:6"}},
+          enumSourceLoc = "enums.h:20:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1179,7 +1217,9 @@
                 valueValue = 404,
                 valueSourceLoc =
                 "enums.h:23:5"}],
-            enumSourceLoc = "enums.h:20:6"}}
+            enumSourceLoc = "enums.h:20:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1227,8 +1267,9 @@
                         valueValue = 404,
                         valueSourceLoc =
                         "enums.h:23:5"}],
-                    enumSourceLoc =
-                    "enums.h:20:6"}})
+                    enumSourceLoc = "enums.h:20:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1276,7 +1317,9 @@
                         valueValue = 404,
                         valueSourceLoc =
                         "enums.h:23:5"}],
-                    enumSourceLoc = "enums.h:20:6"}}
+                    enumSourceLoc = "enums.h:20:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -1344,7 +1387,9 @@
                 valueValue = 404,
                 valueSourceLoc =
                 "enums.h:23:5"}],
-            enumSourceLoc = "enums.h:20:6"}}
+            enumSourceLoc = "enums.h:20:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1400,8 +1445,9 @@
                 valueValue = 404,
                 valueSourceLoc =
                 "enums.h:23:5"}],
-            enumSourceLoc =
-            "enums.h:20:6"}}),
+            enumSourceLoc = "enums.h:20:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1501,8 +1547,9 @@
               valueValue = 2,
               valueSourceLoc =
               "enums.h:27:25"}],
-          enumSourceLoc =
-          "enums.h:26:6"}},
+          enumSourceLoc = "enums.h:26:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1546,7 +1593,9 @@
                 valueValue = 2,
                 valueSourceLoc =
                 "enums.h:27:25"}],
-            enumSourceLoc = "enums.h:26:6"}}
+            enumSourceLoc = "enums.h:26:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -1595,8 +1644,9 @@
                         valueValue = 2,
                         valueSourceLoc =
                         "enums.h:27:25"}],
-                    enumSourceLoc =
-                    "enums.h:26:6"}})
+                    enumSourceLoc = "enums.h:26:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1645,7 +1695,9 @@
                         valueValue = 2,
                         valueSourceLoc =
                         "enums.h:27:25"}],
-                    enumSourceLoc = "enums.h:26:6"}}
+                    enumSourceLoc = "enums.h:26:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -1714,7 +1766,9 @@
                 valueValue = 2,
                 valueSourceLoc =
                 "enums.h:27:25"}],
-            enumSourceLoc = "enums.h:26:6"}}
+            enumSourceLoc = "enums.h:26:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -1771,7 +1825,9 @@
                 valueValue = 2,
                 valueSourceLoc =
                 "enums.h:27:25"}],
-            enumSourceLoc = "enums.h:26:6"}}
+            enumSourceLoc = "enums.h:26:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "PACKED_A")
       (HsName
         "@NsConstr"
@@ -1819,8 +1875,9 @@
                 valueValue = 2,
                 valueSourceLoc =
                 "enums.h:27:25"}],
-            enumSourceLoc =
-            "enums.h:26:6"}}),
+            enumSourceLoc = "enums.h:26:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1915,8 +1972,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:30:23"}],
-          enumSourceLoc =
-          "enums.h:30:9"}},
+          enumSourceLoc = "enums.h:30:9"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1955,7 +2013,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:30:23"}],
-            enumSourceLoc = "enums.h:30:9"}}
+            enumSourceLoc = "enums.h:30:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1999,8 +2059,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:30:23"}],
-                    enumSourceLoc =
-                    "enums.h:30:9"}})
+                    enumSourceLoc = "enums.h:30:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2044,7 +2105,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:30:23"}],
-                    enumSourceLoc = "enums.h:30:9"}}
+                    enumSourceLoc = "enums.h:30:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -2108,7 +2171,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:30:23"}],
-            enumSourceLoc = "enums.h:30:9"}}
+            enumSourceLoc = "enums.h:30:9"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2153,7 +2218,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:30:23"}],
-            enumSourceLoc = "enums.h:30:9"}}
+            enumSourceLoc = "enums.h:30:9"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "A_FOO")
       (HsName "@NsConstr" "A_BAR")),
   DeclInstance
@@ -2194,8 +2261,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:30:23"}],
-            enumSourceLoc =
-            "enums.h:30:9"}}),
+            enumSourceLoc = "enums.h:30:9"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2271,7 +2339,9 @@
               valueSourceLoc =
               "enums.h:32:29"}],
           enumSourceLoc =
-          "enums.h:32:14"}},
+          "enums.h:32:14"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2310,7 +2380,9 @@
                 valueSourceLoc =
                 "enums.h:32:29"}],
             enumSourceLoc =
-            "enums.h:32:14"}}
+            "enums.h:32:14"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2354,7 +2426,9 @@
                         valueSourceLoc =
                         "enums.h:32:29"}],
                     enumSourceLoc =
-                    "enums.h:32:14"}})
+                    "enums.h:32:14"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2398,7 +2472,9 @@
                         valueSourceLoc =
                         "enums.h:32:29"}],
                     enumSourceLoc =
-                    "enums.h:32:14"}}
+                    "enums.h:32:14"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -2462,7 +2538,9 @@
                 valueSourceLoc =
                 "enums.h:32:29"}],
             enumSourceLoc =
-            "enums.h:32:14"}}
+            "enums.h:32:14"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2507,7 +2585,9 @@
                 valueSourceLoc =
                 "enums.h:32:29"}],
             enumSourceLoc =
-            "enums.h:32:14"}}
+            "enums.h:32:14"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "B_FOO")
       (HsName "@NsConstr" "B_BAR")),
   DeclInstance
@@ -2548,7 +2628,9 @@
                 valueSourceLoc =
                 "enums.h:32:29"}],
             enumSourceLoc =
-            "enums.h:32:14"}}),
+            "enums.h:32:14"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2623,8 +2705,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:34:21"}],
-          enumSourceLoc =
-          "enums.h:34:6"}},
+          enumSourceLoc = "enums.h:34:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2662,7 +2745,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:34:21"}],
-            enumSourceLoc = "enums.h:34:6"}}
+            enumSourceLoc = "enums.h:34:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2705,8 +2790,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:34:21"}],
-                    enumSourceLoc =
-                    "enums.h:34:6"}})
+                    enumSourceLoc = "enums.h:34:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2749,7 +2835,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:34:21"}],
-                    enumSourceLoc = "enums.h:34:6"}}
+                    enumSourceLoc = "enums.h:34:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -2812,7 +2900,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:34:21"}],
-            enumSourceLoc = "enums.h:34:6"}}
+            enumSourceLoc = "enums.h:34:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2856,7 +2946,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:34:21"}],
-            enumSourceLoc = "enums.h:34:6"}}
+            enumSourceLoc = "enums.h:34:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "C_FOO")
       (HsName "@NsConstr" "C_BAR")),
   DeclInstance
@@ -2896,8 +2988,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:34:21"}],
-            enumSourceLoc =
-            "enums.h:34:6"}}),
+            enumSourceLoc = "enums.h:34:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2972,8 +3065,9 @@
               valueValue = 1,
               valueSourceLoc =
               "enums.h:37:21"}],
-          enumSourceLoc =
-          "enums.h:37:6"}},
+          enumSourceLoc = "enums.h:37:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3011,7 +3105,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:37:21"}],
-            enumSourceLoc = "enums.h:37:6"}}
+            enumSourceLoc = "enums.h:37:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -3054,8 +3150,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:37:21"}],
-                    enumSourceLoc =
-                    "enums.h:37:6"}})
+                    enumSourceLoc = "enums.h:37:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -3098,7 +3195,9 @@
                         valueValue = 1,
                         valueSourceLoc =
                         "enums.h:37:21"}],
-                    enumSourceLoc = "enums.h:37:6"}}
+                    enumSourceLoc = "enums.h:37:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -3161,7 +3260,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:37:21"}],
-            enumSourceLoc = "enums.h:37:6"}}
+            enumSourceLoc = "enums.h:37:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -3205,7 +3306,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:37:21"}],
-            enumSourceLoc = "enums.h:37:6"}}
+            enumSourceLoc = "enums.h:37:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "D_FOO")
       (HsName "@NsConstr" "D_BAR")),
   DeclInstance
@@ -3245,8 +3348,9 @@
                 valueValue = 1,
                 valueSourceLoc =
                 "enums.h:37:21"}],
-            enumSourceLoc =
-            "enums.h:37:6"}}),
+            enumSourceLoc = "enums.h:37:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3309,7 +3413,9 @@
           typedefType = TypeEnum
             (DeclPathName (CName "enumD")),
           typedefSourceLoc =
-          "enums.h:38:20"}},
+          "enums.h:38:20"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -36,7 +36,12 @@
               "enums.h:6:5"}],
           enumSourceLoc = "enums.h:4:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -75,7 +80,7 @@
                 "enums.h:6:5"}],
             enumSourceLoc = "enums.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -119,7 +124,12 @@
                         "enums.h:6:5"}],
                     enumSourceLoc = "enums.h:4:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -163,7 +173,7 @@
                         "enums.h:6:5"}],
                     enumSourceLoc = "enums.h:4:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -227,7 +237,7 @@
                 "enums.h:6:5"}],
             enumSourceLoc = "enums.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -272,7 +282,7 @@
                 "enums.h:6:5"}],
             enumSourceLoc = "enums.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "FIRST1")
       (HsName "@NsConstr" "FIRST2")),
   DeclInstance
@@ -313,7 +323,12 @@
                 "enums.h:6:5"}],
             enumSourceLoc = "enums.h:4:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -395,7 +410,12 @@
               "enums.h:12:5"}],
           enumSourceLoc = "enums.h:9:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -440,7 +460,7 @@
                 "enums.h:12:5"}],
             enumSourceLoc = "enums.h:9:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -490,7 +510,12 @@
                         "enums.h:12:5"}],
                     enumSourceLoc = "enums.h:9:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -540,7 +565,7 @@
                         "enums.h:12:5"}],
                     enumSourceLoc = "enums.h:9:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -610,7 +635,7 @@
                 "enums.h:12:5"}],
             enumSourceLoc = "enums.h:9:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCInt)
       (Map.fromList
         [
@@ -668,7 +693,7 @@
                 "enums.h:12:5"}],
             enumSourceLoc = "enums.h:9:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "SECOND_A")
       (HsName
         "@NsConstr"
@@ -717,7 +742,12 @@
                 "enums.h:12:5"}],
             enumSourceLoc = "enums.h:9:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -813,7 +843,12 @@
               "enums.h:17:5"}],
           enumSourceLoc = "enums.h:15:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -853,7 +888,7 @@
                 "enums.h:17:5"}],
             enumSourceLoc = "enums.h:15:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -898,7 +933,12 @@
                         "enums.h:17:5"}],
                     enumSourceLoc = "enums.h:15:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -943,7 +983,7 @@
                         "enums.h:17:5"}],
                     enumSourceLoc = "enums.h:15:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1002,7 +1042,7 @@
                 "enums.h:17:5"}],
             enumSourceLoc = "enums.h:15:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1050,7 +1090,7 @@
                 "enums.h:17:5"}],
             enumSourceLoc = "enums.h:15:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "SAME_A")
       (HsName "@NsConstr" "SAME_A")),
   DeclInstance
@@ -1092,7 +1132,12 @@
                 "enums.h:17:5"}],
             enumSourceLoc = "enums.h:15:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1174,7 +1219,12 @@
               "enums.h:23:5"}],
           enumSourceLoc = "enums.h:20:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1219,7 +1269,7 @@
                 "enums.h:23:5"}],
             enumSourceLoc = "enums.h:20:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1269,7 +1319,12 @@
                         "enums.h:23:5"}],
                     enumSourceLoc = "enums.h:20:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1319,7 +1374,7 @@
                         "enums.h:23:5"}],
                     enumSourceLoc = "enums.h:20:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1389,7 +1444,7 @@
                 "enums.h:23:5"}],
             enumSourceLoc = "enums.h:20:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -1447,7 +1502,12 @@
                 "enums.h:23:5"}],
             enumSourceLoc = "enums.h:20:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1549,7 +1609,12 @@
               "enums.h:27:25"}],
           enumSourceLoc = "enums.h:26:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1595,7 +1660,7 @@
                 "enums.h:27:25"}],
             enumSourceLoc = "enums.h:26:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -1646,7 +1711,12 @@
                         "enums.h:27:25"}],
                     enumSourceLoc = "enums.h:26:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1697,7 +1767,7 @@
                         "enums.h:27:25"}],
                     enumSourceLoc = "enums.h:26:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1768,7 +1838,7 @@
                 "enums.h:27:25"}],
             enumSourceLoc = "enums.h:26:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -1827,7 +1897,7 @@
                 "enums.h:27:25"}],
             enumSourceLoc = "enums.h:26:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "PACKED_A")
       (HsName
         "@NsConstr"
@@ -1877,7 +1947,12 @@
                 "enums.h:27:25"}],
             enumSourceLoc = "enums.h:26:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1974,7 +2049,12 @@
               "enums.h:30:23"}],
           enumSourceLoc = "enums.h:30:9"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2015,7 +2095,7 @@
                 "enums.h:30:23"}],
             enumSourceLoc = "enums.h:30:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2061,7 +2141,12 @@
                         "enums.h:30:23"}],
                     enumSourceLoc = "enums.h:30:9"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2107,7 +2192,7 @@
                         "enums.h:30:23"}],
                     enumSourceLoc = "enums.h:30:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -2173,7 +2258,7 @@
                 "enums.h:30:23"}],
             enumSourceLoc = "enums.h:30:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2220,7 +2305,7 @@
                 "enums.h:30:23"}],
             enumSourceLoc = "enums.h:30:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "A_FOO")
       (HsName "@NsConstr" "A_BAR")),
   DeclInstance
@@ -2263,7 +2348,12 @@
                 "enums.h:30:23"}],
             enumSourceLoc = "enums.h:30:9"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2341,7 +2431,12 @@
           enumSourceLoc =
           "enums.h:32:14"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2382,7 +2477,7 @@
             enumSourceLoc =
             "enums.h:32:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2428,7 +2523,12 @@
                     enumSourceLoc =
                     "enums.h:32:14"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2474,7 +2574,7 @@
                     enumSourceLoc =
                     "enums.h:32:14"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -2540,7 +2640,7 @@
             enumSourceLoc =
             "enums.h:32:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2587,7 +2687,7 @@
             enumSourceLoc =
             "enums.h:32:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "B_FOO")
       (HsName "@NsConstr" "B_BAR")),
   DeclInstance
@@ -2630,7 +2730,12 @@
             enumSourceLoc =
             "enums.h:32:14"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -2707,7 +2812,12 @@
               "enums.h:34:21"}],
           enumSourceLoc = "enums.h:34:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2747,7 +2857,7 @@
                 "enums.h:34:21"}],
             enumSourceLoc = "enums.h:34:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -2792,7 +2902,12 @@
                         "enums.h:34:21"}],
                     enumSourceLoc = "enums.h:34:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -2837,7 +2952,7 @@
                         "enums.h:34:21"}],
                     enumSourceLoc = "enums.h:34:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -2902,7 +3017,7 @@
                 "enums.h:34:21"}],
             enumSourceLoc = "enums.h:34:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -2948,7 +3063,7 @@
                 "enums.h:34:21"}],
             enumSourceLoc = "enums.h:34:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "C_FOO")
       (HsName "@NsConstr" "C_BAR")),
   DeclInstance
@@ -2990,7 +3105,12 @@
                 "enums.h:34:21"}],
             enumSourceLoc = "enums.h:34:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3067,7 +3187,12 @@
               "enums.h:37:21"}],
           enumSourceLoc = "enums.h:37:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3107,7 +3232,7 @@
                 "enums.h:37:21"}],
             enumSourceLoc = "enums.h:37:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -3152,7 +3277,12 @@
                         "enums.h:37:21"}],
                     enumSourceLoc = "enums.h:37:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -3197,7 +3327,7 @@
                         "enums.h:37:21"}],
                     enumSourceLoc = "enums.h:37:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -3262,7 +3392,7 @@
                 "enums.h:37:21"}],
             enumSourceLoc = "enums.h:37:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -3308,7 +3438,7 @@
                 "enums.h:37:21"}],
             enumSourceLoc = "enums.h:37:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "D_FOO")
       (HsName "@NsConstr" "D_BAR")),
   DeclInstance
@@ -3350,7 +3480,12 @@
                 "enums.h:37:21"}],
             enumSourceLoc = "enums.h:37:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -3415,10 +3550,39 @@
           typedefSourceLoc =
           "enums.h:38:20"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "EnumD_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "EnumD_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "EnumD_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName
+      "@NsTypeConstr"
+      "EnumD_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "EnumD_t")]

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -576,3 +576,11 @@ newtype EnumD_t = EnumD_t
   }
 
 deriving newtype instance F.Storable EnumD_t
+
+deriving stock instance Eq EnumD_t
+
+deriving stock instance Ord EnumD_t
+
+deriving stock instance Read EnumD_t
+
+deriving stock instance Show EnumD_t

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -257,3 +257,7 @@ pattern D_BAR :: EnumD
 pattern D_BAR = EnumD 1
 newtype EnumD_t = EnumD_t {un_EnumD_t :: EnumD}
 deriving newtype instance Storable EnumD_t
+deriving stock instance Eq EnumD_t
+deriving stock instance Ord EnumD_t
+deriving stock instance Read EnumD_t
+deriving stock instance Show EnumD_t

--- a/hs-bindgen/fixtures/fixedarray.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedarray.extbindings.yaml
@@ -3,7 +3,15 @@ types:
   cname: struct Example
   module: Example
   identifier: Example
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: fixedarray.h
   cname: triple
   module: Example
   identifier: Triple
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -26,10 +26,22 @@
           typedefSourceLoc =
           "fixedarray.h:1:13"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Triple"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Triple"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Triple"),
@@ -119,7 +131,7 @@
           structSourceLoc =
           "fixedarray.h:3:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -207,7 +219,7 @@
             structSourceLoc =
             "fixedarray.h:3:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 48,
         storableAlignment = 4,
@@ -300,7 +312,7 @@
                     structSourceLoc =
                     "fixedarray.h:3:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 12]),
@@ -395,7 +407,7 @@
                     structSourceLoc =
                     "fixedarray.h:3:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -24,7 +24,9 @@
             (TypePrim
               (PrimIntegral PrimInt Signed)),
           typedefSourceLoc =
-          "fixedarray.h:1:13"}},
+          "fixedarray.h:1:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -115,7 +117,9 @@
               "fixedarray.h:5:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "fixedarray.h:3:8"}},
+          "fixedarray.h:3:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -201,7 +205,9 @@
                 "fixedarray.h:5:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "fixedarray.h:3:8"}}
+            "fixedarray.h:3:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 48,
         storableAlignment = 4,
@@ -292,7 +298,9 @@
                         "fixedarray.h:5:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "fixedarray.h:3:8"}})
+                    "fixedarray.h:3:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 12]),
@@ -385,7 +393,9 @@
                         "fixedarray.h:5:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "fixedarray.h:3:8"}}
+                    "fixedarray.h:3:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/fixedarray.pp.hs
+++ b/hs-bindgen/fixtures/fixedarray.pp.hs
@@ -18,6 +18,10 @@ newtype Triple = Triple
 
 deriving newtype instance F.Storable Triple
 
+deriving stock instance Eq Triple
+
+deriving stock instance Show Triple
+
 data Example = Example
   { example_triple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   , example_sudoku :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)

--- a/hs-bindgen/fixtures/fixedarray.th.txt
+++ b/hs-bindgen/fixtures/fixedarray.th.txt
@@ -1,6 +1,8 @@
 -- addDependentFile examples/fixedarray.h
 newtype Triple = Triple {un_Triple :: (ConstantArray 3 CInt)}
 deriving newtype instance Storable Triple
+deriving stock instance Eq Triple
+deriving stock instance Show Triple
 data Example
     = Example {example_triple :: (ConstantArray 3 CInt),
                example_sudoku :: (ConstantArray 3 (ConstantArray 3 CInt))}

--- a/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
+++ b/hs-bindgen/fixtures/fixedwidth.extbindings.yaml
@@ -3,11 +3,43 @@ types:
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: fixedwidth.h
   cname: uint32_t
   module: Example
   identifier: Uint32_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: fixedwidth.h
   cname: uint64_t
   module: Example
   identifier: Uint64_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -23,7 +23,20 @@
           typedefSourceLoc =
           "alltypes.h:131:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -128,7 +141,20 @@
           typedefSourceLoc =
           "alltypes.h:136:25"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -281,7 +307,7 @@
           structSourceLoc =
           "fixedwidth.h:3:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -357,7 +383,7 @@
             structSourceLoc =
             "fixedwidth.h:3:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -438,7 +464,7 @@
                     structSourceLoc =
                     "fixedwidth.h:3:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -521,7 +547,7 @@
                     structSourceLoc =
                     "fixedwidth.h:3:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -21,7 +21,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Unsigned),
           typedefSourceLoc =
-          "alltypes.h:131:25"}},
+          "alltypes.h:131:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -124,7 +126,9 @@
               PrimLong
               Unsigned),
           typedefSourceLoc =
-          "alltypes.h:136:25"}},
+          "alltypes.h:136:25"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -275,7 +279,9 @@
               "fixedwidth.h:5:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "fixedwidth.h:3:8"}},
+          "fixedwidth.h:3:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -349,7 +355,9 @@
                 "fixedwidth.h:5:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "fixedwidth.h:3:8"}}
+            "fixedwidth.h:3:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -428,7 +436,9 @@
                         "fixedwidth.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "fixedwidth.h:3:8"}})
+                    "fixedwidth.h:3:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -509,7 +519,9 @@
                         "fixedwidth.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "fixedwidth.h:3:8"}}
+                    "fixedwidth.h:3:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/flam.extbindings.yaml
+++ b/hs-bindgen/fixtures/flam.extbindings.yaml
@@ -3,11 +3,23 @@ types:
   cname: struct diff
   module: Example
   identifier: Diff
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: flam.h
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: flam.h
   cname: struct pascal
   module: Example
   identifier: Pascal
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -52,7 +52,7 @@
               fieldSourceLoc = "flam.h:4:10"},
           structSourceLoc = "flam.h:2:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -107,7 +107,7 @@
                 fieldSourceLoc = "flam.h:4:10"},
             structSourceLoc = "flam.h:2:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -167,7 +167,7 @@
                         fieldSourceLoc = "flam.h:4:10"},
                     structSourceLoc = "flam.h:2:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -227,7 +227,7 @@
                         fieldSourceLoc = "flam.h:4:10"},
                     structSourceLoc = "flam.h:2:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -301,7 +301,7 @@
                 fieldSourceLoc = "flam.h:4:10"},
             structSourceLoc = "flam.h:2:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       (HsPrimType HsPrimCChar)
       4),
   DeclData
@@ -359,7 +359,7 @@
               fieldSourceLoc = "flam.h:13:4"},
           structSourceLoc = "flam.h:8:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -416,7 +416,7 @@
                 fieldSourceLoc = "flam.h:13:4"},
             structSourceLoc = "flam.h:8:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -478,7 +478,7 @@
                         fieldSourceLoc = "flam.h:13:4"},
                     structSourceLoc = "flam.h:8:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -540,7 +540,7 @@
                         fieldSourceLoc = "flam.h:13:4"},
                     structSourceLoc = "flam.h:8:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -612,7 +612,7 @@
                 fieldSourceLoc = "flam.h:13:4"},
             structSourceLoc = "flam.h:8:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       (HsTypRef
         (HsName
           "@NsTypeConstr"
@@ -690,7 +690,7 @@
           structSourceLoc =
           "flam.h:10:2"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -764,7 +764,7 @@
             structSourceLoc =
             "flam.h:10:2"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -843,7 +843,7 @@
                     structSourceLoc =
                     "flam.h:10:2"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -924,7 +924,7 @@
                     structSourceLoc =
                     "flam.h:10:2"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1027,7 +1027,7 @@
           structSourceLoc =
           "flam.h:17:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1111,7 +1111,7 @@
             structSourceLoc =
             "flam.h:17:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1200,7 +1200,7 @@
                     structSourceLoc =
                     "flam.h:17:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1291,7 +1291,7 @@
                     structSourceLoc =
                     "flam.h:17:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1391,6 +1391,6 @@
             structSourceLoc =
             "flam.h:17:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       (HsPrimType HsPrimCChar)
       9)]

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -50,8 +50,9 @@
                   (PrimSignImplicit
                     (Just Signed))),
               fieldSourceLoc = "flam.h:4:10"},
-          structSourceLoc =
-          "flam.h:2:8"}},
+          structSourceLoc = "flam.h:2:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -104,7 +105,9 @@
                     (PrimSignImplicit
                       (Just Signed))),
                 fieldSourceLoc = "flam.h:4:10"},
-            structSourceLoc = "flam.h:2:8"}}
+            structSourceLoc = "flam.h:2:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -162,8 +165,9 @@
                             (PrimSignImplicit
                               (Just Signed))),
                         fieldSourceLoc = "flam.h:4:10"},
-                    structSourceLoc =
-                    "flam.h:2:8"}})
+                    structSourceLoc = "flam.h:2:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -221,7 +225,9 @@
                             (PrimSignImplicit
                               (Just Signed))),
                         fieldSourceLoc = "flam.h:4:10"},
-                    structSourceLoc = "flam.h:2:8"}}
+                    structSourceLoc = "flam.h:2:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -293,7 +299,9 @@
                     (PrimSignImplicit
                       (Just Signed))),
                 fieldSourceLoc = "flam.h:4:10"},
-            structSourceLoc = "flam.h:2:8"}}
+            structSourceLoc = "flam.h:2:8"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCChar)
       4),
   DeclData
@@ -349,8 +357,9 @@
                     (CName "bar")
                     DeclPathCtxtTop)),
               fieldSourceLoc = "flam.h:13:4"},
-          structSourceLoc =
-          "flam.h:8:8"}},
+          structSourceLoc = "flam.h:8:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -405,7 +414,9 @@
                       (CName "bar")
                       DeclPathCtxtTop)),
                 fieldSourceLoc = "flam.h:13:4"},
-            structSourceLoc = "flam.h:8:8"}}
+            structSourceLoc = "flam.h:8:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -465,8 +476,9 @@
                               (CName "bar")
                               DeclPathCtxtTop)),
                         fieldSourceLoc = "flam.h:13:4"},
-                    structSourceLoc =
-                    "flam.h:8:8"}})
+                    structSourceLoc = "flam.h:8:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -526,7 +538,9 @@
                               (CName "bar")
                               DeclPathCtxtTop)),
                         fieldSourceLoc = "flam.h:13:4"},
-                    structSourceLoc = "flam.h:8:8"}}
+                    structSourceLoc = "flam.h:8:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -596,7 +610,9 @@
                       (CName "bar")
                       DeclPathCtxtTop)),
                 fieldSourceLoc = "flam.h:13:4"},
-            structSourceLoc = "flam.h:8:8"}}
+            structSourceLoc = "flam.h:8:8"},
+        structInstances = Set.fromList
+          []}
       (HsTypRef
         (HsName
           "@NsTypeConstr"
@@ -672,7 +688,9 @@
               "flam.h:12:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "flam.h:10:2"}},
+          "flam.h:10:2"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -744,7 +762,9 @@
                 "flam.h:12:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "flam.h:10:2"}}
+            "flam.h:10:2"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -821,7 +841,9 @@
                         "flam.h:12:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "flam.h:10:2"}})
+                    "flam.h:10:2"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -900,7 +922,9 @@
                         "flam.h:12:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "flam.h:10:2"}}
+                    "flam.h:10:2"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1001,7 +1025,9 @@
                     (Just Signed))),
               fieldSourceLoc = "flam.h:20:7"},
           structSourceLoc =
-          "flam.h:17:8"}},
+          "flam.h:17:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1083,7 +1109,9 @@
                       (Just Signed))),
                 fieldSourceLoc = "flam.h:20:7"},
             structSourceLoc =
-            "flam.h:17:8"}}
+            "flam.h:17:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1170,7 +1198,9 @@
                               (Just Signed))),
                         fieldSourceLoc = "flam.h:20:7"},
                     structSourceLoc =
-                    "flam.h:17:8"}})
+                    "flam.h:17:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1259,7 +1289,9 @@
                               (Just Signed))),
                         fieldSourceLoc = "flam.h:20:7"},
                     structSourceLoc =
-                    "flam.h:17:8"}}
+                    "flam.h:17:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1357,6 +1389,8 @@
                       (Just Signed))),
                 fieldSourceLoc = "flam.h:20:7"},
             structSourceLoc =
-            "flam.h:17:8"}}
+            "flam.h:17:8"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCChar)
       9)]

--- a/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/forward_declaration.extbindings.yaml
@@ -3,11 +3,23 @@ types:
   cname: S1_t
   module: Example
   identifier: S1_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: forward_declaration.h
   cname: struct S1
   module: Example
   identifier: S1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: forward_declaration.h
   cname: struct S2
   module: Example
   identifier: S2
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -43,7 +43,9 @@
               "forward_declaration.h:4:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "forward_declaration.h:3:8"}},
+          "forward_declaration.h:3:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -89,7 +91,9 @@
                 "forward_declaration.h:4:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "forward_declaration.h:3:8"}}
+            "forward_declaration.h:3:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -140,7 +144,9 @@
                         "forward_declaration.h:4:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "forward_declaration.h:3:8"}})
+                    "forward_declaration.h:3:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -191,7 +197,9 @@
                         "forward_declaration.h:4:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "forward_declaration.h:3:8"}}
+                    "forward_declaration.h:3:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -229,7 +237,9 @@
           typedefType = TypeStruct
             (DeclPathName (CName "S1")),
           typedefSourceLoc =
-          "forward_declaration.h:1:19"}},
+          "forward_declaration.h:1:19"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -278,7 +288,9 @@
               "forward_declaration.h:10:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "forward_declaration.h:9:8"}},
+          "forward_declaration.h:9:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -324,7 +336,9 @@
                 "forward_declaration.h:10:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "forward_declaration.h:9:8"}}
+            "forward_declaration.h:9:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -375,7 +389,9 @@
                         "forward_declaration.h:10:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "forward_declaration.h:9:8"}})
+                    "forward_declaration.h:9:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -426,7 +442,9 @@
                         "forward_declaration.h:10:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "forward_declaration.h:9:8"}}
+                    "forward_declaration.h:9:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -45,7 +45,7 @@
           structSourceLoc =
           "forward_declaration.h:3:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -93,7 +93,7 @@
             structSourceLoc =
             "forward_declaration.h:3:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -146,7 +146,7 @@
                     structSourceLoc =
                     "forward_declaration.h:3:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -199,7 +199,7 @@
                     structSourceLoc =
                     "forward_declaration.h:3:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -239,10 +239,18 @@
           typedefSourceLoc =
           "forward_declaration.h:1:19"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "S1_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "S1_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "S1_t"),
   DeclData
     Struct {
@@ -290,7 +298,7 @@
           structSourceLoc =
           "forward_declaration.h:9:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -338,7 +346,7 @@
             structSourceLoc =
             "forward_declaration.h:9:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -391,7 +399,7 @@
                     structSourceLoc =
                     "forward_declaration.h:9:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -444,7 +452,7 @@
                     structSourceLoc =
                     "forward_declaration.h:9:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/forward_declaration.pp.hs
+++ b/hs-bindgen/fixtures/forward_declaration.pp.hs
@@ -41,6 +41,10 @@ newtype S1_t = S1_t
 
 deriving newtype instance F.Storable S1_t
 
+deriving stock instance Eq S1_t
+
+deriving stock instance Show S1_t
+
 data S2 = S2
   { s2_a :: FC.CInt
   }

--- a/hs-bindgen/fixtures/forward_declaration.th.txt
+++ b/hs-bindgen/fixtures/forward_declaration.th.txt
@@ -10,6 +10,8 @@ deriving stock instance Show S1
 deriving stock instance Eq S1
 newtype S1_t = S1_t {un_S1_t :: S1}
 deriving newtype instance Storable S1_t
+deriving stock instance Eq S1_t
+deriving stock instance Show S1_t
 data S2 = S2 {s2_a :: CInt}
 instance Storable S2
     where {sizeOf = \_ -> 4 :: Int;

--- a/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl.extbindings.yaml
@@ -3,19 +3,88 @@ types:
   cname: C
   module: Example
   identifier: C
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_in_fundecl.h
   cname: F
   module: Example
   identifier: F
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Read
+  - Show
+  - Floating
+  - Fractional
+  - Num
+  - Real
+  - RealFloat
+  - RealFrac
+  - Storable
 - headers: macro_in_fundecl.h
   cname: I
   module: Example
   identifier: I
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_in_fundecl.h
   cname: L
   module: Example
   identifier: L
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_in_fundecl.h
   cname: S
   module: Example
   identifier: S
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -36,7 +36,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -127,7 +129,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -217,7 +221,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -303,7 +309,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -395,7 +403,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -38,7 +38,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -131,7 +144,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -223,7 +249,19 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Read,
+          Show,
+          Floating,
+          Fractional,
+          Num,
+          Real,
+          RealFloat,
+          RealFrac,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -311,7 +349,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -405,7 +456,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
@@ -3,31 +3,83 @@ types:
   cname: MC
   module: Example
   identifier: MC
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: TC
   module: Example
   identifier: TC
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct1
   module: Example
   identifier: Struct1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct3
   module: Example
   identifier: Struct3
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct4
   module: Example
   identifier: Struct4
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct2
   module: Example
   identifier: Struct2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct3_t
   module: Example
   identifier: Struct3_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_in_fundecl_vs_typedef.h
   cname: struct4
   module: Example
   identifier: Struct4
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -39,7 +39,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -118,7 +131,20 @@
           typedefSourceLoc =
           "macro_in_fundecl_vs_typedef.h:5:14"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -377,7 +403,7 @@
           structSourceLoc =
           "macro_in_fundecl_vs_typedef.h:18:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -425,7 +451,7 @@
             structSourceLoc =
             "macro_in_fundecl_vs_typedef.h:18:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -478,7 +504,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:18:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -531,7 +557,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:18:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -598,7 +624,7 @@
           structSourceLoc =
           "macro_in_fundecl_vs_typedef.h:19:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -647,7 +673,7 @@
             structSourceLoc =
             "macro_in_fundecl_vs_typedef.h:19:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -701,7 +727,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:19:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -755,7 +781,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:19:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -821,7 +847,7 @@
           structSourceLoc =
           "macro_in_fundecl_vs_typedef.h:20:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -869,7 +895,7 @@
             structSourceLoc =
             "macro_in_fundecl_vs_typedef.h:20:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -922,7 +948,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:20:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -975,7 +1001,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:20:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1022,10 +1048,22 @@
           typedefSourceLoc =
           "macro_in_fundecl_vs_typedef.h:20:35"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Struct3_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Struct3_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Struct3_t"),
@@ -1076,7 +1114,7 @@
           structSourceLoc =
           "macro_in_fundecl_vs_typedef.h:21:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1125,7 +1163,7 @@
             structSourceLoc =
             "macro_in_fundecl_vs_typedef.h:21:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1179,7 +1217,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:21:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1233,7 +1271,7 @@
                     structSourceLoc =
                     "macro_in_fundecl_vs_typedef.h:21:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -37,7 +37,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -114,7 +116,9 @@
               (PrimSignImplicit
                 (Just Signed))),
           typedefSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:5:14"}},
+          "macro_in_fundecl_vs_typedef.h:5:14"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -371,7 +375,9 @@
               "macro_in_fundecl_vs_typedef.h:18:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:18:16"}},
+          "macro_in_fundecl_vs_typedef.h:18:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -417,7 +423,9 @@
                 "macro_in_fundecl_vs_typedef.h:18:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "macro_in_fundecl_vs_typedef.h:18:16"}}
+            "macro_in_fundecl_vs_typedef.h:18:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -468,7 +476,9 @@
                         "macro_in_fundecl_vs_typedef.h:18:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:18:16"}})
+                    "macro_in_fundecl_vs_typedef.h:18:16"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -519,7 +529,9 @@
                         "macro_in_fundecl_vs_typedef.h:18:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:18:16"}}
+                    "macro_in_fundecl_vs_typedef.h:18:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -584,7 +596,9 @@
               "macro_in_fundecl_vs_typedef.h:19:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:19:9"}},
+          "macro_in_fundecl_vs_typedef.h:19:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -631,7 +645,9 @@
                 "macro_in_fundecl_vs_typedef.h:19:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "macro_in_fundecl_vs_typedef.h:19:9"}}
+            "macro_in_fundecl_vs_typedef.h:19:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -683,7 +699,9 @@
                         "macro_in_fundecl_vs_typedef.h:19:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:19:9"}})
+                    "macro_in_fundecl_vs_typedef.h:19:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -735,7 +753,9 @@
                         "macro_in_fundecl_vs_typedef.h:19:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:19:9"}}
+                    "macro_in_fundecl_vs_typedef.h:19:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -799,7 +819,9 @@
               "macro_in_fundecl_vs_typedef.h:20:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:20:16"}},
+          "macro_in_fundecl_vs_typedef.h:20:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -845,7 +867,9 @@
                 "macro_in_fundecl_vs_typedef.h:20:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "macro_in_fundecl_vs_typedef.h:20:16"}}
+            "macro_in_fundecl_vs_typedef.h:20:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -896,7 +920,9 @@
                         "macro_in_fundecl_vs_typedef.h:20:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:20:16"}})
+                    "macro_in_fundecl_vs_typedef.h:20:16"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -947,7 +973,9 @@
                         "macro_in_fundecl_vs_typedef.h:20:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:20:16"}}
+                    "macro_in_fundecl_vs_typedef.h:20:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -992,7 +1020,9 @@
             (DeclPathName
               (CName "struct3")),
           typedefSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:20:35"}},
+          "macro_in_fundecl_vs_typedef.h:20:35"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1044,7 +1074,9 @@
               "macro_in_fundecl_vs_typedef.h:21:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "macro_in_fundecl_vs_typedef.h:21:16"}},
+          "macro_in_fundecl_vs_typedef.h:21:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1091,7 +1123,9 @@
                 "macro_in_fundecl_vs_typedef.h:21:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "macro_in_fundecl_vs_typedef.h:21:16"}}
+            "macro_in_fundecl_vs_typedef.h:21:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1143,7 +1177,9 @@
                         "macro_in_fundecl_vs_typedef.h:21:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:21:16"}})
+                    "macro_in_fundecl_vs_typedef.h:21:16"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1195,7 +1231,9 @@
                         "macro_in_fundecl_vs_typedef.h:21:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "macro_in_fundecl_vs_typedef.h:21:16"}}
+                    "macro_in_fundecl_vs_typedef.h:21:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
@@ -173,6 +173,10 @@ newtype Struct3_t = Struct3_t
 
 deriving newtype instance F.Storable Struct3_t
 
+deriving stock instance Eq Struct3_t
+
+deriving stock instance Show Struct3_t
+
 data Struct4 = Struct4
   { struct4_a :: FC.CInt
   }

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
@@ -65,6 +65,8 @@ deriving stock instance Show Struct3
 deriving stock instance Eq Struct3
 newtype Struct3_t = Struct3_t {un_Struct3_t :: Struct3}
 deriving newtype instance Storable Struct3_t
+deriving stock instance Eq Struct3_t
+deriving stock instance Show Struct3_t
 data Struct4 = Struct4 {struct4_a :: CInt}
 instance Storable Struct4
     where {sizeOf = \_ -> 4 :: Int;

--- a/hs-bindgen/fixtures/macro_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_types.extbindings.yaml
@@ -3,18 +3,44 @@ types:
   cname: Arr1
   module: Example
   identifier: Arr1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: Arr2
   module: Example
   identifier: Arr2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: Arr3
   module: Example
   identifier: Arr3
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: BOOLEAN_T
   module: Example
   identifier: BOOLEAN_T
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_types.h
   cname: Fun1
   module: Example
@@ -23,10 +49,20 @@ types:
   cname: Fun2
   module: Example
   identifier: Fun2
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: Fun3
   module: Example
   identifier: Fun3
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: Fun4
   module: Example
@@ -39,23 +75,87 @@ types:
   cname: MTy
   module: Example
   identifier: MTy
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Read
+  - Show
+  - Floating
+  - Fractional
+  - Num
+  - Real
+  - RealFloat
+  - RealFrac
+  - Storable
 - headers: macro_types.h
   cname: PtrInt
   module: Example
   identifier: PtrInt
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: PtrPtrChar
   module: Example
   identifier: PtrPtrChar
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: macro_types.h
   cname: UINT8_T
   module: Example
   identifier: UINT8_T
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_types.h
   cname: boolean_T
   module: Example
   identifier: Boolean_T
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: macro_types.h
   cname: tty
   module: Example
   identifier: Tty
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Read
+  - Show
+  - Floating
+  - Fractional
+  - Num
+  - Real
+  - RealFloat
+  - RealFrac
+  - Storable

--- a/hs-bindgen/fixtures/macro_types.hs
+++ b/hs-bindgen/fixtures/macro_types.hs
@@ -37,7 +37,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -84,7 +86,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -144,7 +148,9 @@
                               integerLiteralType = Just
                                 (_×_ PrimInt Signed),
                               integerLiteralValue = 2}))),
-                    arrayAttributes = []}})}},
+                    arrayAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -204,7 +210,9 @@
                               integerLiteralType = Just
                                 (_×_ PrimInt Signed),
                               integerLiteralValue = 3}))),
-                    arrayAttributes = []}})}},
+                    arrayAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -297,7 +305,9 @@
                               AbstractName
                               []}}],
                     functionVariadic = False,
-                    functionAttributes = []}})}},
+                    functionAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -371,7 +381,9 @@
                               AbstractName
                               []}}],
                     functionVariadic = False,
-                    functionAttributes = []}})}},
+                    functionAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -471,7 +483,9 @@
                               AbstractName
                               []}}],
                     functionVariadic = False,
-                    functionAttributes = []}})}},
+                    functionAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -551,7 +565,9 @@
                               AbstractName
                               []}}],
                     functionVariadic = False,
-                    functionAttributes = []}})}},
+                    functionAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -709,7 +725,9 @@
                               AbstractName
                               []}}],
                     functionVariadic = False,
-                    functionAttributes = []}})}},
+                    functionAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -824,7 +842,9 @@
                               integerLiteralType = Just
                                 (_×_ PrimInt Signed),
                               integerLiteralValue = 2}))),
-                    arrayAttributes = []}})}},
+                    arrayAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -866,7 +886,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -937,7 +959,9 @@
           typedefType = TypeTypedef
             (CName "MTy"),
           typedefSourceLoc =
-          "macro_types.h:34:13"}},
+          "macro_types.h:34:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -980,7 +1004,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1097,7 +1123,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1128,7 +1156,9 @@
           typedefType = TypeTypedef
             (CName "BOOLEAN_T"),
           typedefSourceLoc =
-          "macro_types.h:38:19"}},
+          "macro_types.h:38:19"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/macro_types.hs
+++ b/hs-bindgen/fixtures/macro_types.hs
@@ -39,10 +39,28 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "PtrInt"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "PtrInt"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "PtrInt"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "PtrInt"),
@@ -88,10 +106,28 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "PtrPtrChar"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "PtrPtrChar"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "PtrPtrChar"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "PtrPtrChar"),
@@ -150,10 +186,18 @@
                               integerLiteralValue = 2}))),
                     arrayAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Arr1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Arr1"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "Arr1"),
   DeclNewtype
     Newtype {
@@ -212,10 +256,18 @@
                               integerLiteralValue = 3}))),
                     arrayAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Arr2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Arr2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "Arr2"),
   DeclNewtype
     Newtype {
@@ -307,10 +359,18 @@
                     functionVariadic = False,
                     functionAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Arr3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Arr3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "Arr3"),
   DeclNewtype
     Newtype {
@@ -384,10 +444,6 @@
                     functionAttributes = []}})},
       newtypeInstances = Set.fromList
         []},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName "@NsTypeConstr" "Fun1"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -485,10 +541,22 @@
                     functionVariadic = False,
                     functionAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Fun2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Fun2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "Fun2"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "Fun2"),
   DeclNewtype
     Newtype {
@@ -567,10 +635,22 @@
                     functionVariadic = False,
                     functionAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Fun3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Fun3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "Fun3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "Fun3"),
   DeclNewtype
     Newtype {
@@ -728,10 +808,6 @@
                     functionAttributes = []}})},
       newtypeInstances = Set.fromList
         []},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName "@NsTypeConstr" "Fun4"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -845,10 +921,6 @@
                     arrayAttributes = []}})},
       newtypeInstances = Set.fromList
         []},
-  DeclNewtypeInstance
-    DeriveNewtype
-    Storable
-    (HsName "@NsTypeConstr" "Fun5"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -888,7 +960,19 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Read,
+          Show,
+          Floating,
+          Fractional,
+          Num,
+          Real,
+          RealFloat,
+          RealFrac,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -961,10 +1045,66 @@
           typedefSourceLoc =
           "macro_types.h:34:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Read,
+          Show,
+          Floating,
+          Fractional,
+          Num,
+          Real,
+          RealFloat,
+          RealFrac,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Floating
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Fractional
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    RealFloat
+    (HsName "@NsTypeConstr" "Tty"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    RealFrac
     (HsName "@NsTypeConstr" "Tty"),
   DeclNewtype
     Newtype {
@@ -1006,7 +1146,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1125,10 +1278,95 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Ix
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bounded
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bits
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    FiniteBits
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Integral
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName
+      "@NsTypeConstr"
+      "BOOLEAN_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
     (HsName
       "@NsTypeConstr"
       "BOOLEAN_T"),
@@ -1158,10 +1396,95 @@
           typedefSourceLoc =
           "macro_types.h:38:19"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Read
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Enum
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Ix
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bounded
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Bits
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    FiniteBits
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Integral
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Num
+    (HsName
+      "@NsTypeConstr"
+      "Boolean_T"),
+  DeclNewtypeInstance
+    DeriveNewtype
+    Real
     (HsName
       "@NsTypeConstr"
       "Boolean_T")]

--- a/hs-bindgen/fixtures/macro_types.pp.hs
+++ b/hs-bindgen/fixtures/macro_types.pp.hs
@@ -20,11 +20,23 @@ newtype PtrInt = PtrInt
 
 deriving newtype instance F.Storable PtrInt
 
+deriving stock instance Eq PtrInt
+
+deriving stock instance Ord PtrInt
+
+deriving stock instance Show PtrInt
+
 newtype PtrPtrChar = PtrPtrChar
   { un_PtrPtrChar :: F.Ptr (F.Ptr FC.CChar)
   }
 
 deriving newtype instance F.Storable PtrPtrChar
+
+deriving stock instance Eq PtrPtrChar
+
+deriving stock instance Ord PtrPtrChar
+
+deriving stock instance Show PtrPtrChar
 
 newtype Arr1 = Arr1
   { un_Arr1 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 2) FC.CInt
@@ -32,11 +44,19 @@ newtype Arr1 = Arr1
 
 deriving newtype instance F.Storable Arr1
 
+deriving stock instance Eq Arr1
+
+deriving stock instance Show Arr1
+
 newtype Arr2 = Arr2
   { un_Arr2 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) (F.Ptr FC.CFloat)
   }
 
 deriving newtype instance F.Storable Arr2
+
+deriving stock instance Eq Arr2
+
+deriving stock instance Show Arr2
 
 newtype Arr3 = Arr3
   { un_Arr3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) (F.FunPtr (FC.CDouble -> IO FC.CFloat))
@@ -44,11 +64,13 @@ newtype Arr3 = Arr3
 
 deriving newtype instance F.Storable Arr3
 
+deriving stock instance Eq Arr3
+
+deriving stock instance Show Arr3
+
 newtype Fun1 = Fun1
   { un_Fun1 :: FC.CInt -> IO (F.Ptr FC.CFloat)
   }
-
-deriving newtype instance F.Storable Fun1
 
 newtype Fun2 = Fun2
   { un_Fun2 :: F.FunPtr (FC.CFloat -> (F.Ptr FC.CDouble) -> IO FC.CInt)
@@ -56,23 +78,31 @@ newtype Fun2 = Fun2
 
 deriving newtype instance F.Storable Fun2
 
+deriving stock instance Eq Fun2
+
+deriving stock instance Ord Fun2
+
+deriving stock instance Show Fun2
+
 newtype Fun3 = Fun3
   { un_Fun3 :: F.FunPtr ((F.Ptr FC.CFloat) -> IO (F.Ptr FC.CInt))
   }
 
 deriving newtype instance F.Storable Fun3
 
+deriving stock instance Eq Fun3
+
+deriving stock instance Ord Fun3
+
+deriving stock instance Show Fun3
+
 newtype Fun4 = Fun4
   { un_Fun4 :: FC.CInt -> (F.Ptr FC.CLong) -> IO (F.FunPtr (FC.CFloat -> (F.Ptr FC.CDouble) -> IO (F.Ptr FC.CLong)))
   }
 
-deriving newtype instance F.Storable Fun4
-
 newtype Fun5 = Fun5
   { un_Fun5 :: ((HsBindgen.Runtime.ConstantArray.ConstantArray 8) FC.CChar) -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) (F.Ptr FC.CShort)))
   }
-
-deriving newtype instance F.Storable Fun5
 
 newtype MTy = MTy
   { un_MTy :: FC.CFloat
@@ -107,6 +137,28 @@ newtype Tty = Tty
   }
 
 deriving newtype instance F.Storable Tty
+
+deriving stock instance Eq Tty
+
+deriving stock instance Ord Tty
+
+deriving stock instance Read Tty
+
+deriving stock instance Show Tty
+
+deriving newtype instance Enum Tty
+
+deriving newtype instance Floating Tty
+
+deriving newtype instance Fractional Tty
+
+deriving newtype instance Num Tty
+
+deriving newtype instance Real Tty
+
+deriving newtype instance RealFloat Tty
+
+deriving newtype instance RealFrac Tty
 
 newtype UINT8_T = UINT8_T
   { un_UINT8_T :: FC.CUChar
@@ -144,8 +196,56 @@ newtype BOOLEAN_T = BOOLEAN_T
 
 deriving newtype instance F.Storable BOOLEAN_T
 
+deriving stock instance Eq BOOLEAN_T
+
+deriving stock instance Ord BOOLEAN_T
+
+deriving stock instance Read BOOLEAN_T
+
+deriving stock instance Show BOOLEAN_T
+
+deriving newtype instance Enum BOOLEAN_T
+
+deriving newtype instance Ix.Ix BOOLEAN_T
+
+deriving newtype instance Bounded BOOLEAN_T
+
+deriving newtype instance Bits.Bits BOOLEAN_T
+
+deriving newtype instance FiniteBits BOOLEAN_T
+
+deriving newtype instance Integral BOOLEAN_T
+
+deriving newtype instance Num BOOLEAN_T
+
+deriving newtype instance Real BOOLEAN_T
+
 newtype Boolean_T = Boolean_T
   { un_Boolean_T :: BOOLEAN_T
   }
 
 deriving newtype instance F.Storable Boolean_T
+
+deriving stock instance Eq Boolean_T
+
+deriving stock instance Ord Boolean_T
+
+deriving stock instance Read Boolean_T
+
+deriving stock instance Show Boolean_T
+
+deriving newtype instance Enum Boolean_T
+
+deriving newtype instance Ix.Ix Boolean_T
+
+deriving newtype instance Bounded Boolean_T
+
+deriving newtype instance Bits.Bits Boolean_T
+
+deriving newtype instance FiniteBits Boolean_T
+
+deriving newtype instance Integral Boolean_T
+
+deriving newtype instance Num Boolean_T
+
+deriving newtype instance Real Boolean_T

--- a/hs-bindgen/fixtures/macro_types.th.txt
+++ b/hs-bindgen/fixtures/macro_types.th.txt
@@ -1,34 +1,49 @@
 -- addDependentFile examples/macro_types.h
 newtype PtrInt = PtrInt {un_PtrInt :: (Ptr CInt)}
 deriving newtype instance Storable PtrInt
+deriving stock instance Eq PtrInt
+deriving stock instance Ord PtrInt
+deriving stock instance Show PtrInt
 newtype PtrPtrChar
     = PtrPtrChar {un_PtrPtrChar :: (Ptr (Ptr CChar))}
 deriving newtype instance Storable PtrPtrChar
+deriving stock instance Eq PtrPtrChar
+deriving stock instance Ord PtrPtrChar
+deriving stock instance Show PtrPtrChar
 newtype Arr1 = Arr1 {un_Arr1 :: (ConstantArray 2 CInt)}
 deriving newtype instance Storable Arr1
+deriving stock instance Eq Arr1
+deriving stock instance Show Arr1
 newtype Arr2 = Arr2 {un_Arr2 :: (ConstantArray 3 (Ptr CFloat))}
 deriving newtype instance Storable Arr2
+deriving stock instance Eq Arr2
+deriving stock instance Show Arr2
 newtype Arr3
     = Arr3 {un_Arr3 :: (ConstantArray 4
                                       (FunPtr (CDouble -> IO CFloat)))}
 deriving newtype instance Storable Arr3
+deriving stock instance Eq Arr3
+deriving stock instance Show Arr3
 newtype Fun1 = Fun1 {un_Fun1 :: (CInt -> IO (Ptr CFloat))}
-deriving newtype instance Storable Fun1
 newtype Fun2
     = Fun2 {un_Fun2 :: (FunPtr (CFloat -> Ptr CDouble -> IO CInt))}
 deriving newtype instance Storable Fun2
+deriving stock instance Eq Fun2
+deriving stock instance Ord Fun2
+deriving stock instance Show Fun2
 newtype Fun3
     = Fun3 {un_Fun3 :: (FunPtr (Ptr CFloat -> IO (Ptr CInt)))}
 deriving newtype instance Storable Fun3
+deriving stock instance Eq Fun3
+deriving stock instance Ord Fun3
+deriving stock instance Show Fun3
 newtype Fun4
     = Fun4 {un_Fun4 :: (CInt ->
                         Ptr CLong ->
                         IO (FunPtr (CFloat -> Ptr CDouble -> IO (Ptr CLong))))}
-deriving newtype instance Storable Fun4
 newtype Fun5
     = Fun5 {un_Fun5 :: (ConstantArray 8 CChar ->
                         IO (Ptr (ConstantArray 2 (Ptr CShort))))}
-deriving newtype instance Storable Fun5
 newtype MTy = MTy {un_MTy :: CFloat}
 deriving newtype instance Storable MTy
 deriving stock instance Eq MTy
@@ -44,6 +59,17 @@ deriving newtype instance RealFloat MTy
 deriving newtype instance RealFrac MTy
 newtype Tty = Tty {un_Tty :: MTy}
 deriving newtype instance Storable Tty
+deriving stock instance Eq Tty
+deriving stock instance Ord Tty
+deriving stock instance Read Tty
+deriving stock instance Show Tty
+deriving newtype instance Enum Tty
+deriving newtype instance Floating Tty
+deriving newtype instance Fractional Tty
+deriving newtype instance Num Tty
+deriving newtype instance Real Tty
+deriving newtype instance RealFloat Tty
+deriving newtype instance RealFrac Tty
 newtype UINT8_T = UINT8_T {un_UINT8_T :: CUChar}
 deriving newtype instance Storable UINT8_T
 deriving stock instance Eq UINT8_T
@@ -60,5 +86,29 @@ deriving newtype instance Num UINT8_T
 deriving newtype instance Real UINT8_T
 newtype BOOLEAN_T = BOOLEAN_T {un_BOOLEAN_T :: UINT8_T}
 deriving newtype instance Storable BOOLEAN_T
+deriving stock instance Eq BOOLEAN_T
+deriving stock instance Ord BOOLEAN_T
+deriving stock instance Read BOOLEAN_T
+deriving stock instance Show BOOLEAN_T
+deriving newtype instance Enum BOOLEAN_T
+deriving newtype instance Ix BOOLEAN_T
+deriving newtype instance Bounded BOOLEAN_T
+deriving newtype instance Bits BOOLEAN_T
+deriving newtype instance FiniteBits BOOLEAN_T
+deriving newtype instance Integral BOOLEAN_T
+deriving newtype instance Num BOOLEAN_T
+deriving newtype instance Real BOOLEAN_T
 newtype Boolean_T = Boolean_T {un_Boolean_T :: BOOLEAN_T}
 deriving newtype instance Storable Boolean_T
+deriving stock instance Eq Boolean_T
+deriving stock instance Ord Boolean_T
+deriving stock instance Read Boolean_T
+deriving stock instance Show Boolean_T
+deriving newtype instance Enum Boolean_T
+deriving newtype instance Ix Boolean_T
+deriving newtype instance Bounded Boolean_T
+deriving newtype instance Bits Boolean_T
+deriving newtype instance FiniteBits Boolean_T
+deriving newtype instance Integral Boolean_T
+deriving newtype instance Num Boolean_T
+deriving newtype instance Real Boolean_T

--- a/hs-bindgen/fixtures/manual_examples.extbindings.yaml
+++ b/hs-bindgen/fixtures/manual_examples.extbindings.yaml
@@ -3,78 +3,228 @@ types:
   cname: DAY
   module: Example
   identifier: DAY
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: MONTH
   module: Example
   identifier: MONTH
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: YEAR
   module: Example
   identifier: YEAR
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: adiós
   module: Example
   identifier: Adio'0301s
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: average
   module: Example
   identifier: Average
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Read
+  - Show
+  - Floating
+  - Fractional
+  - Num
+  - Real
+  - RealFloat
+  - RealFrac
+  - Storable
 - headers: manual_examples.h
   cname: config
   module: Example
   identifier: Config
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: data
   module: Example
   identifier: Data
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: date
   module: Example
   identifier: Date
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum CXCursorKind
   module: Example
   identifier: CXCursorKind
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum HTTP_status
   module: Example
   identifier: HTTP_status
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum descending
   module: Example
   identifier: Descending
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum index
   module: Example
   identifier: Index
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum result
   module: Example
   identifier: Result
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum signal
   module: Example
   identifier: Signal
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: enum vote
   module: Example
   identifier: Vote
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: index
   module: Example
   identifier: Index
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: occupation
   module: Example
   identifier: Occupation
+  instances:
+  - Storable
 - headers: manual_examples.h
   cname: struct date
   module: Example
   identifier: Date
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: struct employee
   module: Example
   identifier: Employee
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: struct person
   module: Example
@@ -83,27 +233,73 @@ types:
   cname: struct rect
   module: Example
   identifier: Rect
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: struct student
   module: Example
   identifier: Student
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: struct triple
   module: Example
   identifier: Triple
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: sum
   module: Example
   identifier: Sum
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: manual_examples.h
   cname: triple
   module: Example
   identifier: Triple
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: manual_examples.h
   cname: union occupation
   module: Example
   identifier: Occupation
+  instances:
+  - Storable
 - headers: manual_examples.h
   cname: 数字
   module: Example
   identifier: C数字
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -92,7 +92,9 @@
               "manual_examples.h:17:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:14:16"}},
+          "manual_examples.h:14:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -187,7 +189,9 @@
                 "manual_examples.h:17:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:14:16"}}
+            "manual_examples.h:14:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -287,7 +291,9 @@
                         "manual_examples.h:17:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:14:16"}})
+                    "manual_examples.h:14:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -390,7 +396,9 @@
                         "manual_examples.h:17:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:14:16"}}
+                    "manual_examples.h:14:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -510,7 +518,9 @@
               valueSourceLoc =
               "manual_examples.h:29:5"}],
           enumSourceLoc =
-          "manual_examples.h:26:14"}},
+          "manual_examples.h:26:14"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -554,7 +564,9 @@
                 valueSourceLoc =
                 "manual_examples.h:29:5"}],
             enumSourceLoc =
-            "manual_examples.h:26:14"}}
+            "manual_examples.h:26:14"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -603,7 +615,9 @@
                         valueSourceLoc =
                         "manual_examples.h:29:5"}],
                     enumSourceLoc =
-                    "manual_examples.h:26:14"}})
+                    "manual_examples.h:26:14"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -652,7 +666,9 @@
                         valueSourceLoc =
                         "manual_examples.h:29:5"}],
                     enumSourceLoc =
-                    "manual_examples.h:26:14"}}
+                    "manual_examples.h:26:14"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -721,7 +737,9 @@
                 valueSourceLoc =
                 "manual_examples.h:29:5"}],
             enumSourceLoc =
-            "manual_examples.h:26:14"}}
+            "manual_examples.h:26:14"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -772,7 +790,9 @@
                 valueSourceLoc =
                 "manual_examples.h:29:5"}],
             enumSourceLoc =
-            "manual_examples.h:26:14"}}
+            "manual_examples.h:26:14"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "A")
       (HsName "@NsConstr" "C")),
   DeclInstance
@@ -818,7 +838,9 @@
                 valueSourceLoc =
                 "manual_examples.h:29:5"}],
             enumSourceLoc =
-            "manual_examples.h:26:14"}}),
+            "manual_examples.h:26:14"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -946,7 +968,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "manual_examples.h:38:13"}},
+          "manual_examples.h:38:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1021,7 +1045,9 @@
           typedefType = TypePrim
             (PrimFloating PrimDouble),
           typedefSourceLoc =
-          "manual_examples.h:39:16"}},
+          "manual_examples.h:39:16"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1323,7 +1349,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1413,7 +1441,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1529,7 +1559,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1676,7 +1708,9 @@
               "manual_examples.h:60:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:57:16"}},
+          "manual_examples.h:57:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1772,7 +1806,9 @@
                 "manual_examples.h:60:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:57:16"}}
+            "manual_examples.h:57:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1873,7 +1909,9 @@
                         "manual_examples.h:60:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:57:16"}})
+                    "manual_examples.h:57:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -1977,7 +2015,9 @@
                         "manual_examples.h:60:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:57:16"}}
+                    "manual_examples.h:57:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -2107,7 +2147,9 @@
               "manual_examples.h:72:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:70:10"}},
+          "manual_examples.h:70:10"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2183,7 +2225,9 @@
                 "manual_examples.h:72:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:70:10"}}
+            "manual_examples.h:70:10"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2264,7 +2308,9 @@
                         "manual_examples.h:72:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:70:10"}})
+                    "manual_examples.h:70:10"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -2347,7 +2393,9 @@
                         "manual_examples.h:72:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:70:10"}}
+                    "manual_examples.h:70:10"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2473,7 +2521,9 @@
               "manual_examples.h:78:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:75:10"}},
+          "manual_examples.h:75:10"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2580,7 +2630,9 @@
                 "manual_examples.h:78:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:75:10"}}
+            "manual_examples.h:75:10"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 24,
         storableAlignment = 8,
@@ -2692,7 +2744,9 @@
                         "manual_examples.h:78:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:75:10"}})
+                    "manual_examples.h:75:10"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8,
@@ -2807,7 +2861,9 @@
                         "manual_examples.h:78:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:75:10"}}
+                    "manual_examples.h:75:10"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -2868,7 +2924,9 @@
               ufieldSourceLoc =
               "manual_examples.h:79:5"}],
           unionSourceLoc =
-          "manual_examples.h:69:15"}},
+          "manual_examples.h:69:15"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 24 8))
@@ -3047,7 +3105,9 @@
               "manual_examples.h:91:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:89:3"}},
+          "manual_examples.h:89:3"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3120,7 +3180,9 @@
                 "manual_examples.h:91:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:89:3"}}
+            "manual_examples.h:89:3"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -3198,7 +3260,9 @@
                         "manual_examples.h:91:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:89:3"}})
+                    "manual_examples.h:89:3"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -3278,7 +3342,9 @@
                         "manual_examples.h:91:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:89:3"}}
+                    "manual_examples.h:89:3"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -3370,7 +3436,9 @@
               "manual_examples.h:96:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:94:3"}},
+          "manual_examples.h:94:3"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3443,7 +3511,9 @@
                 "manual_examples.h:96:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:94:3"}}
+            "manual_examples.h:94:3"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -3521,7 +3591,9 @@
                         "manual_examples.h:96:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:94:3"}})
+                    "manual_examples.h:94:3"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -3601,7 +3673,9 @@
                         "manual_examples.h:96:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:94:3"}}
+                    "manual_examples.h:94:3"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -3710,7 +3784,9 @@
               "manual_examples.h:97:5"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:88:8"}},
+          "manual_examples.h:88:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3800,7 +3876,9 @@
                 "manual_examples.h:97:5"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:88:8"}}
+            "manual_examples.h:88:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -3895,7 +3973,9 @@
                         "manual_examples.h:97:5"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:88:8"}})
+                    "manual_examples.h:88:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -3992,7 +4072,9 @@
                         "manual_examples.h:97:5"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:88:8"}}
+                    "manual_examples.h:88:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -4079,7 +4161,9 @@
               "manual_examples.h:102:7"}],
           structFlam = Nothing,
           structSourceLoc =
-          "manual_examples.h:100:9"}},
+          "manual_examples.h:100:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -4151,7 +4235,9 @@
                 "manual_examples.h:102:7"}],
             structFlam = Nothing,
             structSourceLoc =
-            "manual_examples.h:100:9"}}
+            "manual_examples.h:100:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -4228,7 +4314,9 @@
                         "manual_examples.h:102:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:100:9"}})
+                    "manual_examples.h:100:9"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -4307,7 +4395,9 @@
                         "manual_examples.h:102:7"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "manual_examples.h:100:9"}}
+                    "manual_examples.h:100:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -4357,7 +4447,9 @@
                   (DeclPathCtxtTypedef
                     (CName "config"))))),
           typedefSourceLoc =
-          "manual_examples.h:103:4"}},
+          "manual_examples.h:103:4"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4386,7 +4478,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "manual_examples.h:109:13"}},
+          "manual_examples.h:109:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4512,7 +4606,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "manual_examples.h:111:13"}},
+          "manual_examples.h:111:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4635,7 +4731,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "manual_examples.h:113:13"}},
+          "manual_examples.h:113:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4758,7 +4856,9 @@
               valueSourceLoc =
               "manual_examples.h:124:3"}],
           enumSourceLoc =
-          "manual_examples.h:120:6"}},
+          "manual_examples.h:120:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -4807,7 +4907,9 @@
                 valueSourceLoc =
                 "manual_examples.h:124:3"}],
             enumSourceLoc =
-            "manual_examples.h:120:6"}}
+            "manual_examples.h:120:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -4861,7 +4963,9 @@
                         valueSourceLoc =
                         "manual_examples.h:124:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:120:6"}})
+                    "manual_examples.h:120:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -4915,7 +5019,9 @@
                         valueSourceLoc =
                         "manual_examples.h:124:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:120:6"}}
+                    "manual_examples.h:120:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -4989,7 +5095,9 @@
                 valueSourceLoc =
                 "manual_examples.h:124:3"}],
             enumSourceLoc =
-            "manual_examples.h:120:6"}}
+            "manual_examples.h:120:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -5046,7 +5154,9 @@
                 valueSourceLoc =
                 "manual_examples.h:124:3"}],
             enumSourceLoc =
-            "manual_examples.h:120:6"}}
+            "manual_examples.h:120:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "Start")
       (HsName "@NsConstr" "Stop")),
   DeclInstance
@@ -5097,7 +5207,9 @@
                 valueSourceLoc =
                 "manual_examples.h:124:3"}],
             enumSourceLoc =
-            "manual_examples.h:120:6"}}),
+            "manual_examples.h:120:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -5227,7 +5339,9 @@
               valueSourceLoc =
               "manual_examples.h:132:3"}],
           enumSourceLoc =
-          "manual_examples.h:127:6"}},
+          "manual_examples.h:127:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -5282,7 +5396,9 @@
                 valueSourceLoc =
                 "manual_examples.h:132:3"}],
             enumSourceLoc =
-            "manual_examples.h:127:6"}}
+            "manual_examples.h:127:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -5342,7 +5458,9 @@
                         valueSourceLoc =
                         "manual_examples.h:132:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:127:6"}})
+                    "manual_examples.h:127:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -5402,7 +5520,9 @@
                         valueSourceLoc =
                         "manual_examples.h:132:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:127:6"}}
+                    "manual_examples.h:127:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -5482,7 +5602,9 @@
                 valueSourceLoc =
                 "manual_examples.h:132:3"}],
             enumSourceLoc =
-            "manual_examples.h:127:6"}}
+            "manual_examples.h:127:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -5552,7 +5674,9 @@
                 valueSourceLoc =
                 "manual_examples.h:132:3"}],
             enumSourceLoc =
-            "manual_examples.h:127:6"}}),
+            "manual_examples.h:127:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -5696,7 +5820,9 @@
               valueSourceLoc =
               "manual_examples.h:139:3"}],
           enumSourceLoc =
-          "manual_examples.h:135:6"}},
+          "manual_examples.h:135:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -5745,7 +5871,9 @@
                 valueSourceLoc =
                 "manual_examples.h:139:3"}],
             enumSourceLoc =
-            "manual_examples.h:135:6"}}
+            "manual_examples.h:135:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -5799,7 +5927,9 @@
                         valueSourceLoc =
                         "manual_examples.h:139:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:135:6"}})
+                    "manual_examples.h:135:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -5853,7 +5983,9 @@
                         valueSourceLoc =
                         "manual_examples.h:139:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:135:6"}}
+                    "manual_examples.h:135:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -5927,7 +6059,9 @@
                 valueSourceLoc =
                 "manual_examples.h:139:3"}],
             enumSourceLoc =
-            "manual_examples.h:135:6"}}
+            "manual_examples.h:135:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -5985,7 +6119,9 @@
                 valueSourceLoc =
                 "manual_examples.h:139:3"}],
             enumSourceLoc =
-            "manual_examples.h:135:6"}}
+            "manual_examples.h:135:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "Z")
       (HsName "@NsConstr" "X")),
   DeclInstance
@@ -6036,7 +6172,9 @@
                 valueSourceLoc =
                 "manual_examples.h:139:3"}],
             enumSourceLoc =
-            "manual_examples.h:135:6"}}),
+            "manual_examples.h:135:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -6161,7 +6299,9 @@
               valueSourceLoc =
               "manual_examples.h:146:3"}],
           enumSourceLoc =
-          "manual_examples.h:142:6"}},
+          "manual_examples.h:142:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -6211,7 +6351,9 @@
                 valueSourceLoc =
                 "manual_examples.h:146:3"}],
             enumSourceLoc =
-            "manual_examples.h:142:6"}}
+            "manual_examples.h:142:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -6266,7 +6408,9 @@
                         valueSourceLoc =
                         "manual_examples.h:146:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:142:6"}})
+                    "manual_examples.h:142:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -6321,7 +6465,9 @@
                         valueSourceLoc =
                         "manual_examples.h:146:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:142:6"}}
+                    "manual_examples.h:142:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -6396,7 +6542,9 @@
                 valueSourceLoc =
                 "manual_examples.h:146:3"}],
             enumSourceLoc =
-            "manual_examples.h:142:6"}}
+            "manual_examples.h:142:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCInt)
       (Map.fromList
         [
@@ -6460,7 +6608,9 @@
                 valueSourceLoc =
                 "manual_examples.h:146:3"}],
             enumSourceLoc =
-            "manual_examples.h:142:6"}}
+            "manual_examples.h:142:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "Failed")
       (HsName
         "@NsConstr"
@@ -6514,7 +6664,9 @@
                 valueSourceLoc =
                 "manual_examples.h:146:3"}],
             enumSourceLoc =
-            "manual_examples.h:142:6"}}),
+            "manual_examples.h:142:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -6635,7 +6787,9 @@
               valueSourceLoc =
               "manual_examples.h:152:3"}],
           enumSourceLoc =
-          "manual_examples.h:149:6"}},
+          "manual_examples.h:149:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -6680,7 +6834,9 @@
                 valueSourceLoc =
                 "manual_examples.h:152:3"}],
             enumSourceLoc =
-            "manual_examples.h:149:6"}}
+            "manual_examples.h:149:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -6730,7 +6886,9 @@
                         valueSourceLoc =
                         "manual_examples.h:152:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:149:6"}})
+                    "manual_examples.h:149:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -6780,7 +6938,9 @@
                         valueSourceLoc =
                         "manual_examples.h:152:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:149:6"}}
+                    "manual_examples.h:149:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -6844,7 +7004,9 @@
                 valueSourceLoc =
                 "manual_examples.h:152:3"}],
             enumSourceLoc =
-            "manual_examples.h:149:6"}}
+            "manual_examples.h:149:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -6900,7 +7062,9 @@
                 valueSourceLoc =
                 "manual_examples.h:152:3"}],
             enumSourceLoc =
-            "manual_examples.h:149:6"}}
+            "manual_examples.h:149:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "Infavour")
       (HsName "@NsConstr" "Abstain")),
   DeclInstance
@@ -6947,7 +7111,9 @@
                 valueSourceLoc =
                 "manual_examples.h:152:3"}],
             enumSourceLoc =
-            "manual_examples.h:149:6"}}),
+            "manual_examples.h:149:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -7104,7 +7270,9 @@
               valueSourceLoc =
               "manual_examples.h:172:3"}],
           enumSourceLoc =
-          "manual_examples.h:157:6"}},
+          "manual_examples.h:157:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -7205,7 +7373,9 @@
                 valueSourceLoc =
                 "manual_examples.h:172:3"}],
             enumSourceLoc =
-            "manual_examples.h:157:6"}}
+            "manual_examples.h:157:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -7311,7 +7481,9 @@
                         valueSourceLoc =
                         "manual_examples.h:172:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:157:6"}})
+                    "manual_examples.h:157:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -7417,7 +7589,9 @@
                         valueSourceLoc =
                         "manual_examples.h:172:3"}],
                     enumSourceLoc =
-                    "manual_examples.h:157:6"}}
+                    "manual_examples.h:157:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -7543,7 +7717,9 @@
                 valueSourceLoc =
                 "manual_examples.h:172:3"}],
             enumSourceLoc =
-            "manual_examples.h:157:6"}}
+            "manual_examples.h:157:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -7688,7 +7864,9 @@
                 valueSourceLoc =
                 "manual_examples.h:172:3"}],
             enumSourceLoc =
-            "manual_examples.h:157:6"}}),
+            "manual_examples.h:157:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -94,7 +94,7 @@
           structSourceLoc =
           "manual_examples.h:14:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -191,7 +191,7 @@
             structSourceLoc =
             "manual_examples.h:14:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -293,7 +293,7 @@
                     structSourceLoc =
                     "manual_examples.h:14:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -398,7 +398,7 @@
                     structSourceLoc =
                     "manual_examples.h:14:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -520,7 +520,12 @@
           enumSourceLoc =
           "manual_examples.h:26:14"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -566,7 +571,7 @@
             enumSourceLoc =
             "manual_examples.h:26:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -617,7 +622,12 @@
                     enumSourceLoc =
                     "manual_examples.h:26:14"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -668,7 +678,7 @@
                     enumSourceLoc =
                     "manual_examples.h:26:14"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -739,7 +749,7 @@
             enumSourceLoc =
             "manual_examples.h:26:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -792,7 +802,7 @@
             enumSourceLoc =
             "manual_examples.h:26:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "A")
       (HsName "@NsConstr" "C")),
   DeclInstance
@@ -840,7 +850,12 @@
             enumSourceLoc =
             "manual_examples.h:26:14"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -970,7 +985,20 @@
           typedefSourceLoc =
           "manual_examples.h:38:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1047,7 +1075,19 @@
           typedefSourceLoc =
           "manual_examples.h:39:16"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Read,
+          Show,
+          Floating,
+          Fractional,
+          Num,
+          Real,
+          RealFloat,
+          RealFrac,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1351,7 +1391,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1443,7 +1496,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1561,7 +1627,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1710,7 +1789,7 @@
           structSourceLoc =
           "manual_examples.h:57:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1808,7 +1887,7 @@
             structSourceLoc =
             "manual_examples.h:57:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1911,7 +1990,7 @@
                     structSourceLoc =
                     "manual_examples.h:57:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -2017,7 +2096,7 @@
                     structSourceLoc =
                     "manual_examples.h:57:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -2149,7 +2228,7 @@
           structSourceLoc =
           "manual_examples.h:70:10"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2227,7 +2306,7 @@
             structSourceLoc =
             "manual_examples.h:70:10"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2310,7 +2389,7 @@
                     structSourceLoc =
                     "manual_examples.h:70:10"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -2395,7 +2474,7 @@
                     structSourceLoc =
                     "manual_examples.h:70:10"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2523,7 +2602,7 @@
           structSourceLoc =
           "manual_examples.h:75:10"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2632,7 +2711,7 @@
             structSourceLoc =
             "manual_examples.h:75:10"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 24,
         storableAlignment = 8,
@@ -2746,7 +2825,7 @@
                     structSourceLoc =
                     "manual_examples.h:75:10"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8,
@@ -2863,7 +2942,7 @@
                     structSourceLoc =
                     "manual_examples.h:75:10"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -2926,7 +3005,7 @@
           unionSourceLoc =
           "manual_examples.h:69:15"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 24 8))
@@ -3107,7 +3186,7 @@
           structSourceLoc =
           "manual_examples.h:89:3"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3182,7 +3261,7 @@
             structSourceLoc =
             "manual_examples.h:89:3"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -3262,7 +3341,7 @@
                     structSourceLoc =
                     "manual_examples.h:89:3"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -3344,7 +3423,7 @@
                     structSourceLoc =
                     "manual_examples.h:89:3"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -3438,7 +3517,7 @@
           structSourceLoc =
           "manual_examples.h:94:3"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3513,7 +3592,7 @@
             structSourceLoc =
             "manual_examples.h:94:3"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -3593,7 +3672,7 @@
                     structSourceLoc =
                     "manual_examples.h:94:3"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -3675,7 +3754,7 @@
                     structSourceLoc =
                     "manual_examples.h:94:3"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -3786,7 +3865,7 @@
           structSourceLoc =
           "manual_examples.h:88:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -3878,7 +3957,7 @@
             structSourceLoc =
             "manual_examples.h:88:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -3975,7 +4054,7 @@
                     structSourceLoc =
                     "manual_examples.h:88:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -4074,7 +4153,7 @@
                     structSourceLoc =
                     "manual_examples.h:88:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -4163,7 +4242,7 @@
           structSourceLoc =
           "manual_examples.h:100:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -4237,7 +4316,7 @@
             structSourceLoc =
             "manual_examples.h:100:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -4316,7 +4395,7 @@
                     structSourceLoc =
                     "manual_examples.h:100:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -4397,7 +4476,7 @@
                     structSourceLoc =
                     "manual_examples.h:100:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -4449,10 +4528,28 @@
           typedefSourceLoc =
           "manual_examples.h:103:4"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Config"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Config"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "Config"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Config"),
@@ -4480,7 +4577,20 @@
           typedefSourceLoc =
           "manual_examples.h:109:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4608,7 +4718,20 @@
           typedefSourceLoc =
           "manual_examples.h:111:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4733,7 +4856,20 @@
           typedefSourceLoc =
           "manual_examples.h:113:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -4858,7 +4994,12 @@
           enumSourceLoc =
           "manual_examples.h:120:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -4909,7 +5050,7 @@
             enumSourceLoc =
             "manual_examples.h:120:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -4965,7 +5106,12 @@
                     enumSourceLoc =
                     "manual_examples.h:120:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -5021,7 +5167,7 @@
                     enumSourceLoc =
                     "manual_examples.h:120:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -5097,7 +5243,7 @@
             enumSourceLoc =
             "manual_examples.h:120:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -5156,7 +5302,7 @@
             enumSourceLoc =
             "manual_examples.h:120:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "Start")
       (HsName "@NsConstr" "Stop")),
   DeclInstance
@@ -5209,7 +5355,12 @@
             enumSourceLoc =
             "manual_examples.h:120:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -5341,7 +5492,12 @@
           enumSourceLoc =
           "manual_examples.h:127:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -5398,7 +5554,7 @@
             enumSourceLoc =
             "manual_examples.h:127:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -5460,7 +5616,12 @@
                     enumSourceLoc =
                     "manual_examples.h:127:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -5522,7 +5683,7 @@
                     enumSourceLoc =
                     "manual_examples.h:127:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -5604,7 +5765,7 @@
             enumSourceLoc =
             "manual_examples.h:127:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -5676,7 +5837,12 @@
             enumSourceLoc =
             "manual_examples.h:127:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -5822,7 +5988,12 @@
           enumSourceLoc =
           "manual_examples.h:135:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -5873,7 +6044,7 @@
             enumSourceLoc =
             "manual_examples.h:135:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -5929,7 +6100,12 @@
                     enumSourceLoc =
                     "manual_examples.h:135:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -5985,7 +6161,7 @@
                     enumSourceLoc =
                     "manual_examples.h:135:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -6061,7 +6237,7 @@
             enumSourceLoc =
             "manual_examples.h:135:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -6121,7 +6297,7 @@
             enumSourceLoc =
             "manual_examples.h:135:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "Z")
       (HsName "@NsConstr" "X")),
   DeclInstance
@@ -6174,7 +6350,12 @@
             enumSourceLoc =
             "manual_examples.h:135:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -6301,7 +6482,12 @@
           enumSourceLoc =
           "manual_examples.h:142:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -6353,7 +6539,7 @@
             enumSourceLoc =
             "manual_examples.h:142:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -6410,7 +6596,12 @@
                     enumSourceLoc =
                     "manual_examples.h:142:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -6467,7 +6658,7 @@
                     enumSourceLoc =
                     "manual_examples.h:142:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -6544,7 +6735,7 @@
             enumSourceLoc =
             "manual_examples.h:142:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCInt)
       (Map.fromList
         [
@@ -6610,7 +6801,7 @@
             enumSourceLoc =
             "manual_examples.h:142:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "Failed")
       (HsName
         "@NsConstr"
@@ -6666,7 +6857,12 @@
             enumSourceLoc =
             "manual_examples.h:142:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -6789,7 +6985,12 @@
           enumSourceLoc =
           "manual_examples.h:149:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -6836,7 +7037,7 @@
             enumSourceLoc =
             "manual_examples.h:149:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -6888,7 +7089,12 @@
                     enumSourceLoc =
                     "manual_examples.h:149:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -6940,7 +7146,7 @@
                     enumSourceLoc =
                     "manual_examples.h:149:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -7006,7 +7212,7 @@
             enumSourceLoc =
             "manual_examples.h:149:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUChar)
       (Map.fromList
         [
@@ -7064,7 +7270,7 @@
             enumSourceLoc =
             "manual_examples.h:149:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "Infavour")
       (HsName "@NsConstr" "Abstain")),
   DeclInstance
@@ -7113,7 +7319,12 @@
             enumSourceLoc =
             "manual_examples.h:149:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -7272,7 +7483,12 @@
           enumSourceLoc =
           "manual_examples.h:157:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -7375,7 +7591,7 @@
             enumSourceLoc =
             "manual_examples.h:157:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -7483,7 +7699,12 @@
                     enumSourceLoc =
                     "manual_examples.h:157:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -7591,7 +7812,7 @@
                     enumSourceLoc =
                     "manual_examples.h:157:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -7719,7 +7940,7 @@
             enumSourceLoc =
             "manual_examples.h:157:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -7866,7 +8087,12 @@
             enumSourceLoc =
             "manual_examples.h:157:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -542,6 +542,12 @@ newtype Config = Config
 
 deriving newtype instance F.Storable Config
 
+deriving stock instance Eq Config
+
+deriving stock instance Ord Config
+
+deriving stock instance Show Config
+
 newtype Adio'0301s = Adio'0301s
   { un_Adio'0301s :: FC.CInt
   }

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -229,6 +229,9 @@ deriving stock instance Show Config_Deref
 deriving stock instance Eq Config_Deref
 newtype Config = Config {un_Config :: (Ptr Config_Deref)}
 deriving newtype instance Storable Config
+deriving stock instance Eq Config
+deriving stock instance Ord Config
+deriving stock instance Show Config
 newtype Adio'0301s = Adio'0301s {un_Adio'0301s :: CInt}
 deriving newtype instance Storable Adio'0301s
 deriving stock instance Eq Adio'0301s

--- a/hs-bindgen/fixtures/nested_enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_enums.extbindings.yaml
@@ -3,11 +3,25 @@ types:
   cname: enum enumA
   module: Example
   identifier: EnumA
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: nested_enums.h
   cname: struct exA
   module: Example
   identifier: ExA
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: nested_enums.h
   cname: struct exB
   module: Example
   identifier: ExB
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -38,7 +38,12 @@
           enumSourceLoc =
           "nested_enums.h:2:14"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -79,7 +84,7 @@
             enumSourceLoc =
             "nested_enums.h:2:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -125,7 +130,12 @@
                     enumSourceLoc =
                     "nested_enums.h:2:14"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -171,7 +181,7 @@
                     enumSourceLoc =
                     "nested_enums.h:2:14"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -237,7 +247,7 @@
             enumSourceLoc =
             "nested_enums.h:2:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -284,7 +294,7 @@
             enumSourceLoc =
             "nested_enums.h:2:14"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "VALA_1")
       (HsName "@NsConstr" "VALA_2")),
   DeclInstance
@@ -327,7 +337,12 @@
             enumSourceLoc =
             "nested_enums.h:2:14"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -414,7 +429,7 @@
           structSourceLoc =
           "nested_enums.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -464,7 +479,7 @@
             structSourceLoc =
             "nested_enums.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -519,7 +534,7 @@
                     structSourceLoc =
                     "nested_enums.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -574,7 +589,7 @@
                     structSourceLoc =
                     "nested_enums.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -632,7 +647,12 @@
           enumSourceLoc =
           "nested_enums.h:9:9"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -676,7 +696,7 @@
             enumSourceLoc =
             "nested_enums.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -725,7 +745,12 @@
                     enumSourceLoc =
                     "nested_enums.h:9:9"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -774,7 +799,7 @@
                     enumSourceLoc =
                     "nested_enums.h:9:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -843,7 +868,7 @@
             enumSourceLoc =
             "nested_enums.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -893,7 +918,7 @@
             enumSourceLoc =
             "nested_enums.h:9:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "VALB_1")
       (HsName "@NsConstr" "VALB_2")),
   DeclInstance
@@ -939,7 +964,12 @@
             enumSourceLoc =
             "nested_enums.h:9:9"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -1034,7 +1064,7 @@
           structSourceLoc =
           "nested_enums.h:8:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1092,7 +1122,7 @@
             structSourceLoc =
             "nested_enums.h:8:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1155,7 +1185,7 @@
                     structSourceLoc =
                     "nested_enums.h:8:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1218,7 +1248,7 @@
                     structSourceLoc =
                     "nested_enums.h:8:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -36,7 +36,9 @@
               valueSourceLoc =
               "nested_enums.h:4:17"}],
           enumSourceLoc =
-          "nested_enums.h:2:14"}},
+          "nested_enums.h:2:14"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -75,7 +77,9 @@
                 valueSourceLoc =
                 "nested_enums.h:4:17"}],
             enumSourceLoc =
-            "nested_enums.h:2:14"}}
+            "nested_enums.h:2:14"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -119,7 +123,9 @@
                         valueSourceLoc =
                         "nested_enums.h:4:17"}],
                     enumSourceLoc =
-                    "nested_enums.h:2:14"}})
+                    "nested_enums.h:2:14"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -163,7 +169,9 @@
                         valueSourceLoc =
                         "nested_enums.h:4:17"}],
                     enumSourceLoc =
-                    "nested_enums.h:2:14"}}
+                    "nested_enums.h:2:14"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -227,7 +235,9 @@
                 valueSourceLoc =
                 "nested_enums.h:4:17"}],
             enumSourceLoc =
-            "nested_enums.h:2:14"}}
+            "nested_enums.h:2:14"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -272,7 +282,9 @@
                 valueSourceLoc =
                 "nested_enums.h:4:17"}],
             enumSourceLoc =
-            "nested_enums.h:2:14"}}
+            "nested_enums.h:2:14"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "VALA_1")
       (HsName "@NsConstr" "VALA_2")),
   DeclInstance
@@ -313,7 +325,9 @@
                 valueSourceLoc =
                 "nested_enums.h:4:17"}],
             enumSourceLoc =
-            "nested_enums.h:2:14"}}),
+            "nested_enums.h:2:14"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -398,7 +412,9 @@
               "nested_enums.h:5:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_enums.h:1:8"}},
+          "nested_enums.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -446,7 +462,9 @@
                 "nested_enums.h:5:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_enums.h:1:8"}}
+            "nested_enums.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -499,7 +517,9 @@
                         "nested_enums.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_enums.h:1:8"}})
+                    "nested_enums.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -552,7 +572,9 @@
                         "nested_enums.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_enums.h:1:8"}}
+                    "nested_enums.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -608,7 +630,9 @@
               valueSourceLoc =
               "nested_enums.h:11:17"}],
           enumSourceLoc =
-          "nested_enums.h:9:9"}},
+          "nested_enums.h:9:9"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -650,7 +674,9 @@
                 valueSourceLoc =
                 "nested_enums.h:11:17"}],
             enumSourceLoc =
-            "nested_enums.h:9:9"}}
+            "nested_enums.h:9:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -697,7 +723,9 @@
                         valueSourceLoc =
                         "nested_enums.h:11:17"}],
                     enumSourceLoc =
-                    "nested_enums.h:9:9"}})
+                    "nested_enums.h:9:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -744,7 +772,9 @@
                         valueSourceLoc =
                         "nested_enums.h:11:17"}],
                     enumSourceLoc =
-                    "nested_enums.h:9:9"}}
+                    "nested_enums.h:9:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -811,7 +841,9 @@
                 valueSourceLoc =
                 "nested_enums.h:11:17"}],
             enumSourceLoc =
-            "nested_enums.h:9:9"}}
+            "nested_enums.h:9:9"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -859,7 +891,9 @@
                 valueSourceLoc =
                 "nested_enums.h:11:17"}],
             enumSourceLoc =
-            "nested_enums.h:9:9"}}
+            "nested_enums.h:9:9"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "VALB_1")
       (HsName "@NsConstr" "VALB_2")),
   DeclInstance
@@ -903,7 +937,9 @@
                 valueSourceLoc =
                 "nested_enums.h:11:17"}],
             enumSourceLoc =
-            "nested_enums.h:9:9"}}),
+            "nested_enums.h:9:9"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -996,7 +1032,9 @@
               "nested_enums.h:12:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_enums.h:8:8"}},
+          "nested_enums.h:8:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1052,7 +1090,9 @@
                 "nested_enums.h:12:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_enums.h:8:8"}}
+            "nested_enums.h:8:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -1113,7 +1153,9 @@
                         "nested_enums.h:12:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_enums.h:8:8"}})
+                    "nested_enums.h:8:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1174,7 +1216,9 @@
                         "nested_enums.h:12:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_enums.h:8:8"}}
+                    "nested_enums.h:8:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_types.extbindings.yaml
@@ -3,19 +3,39 @@ types:
   cname: struct bar
   module: Example
   identifier: Bar
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: nested_types.h
   cname: struct ex3
   module: Example
   identifier: Ex3
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: nested_types.h
   cname: struct ex4_even
   module: Example
   identifier: Ex4_even
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: nested_types.h
   cname: struct ex4_odd
   module: Example
   identifier: Ex4_odd
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: nested_types.h
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -73,7 +73,7 @@
           structSourceLoc =
           "nested_types.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -149,7 +149,7 @@
             structSourceLoc =
             "nested_types.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -230,7 +230,7 @@
                     structSourceLoc =
                     "nested_types.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -313,7 +313,7 @@
                     structSourceLoc =
                     "nested_types.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -400,7 +400,7 @@
           structSourceLoc =
           "nested_types.h:6:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -472,7 +472,7 @@
             structSourceLoc =
             "nested_types.h:6:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -549,7 +549,7 @@
                     structSourceLoc =
                     "nested_types.h:6:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -628,7 +628,7 @@
                     structSourceLoc =
                     "nested_types.h:6:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -691,7 +691,7 @@
           structSourceLoc =
           "nested_types.h:11:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -739,7 +739,7 @@
             structSourceLoc =
             "nested_types.h:11:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -792,7 +792,7 @@
                     structSourceLoc =
                     "nested_types.h:11:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 8]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -845,7 +845,7 @@
                     structSourceLoc =
                     "nested_types.h:11:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -938,7 +938,7 @@
           structSourceLoc =
           "nested_types.h:22:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1017,7 +1017,7 @@
             structSourceLoc =
             "nested_types.h:22:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1101,7 +1101,7 @@
                     structSourceLoc =
                     "nested_types.h:22:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1187,7 +1187,7 @@
                     structSourceLoc =
                     "nested_types.h:22:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1285,7 +1285,7 @@
           structSourceLoc =
           "nested_types.h:24:12"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1364,7 +1364,7 @@
             structSourceLoc =
             "nested_types.h:24:12"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1448,7 +1448,7 @@
                     structSourceLoc =
                     "nested_types.h:24:12"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1534,7 +1534,7 @@
                     structSourceLoc =
                     "nested_types.h:24:12"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -71,7 +71,9 @@
               "nested_types.h:3:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_types.h:1:8"}},
+          "nested_types.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -145,7 +147,9 @@
                 "nested_types.h:3:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_types.h:1:8"}}
+            "nested_types.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -224,7 +228,9 @@
                         "nested_types.h:3:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:1:8"}})
+                    "nested_types.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -305,7 +311,9 @@
                         "nested_types.h:3:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:1:8"}}
+                    "nested_types.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -390,7 +398,9 @@
               "nested_types.h:8:16"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_types.h:6:8"}},
+          "nested_types.h:6:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -460,7 +470,9 @@
                 "nested_types.h:8:16"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_types.h:6:8"}}
+            "nested_types.h:6:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -535,7 +547,9 @@
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:6:8"}})
+                    "nested_types.h:6:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -612,7 +626,9 @@
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:6:8"}}
+                    "nested_types.h:6:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -673,7 +689,9 @@
               "nested_types.h:16:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_types.h:11:8"}},
+          "nested_types.h:11:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -719,7 +737,9 @@
                 "nested_types.h:16:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_types.h:11:8"}}
+            "nested_types.h:11:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -770,7 +790,9 @@
                         "nested_types.h:16:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:11:8"}})
+                    "nested_types.h:11:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 8]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -821,7 +843,9 @@
                         "nested_types.h:16:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:11:8"}}
+                    "nested_types.h:11:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -912,7 +936,9 @@
               "nested_types.h:27:8"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_types.h:22:8"}},
+          "nested_types.h:22:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -989,7 +1015,9 @@
                 "nested_types.h:27:8"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_types.h:22:8"}}
+            "nested_types.h:22:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1071,7 +1099,9 @@
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:22:8"}})
+                    "nested_types.h:22:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1155,7 +1185,9 @@
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:22:8"}}
+                    "nested_types.h:22:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1251,7 +1283,9 @@
               "nested_types.h:26:25"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_types.h:24:12"}},
+          "nested_types.h:24:12"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1328,7 +1362,9 @@
                 "nested_types.h:26:25"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_types.h:24:12"}}
+            "nested_types.h:24:12"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1410,7 +1446,9 @@
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:24:12"}})
+                    "nested_types.h:24:12"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1494,7 +1532,9 @@
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_types.h:24:12"}}
+                    "nested_types.h:24:12"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_unions.extbindings.yaml
@@ -3,11 +3,17 @@ types:
   cname: struct exA
   module: Example
   identifier: ExA
+  instances:
+  - Storable
 - headers: nested_unions.h
   cname: struct exB
   module: Example
   identifier: ExB
+  instances:
+  - Storable
 - headers: nested_unions.h
   cname: union unionA
   module: Example
   identifier: UnionA
+  instances:
+  - Storable

--- a/hs-bindgen/fixtures/nested_unions.hs
+++ b/hs-bindgen/fixtures/nested_unions.hs
@@ -39,7 +39,7 @@
           unionSourceLoc =
           "nested_unions.h:2:15"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 4 4))
@@ -127,7 +127,7 @@
           structSourceLoc =
           "nested_unions.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -177,7 +177,7 @@
             structSourceLoc =
             "nested_unions.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -232,7 +232,7 @@
                     structSourceLoc =
                     "nested_unions.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -287,7 +287,7 @@
                     structSourceLoc =
                     "nested_unions.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Storable]}
               (Add 1)
               (Seq
                 [
@@ -295,14 +295,6 @@
                     (Idx 2)
                     0
                     (Idx 0)])))}),
-  DeclNewtypeInstance
-    DeriveStock
-    Show
-    (HsName "@NsTypeConstr" "ExA"),
-  DeclNewtypeInstance
-    DeriveStock
-    Eq
-    (HsName "@NsTypeConstr" "ExA"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -346,7 +338,7 @@
           unionSourceLoc =
           "nested_unions.h:9:9"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 4 4))
@@ -442,7 +434,7 @@
           structSourceLoc =
           "nested_unions.h:8:8"},
       structInstances = Set.fromList
-        []},
+        [Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -500,7 +492,7 @@
             structSourceLoc =
             "nested_unions.h:8:8"},
         structInstances = Set.fromList
-          []}
+          [Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -563,7 +555,7 @@
                     structSourceLoc =
                     "nested_unions.h:8:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -626,19 +618,11 @@
                     structSourceLoc =
                     "nested_unions.h:8:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Storable]}
               (Add 1)
               (Seq
                 [
                   PokeByteOff
                     (Idx 2)
                     0
-                    (Idx 0)])))}),
-  DeclNewtypeInstance
-    DeriveStock
-    Show
-    (HsName "@NsTypeConstr" "ExB"),
-  DeclNewtypeInstance
-    DeriveStock
-    Eq
-    (HsName "@NsTypeConstr" "ExB")]
+                    (Idx 0)])))})]

--- a/hs-bindgen/fixtures/nested_unions.hs
+++ b/hs-bindgen/fixtures/nested_unions.hs
@@ -37,7 +37,9 @@
               ufieldSourceLoc =
               "nested_unions.h:4:22"}],
           unionSourceLoc =
-          "nested_unions.h:2:15"}},
+          "nested_unions.h:2:15"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 4 4))
@@ -123,7 +125,9 @@
               "nested_unions.h:5:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_unions.h:1:8"}},
+          "nested_unions.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -171,7 +175,9 @@
                 "nested_unions.h:5:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_unions.h:1:8"}}
+            "nested_unions.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -224,7 +230,9 @@
                         "nested_unions.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_unions.h:1:8"}})
+                    "nested_unions.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -277,7 +285,9 @@
                         "nested_unions.h:5:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_unions.h:1:8"}}
+                    "nested_unions.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -334,7 +344,9 @@
               ufieldSourceLoc =
               "nested_unions.h:11:22"}],
           unionSourceLoc =
-          "nested_unions.h:9:9"}},
+          "nested_unions.h:9:9"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 4 4))
@@ -428,7 +440,9 @@
               "nested_unions.h:12:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "nested_unions.h:8:8"}},
+          "nested_unions.h:8:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -484,7 +498,9 @@
                 "nested_unions.h:12:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "nested_unions.h:8:8"}}
+            "nested_unions.h:8:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -545,7 +561,9 @@
                         "nested_unions.h:12:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_unions.h:8:8"}})
+                    "nested_unions.h:8:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -606,7 +624,9 @@
                         "nested_unions.h:12:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "nested_unions.h:8:8"}}
+                    "nested_unions.h:8:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/nested_unions.pp.hs
+++ b/hs-bindgen/fixtures/nested_unions.pp.hs
@@ -12,7 +12,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.SizedByteArray
-import Prelude ((<*>), Eq, Int, Show, pure)
+import Prelude ((<*>), Int, pure)
 
 newtype UnionA = UnionA
   { un_UnionA :: Data.Array.Byte.ByteArray
@@ -53,10 +53,6 @@ instance F.Storable ExA where
         case s1 of
           ExA exA_fieldA12 -> F.pokeByteOff ptr0 (0 :: Int) exA_fieldA12
 
-deriving stock instance Show ExA
-
-deriving stock instance Eq ExA
-
 newtype ExB_fieldB1 = ExB_fieldB1
   { un_ExB_fieldB1 :: Data.Array.Byte.ByteArray
   }
@@ -95,7 +91,3 @@ instance F.Storable ExB where
       \s1 ->
         case s1 of
           ExB exB_fieldB12 -> F.pokeByteOff ptr0 (0 :: Int) exB_fieldB12
-
-deriving stock instance Show ExB
-
-deriving stock instance Eq ExB

--- a/hs-bindgen/fixtures/nested_unions.th.txt
+++ b/hs-bindgen/fixtures/nested_unions.th.txt
@@ -16,8 +16,6 @@ instance Storable ExA
            peek = \ptr_0 -> pure ExA <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {ExA exA_fieldA1_3 -> pokeByteOff ptr_1 (0 :: Int) exA_fieldA1_3}}
-deriving stock instance Show ExA
-deriving stock instance Eq ExA
 newtype ExB_fieldB1 = ExB_fieldB1 {un_ExB_fieldB1 :: ByteArray}
 deriving via (SizedByteArray 4 4) instance Storable ExB_fieldB1
 get_exB_fieldB1_a :: ExB_fieldB1 -> CInt
@@ -35,5 +33,3 @@ instance Storable ExB
            peek = \ptr_0 -> pure ExB <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {ExB exB_fieldB1_3 -> pokeByteOff ptr_1 (0 :: Int) exB_fieldB1_3}}
-deriving stock instance Show ExB
-deriving stock instance Eq ExB

--- a/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
+++ b/hs-bindgen/fixtures/opaque_declaration.extbindings.yaml
@@ -7,10 +7,18 @@ types:
   cname: struct bar
   module: Example
   identifier: Bar
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: opaque_declaration.h
   cname: struct baz
   module: Example
   identifier: Baz
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: opaque_declaration.h
   cname: struct foo
   module: Example

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -87,7 +87,7 @@
           structSourceLoc =
           "opaque_declaration.h:4:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -165,7 +165,7 @@
             structSourceLoc =
             "opaque_declaration.h:4:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -248,7 +248,7 @@
                     structSourceLoc =
                     "opaque_declaration.h:4:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -333,7 +333,7 @@
                     structSourceLoc =
                     "opaque_declaration.h:4:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -372,7 +372,7 @@
           structSourceLoc =
           "opaque_declaration.h:9:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -396,7 +396,7 @@
             structSourceLoc =
             "opaque_declaration.h:9:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 0,
         storableAlignment = 1,
@@ -425,7 +425,7 @@
                     structSourceLoc =
                     "opaque_declaration.h:9:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             []),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -454,7 +454,7 @@
                     structSourceLoc =
                     "opaque_declaration.h:9:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 0)
               (Seq [])))}),
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -85,7 +85,9 @@
               "opaque_declaration.h:6:17"}],
           structFlam = Nothing,
           structSourceLoc =
-          "opaque_declaration.h:4:8"}},
+          "opaque_declaration.h:4:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -161,7 +163,9 @@
                 "opaque_declaration.h:6:17"}],
             structFlam = Nothing,
             structSourceLoc =
-            "opaque_declaration.h:4:8"}}
+            "opaque_declaration.h:4:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -242,7 +246,9 @@
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "opaque_declaration.h:4:8"}})
+                    "opaque_declaration.h:4:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -325,7 +331,9 @@
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "opaque_declaration.h:4:8"}}
+                    "opaque_declaration.h:4:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -362,7 +370,9 @@
           structFields = [],
           structFlam = Nothing,
           structSourceLoc =
-          "opaque_declaration.h:9:8"}},
+          "opaque_declaration.h:9:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -384,7 +394,9 @@
             structFields = [],
             structFlam = Nothing,
             structSourceLoc =
-            "opaque_declaration.h:9:8"}}
+            "opaque_declaration.h:9:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 0,
         storableAlignment = 1,
@@ -411,7 +423,9 @@
                     structFields = [],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "opaque_declaration.h:9:8"}})
+                    "opaque_declaration.h:9:8"},
+                structInstances = Set.fromList
+                  []})
             []),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -438,7 +452,9 @@
                     structFields = [],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "opaque_declaration.h:9:8"}}
+                    "opaque_declaration.h:9:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 0)
               (Seq [])))}),
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/primitive_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/primitive_types.extbindings.yaml
@@ -3,3 +3,7 @@ types:
   cname: struct primitive
   module: Example
   identifier: Primitive
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -741,7 +741,7 @@
           structSourceLoc =
           "primitive_types.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1485,7 +1485,7 @@
             structSourceLoc =
             "primitive_types.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 152,
         storableAlignment = 8,
@@ -2234,7 +2234,7 @@
                     structSourceLoc =
                     "primitive_types.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -3011,7 +3011,7 @@
                     structSourceLoc =
                     "primitive_types.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 28)
               (Seq
                 [

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -739,7 +739,9 @@
               "primitive_types.h:38:12"}],
           structFlam = Nothing,
           structSourceLoc =
-          "primitive_types.h:1:8"}},
+          "primitive_types.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1481,7 +1483,9 @@
                 "primitive_types.h:38:12"}],
             structFlam = Nothing,
             structSourceLoc =
-            "primitive_types.h:1:8"}}
+            "primitive_types.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 152,
         storableAlignment = 8,
@@ -2228,7 +2232,9 @@
                         "primitive_types.h:38:12"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "primitive_types.h:1:8"}})
+                    "primitive_types.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 1,
@@ -3003,7 +3009,9 @@
                         "primitive_types.h:38:12"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "primitive_types.h:1:8"}}
+                    "primitive_types.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 28)
               (Seq
                 [

--- a/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
+++ b/hs-bindgen/fixtures/recursive_struct.extbindings.yaml
@@ -3,15 +3,31 @@ types:
   cname: linked_list_A_t
   module: Example
   identifier: Linked_list_A_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: recursive_struct.h
   cname: linked_list_B_t
   module: Example
   identifier: Linked_list_B_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: recursive_struct.h
   cname: struct linked_list_A_s
   module: Example
   identifier: Linked_list_A_s
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: recursive_struct.h
   cname: struct linked_list_B_t
   module: Example
   identifier: Linked_list_B_t
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -74,7 +74,9 @@
               "recursive_struct.h:3:27"}],
           structFlam = Nothing,
           structSourceLoc =
-          "recursive_struct.h:1:16"}},
+          "recursive_struct.h:1:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -151,7 +153,9 @@
                 "recursive_struct.h:3:27"}],
             structFlam = Nothing,
             structSourceLoc =
-            "recursive_struct.h:1:16"}}
+            "recursive_struct.h:1:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -233,7 +237,9 @@
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "recursive_struct.h:1:16"}})
+                    "recursive_struct.h:1:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -317,7 +323,9 @@
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "recursive_struct.h:1:16"}}
+                    "recursive_struct.h:1:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -364,7 +372,9 @@
             (DeclPathName
               (CName "linked_list_A_s")),
           typedefSourceLoc =
-          "recursive_struct.h:4:3"}},
+          "recursive_struct.h:4:3"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -447,7 +457,9 @@
               "recursive_struct.h:11:20"}],
           structFlam = Nothing,
           structSourceLoc =
-          "recursive_struct.h:9:8"}},
+          "recursive_struct.h:9:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -525,7 +537,9 @@
                 "recursive_struct.h:11:20"}],
             structFlam = Nothing,
             structSourceLoc =
-            "recursive_struct.h:9:8"}}
+            "recursive_struct.h:9:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -608,7 +622,9 @@
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "recursive_struct.h:9:8"}})
+                    "recursive_struct.h:9:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -693,7 +709,9 @@
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "recursive_struct.h:9:8"}}
+                    "recursive_struct.h:9:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -76,7 +76,7 @@
           structSourceLoc =
           "recursive_struct.h:1:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -155,7 +155,7 @@
             structSourceLoc =
             "recursive_struct.h:1:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -239,7 +239,7 @@
                     structSourceLoc =
                     "recursive_struct.h:1:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -325,7 +325,7 @@
                     structSourceLoc =
                     "recursive_struct.h:1:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -374,10 +374,22 @@
           typedefSourceLoc =
           "recursive_struct.h:4:3"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Linked_list_A_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Linked_list_A_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Linked_list_A_t"),
@@ -459,7 +471,7 @@
           structSourceLoc =
           "recursive_struct.h:9:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -539,7 +551,7 @@
             structSourceLoc =
             "recursive_struct.h:9:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -624,7 +636,7 @@
                     structSourceLoc =
                     "recursive_struct.h:9:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -711,7 +723,7 @@
                     structSourceLoc =
                     "recursive_struct.h:9:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [

--- a/hs-bindgen/fixtures/recursive_struct.pp.hs
+++ b/hs-bindgen/fixtures/recursive_struct.pp.hs
@@ -45,6 +45,10 @@ newtype Linked_list_A_t = Linked_list_A_t
 
 deriving newtype instance F.Storable Linked_list_A_t
 
+deriving stock instance Eq Linked_list_A_t
+
+deriving stock instance Show Linked_list_A_t
+
 data Linked_list_B_t = Linked_list_B_t
   { linked_list_B_t_x :: FC.CInt
   , linked_list_B_t_next :: F.Ptr Linked_list_B_t

--- a/hs-bindgen/fixtures/recursive_struct.th.txt
+++ b/hs-bindgen/fixtures/recursive_struct.th.txt
@@ -14,6 +14,8 @@ deriving stock instance Eq Linked_list_A_s
 newtype Linked_list_A_t
     = Linked_list_A_t {un_Linked_list_A_t :: Linked_list_A_s}
 deriving newtype instance Storable Linked_list_A_t
+deriving stock instance Eq Linked_list_A_t
+deriving stock instance Show Linked_list_A_t
 data Linked_list_B_t
     = Linked_list_B_t {linked_list_B_t_x :: CInt,
                        linked_list_B_t_next :: (Ptr Linked_list_B_t)}

--- a/hs-bindgen/fixtures/simple_structs.extbindings.yaml
+++ b/hs-bindgen/fixtures/simple_structs.extbindings.yaml
@@ -3,43 +3,89 @@ types:
   cname: S2_t
   module: Example
   identifier: S2_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: S3_t
   module: Example
   identifier: S3_t
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: S5
   module: Example
   identifier: S5
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: S6
   module: Example
   identifier: S6
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: S7a
   module: Example
   identifier: S7a
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: S7b
   module: Example
   identifier: S7b
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: struct S1
   module: Example
   identifier: S1
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: struct S2
   module: Example
   identifier: S2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: struct S4
   module: Example
   identifier: S4
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: struct S5
   module: Example
   identifier: S5
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: simple_structs.h
   cname: struct S6
   module: Example
   identifier: S6
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -73,7 +73,7 @@
           structSourceLoc =
           "simple_structs.h:2:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -149,7 +149,7 @@
             structSourceLoc =
             "simple_structs.h:2:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -230,7 +230,7 @@
                     structSourceLoc =
                     "simple_structs.h:2:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -313,7 +313,7 @@
                     structSourceLoc =
                     "simple_structs.h:2:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -428,7 +428,7 @@
           structSourceLoc =
           "simple_structs.h:8:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -528,7 +528,7 @@
             structSourceLoc =
             "simple_structs.h:8:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -633,7 +633,7 @@
                     structSourceLoc =
                     "simple_structs.h:8:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -741,7 +741,7 @@
                     structSourceLoc =
                     "simple_structs.h:8:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -783,10 +783,18 @@
           typedefSourceLoc =
           "simple_structs.h:12:3"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "S2_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "S2_t"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "S2_t"),
   DeclData
     Struct {
@@ -839,7 +847,7 @@
           structSourceLoc =
           "simple_structs.h:15:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -892,7 +900,7 @@
             structSourceLoc =
             "simple_structs.h:15:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -950,7 +958,7 @@
                     structSourceLoc =
                     "simple_structs.h:15:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1008,7 +1016,7 @@
                     structSourceLoc =
                     "simple_structs.h:15:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -1124,7 +1132,7 @@
           structSourceLoc =
           "simple_structs.h:19:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1226,7 +1234,7 @@
             structSourceLoc =
             "simple_structs.h:19:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1333,7 +1341,7 @@
                     structSourceLoc =
                     "simple_structs.h:19:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -1443,7 +1451,7 @@
                     structSourceLoc =
                     "simple_structs.h:19:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -1535,7 +1543,7 @@
           structSourceLoc =
           "simple_structs.h:26:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1611,7 +1619,7 @@
             structSourceLoc =
             "simple_structs.h:26:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1692,7 +1700,7 @@
                     structSourceLoc =
                     "simple_structs.h:26:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1775,7 +1783,7 @@
                     structSourceLoc =
                     "simple_structs.h:26:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1866,7 +1874,7 @@
           structSourceLoc =
           "simple_structs.h:31:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1942,7 +1950,7 @@
             structSourceLoc =
             "simple_structs.h:31:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2023,7 +2031,7 @@
                     structSourceLoc =
                     "simple_structs.h:31:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2106,7 +2114,7 @@
                     structSourceLoc =
                     "simple_structs.h:31:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2199,7 +2207,7 @@
           structSourceLoc =
           "simple_structs.h:34:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2277,7 +2285,7 @@
             structSourceLoc =
             "simple_structs.h:34:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2360,7 +2368,7 @@
                     structSourceLoc =
                     "simple_structs.h:34:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2445,7 +2453,7 @@
                     structSourceLoc =
                     "simple_structs.h:34:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2497,10 +2505,22 @@
           typedefSourceLoc =
           "simple_structs.h:34:36"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "S7a"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "S7a"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "S7a"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "S7a"),
   DeclData
     Struct {
@@ -2580,7 +2600,7 @@
           structSourceLoc =
           "simple_structs.h:35:9"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2660,7 +2680,7 @@
             structSourceLoc =
             "simple_structs.h:35:9"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2745,7 +2765,7 @@
                     structSourceLoc =
                     "simple_structs.h:35:9"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2832,7 +2852,7 @@
                     structSourceLoc =
                     "simple_structs.h:35:9"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2890,8 +2910,20 @@
           typedefSourceLoc =
           "simple_structs.h:35:38"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "S7b"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "S7b"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "S7b"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "S7b")]

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -71,7 +71,9 @@
               "simple_structs.h:4:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:2:8"}},
+          "simple_structs.h:2:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -145,7 +147,9 @@
                 "simple_structs.h:4:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:2:8"}}
+            "simple_structs.h:2:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -224,7 +228,9 @@
                         "simple_structs.h:4:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:2:8"}})
+                    "simple_structs.h:2:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -305,7 +311,9 @@
                         "simple_structs.h:4:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:2:8"}}
+                    "simple_structs.h:2:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -418,7 +426,9 @@
               "simple_structs.h:11:11"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:8:16"}},
+          "simple_structs.h:8:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -516,7 +526,9 @@
                 "simple_structs.h:11:11"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:8:16"}}
+            "simple_structs.h:8:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -619,7 +631,9 @@
                         "simple_structs.h:11:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:8:16"}})
+                    "simple_structs.h:8:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -725,7 +739,9 @@
                         "simple_structs.h:11:11"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:8:16"}}
+                    "simple_structs.h:8:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -765,7 +781,9 @@
           typedefType = TypeStruct
             (DeclPathName (CName "S2")),
           typedefSourceLoc =
-          "simple_structs.h:12:3"}},
+          "simple_structs.h:12:3"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -819,7 +837,9 @@
               "simple_structs.h:16:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:15:9"}},
+          "simple_structs.h:15:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -870,7 +890,9 @@
                 "simple_structs.h:16:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:15:9"}}
+            "simple_structs.h:15:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 1,
         storableAlignment = 1,
@@ -926,7 +948,9 @@
                         "simple_structs.h:16:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:15:9"}})
+                    "simple_structs.h:15:9"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -982,7 +1006,9 @@
                         "simple_structs.h:16:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:15:9"}}
+                    "simple_structs.h:15:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -1096,7 +1122,9 @@
               "simple_structs.h:22:10"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:19:8"}},
+          "simple_structs.h:19:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1196,7 +1224,9 @@
                 "simple_structs.h:22:10"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:19:8"}}
+            "simple_structs.h:19:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1301,7 +1331,9 @@
                         "simple_structs.h:22:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:19:8"}})
+                    "simple_structs.h:19:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -1409,7 +1441,9 @@
                         "simple_structs.h:22:10"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:19:8"}}
+                    "simple_structs.h:19:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -1499,7 +1533,9 @@
               "simple_structs.h:28:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:26:16"}},
+          "simple_structs.h:26:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1573,7 +1609,9 @@
                 "simple_structs.h:28:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:26:16"}}
+            "simple_structs.h:26:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1652,7 +1690,9 @@
                         "simple_structs.h:28:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:26:16"}})
+                    "simple_structs.h:26:16"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1733,7 +1773,9 @@
                         "simple_structs.h:28:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:26:16"}}
+                    "simple_structs.h:26:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1822,7 +1864,9 @@
               "simple_structs.h:31:25"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:31:8"}},
+          "simple_structs.h:31:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1896,7 +1940,9 @@
                 "simple_structs.h:31:25"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:31:8"}}
+            "simple_structs.h:31:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -1975,7 +2021,9 @@
                         "simple_structs.h:31:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:31:8"}})
+                    "simple_structs.h:31:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2056,7 +2104,9 @@
                         "simple_structs.h:31:25"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:31:8"}}
+                    "simple_structs.h:31:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2147,7 +2197,9 @@
               "simple_structs.h:34:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:34:9"}},
+          "simple_structs.h:34:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2223,7 +2275,9 @@
                 "simple_structs.h:34:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:34:9"}}
+            "simple_structs.h:34:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2304,7 +2358,9 @@
                         "simple_structs.h:34:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:34:9"}})
+                    "simple_structs.h:34:9"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2387,7 +2443,9 @@
                         "simple_structs.h:34:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:34:9"}}
+                    "simple_structs.h:34:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2437,7 +2495,9 @@
                   (DeclPathCtxtTypedef
                     (CName "S7a"))))),
           typedefSourceLoc =
-          "simple_structs.h:34:36"}},
+          "simple_structs.h:34:36"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -2518,7 +2578,9 @@
               "simple_structs.h:35:30"}],
           structFlam = Nothing,
           structSourceLoc =
-          "simple_structs.h:35:9"}},
+          "simple_structs.h:35:9"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2596,7 +2658,9 @@
                 "simple_structs.h:35:30"}],
             structFlam = Nothing,
             structSourceLoc =
-            "simple_structs.h:35:9"}}
+            "simple_structs.h:35:9"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -2679,7 +2743,9 @@
                         "simple_structs.h:35:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:35:9"}})
+                    "simple_structs.h:35:9"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -2764,7 +2830,9 @@
                         "simple_structs.h:35:30"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "simple_structs.h:35:9"}}
+                    "simple_structs.h:35:9"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2820,7 +2888,9 @@
                           (DeclPathCtxtTypedef
                             (CName "S7b"))))))))),
           typedefSourceLoc =
-          "simple_structs.h:35:38"}},
+          "simple_structs.h:35:38"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/simple_structs.pp.hs
+++ b/hs-bindgen/fixtures/simple_structs.pp.hs
@@ -8,7 +8,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
-import Prelude ((<*>), (>>), Eq, Int, Show, pure)
+import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 data S1 = S1
   { s1_a :: FC.CInt
@@ -76,6 +76,10 @@ newtype S2_t = S2_t
   }
 
 deriving newtype instance F.Storable S2_t
+
+deriving stock instance Eq S2_t
+
+deriving stock instance Show S2_t
 
 data S3_t = S3_t
   { s3_t_a :: FC.CChar
@@ -227,6 +231,12 @@ newtype S7a = S7a
 
 deriving newtype instance F.Storable S7a
 
+deriving stock instance Eq S7a
+
+deriving stock instance Ord S7a
+
+deriving stock instance Show S7a
+
 data S7b_Deref = S7b_Deref
   { s7b_Deref_a :: FC.CChar
   , s7b_Deref_b :: FC.CInt
@@ -261,3 +271,9 @@ newtype S7b = S7b
   }
 
 deriving newtype instance F.Storable S7b
+
+deriving stock instance Eq S7b
+
+deriving stock instance Ord S7b
+
+deriving stock instance Show S7b

--- a/hs-bindgen/fixtures/simple_structs.th.txt
+++ b/hs-bindgen/fixtures/simple_structs.th.txt
@@ -22,6 +22,8 @@ deriving stock instance Show S2
 deriving stock instance Eq S2
 newtype S2_t = S2_t {un_S2_t :: S2}
 deriving newtype instance Storable S2_t
+deriving stock instance Eq S2_t
+deriving stock instance Show S2_t
 data S3_t = S3_t {s3_t_a :: CChar}
 instance Storable S3_t
     where {sizeOf = \_ -> 1 :: Int;
@@ -75,6 +77,9 @@ deriving stock instance Show S7a_Deref
 deriving stock instance Eq S7a_Deref
 newtype S7a = S7a {un_S7a :: (Ptr S7a_Deref)}
 deriving newtype instance Storable S7a
+deriving stock instance Eq S7a
+deriving stock instance Ord S7a
+deriving stock instance Show S7a
 data S7b_Deref
     = S7b_Deref {s7b_Deref_a :: CChar, s7b_Deref_b :: CInt}
 instance Storable S7b_Deref
@@ -88,3 +93,6 @@ deriving stock instance Show S7b_Deref
 deriving stock instance Eq S7b_Deref
 newtype S7b = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Deref)))}
 deriving newtype instance Storable S7b
+deriving stock instance Eq S7b
+deriving stock instance Ord S7b
+deriving stock instance Show S7b

--- a/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedef_vs_macro.extbindings.yaml
@@ -3,35 +3,122 @@ types:
   cname: M1
   module: Example
   identifier: M1
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: typedef_vs_macro.h
   cname: M2
   module: Example
   identifier: M2
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: typedef_vs_macro.h
   cname: M3
   module: Example
   identifier: M3
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: typedef_vs_macro.h
   cname: M4
   module: Example
   identifier: M4
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: typedef_vs_macro.h
   cname: T1
   module: Example
   identifier: T1
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: typedef_vs_macro.h
   cname: T2
   module: Example
   identifier: T2
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable
 - headers: typedef_vs_macro.h
   cname: struct ExampleStruct
   module: Example
   identifier: ExampleStruct
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: typedef_vs_macro.h
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: typedef_vs_macro.h
   cname: uint64_t
   module: Example
   identifier: Uint64_t
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -21,7 +21,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "typedef_vs_macro.h:1:13"}},
+          "typedef_vs_macro.h:1:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -98,7 +100,9 @@
               (PrimSignImplicit
                 (Just Signed))),
           typedefSourceLoc =
-          "typedef_vs_macro.h:2:14"}},
+          "typedef_vs_macro.h:2:14"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -188,7 +192,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -279,7 +285,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -385,7 +393,9 @@
                               integerLiteralType = Just
                                 (_×_ PrimInt Signed),
                               integerLiteralValue = 3}))),
-                    arrayAttributes = []}})}},
+                    arrayAttributes = []}})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -428,7 +438,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -549,7 +561,9 @@
               "typedef_vs_macro.h:13:6"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:9:8"}},
+          "typedef_vs_macro.h:9:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -667,7 +681,9 @@
                 "typedef_vs_macro.h:13:6"}],
             structFlam = Nothing,
             structSourceLoc =
-            "typedef_vs_macro.h:9:8"}}
+            "typedef_vs_macro.h:9:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -790,7 +806,9 @@
                         "typedef_vs_macro.h:13:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:9:8"}})
+                    "typedef_vs_macro.h:9:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -917,7 +935,9 @@
                         "typedef_vs_macro.h:13:6"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:9:8"}}
+                    "typedef_vs_macro.h:9:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 4)
               (Seq
                 [
@@ -977,7 +997,9 @@
                 directDeclarator =
                 IdentifierDeclarator
                   AbstractName
-                  []})}},
+                  []})},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1105,7 +1127,9 @@
               "typedef_vs_macro.h:19:13"}],
           structFlam = Nothing,
           structSourceLoc =
-          "typedef_vs_macro.h:18:8"}},
+          "typedef_vs_macro.h:18:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1156,7 +1180,9 @@
                 "typedef_vs_macro.h:19:13"}],
             structFlam = Nothing,
             structSourceLoc =
-            "typedef_vs_macro.h:18:8"}}
+            "typedef_vs_macro.h:18:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 8,
@@ -1212,7 +1238,9 @@
                         "typedef_vs_macro.h:19:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:18:8"}})
+                    "typedef_vs_macro.h:18:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1268,7 +1296,9 @@
                         "typedef_vs_macro.h:19:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "typedef_vs_macro.h:18:8"}}
+                    "typedef_vs_macro.h:18:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -23,7 +23,20 @@
           typedefSourceLoc =
           "typedef_vs_macro.h:1:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -102,7 +115,20 @@
           typedefSourceLoc =
           "typedef_vs_macro.h:2:14"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -194,7 +220,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -287,7 +326,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -395,10 +447,18 @@
                               integerLiteralValue = 3}))),
                     arrayAttributes = []}})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "M3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "M3"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "M3"),
   DeclNewtype
     Newtype {
@@ -440,10 +500,22 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName "@NsTypeConstr" "M4"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName "@NsTypeConstr" "M4"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName "@NsTypeConstr" "M4"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName "@NsTypeConstr" "M4"),
   DeclData
     Struct {
@@ -563,7 +635,7 @@
           structSourceLoc =
           "typedef_vs_macro.h:9:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -683,7 +755,7 @@
             structSourceLoc =
             "typedef_vs_macro.h:9:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 4,
@@ -808,7 +880,7 @@
                     structSourceLoc =
                     "typedef_vs_macro.h:9:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -937,7 +1009,7 @@
                     structSourceLoc =
                     "typedef_vs_macro.h:9:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 4)
               (Seq
                 [
@@ -999,7 +1071,20 @@
                   AbstractName
                   []})},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -1129,7 +1214,7 @@
           structSourceLoc =
           "typedef_vs_macro.h:18:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1182,7 +1267,7 @@
             structSourceLoc =
             "typedef_vs_macro.h:18:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 8,
@@ -1240,7 +1325,7 @@
                     structSourceLoc =
                     "typedef_vs_macro.h:18:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -1298,7 +1383,7 @@
                     structSourceLoc =
                     "typedef_vs_macro.h:18:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
@@ -140,11 +140,21 @@ newtype M3 = M3
 
 deriving newtype instance F.Storable M3
 
+deriving stock instance Eq M3
+
+deriving stock instance Show M3
+
 newtype M4 = M4
   { un_M4 :: F.Ptr FC.CInt
   }
 
 deriving newtype instance F.Storable M4
+
+deriving stock instance Eq M4
+
+deriving stock instance Ord M4
+
+deriving stock instance Show M4
 
 data ExampleStruct = ExampleStruct
   { exampleStruct_t1 :: T1

--- a/hs-bindgen/fixtures/typedef_vs_macro.th.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.th.txt
@@ -57,8 +57,13 @@ deriving newtype instance Num M2
 deriving newtype instance Real M2
 newtype M3 = M3 {un_M3 :: (ConstantArray 3 CInt)}
 deriving newtype instance Storable M3
+deriving stock instance Eq M3
+deriving stock instance Show M3
 newtype M4 = M4 {un_M4 :: (Ptr CInt)}
 deriving newtype instance Storable M4
+deriving stock instance Eq M4
+deriving stock instance Ord M4
+deriving stock instance Show M4
 data ExampleStruct
     = ExampleStruct {exampleStruct_t1 :: T1,
                      exampleStruct_t2 :: T2,

--- a/hs-bindgen/fixtures/typedefs.extbindings.yaml
+++ b/hs-bindgen/fixtures/typedefs.extbindings.yaml
@@ -3,7 +3,26 @@ types:
   cname: intptr
   module: Example
   identifier: Intptr
+  instances:
+  - Eq
+  - Ord
+  - Show
+  - Storable
 - headers: typedefs.h
   cname: myint
   module: Example
   identifier: Myint
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Ix
+  - Bounded
+  - Read
+  - Show
+  - Bits
+  - FiniteBits
+  - Integral
+  - Num
+  - Real
+  - Storable

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -23,7 +23,20 @@
           typedefSourceLoc =
           "typedefs.h:1:13"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Ix,
+          Bounded,
+          Read,
+          Show,
+          Bits,
+          FiniteBits,
+          Integral,
+          Num,
+          Real,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -127,10 +140,28 @@
           typedefSourceLoc =
           "typedefs.h:2:15"},
       newtypeInstances = Set.fromList
-        []},
+        [Eq, Ord, Show, Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
+    (HsName
+      "@NsTypeConstr"
+      "Intptr"),
+  DeclNewtypeInstance
+    DeriveStock
+    Eq
+    (HsName
+      "@NsTypeConstr"
+      "Intptr"),
+  DeclNewtypeInstance
+    DeriveStock
+    Ord
+    (HsName
+      "@NsTypeConstr"
+      "Intptr"),
+  DeclNewtypeInstance
+    DeriveStock
+    Show
     (HsName
       "@NsTypeConstr"
       "Intptr")]

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -21,7 +21,9 @@
           typedefType = TypePrim
             (PrimIntegral PrimInt Signed),
           typedefSourceLoc =
-          "typedefs.h:1:13"}},
+          "typedefs.h:1:13"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable
@@ -123,7 +125,9 @@
             (TypePrim
               (PrimIntegral PrimInt Signed)),
           typedefSourceLoc =
-          "typedefs.h:2:15"}},
+          "typedefs.h:2:15"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/typedefs.pp.hs
+++ b/hs-bindgen/fixtures/typedefs.pp.hs
@@ -48,3 +48,9 @@ newtype Intptr = Intptr
   }
 
 deriving newtype instance F.Storable Intptr
+
+deriving stock instance Eq Intptr
+
+deriving stock instance Ord Intptr
+
+deriving stock instance Show Intptr

--- a/hs-bindgen/fixtures/typedefs.th.txt
+++ b/hs-bindgen/fixtures/typedefs.th.txt
@@ -15,3 +15,6 @@ deriving newtype instance Num Myint
 deriving newtype instance Real Myint
 newtype Intptr = Intptr {un_Intptr :: (Ptr CInt)}
 deriving newtype instance Storable Intptr
+deriving stock instance Eq Intptr
+deriving stock instance Ord Intptr
+deriving stock instance Show Intptr

--- a/hs-bindgen/fixtures/typenames.extbindings.yaml
+++ b/hs-bindgen/fixtures/typenames.extbindings.yaml
@@ -3,7 +3,26 @@ types:
   cname: enum foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
 - headers: typenames.h
   cname: foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Ord
+  - Enum
+  - Read
+  - Show
+  - Floating
+  - Fractional
+  - Num
+  - Real
+  - RealFloat
+  - RealFrac
+  - Storable

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -38,7 +38,12 @@
           enumSourceLoc =
           "typenames.h:14:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -79,7 +84,7 @@
             enumSourceLoc =
             "typenames.h:14:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -125,7 +130,12 @@
                     enumSourceLoc =
                     "typenames.h:14:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -171,7 +181,7 @@
                     enumSourceLoc =
                     "typenames.h:14:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -231,7 +241,7 @@
             enumSourceLoc =
             "typenames.h:14:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -278,7 +288,7 @@
             enumSourceLoc =
             "typenames.h:14:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName "@NsConstr" "FOO1")
       (HsName "@NsConstr" "FOO2")),
   DeclInstance
@@ -321,7 +331,12 @@
             enumSourceLoc =
             "typenames.h:14:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -384,7 +399,19 @@
           typedefSourceLoc =
           "typenames.h:19:16"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Enum,
+          Read,
+          Show,
+          Floating,
+          Fractional,
+          Num,
+          Real,
+          RealFloat,
+          RealFrac,
+          Storable]},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -36,7 +36,9 @@
               valueSourceLoc =
               "typenames.h:16:2"}],
           enumSourceLoc =
-          "typenames.h:14:6"}},
+          "typenames.h:14:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -75,7 +77,9 @@
                 valueSourceLoc =
                 "typenames.h:16:2"}],
             enumSourceLoc =
-            "typenames.h:14:6"}}
+            "typenames.h:14:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -119,7 +123,9 @@
                         valueSourceLoc =
                         "typenames.h:16:2"}],
                     enumSourceLoc =
-                    "typenames.h:14:6"}})
+                    "typenames.h:14:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -163,7 +169,9 @@
                         valueSourceLoc =
                         "typenames.h:16:2"}],
                     enumSourceLoc =
-                    "typenames.h:14:6"}}
+                    "typenames.h:14:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -221,7 +229,9 @@
                 valueSourceLoc =
                 "typenames.h:16:2"}],
             enumSourceLoc =
-            "typenames.h:14:6"}}
+            "typenames.h:14:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -266,7 +276,9 @@
                 valueSourceLoc =
                 "typenames.h:16:2"}],
             enumSourceLoc =
-            "typenames.h:14:6"}}
+            "typenames.h:14:6"},
+        structInstances = Set.fromList
+          []}
       (HsName "@NsConstr" "FOO1")
       (HsName "@NsConstr" "FOO2")),
   DeclInstance
@@ -307,7 +319,9 @@
                 valueSourceLoc =
                 "typenames.h:16:2"}],
             enumSourceLoc =
-            "typenames.h:14:6"}}),
+            "typenames.h:14:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName
@@ -368,7 +382,9 @@
           typedefType = TypePrim
             (PrimFloating PrimDouble),
           typedefSourceLoc =
-          "typenames.h:19:16"}},
+          "typenames.h:19:16"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     DeriveNewtype
     Storable

--- a/hs-bindgen/fixtures/unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/unions.extbindings.yaml
@@ -3,31 +3,51 @@ types:
   cname: DimPayloadB
   module: Example
   identifier: DimPayloadB
+  instances:
+  - Storable
 - headers: unions.h
   cname: struct Dim
   module: Example
   identifier: Dim
+  instances:
+  - Storable
 - headers: unions.h
   cname: struct Dim2
   module: Example
   identifier: Dim2
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: unions.h
   cname: struct Dim3
   module: Example
   identifier: Dim3
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: unions.h
   cname: struct DimB
   module: Example
   identifier: DimB
+  instances:
+  - Storable
 - headers: unions.h
   cname: union AnonA
   module: Example
   identifier: AnonA
+  instances:
+  - Storable
 - headers: unions.h
   cname: union DimPayload
   module: Example
   identifier: DimPayload
+  instances:
+  - Storable
 - headers: unions.h
   cname: union DimPayloadB
   module: Example
   identifier: DimPayloadB
+  instances:
+  - Storable

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -69,7 +69,7 @@
           structSourceLoc =
           "unions.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -141,7 +141,7 @@
             structSourceLoc =
             "unions.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -218,7 +218,7 @@
                     structSourceLoc =
                     "unions.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -297,7 +297,7 @@
                     structSourceLoc =
                     "unions.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -408,7 +408,7 @@
           structSourceLoc =
           "unions.h:6:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -504,7 +504,7 @@
             structSourceLoc =
             "unions.h:6:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -605,7 +605,7 @@
                     structSourceLoc =
                     "unions.h:6:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -709,7 +709,7 @@
                     structSourceLoc =
                     "unions.h:6:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 3)
               (Seq
                 [
@@ -765,7 +765,7 @@
           unionSourceLoc =
           "unions.h:12:7"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 8 4))
@@ -883,7 +883,7 @@
           structSourceLoc =
           "unions.h:17:8"},
       structInstances = Set.fromList
-        []},
+        [Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -959,7 +959,7 @@
             structSourceLoc =
             "unions.h:17:8"},
         structInstances = Set.fromList
-          []}
+          [Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1040,7 +1040,7 @@
                     structSourceLoc =
                     "unions.h:17:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1123,7 +1123,7 @@
                     structSourceLoc =
                     "unions.h:17:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Storable]}
               (Add 2)
               (Seq
                 [
@@ -1132,14 +1132,6 @@
                     (Idx 3)
                     4
                     (Idx 1)])))}),
-  DeclNewtypeInstance
-    DeriveStock
-    Show
-    (HsName "@NsTypeConstr" "Dim"),
-  DeclNewtypeInstance
-    DeriveStock
-    Eq
-    (HsName "@NsTypeConstr" "Dim"),
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1179,7 +1171,7 @@
           unionSourceLoc =
           "unions.h:23:15"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 8 4))
@@ -1297,7 +1289,7 @@
           structSourceLoc =
           "unions.h:28:8"},
       structInstances = Set.fromList
-        []},
+        [Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1373,7 +1365,7 @@
             structSourceLoc =
             "unions.h:28:8"},
         structInstances = Set.fromList
-          []}
+          [Storable]}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1454,7 +1446,7 @@
                     structSourceLoc =
                     "unions.h:28:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1537,7 +1529,7 @@
                     structSourceLoc =
                     "unions.h:28:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Storable]}
               (Add 2)
               (Seq
                 [
@@ -1546,14 +1538,6 @@
                     (Idx 3)
                     4
                     (Idx 1)])))}),
-  DeclNewtypeInstance
-    DeriveStock
-    Show
-    (HsName "@NsTypeConstr" "DimB"),
-  DeclNewtypeInstance
-    DeriveStock
-    Eq
-    (HsName "@NsTypeConstr" "DimB"),
   DeclData
     Struct {
       structName = HsName
@@ -1627,7 +1611,7 @@
           structSourceLoc =
           "unions.h:35:5"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1702,7 +1686,7 @@
             structSourceLoc =
             "unions.h:35:5"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1782,7 +1766,7 @@
                     structSourceLoc =
                     "unions.h:35:5"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1864,7 +1848,7 @@
                     structSourceLoc =
                     "unions.h:35:5"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -1958,7 +1942,7 @@
           structSourceLoc =
           "unions.h:36:5"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -2033,7 +2017,7 @@
             structSourceLoc =
             "unions.h:36:5"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2113,7 +2097,7 @@
                     structSourceLoc =
                     "unions.h:36:5"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -2195,7 +2179,7 @@
                     structSourceLoc =
                     "unions.h:36:5"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 2)
               (Seq
                 [
@@ -2262,7 +2246,7 @@
           unionSourceLoc =
           "unions.h:34:7"},
       newtypeInstances = Set.fromList
-        []},
+        [Storable]},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 16 8))

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -67,7 +67,9 @@
               "unions.h:3:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:1:8"}},
+          "unions.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -137,7 +139,9 @@
                 "unions.h:3:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:1:8"}}
+            "unions.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 8,
         storableAlignment = 4,
@@ -212,7 +216,9 @@
                         "unions.h:3:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:1:8"}})
+                    "unions.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -289,7 +295,9 @@
                         "unions.h:3:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:1:8"}}
+                    "unions.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -398,7 +406,9 @@
               "unions.h:9:9"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:6:8"}},
+          "unions.h:6:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -492,7 +502,9 @@
                 "unions.h:9:9"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:6:8"}}
+            "unions.h:6:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -591,7 +603,9 @@
                         "unions.h:9:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:6:8"}})
+                    "unions.h:6:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4,
@@ -693,7 +707,9 @@
                         "unions.h:9:9"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:6:8"}}
+                    "unions.h:6:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 3)
               (Seq
                 [
@@ -747,7 +763,9 @@
               ufieldSourceLoc =
               "unions.h:14:17"}],
           unionSourceLoc =
-          "unions.h:12:7"}},
+          "unions.h:12:7"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 8 4))
@@ -863,7 +881,9 @@
               "unions.h:19:22"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:17:8"}},
+          "unions.h:17:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -937,7 +957,9 @@
                 "unions.h:19:22"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:17:8"}}
+            "unions.h:17:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1016,7 +1038,9 @@
                         "unions.h:19:22"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:17:8"}})
+                    "unions.h:17:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1097,7 +1121,9 @@
                         "unions.h:19:22"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:17:8"}}
+                    "unions.h:17:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1151,7 +1177,9 @@
               ufieldSourceLoc =
               "unions.h:25:17"}],
           unionSourceLoc =
-          "unions.h:23:15"}},
+          "unions.h:23:15"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 8 4))
@@ -1267,7 +1295,9 @@
               "unions.h:30:17"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:28:8"}},
+          "unions.h:28:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1341,7 +1371,9 @@
                 "unions.h:30:17"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:28:8"}}
+            "unions.h:28:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 12,
         storableAlignment = 4,
@@ -1420,7 +1452,9 @@
                         "unions.h:30:17"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:28:8"}})
+                    "unions.h:28:8"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 4]),
@@ -1501,7 +1535,9 @@
                         "unions.h:30:17"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:28:8"}}
+                    "unions.h:28:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1589,7 +1625,9 @@
               "unions.h:35:31"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:35:5"}},
+          "unions.h:35:5"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1662,7 +1700,9 @@
                 "unions.h:35:31"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:35:5"}}
+            "unions.h:35:5"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -1740,7 +1780,9 @@
                         "unions.h:35:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:35:5"}})
+                    "unions.h:35:5"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -1820,7 +1862,9 @@
                         "unions.h:35:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:35:5"}}
+                    "unions.h:35:5"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -1912,7 +1956,9 @@
               "unions.h:36:31"}],
           structFlam = Nothing,
           structSourceLoc =
-          "unions.h:36:5"}},
+          "unions.h:36:5"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -1985,7 +2031,9 @@
                 "unions.h:36:31"}],
             structFlam = Nothing,
             structSourceLoc =
-            "unions.h:36:5"}}
+            "unions.h:36:5"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 16,
         storableAlignment = 8,
@@ -2063,7 +2111,9 @@
                         "unions.h:36:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:36:5"}})
+                    "unions.h:36:5"},
+                structInstances = Set.fromList
+                  []})
             [
               PeekByteOff (Idx 0) 0,
               PeekByteOff (Idx 0) 8]),
@@ -2143,7 +2193,9 @@
                         "unions.h:36:31"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "unions.h:36:5"}}
+                    "unions.h:36:5"},
+                structInstances = Set.fromList
+                  []}
               (Add 2)
               (Seq
                 [
@@ -2208,7 +2260,9 @@
               ufieldSourceLoc =
               "unions.h:36:36"}],
           unionSourceLoc =
-          "unions.h:34:7"}},
+          "unions.h:34:7"},
+      newtypeInstances = Set.fromList
+        []},
   DeclNewtypeInstance
     (DeriveVia
       (HsSizedByteArray 16 8))

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -118,10 +118,6 @@ instance F.Storable Dim where
                F.pokeByteOff ptr0 (0 :: Int) dim_tag2
             >> F.pokeByteOff ptr0 (4 :: Int) dim_payload3
 
-deriving stock instance Show Dim
-
-deriving stock instance Eq Dim
-
 newtype DimPayloadB = DimPayloadB
   { un_DimPayloadB :: Data.Array.Byte.ByteArray
   }
@@ -164,10 +160,6 @@ instance F.Storable DimB where
           DimB dimB_tag2 dimB_payload3 ->
                F.pokeByteOff ptr0 (0 :: Int) dimB_tag2
             >> F.pokeByteOff ptr0 (4 :: Int) dimB_payload3
-
-deriving stock instance Show DimB
-
-deriving stock instance Eq DimB
 
 data AnonA_xy = AnonA_xy
   { anonA_xy_x :: FC.CDouble

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -38,8 +38,6 @@ instance Storable Dim
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Dim dim_tag_3
                                          dim_payload_4 -> pokeByteOff ptr_1 (0 :: Int) dim_tag_3 >> pokeByteOff ptr_1 (4 :: Int) dim_payload_4}}
-deriving stock instance Show Dim
-deriving stock instance Eq Dim
 newtype DimPayloadB = DimPayloadB {un_DimPayloadB :: ByteArray}
 deriving via (SizedByteArray 8 4) instance Storable DimPayloadB
 get_dimPayloadB_dim2 :: DimPayloadB -> Dim2
@@ -58,8 +56,6 @@ instance Storable DimB
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {DimB dimB_tag_3
                                           dimB_payload_4 -> pokeByteOff ptr_1 (0 :: Int) dimB_tag_3 >> pokeByteOff ptr_1 (4 :: Int) dimB_payload_4}}
-deriving stock instance Show DimB
-deriving stock instance Eq DimB
 data AnonA_xy
     = AnonA_xy {anonA_xy_x :: CDouble, anonA_xy_y :: CDouble}
 instance Storable AnonA_xy

--- a/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
+++ b/hs-bindgen/fixtures/uses_utf8.extbindings.yaml
@@ -3,3 +3,9 @@ types:
   cname: enum MyEnum
   module: Example
   identifier: MyEnum
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -40,7 +40,12 @@
           enumSourceLoc =
           "uses_utf8.h:4:6"},
       newtypeInstances = Set.fromList
-        []},
+        [
+          Eq,
+          Ord,
+          Read,
+          Show,
+          Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -83,7 +88,7 @@
             enumSourceLoc =
             "uses_utf8.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -131,7 +136,12 @@
                     enumSourceLoc =
                     "uses_utf8.h:4:6"},
                 structInstances = Set.fromList
-                  []})
+                  [
+                    Eq,
+                    Ord,
+                    Read,
+                    Show,
+                    Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -179,7 +189,7 @@
                     enumSourceLoc =
                     "uses_utf8.h:4:6"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Ord, Read, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -247,7 +257,7 @@
             enumSourceLoc =
             "uses_utf8.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -302,7 +312,7 @@
             enumSourceLoc =
             "uses_utf8.h:4:6"},
         structInstances = Set.fromList
-          []}
+          [Eq, Ord, Read, Show, Storable]}
       (HsName
         "@NsConstr"
         "Say\20320\22909")
@@ -351,7 +361,12 @@
             enumSourceLoc =
             "uses_utf8.h:4:6"},
         structInstances = Set.fromList
-          []}),
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -38,7 +38,9 @@
               valueSourceLoc =
               "uses_utf8.h:6:9"}],
           enumSourceLoc =
-          "uses_utf8.h:4:6"}},
+          "uses_utf8.h:4:6"},
+      newtypeInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -79,7 +81,9 @@
                 valueSourceLoc =
                 "uses_utf8.h:6:9"}],
             enumSourceLoc =
-            "uses_utf8.h:4:6"}}
+            "uses_utf8.h:4:6"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -125,7 +129,9 @@
                         valueSourceLoc =
                         "uses_utf8.h:6:9"}],
                     enumSourceLoc =
-                    "uses_utf8.h:4:6"}})
+                    "uses_utf8.h:4:6"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -171,7 +177,9 @@
                         valueSourceLoc =
                         "uses_utf8.h:6:9"}],
                     enumSourceLoc =
-                    "uses_utf8.h:4:6"}}
+                    "uses_utf8.h:4:6"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -237,7 +245,9 @@
                 valueSourceLoc =
                 "uses_utf8.h:6:9"}],
             enumSourceLoc =
-            "uses_utf8.h:4:6"}}
+            "uses_utf8.h:4:6"},
+        structInstances = Set.fromList
+          []}
       (HsPrimType HsPrimCUInt)
       (Map.fromList
         [
@@ -290,7 +300,9 @@
                 valueSourceLoc =
                 "uses_utf8.h:6:9"}],
             enumSourceLoc =
-            "uses_utf8.h:4:6"}}
+            "uses_utf8.h:4:6"},
+        structInstances = Set.fromList
+          []}
       (HsName
         "@NsConstr"
         "Say\20320\22909")
@@ -337,7 +349,9 @@
                 valueSourceLoc =
                 "uses_utf8.h:6:9"}],
             enumSourceLoc =
-            "uses_utf8.h:4:6"}}),
+            "uses_utf8.h:4:6"},
+        structInstances = Set.fromList
+          []}),
   DeclPatSyn
     PatSyn {
       patSynName = HsName

--- a/hs-bindgen/fixtures/weird01.extbindings.yaml
+++ b/hs-bindgen/fixtures/weird01.extbindings.yaml
@@ -3,7 +3,15 @@ types:
   cname: struct bar
   module: Example
   identifier: Bar
+  instances:
+  - Eq
+  - Show
+  - Storable
 - headers: weird01.h
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -43,7 +43,9 @@
               "weird01.h:2:13"}],
           structFlam = Nothing,
           structSourceLoc =
-          "weird01.h:1:8"}},
+          "weird01.h:1:8"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -89,7 +91,9 @@
                 "weird01.h:2:13"}],
             structFlam = Nothing,
             structSourceLoc =
-            "weird01.h:1:8"}}
+            "weird01.h:1:8"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -140,7 +144,9 @@
                         "weird01.h:2:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "weird01.h:1:8"}})
+                    "weird01.h:1:8"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -191,7 +197,9 @@
                         "weird01.h:2:13"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "weird01.h:1:8"}}
+                    "weird01.h:1:8"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [
@@ -251,7 +259,9 @@
               "weird01.h:4:21"}],
           structFlam = Nothing,
           structSourceLoc =
-          "weird01.h:3:16"}},
+          "weird01.h:3:16"},
+      structInstances = Set.fromList
+        []},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -297,7 +307,9 @@
                 "weird01.h:4:21"}],
             structFlam = Nothing,
             structSourceLoc =
-            "weird01.h:3:16"}}
+            "weird01.h:3:16"},
+        structInstances = Set.fromList
+          []}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -348,7 +360,9 @@
                         "weird01.h:4:21"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "weird01.h:3:16"}})
+                    "weird01.h:3:16"},
+                structInstances = Set.fromList
+                  []})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -399,7 +413,9 @@
                         "weird01.h:4:21"}],
                     structFlam = Nothing,
                     structSourceLoc =
-                    "weird01.h:3:16"}}
+                    "weird01.h:3:16"},
+                structInstances = Set.fromList
+                  []}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -45,7 +45,7 @@
           structSourceLoc =
           "weird01.h:1:8"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -93,7 +93,7 @@
             structSourceLoc =
             "weird01.h:1:8"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -146,7 +146,7 @@
                     structSourceLoc =
                     "weird01.h:1:8"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -199,7 +199,7 @@
                     structSourceLoc =
                     "weird01.h:1:8"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [
@@ -261,7 +261,7 @@
           structSourceLoc =
           "weird01.h:3:16"},
       structInstances = Set.fromList
-        []},
+        [Eq, Show, Storable]},
   DeclInstance
     (InstanceStorable
       Struct {
@@ -309,7 +309,7 @@
             structSourceLoc =
             "weird01.h:3:16"},
         structInstances = Set.fromList
-          []}
+          [Eq, Show, Storable]}
       StorableInstance {
         storableSizeOf = 4,
         storableAlignment = 4,
@@ -362,7 +362,7 @@
                     structSourceLoc =
                     "weird01.h:3:16"},
                 structInstances = Set.fromList
-                  []})
+                  [Eq, Show, Storable]})
             [PeekByteOff (Idx 0) 0]),
         storablePoke = Lambda
           (NameHint "ptr")
@@ -415,7 +415,7 @@
                     structSourceLoc =
                     "weird01.h:3:16"},
                 structInstances = Set.fromList
-                  []}
+                  [Eq, Show, Storable]}
               (Add 1)
               (Seq
                 [

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Names.hs
@@ -38,6 +38,7 @@ import HsBindgen.Runtime.ByteArray qualified
 import HsBindgen.Runtime.ConstantArray qualified
 import HsBindgen.Runtime.CEnum qualified
 import HsBindgen.Runtime.FlexibleArrayMember qualified
+import HsBindgen.Runtime.Marshal qualified
 import HsBindgen.Runtime.Syntax qualified
 import HsBindgen.Runtime.SizedByteArray qualified
 
@@ -189,6 +190,9 @@ resolveGlobal = \case
     Applicative_seq      -> importU '(<*>)
     Monad_return         -> importU 'return
     Monad_seq            -> importU '(>>)
+    StaticSize_class     -> importQ ''HsBindgen.Runtime.Marshal.StaticSize
+    ReadRaw_class        -> importQ ''HsBindgen.Runtime.Marshal.ReadRaw
+    WriteRaw_class       -> importQ ''HsBindgen.Runtime.Marshal.WriteRaw
     Storable_class       -> importQ ''Foreign.Storable
     Storable_sizeOf      -> importQ 'Foreign.sizeOf
     Storable_alignment   -> importQ 'Foreign.alignment

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -41,6 +41,7 @@ import HsBindgen.Runtime.ByteArray qualified
 import HsBindgen.Runtime.CEnum qualified
 import HsBindgen.Runtime.ConstantArray qualified
 import HsBindgen.Runtime.FlexibleArrayMember qualified
+import HsBindgen.Runtime.Marshal qualified
 import HsBindgen.Runtime.Syntax qualified
 import HsBindgen.Runtime.SizedByteArray qualified
 import HsBindgen.SHs.AST
@@ -61,6 +62,9 @@ mkGlobal = \case
       Applicative_seq      -> '(<*>)
       Monad_return         -> 'return
       Monad_seq            -> '(>>)
+      StaticSize_class     -> ''HsBindgen.Runtime.Marshal.StaticSize
+      ReadRaw_class        -> ''HsBindgen.Runtime.Marshal.ReadRaw
+      WriteRaw_class       -> ''HsBindgen.Runtime.Marshal.WriteRaw
       Storable_class       -> ''Foreign.Storable.Storable
       Storable_sizeOf      -> 'Foreign.Storable.sizeOf
       Storable_alignment   -> 'Foreign.Storable.alignment
@@ -232,6 +236,9 @@ mkGlobalExpr n = case n of -- in definition order, no wildcards
     Applicative_seq      -> TH.varE name
     Monad_return         -> TH.varE name
     Monad_seq            -> TH.varE name
+    StaticSize_class     -> panicPure "class in expression"
+    ReadRaw_class        -> panicPure "class in expression"
+    WriteRaw_class       -> panicPure "class in expression"
     Storable_class       -> panicPure "class in expression"
     Storable_sizeOf      -> TH.varE name
     Storable_alignment   -> TH.varE name

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -66,6 +66,9 @@ genExtBindings headerIncludePath extIdentifierModule =
         unresolvedExtBindingsTypes = Map.empty
       }
 
+    extIdentifierInstances :: Set HsTypeClass
+    extIdentifierInstances = Set.empty -- TODO
+
 {-------------------------------------------------------------------------------
   Auxiliary functions
 -------------------------------------------------------------------------------}

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -39,7 +39,7 @@ module HsBindgen.Hs.AST (
   , VarDeclRHSAppHead(..)
     -- ** Deriving instances
   , Strategy(..)
-  , TypeClass(..)
+  , HsTypeClass(..)
     -- ** Foreign imports
   , ForeignImportDecl(..)
   , ForeignImportDeclOrigin(..)
@@ -64,6 +64,7 @@ import Data.Type.Nat qualified as Nat
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro
 
+import HsBindgen.ExtBindings (HsTypeClass(..))
 import HsBindgen.Imports
 import HsBindgen.NameHint
 import HsBindgen.Hs.AST.Name
@@ -174,7 +175,7 @@ data Decl where
     DeclNewtype         :: Newtype -> Decl
     DeclPatSyn          :: PatSyn -> Decl
     DeclDefineInstance  :: InstanceDecl -> Decl
-    DeclDeriveInstance  :: Strategy HsType -> TypeClass -> HsName NsTypeConstr -> Decl
+    DeclDeriveInstance  :: Strategy HsType -> HsTypeClass -> HsName NsTypeConstr -> Decl
     DeclForeignImport   :: ForeignImportDecl -> Decl
     DeclVar             :: VarDecl -> Decl
     DeclUnionGetter     :: HsName NsTypeConstr -> HsType -> HsName NsVar -> Decl
@@ -188,32 +189,6 @@ data Strategy ty =
   | DeriveStock
   | DeriveVia ty
   deriving stock (Generic, Show, Functor, Foldable, Traversable)
-
--- | Class instance names (for instances that /ghc/ generates)
-data TypeClass =
-    Storable
-
-    -- Haskell98 derivable classes
-    -- <https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/deriving.html>
-  | Eq
-  | Ord
-  | Enum
-  | Ix
-  | Bounded
-  | Read
-  | Show
-
-    -- Classes we can only derive through newtype deriving
-  | Bits
-  | FiniteBits
-  | Floating
-  | Fractional
-  | Integral
-  | Num
-  | Real
-  | RealFloat
-  | RealFrac
-  deriving stock (Generic, Show, Eq, Ord)
 
 -- | Class instance declaration (with code that /we/ generate)
 type InstanceDecl :: Star

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -93,10 +93,11 @@ data FieldOrigin =
   deriving stock (Generic, Show)
 
 data Struct (n :: Nat) = Struct {
-      structName   :: HsName NsTypeConstr
-    , structConstr :: HsName NsConstr
-    , structFields :: Vec n Field
-    , structOrigin :: StructOrigin
+      structName      :: HsName NsTypeConstr
+    , structConstr    :: HsName NsConstr
+    , structFields    :: Vec n Field
+    , structOrigin    :: StructOrigin
+    , structInstances :: Set HsTypeClass
     }
   deriving stock (Generic, Show)
 
@@ -117,10 +118,11 @@ data EmptyDataOrigin =
   deriving stock (Generic, Show)
 
 data Newtype = Newtype {
-      newtypeName   :: HsName NsTypeConstr
-    , newtypeConstr :: HsName NsConstr
-    , newtypeField  :: Field
-    , newtypeOrigin :: NewtypeOrigin
+      newtypeName      :: HsName NsTypeConstr
+    , newtypeConstr    :: HsName NsConstr
+    , newtypeField     :: Field
+    , newtypeOrigin    :: NewtypeOrigin
+    , newtypeInstances :: Set HsTypeClass
     }
   deriving stock (Generic, Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -25,6 +25,7 @@ import Data.List qualified as List
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Type.Nat (SNatI, induction)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Vec.Lazy qualified as Vec
 import GHC.Exts qualified as IsList (IsList(..))
@@ -211,6 +212,7 @@ structDecs opts nm struct fields = return $ concat
             , fieldOrigin = Hs.FieldOriginStructField f
             }
           structOrigin = Hs.StructOriginStruct struct
+          structInstances = Set.empty
       in  Hs.Struct{..}
 
     storable :: Hs.StorableInstance
@@ -300,6 +302,7 @@ unionDecs _opts nm union = return $
       , fieldOrigin = Hs.FieldOriginNone
       }
     newtypeOrigin = Hs.NewtypeOriginUnion union
+    newtypeInstances = Set.empty
 
     sba :: Hs.HsType
     sba = HsSizedByteArray (fromIntegral (C.unionSizeof union)) (fromIntegral (C.unionAlignment union))
@@ -333,6 +336,7 @@ enumDecs opts nm e = return $ concat [
       , fieldOrigin = Hs.FieldOriginNone
       }
     newtypeOrigin = Hs.NewtypeOriginEnum e
+    newtypeInstances = Set.empty
 
     hs :: Hs.Struct (S Z)
     hs =
@@ -340,6 +344,7 @@ enumDecs opts nm e = return $ concat [
           structConstr = newtypeConstr
           structFields = Vec.singleton newtypeField
           structOrigin = Hs.StructOriginEnum e
+          structInstances = Set.empty
       in  Hs.Struct{..}
 
     storable :: Hs.StorableInstance
@@ -423,6 +428,7 @@ typedefDecs opts nm d = return $ concat [
       , fieldOrigin = Hs.FieldOriginNone
       }
     newtypeOrigin = Hs.NewtypeOriginTypedef d
+    newtypeInstances = Set.empty
 
 primTypeInstances :: C.PrimType -> [HsTypeClass]
 primTypeInstances (C.PrimFloating _) = [
@@ -500,6 +506,7 @@ macroDecsTypedef opts nm m =
     newtypeName   = mangle nm $ NameTycon (C.DeclPathName cName)
     newtypeConstr = mangle nm $ NameDatacon (C.DeclPathName cName)
     newtypeOrigin = Hs.NewtypeOriginMacro m
+    newtypeInstances = Set.empty
 
     mkField :: C.Type -> Hs.Field
     mkField ty = Hs.Field {

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -37,6 +37,7 @@ import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Errors
 import HsBindgen.ExtBindings (HsTypeClass)
+import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
@@ -52,6 +53,14 @@ import DeBruijn
   Configuration
 -------------------------------------------------------------------------------}
 
+-- | Translation options
+--
+-- These options allow users to specify instances that /may/ be derived for all
+-- structs, enums, and typedefs, along with the strategy to use.  Instances are
+-- only derived when possible, however.  For example, an @Eq@ instance may only
+-- be derived if all fields have @Eq@ instances.  Note that type classes that
+-- @hs-bindgen@ generates instances for must not be included in this
+-- configuration.
 data TranslationOpts = TranslationOpts {
       -- | Default set of classes to derive for structs
       translationDeriveStruct :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
@@ -59,18 +68,8 @@ data TranslationOpts = TranslationOpts {
       -- | Default set of classes to derive for enums
     , translationDeriveEnum :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
 
-      -- | Default set of classes to derive for typedefs around primitive types
-      --
-      -- The situation for typedefs is more intricate, because the instances we
-      -- can generate depend on the instances available for the type we're
-      -- defining a newtype for. However, for typedefs of /primitive/ types
-      -- this is easier, as we do know which instances are available for those.
-      --
-      -- Any classes in this list that are /not/ supported by the underlying
-      -- (primitive) type will simply not be generated, so it's okay for this
-      -- to contain classes such as 'Num' which are only supported by /some/
-      -- primitive types.
-    , translationDeriveTypedefPrim :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
+      -- | Default set of classes to derive for typedefs
+    , translationDeriveTypedef :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
     }
   deriving stock (Show)
 
@@ -85,7 +84,7 @@ defaultTranslationOpts = TranslationOpts {
         , (Hs.DeriveStock, Hs.Ord)
         , (Hs.DeriveStock, Hs.Read)
         ]
-    , translationDeriveTypedefPrim = [
+    , translationDeriveTypedef = [
           (Hs.DeriveStock, Hs.Eq)
         , (Hs.DeriveStock, Hs.Ord)
         , (Hs.DeriveStock, Hs.Read)
@@ -154,6 +153,140 @@ generateDeclarations opts _mu nm (C.Header decs) =
 
 type InstanceMap = Map (HsName NsTypeConstr) (Set HsTypeClass)
 
+getInstances ::
+     InstanceMap         -- ^ Current state
+  -> HsName NsTypeConstr -- ^ Name of current type
+  -> Set HsTypeClass     -- ^ Candidate instances
+  -> [HsType]            -- ^ Dependencies
+  -> Set HsTypeClass
+getInstances instanceMap name = aux
+  where
+    aux :: Set HsTypeClass -> [HsType] -> Set HsTypeClass
+    aux acc [] = acc
+    aux acc (hsType:hsTypes)
+      | Set.null acc = acc
+      | otherwise = case hsType of
+          HsPrimType primType -> aux (acc /\ hsPrimTypeInsts primType) hsTypes
+          HsTypRef name'
+            | name' == name -> aux acc hsTypes
+            | otherwise -> case Map.lookup name' instanceMap of
+                Just instances -> aux (acc /\ instances) hsTypes
+                Nothing -> panicPure $ "type not found: " ++ show name'
+          HsConstArray _n hsType' ->
+            -- constrain by ConstantArray item type in next step
+            aux (acc /\ cArrayInsts) $ hsType' : hsTypes
+          HsPtr{} -> aux (acc /\ ptrInsts) hsTypes
+          HsFunPtr{} -> aux (acc /\ ptrInsts) hsTypes
+          HsIO{} -> Set.empty
+          HsFun{} -> Set.empty
+          HsExtBinding extId _cType ->
+            let acc' = acc /\ ExtBindings.extIdentifierInstances extId
+            in  aux acc' hsTypes
+          HsByteArray{} ->
+            let acc' = acc /\ Set.fromList [Hs.Eq, Hs.Ord, Hs.Show]
+            in  aux acc' hsTypes
+          HsSizedByteArray{} ->
+            let acc' = acc /\ Set.fromList [Hs.Eq, Hs.Show]
+            in  aux acc' hsTypes
+
+    (/\) :: Ord a => Set a -> Set a -> Set a
+    (/\) = Set.intersection
+
+    hsPrimTypeInsts :: HsPrimType -> Set HsTypeClass
+    hsPrimTypeInsts = \case
+      HsPrimVoid       -> Set.fromList [Hs.Eq, Hs.Ix, Hs.Ord, Hs.Read, Hs.Show]
+      HsPrimUnit       -> unitInsts
+      HsPrimCChar      -> integralInsts
+      HsPrimCSChar     -> integralInsts
+      HsPrimCUChar     -> integralInsts
+      HsPrimCInt       -> integralInsts
+      HsPrimCUInt      -> integralInsts
+      HsPrimCShort     -> integralInsts
+      HsPrimCUShort    -> integralInsts
+      HsPrimCLong      -> integralInsts
+      HsPrimCULong     -> integralInsts
+      HsPrimCPtrDiff   -> integralInsts
+      HsPrimCSize      -> integralInsts
+      HsPrimCLLong     -> integralInsts
+      HsPrimCULLong    -> integralInsts
+      HsPrimCBool      -> integralInsts
+      HsPrimCFloat     -> floatingInsts
+      HsPrimCDouble    -> floatingInsts
+      HsPrimCStringLen -> Set.fromList [Hs.Eq, Hs.Ord, Hs.Show]
+      HsPrimInt        -> integralInsts
+
+    unitInsts :: Set HsTypeClass
+    unitInsts = Set.fromList [
+        Hs.Eq
+      , Hs.Ord
+      , Hs.Read
+      , Hs.ReadRaw
+      , Hs.Show
+      , Hs.StaticSize
+      , Hs.Storable
+      , Hs.WriteRaw
+      ]
+
+    integralInsts :: Set HsTypeClass
+    integralInsts = Set.fromList [
+        Hs.Bits
+      , Hs.Bounded
+      , Hs.Enum
+      , Hs.Eq
+      , Hs.FiniteBits
+      , Hs.Integral
+      , Hs.Ix
+      , Hs.Num
+      , Hs.Ord
+      , Hs.Read
+      , Hs.ReadRaw
+      , Hs.Real
+      , Hs.Show
+      , Hs.StaticSize
+      , Hs.Storable
+      , Hs.WriteRaw
+      ]
+
+    floatingInsts :: Set HsTypeClass
+    floatingInsts = Set.fromList [
+        Hs.Enum
+      , Hs.Eq
+      , Hs.Floating
+      , Hs.Fractional
+      , Hs.Num
+      , Hs.Ord
+      , Hs.Read
+      , Hs.ReadRaw
+      , Hs.Real
+      , Hs.RealFloat
+      , Hs.RealFrac
+      , Hs.Show
+      , Hs.StaticSize
+      , Hs.Storable
+      , Hs.WriteRaw
+      ]
+
+    ptrInsts :: Set HsTypeClass
+    ptrInsts = Set.fromList [
+        Hs.Eq
+      , Hs.Ord
+      , Hs.ReadRaw
+      , Hs.Show
+      , Hs.StaticSize
+      , Hs.Storable
+      , Hs.WriteRaw
+      ]
+
+    cArrayInsts :: Set HsTypeClass
+    cArrayInsts = Set.fromList [
+        Hs.Eq
+      , Hs.ReadRaw
+      , Hs.Show
+      , Hs.StaticSize
+      , Hs.Storable
+      , Hs.WriteRaw
+      ]
+
 {-------------------------------------------------------------------------------
   Declarations
 ------------------------------------------------------------------------------}
@@ -167,13 +300,13 @@ generateDecs ::
   -> m [Hs.Decl]
 generateDecs opts nm typedefs = \case
     C.DeclStruct struct  -> reifyStructFields struct $ structDecs opts nm struct
-    C.DeclUnion union    -> unionDecs opts nm union
-    C.DeclOpaqueStruct o -> opaqueStructDecs opts nm o
+    C.DeclUnion union    -> unionDecs nm union
+    C.DeclOpaqueStruct o -> opaqueStructDecs nm o
     C.DeclEnum e         -> enumDecs opts nm e
-    C.DeclOpaqueEnum o   -> opaqueEnumDecs opts nm o -- TODO?
+    C.DeclOpaqueEnum o   -> opaqueEnumDecs nm o -- TODO?
     C.DeclTypedef d      -> typedefDecs opts nm d
     C.DeclMacro m        -> macroDecs opts nm m
-    C.DeclFunction f     -> functionDecs opts nm typedefs f
+    C.DeclFunction f     -> return $ functionDecs nm typedefs f
 
 {-------------------------------------------------------------------------------
   Structs
@@ -193,55 +326,88 @@ structDecs :: forall n m.
   -> C.Struct
   -> Vec n C.StructField
   -> m [Hs.Decl]
-structDecs opts nm struct fields = return $ concat
-    [ [ Hs.DeclData hs ]
-    , [ Hs.DeclDefineInstance $ Hs.InstanceStorable hs storable]
-    , [ Hs.DeclDeriveInstance strat clss (Hs.structName hs)
-      | (strat, clss) <- translationDeriveStruct opts
-      ]
-    , flamInstance
-    ]
+structDecs opts nm struct fields = do
+    (insts, decls) <- aux <$> State.get
+    State.modify' $ Map.insert structName insts
+    return decls
   where
-    hs :: Hs.Struct n
-    hs =
-      let structName = mangle nm $ NameTycon $ C.structDeclPath struct
-          structConstr = mangle nm $ NameDatacon $ C.structDeclPath struct
-          structFields = flip Vec.map fields $ \f -> Hs.Field {
-              fieldName   = mangle nm $ NameField (C.structDeclPath struct) (C.fieldName f)
-            , fieldType   = typ nm (C.fieldType f)
-            , fieldOrigin = Hs.FieldOriginStructField f
-            }
-          structOrigin = Hs.StructOriginStruct struct
-          structInstances = Set.empty
-      in  Hs.Struct{..}
+    declPath :: C.DeclPath
+    declPath = C.structDeclPath struct
 
-    storable :: Hs.StorableInstance
-    storable = Hs.StorableInstance {
-          Hs.storableSizeOf    = C.structSizeof struct
-        , Hs.storableAlignment = C.structAlignment struct
-        , Hs.storablePeek      = Hs.Lambda "ptr" $
-            Hs.Ap (Hs.StructCon hs) $ map (peek IZ) (C.structFields struct)
-        , Hs.storablePoke      = Hs.Lambda "ptr" $ Hs.Lambda "s" $
-            Hs.makeElimStruct IZ hs $ \wk xs -> Hs.Seq $ toList $ Vec.zipWith (poke (weaken wk I1)) fields xs
-        }
+    structName :: HsName NsTypeConstr
+    structName = mangle nm $ NameTycon declPath
 
-    peek :: Idx ctx -> C.StructField -> Hs.PeekByteOff ctx
-    peek ptr f = case C.fieldWidth f of
-      Nothing -> Hs.PeekByteOff ptr (C.fieldOffset f `div` 8)
-      Just w  -> Hs.PeekBitOffWidth ptr (C.fieldOffset f) w
+    structFields :: Vec n Hs.Field
+    structFields = flip Vec.map fields $ \f -> Hs.Field {
+        fieldName   = mangle nm $ NameField declPath (C.fieldName f)
+      , fieldType   = typ nm (C.fieldType f)
+      , fieldOrigin = Hs.FieldOriginStructField f
+      }
 
-    poke :: Idx ctx -> C.StructField -> Idx ctx -> Hs.PokeByteOff ctx
-    poke ptr f i = case C.fieldWidth f of
-      Nothing -> Hs.PokeByteOff ptr (C.fieldOffset f `div` 8) i
-      Just w  -> Hs.PokeBitOffWidth ptr (C.fieldOffset f) w i
+    candidateInsts :: Set HsTypeClass
+    candidateInsts = Set.union (Set.singleton Hs.Storable) $
+      Set.fromList (snd <$> translationDeriveStruct opts)
 
-    flamInstance :: [Hs.Decl]
-    flamInstance = case C.structFlam struct of
-      Nothing  -> []
-      Just flam -> singleton $ Hs.DeclDefineInstance $ Hs.InstanceHasFLAM
-        hs
-        (typ nm (C.fieldType flam))
-        (C.fieldOffset flam `div` 8)
+    -- everything in aux is state-dependent
+    aux :: InstanceMap -> (Set HsTypeClass, [Hs.Decl])
+    aux instanceMap = (insts,) $
+        structDecl : storableDecl ++ optDecls ++ hasFlamDecl
+      where
+        insts :: Set HsTypeClass
+        insts = getInstances instanceMap structName candidateInsts $
+          Hs.fieldType <$> Vec.toList structFields
+
+        hsStruct :: Hs.Struct n
+        hsStruct = Hs.Struct {
+            structName      = structName
+          , structConstr    = mangle nm $ NameDatacon declPath
+          , structFields    = structFields
+          , structOrigin    = Hs.StructOriginStruct struct
+          , structInstances = insts
+          }
+
+        structDecl :: Hs.Decl
+        structDecl = Hs.DeclData hsStruct
+
+        storableDecl :: [Hs.Decl]
+        storableDecl
+          | Hs.Storable `Set.notMember` insts = []
+          | otherwise = singleton $ Hs.DeclDefineInstance $
+              Hs.InstanceStorable hsStruct Hs.StorableInstance {
+                  Hs.storableSizeOf    = C.structSizeof struct
+                , Hs.storableAlignment = C.structAlignment struct
+                , Hs.storablePeek      = Hs.Lambda "ptr" $
+                    Hs.Ap (Hs.StructCon hsStruct) $
+                      map (peekStructField IZ) (C.structFields struct)
+                , Hs.storablePoke      = Hs.Lambda "ptr" $ Hs.Lambda "s" $
+                    Hs.makeElimStruct IZ hsStruct $ \wk xs -> Hs.Seq $ toList $
+                      Vec.zipWith (pokeStructField (weaken wk I1)) fields xs
+                }
+
+        optDecls :: [Hs.Decl]
+        optDecls = [
+            Hs.DeclDeriveInstance strat clss structName
+          | (strat, clss) <- translationDeriveStruct opts
+          , clss `Set.member` insts
+          ]
+
+        hasFlamDecl :: [Hs.Decl]
+        hasFlamDecl = case C.structFlam struct of
+          Nothing   -> []
+          Just flam -> singleton $ Hs.DeclDefineInstance $ Hs.InstanceHasFLAM
+            hsStruct
+            (typ nm (C.fieldType flam))
+            (C.fieldOffset flam `div` 8)
+
+peekStructField :: Idx ctx -> C.StructField -> Hs.PeekByteOff ctx
+peekStructField ptr f = case C.fieldWidth f of
+    Nothing -> Hs.PeekByteOff ptr (C.fieldOffset f `div` 8)
+    Just w  -> Hs.PeekBitOffWidth ptr (C.fieldOffset f) w
+
+pokeStructField :: Idx ctx -> C.StructField -> Idx ctx -> Hs.PokeByteOff ctx
+pokeStructField ptr f i = case C.fieldWidth f of
+    Nothing -> Hs.PokeByteOff ptr (C.fieldOffset f `div` 8) i
+    Just w  -> Hs.PokeBitOffWidth ptr (C.fieldOffset f) w i
 
 {-------------------------------------------------------------------------------
   Opaque struct and opaque enum
@@ -249,29 +415,39 @@ structDecs opts nm struct fields = return $ concat
 
 opaqueStructDecs ::
      State.MonadState InstanceMap m
-  => TranslationOpts
-  -> NameMangler
+  => NameMangler
   -> C.OpaqueStruct
   -> m [Hs.Decl]
-opaqueStructDecs _opts nm o = return $
-    [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueStructTag o)
-        , emptyDataOrigin = Hs.EmptyDataOriginOpaqueStruct o
-        }
-    ]
+opaqueStructDecs nm o = do
+    State.modify' $ Map.insert name Set.empty
+    return [decl]
+  where
+    name :: HsName NsTypeConstr
+    name = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueStructTag o)
+
+    decl :: Hs.Decl
+    decl = Hs.DeclEmpty Hs.EmptyData {
+        emptyDataName   = name
+      , emptyDataOrigin = Hs.EmptyDataOriginOpaqueStruct o
+      }
 
 opaqueEnumDecs ::
      State.MonadState InstanceMap m
-  => TranslationOpts
-  -> NameMangler
+  => NameMangler
   -> C.OpaqueEnum
   -> m [Hs.Decl]
-opaqueEnumDecs _opts nm o = return $
-    [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueEnumTag o)
-        , emptyDataOrigin = Hs.EmptyDataOriginOpaqueEnum o
-        }
-    ]
+opaqueEnumDecs nm o = do
+    State.modify' $ Map.insert name Set.empty
+    return [decl]
+  where
+    name :: HsName NsTypeConstr
+    name = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueEnumTag o)
+
+    decl :: Hs.Decl
+    decl = Hs.DeclEmpty Hs.EmptyData {
+        emptyDataName   = name
+      , emptyDataOrigin = Hs.EmptyDataOriginOpaqueEnum o
+      }
 
 {-------------------------------------------------------------------------------
   Unions
@@ -279,33 +455,68 @@ opaqueEnumDecs _opts nm o = return $
 
 unionDecs ::
      State.MonadState InstanceMap m
-  => TranslationOpts
-  -> NameMangler
+  => NameMangler
   -> C.Union
   -> m [Hs.Decl]
-unionDecs _opts nm union = return $
-    [ Hs.DeclNewtype Hs.Newtype {..}
-    , Hs.DeclDeriveInstance (Hs.DeriveVia sba) Hs.Storable newtypeName
-    ] ++ concat
-    [ [ Hs.DeclUnionGetter newtypeName (typ nm ufieldType) (mangle nm $ NameGetter declPath ufieldName)
-      , Hs.DeclUnionSetter newtypeName (typ nm ufieldType) (mangle nm $ NameBuilder declPath ufieldName)
-      ]
-    | C.UnionField {..} <- C.unionFields union
-    ]
+unionDecs nm union = do
+    decls <- aux <$> State.get
+    State.modify' $ Map.insert newtypeName insts
+    return decls
   where
-    declPath      = C.unionDeclPath union
-    newtypeName   = mangle nm $ NameTycon declPath
-    newtypeConstr = mangle nm $ NameDatacon declPath
-    newtypeField  = Hs.Field {
-        fieldName   = mangle nm $ NameDecon declPath
-      , fieldType   = Hs.HsByteArray
-      , fieldOrigin = Hs.FieldOriginNone
+    declPath :: C.DeclPath
+    declPath = C.unionDeclPath union
+
+    newtypeName :: HsName NsTypeConstr
+    newtypeName = mangle nm $ NameTycon declPath
+
+    insts :: Set HsTypeClass
+    insts = Set.singleton Hs.Storable
+
+    hsNewtype :: Hs.Newtype
+    hsNewtype = Hs.Newtype {
+        newtypeName      = newtypeName
+      , newtypeConstr    = mangle nm $ NameDatacon declPath
+      , newtypeField     = Hs.Field {
+            fieldName   = mangle nm $ NameDecon declPath
+          , fieldType   = Hs.HsByteArray
+          , fieldOrigin = Hs.FieldOriginNone
+          }
+      , newtypeOrigin    = Hs.NewtypeOriginUnion union
+      , newtypeInstances = insts
       }
-    newtypeOrigin = Hs.NewtypeOriginUnion union
-    newtypeInstances = Set.empty
+
+    newtypeDecl :: Hs.Decl
+    newtypeDecl = Hs.DeclNewtype hsNewtype
+
+    storableDecl :: Hs.Decl
+    storableDecl =
+      Hs.DeclDeriveInstance (Hs.DeriveVia sba) Hs.Storable newtypeName
 
     sba :: Hs.HsType
-    sba = HsSizedByteArray (fromIntegral (C.unionSizeof union)) (fromIntegral (C.unionAlignment union))
+    sba =
+      HsSizedByteArray
+        (fromIntegral (C.unionSizeof union))
+        (fromIntegral (C.unionAlignment union))
+
+    -- everything in aux is state-dependent
+    aux :: InstanceMap -> [Hs.Decl]
+    aux instanceMap = newtypeDecl : storableDecl : accessorDecls
+      where
+        accessorDecls :: [Hs.Decl]
+        accessorDecls = concatMap getAccessorDecls (C.unionFields union)
+
+        getAccessorDecls :: C.UnionField -> [Hs.Decl]
+        getAccessorDecls C.UnionField{..} =
+          let hsType = typ nm ufieldType
+              fInsts = getInstances instanceMap newtypeName insts [hsType]
+          in  if Hs.Storable `Set.notMember` fInsts
+                then []
+                else
+                  [ Hs.DeclUnionGetter newtypeName hsType $
+                      mangle nm (NameGetter declPath ufieldName)
+                  , Hs.DeclUnionSetter newtypeName hsType $
+                      mangle nm (NameBuilder declPath ufieldName)
+                  ]
 
 {-------------------------------------------------------------------------------
   Enum
@@ -317,51 +528,69 @@ enumDecs ::
   -> NameMangler
   -> C.Enu
   -> m [Hs.Decl]
-enumDecs opts nm e = return $ concat [
-      [ Hs.DeclNewtype Hs.Newtype{..} ]
-    , [ Hs.DeclDefineInstance $ Hs.InstanceStorable hs storable ]
-    , [ Hs.DeclDeriveInstance strat clss (Hs.structName hs)
-      | (strat, clss) <- translationDeriveEnum opts
-      ]
-    , cEnumInstanceDecls
-    , valueDecls
-    ]
+enumDecs opts nm e = do
+    State.modify' $ Map.insert newtypeName insts
+    return $
+      newtypeDecl : storableDecl : optDecls ++ cEnumInstanceDecls ++ valueDecls
   where
-    declPath      = C.enumDeclPath e
-    newtypeName   = mangle nm $ NameTycon declPath
+    declPath :: C.DeclPath
+    declPath = C.enumDeclPath e
+
+    newtypeName :: HsName NsTypeConstr
+    newtypeName = mangle nm $ NameTycon declPath
+
+    newtypeConstr :: HsName NsConstr
     newtypeConstr = mangle nm $ NameDatacon declPath
-    newtypeField  = Hs.Field {
+
+    newtypeField :: Hs.Field
+    newtypeField = Hs.Field {
         fieldName   = mangle nm $ NameDecon declPath
       , fieldType   = typ nm (C.enumType e)
       , fieldOrigin = Hs.FieldOriginNone
       }
-    newtypeOrigin = Hs.NewtypeOriginEnum e
-    newtypeInstances = Set.empty
 
-    hs :: Hs.Struct (S Z)
-    hs =
-      let structName = newtypeName
-          structConstr = newtypeConstr
-          structFields = Vec.singleton newtypeField
-          structOrigin = Hs.StructOriginEnum e
-          structInstances = Set.empty
-      in  Hs.Struct{..}
+    insts :: Set HsTypeClass
+    insts = Set.union (Set.fromList [Hs.Show, Hs.Storable]) $
+      Set.fromList (snd <$> translationDeriveEnum opts)
 
-    storable :: Hs.StorableInstance
-    storable = Hs.StorableInstance {
+    hsNewtype :: Hs.Newtype
+    hsNewtype = Hs.Newtype {
+        newtypeName      = newtypeName
+      , newtypeConstr    = newtypeConstr
+      , newtypeField     = newtypeField
+      , newtypeOrigin    = Hs.NewtypeOriginEnum e
+      , newtypeInstances = insts
+      }
+
+    newtypeDecl :: Hs.Decl
+    newtypeDecl = Hs.DeclNewtype hsNewtype
+
+    hsStruct :: Hs.Struct (S Z)
+    hsStruct = Hs.Struct {
+        structName      = newtypeName
+      , structConstr    = newtypeConstr
+      , structFields    = Vec.singleton newtypeField
+      , structOrigin    = Hs.StructOriginEnum e
+      , structInstances = insts
+      }
+
+    storableDecl :: Hs.Decl
+    storableDecl = Hs.DeclDefineInstance $
+      Hs.InstanceStorable hsStruct Hs.StorableInstance {
           Hs.storableSizeOf    = C.enumSizeof e
         , Hs.storableAlignment = C.enumAlignment e
         , Hs.storablePeek      = Hs.Lambda "ptr" $
-            Hs.Ap (Hs.StructCon hs) [ peek IZ 0 ]
+            Hs.Ap (Hs.StructCon hsStruct) [ Hs.PeekByteOff IZ 0 ]
         , Hs.storablePoke      = Hs.Lambda "ptr" $ Hs.Lambda "s" $
-            Hs.ElimStruct IZ hs (AS AZ) $ Hs.Seq [ poke I2 0 IZ ]
+            Hs.ElimStruct IZ hsStruct (AS AZ) $
+              Hs.Seq [ Hs.PokeByteOff I2 0 IZ ]
         }
 
-    peek :: Idx ctx -> Int -> Hs.PeekByteOff ctx
-    peek = Hs.PeekByteOff
-
-    poke :: Idx ctx -> Int -> Idx ctx -> Hs.PokeByteOff ctx
-    poke = Hs.PokeByteOff
+    optDecls :: [Hs.Decl]
+    optDecls = [
+        Hs.DeclDeriveInstance strat clss newtypeName
+      | (strat, clss) <- translationDeriveEnum opts
+      ]
 
     valueDecls :: [Hs.Decl]
     valueDecls =
@@ -391,13 +620,13 @@ enumDecs opts nm e = return $ concat [
           fTyp = Hs.fieldType newtypeField
           vStrs = fmap (T.unpack . getHsName) <$> vNames
           cEnumDecl = Hs.DeclDefineInstance $
-            Hs.InstanceCEnum hs fTyp vStrs (isJust mSeqBounds)
-          cEnumShowDecl = [Hs.DeclDefineInstance (Hs.InstanceCEnumShow hs)]
+            Hs.InstanceCEnum hsStruct fTyp vStrs (isJust mSeqBounds)
+          cEnumShowDecl = Hs.DeclDefineInstance (Hs.InstanceCEnumShow hsStruct)
           sequentialCEnumDecl = case mSeqBounds of
             Just (nameMin, nameMax) -> List.singleton . Hs.DeclDefineInstance $
-              Hs.InstanceSequentialCEnum hs nameMin nameMax
+              Hs.InstanceSequentialCEnum hsStruct nameMin nameMax
             Nothing -> []
-      in  cEnumDecl : sequentialCEnumDecl ++ cEnumShowDecl
+      in  cEnumDecl : sequentialCEnumDecl ++ [cEnumShowDecl]
 
 {-------------------------------------------------------------------------------
   Typedef
@@ -409,57 +638,65 @@ typedefDecs ::
   -> NameMangler
   -> C.Typedef
   -> m [Hs.Decl]
-typedefDecs opts nm d = return $ concat [
-      [ Hs.DeclNewtype Hs.Newtype{..} ]
-    , [ Hs.DeclDeriveInstance Hs.DeriveNewtype Hs.Storable newtypeName ]
-    , [ Hs.DeclDeriveInstance strat clss newtypeName
-      | C.TypePrim pt <- [C.typedefType d]
-      , (strat, clss) <- translationDeriveTypedefPrim opts
-      , clss `elem` primTypeInstances pt
-      ]
-    ]
+typedefDecs opts nm typedef = do
+    (insts, decls) <- aux <$> State.get
+    State.modify' $ Map.insert newtypeName insts
+    return decls
   where
-    cName         = C.typedefName d
-    newtypeName   = mangle nm $ NameTycon (C.DeclPathName cName)
-    newtypeConstr = mangle nm $ NameDatacon (C.DeclPathName cName)
-    newtypeField  = Hs.Field {
-        fieldName   = mangle nm $ NameDecon (C.DeclPathName cName)
-      , fieldType   = typ nm (C.typedefType d)
+    declPath :: C.DeclPath
+    declPath = C.DeclPathName $ C.typedefName typedef
+
+    newtypeName :: HsName NsTypeConstr
+    newtypeName = mangle nm $ NameTycon declPath
+
+    newtypeField :: Hs.Field
+    newtypeField = Hs.Field {
+        fieldName   = mangle nm $ NameDecon declPath
+      , fieldType   = typ nm (C.typedefType typedef)
       , fieldOrigin = Hs.FieldOriginNone
       }
-    newtypeOrigin = Hs.NewtypeOriginTypedef d
-    newtypeInstances = Set.empty
 
-primTypeInstances :: C.PrimType -> [HsTypeClass]
-primTypeInstances (C.PrimFloating _) = [
-      Hs.Enum
-    , Hs.Floating
-    , Hs.RealFloat
-    , Hs.Storable
-    , Hs.Num
-    , Hs.Read
-    , Hs.Fractional
-    , Hs.Real
-    , Hs.RealFrac
-    , Hs.Show
-    , Hs.Eq
-    , Hs.Ord
-    ]
-primTypeInstances _otherwise = [
-      Hs.Bits
-    , Hs.FiniteBits
-    , Hs.Bounded
-    , Hs.Enum
-    , Hs.Storable
-    , Hs.Ix
-    , Hs.Num
-    , Hs.Read
-    , Hs.Integral
-    , Hs.Real
-    , Hs.Show
-    , Hs.Eq
-    , Hs.Ord
-    ]
+    candidateInsts :: Set HsTypeClass
+    candidateInsts = Set.union (Set.singleton Hs.Storable) $
+      Set.fromList (snd <$> translationDeriveTypedef opts)
+
+    -- everything in aux is state-dependent
+    aux :: InstanceMap -> (Set HsTypeClass, [Hs.Decl])
+    aux instanceMap = (insts,) $
+        newtypeDecl : storableDecl ++ optDecls
+      where
+        insts :: Set HsTypeClass
+        insts =
+          getInstances
+            instanceMap
+            newtypeName
+            candidateInsts
+            [Hs.fieldType newtypeField]
+
+        hsNewtype :: Hs.Newtype
+        hsNewtype = Hs.Newtype {
+            newtypeName      = newtypeName
+          , newtypeConstr    = mangle nm $ NameDatacon declPath
+          , newtypeField     = newtypeField
+          , newtypeOrigin    = Hs.NewtypeOriginTypedef typedef
+          , newtypeInstances = insts
+          }
+
+        newtypeDecl :: Hs.Decl
+        newtypeDecl = Hs.DeclNewtype hsNewtype
+
+        storableDecl :: [Hs.Decl]
+        storableDecl
+          | Hs.Storable `Set.notMember` insts = []
+          | otherwise = singleton $
+              Hs.DeclDeriveInstance Hs.DeriveNewtype Hs.Storable newtypeName
+
+        optDecls :: [Hs.Decl]
+        optDecls = [
+            Hs.DeclDeriveInstance strat clss newtypeName
+          | (strat, clss) <- translationDeriveTypedef opts
+          , clss `Set.member` insts
+          ]
 
 {-------------------------------------------------------------------------------
   Macros
@@ -474,7 +711,7 @@ macroDecs ::
 macroDecs opts nm C.MacroDecl { macroDeclMacro = m, macroDeclMacroTy = ty }
     | Macro.Quant bf <- ty
     , Macro.isPrimTy bf
-    = return $ macroDecsTypedef opts nm m
+    = macroDecsTypedef opts nm m
 
     | otherwise
     = return $ macroVarDecs nm m ty
@@ -483,37 +720,70 @@ macroDecs opts nm C.MacroDecl { macroDeclMacro = m, macroDeclMacroTy = ty }
 macroDecs _ _ C.MacroReparseError {} = return []
 macroDecs _ _ C.MacroTcError {}      = return []
 
-macroDecsTypedef :: TranslationOpts -> NameMangler -> C.Macro -> [Hs.Decl]
-macroDecsTypedef opts nm m =
-    case C.macroBody m of
-      C.TypeMacro tyNm
-        | Right ty <- C.typeNameType tyNm
-        ->
-        let newtypeField = mkField ty in
-        concat [
-            [ Hs.DeclNewtype Hs.Newtype{..} ]
-          , [ Hs.DeclDeriveInstance Hs.DeriveNewtype Hs.Storable newtypeName ]
-          , [ Hs.DeclDeriveInstance strat clss newtypeName
-            | C.TypePrim pt <- [ty]
-            , (strat, clss) <- translationDeriveTypedefPrim opts
-            , clss `elem` primTypeInstances pt
-            ]
-          ]
-      _otherwise ->
-        []
+macroDecsTypedef ::
+     State.MonadState InstanceMap m
+  => TranslationOpts
+  -> NameMangler
+  -> C.Macro
+  -> m [Hs.Decl]
+macroDecsTypedef opts nm macro = case C.macroBody macro of
+    C.TypeMacro tyNm
+      | Right ty <- C.typeNameType tyNm
+      -> do
+        (insts, decls) <- aux ty <$> State.get
+        State.modify' $ Map.insert newtypeName insts
+        return decls
+    _otherwise -> return []
   where
-    cName         = C.macroName m
-    newtypeName   = mangle nm $ NameTycon (C.DeclPathName cName)
-    newtypeConstr = mangle nm $ NameDatacon (C.DeclPathName cName)
-    newtypeOrigin = Hs.NewtypeOriginMacro m
-    newtypeInstances = Set.empty
+    declPath :: C.DeclPath
+    declPath = C.DeclPathName $ C.macroName macro
 
-    mkField :: C.Type -> Hs.Field
-    mkField ty = Hs.Field {
-          fieldName   = mangle nm $ NameDecon (C.DeclPathName cName)
-        , fieldType   = typ nm ty
-        , fieldOrigin = Hs.FieldOriginNone
-        }
+    newtypeName :: HsName NsTypeConstr
+    newtypeName = mangle nm $ NameTycon declPath
+
+    candidateInsts :: Set HsTypeClass
+    candidateInsts = Set.union (Set.singleton Hs.Storable) $
+      Set.fromList (snd <$> translationDeriveTypedef opts)
+
+    -- everything in aux is state-dependent
+    aux :: C.Type -> InstanceMap -> (Set HsTypeClass, [Hs.Decl])
+    aux ty instanceMap = (insts,) $
+        newtypeDecl : storableDecl ++ optDecls
+      where
+        fieldType :: HsType
+        fieldType = typ nm ty
+
+        insts :: Set HsTypeClass
+        insts = getInstances instanceMap newtypeName candidateInsts [fieldType]
+
+        hsNewtype :: Hs.Newtype
+        hsNewtype = Hs.Newtype {
+            newtypeName      = newtypeName
+          , newtypeConstr    = mangle nm $ NameDatacon declPath
+          , newtypeField     = Hs.Field {
+                fieldName   = mangle nm $ NameDecon declPath
+              , fieldType   = fieldType
+              , fieldOrigin = Hs.FieldOriginNone
+              }
+          , newtypeOrigin    = Hs.NewtypeOriginMacro macro
+          , newtypeInstances = insts
+          }
+
+        newtypeDecl :: Hs.Decl
+        newtypeDecl = Hs.DeclNewtype hsNewtype
+
+        storableDecl :: [Hs.Decl]
+        storableDecl
+          | Hs.Storable `Set.notMember` insts = []
+          | otherwise = singleton $
+              Hs.DeclDeriveInstance Hs.DeriveNewtype Hs.Storable newtypeName
+
+        optDecls :: [Hs.Decl]
+        optDecls = [
+            Hs.DeclDeriveInstance strat clss newtypeName
+          | (strat, clss) <- translationDeriveTypedef opts
+          , clss `Set.member` insts
+          ]
 
 {-------------------------------------------------------------------------------
   Types
@@ -610,16 +880,14 @@ floatingType = \case
 -------------------------------------------------------------------------------}
 
 functionDecs ::
-     State.MonadState InstanceMap m
-  => TranslationOpts
-  -> NameMangler
+     NameMangler
   -> Map C.CName C.Type -- ^ typedefs
   -> C.Function
-  -> m [Hs.Decl]
-functionDecs _opts nm typedefs f
+  -> [Hs.Decl]
+functionDecs nm typedefs f
   | any isFancy (C.functionRes f : C.functionArgs f)
   = throwPure_TODO 37 "Struct value arguments and results are not supported"
-  | otherwise = return $
+  | otherwise =
     [ Hs.DeclForeignImport $ Hs.ForeignImportDecl
         { foreignImportName       = mangle nm $ NameVar $ C.functionName f
         , foreignImportType       = ty

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -34,6 +34,7 @@ import Clang.Paths
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Errors
+import HsBindgen.ExtBindings (HsTypeClass)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
@@ -51,10 +52,10 @@ import DeBruijn
 
 data TranslationOpts = TranslationOpts {
       -- | Default set of classes to derive for structs
-      translationDeriveStruct :: [(Hs.Strategy Hs.HsType, Hs.TypeClass)]
+      translationDeriveStruct :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
 
       -- | Default set of classes to derive for enums
-    , translationDeriveEnum :: [(Hs.Strategy Hs.HsType, Hs.TypeClass)]
+    , translationDeriveEnum :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
 
       -- | Default set of classes to derive for typedefs around primitive types
       --
@@ -67,7 +68,7 @@ data TranslationOpts = TranslationOpts {
       -- (primitive) type will simply not be generated, so it's okay for this
       -- to contain classes such as 'Num' which are only supported by /some/
       -- primitive types.
-    , translationDeriveTypedefPrim :: [(Hs.Strategy Hs.HsType, Hs.TypeClass)]
+    , translationDeriveTypedefPrim :: [(Hs.Strategy Hs.HsType, HsTypeClass)]
     }
   deriving stock (Show)
 
@@ -383,7 +384,7 @@ typedefDecs opts nm d = concat [
       }
     newtypeOrigin = Hs.NewtypeOriginTypedef d
 
-primTypeInstances :: C.PrimType -> [Hs.TypeClass]
+primTypeInstances :: C.PrimType -> [HsTypeClass]
 primTypeInstances (C.PrimFloating _) = [
       Hs.Enum
     , Hs.Floating

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -41,6 +41,9 @@ data Global =
   | Applicative_seq
   | Monad_return
   | Monad_seq
+  | StaticSize_class
+  | ReadRaw_class
+  | WriteRaw_class
   | Storable_class
   | Storable_sizeOf
   | Storable_alignment

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -13,6 +13,7 @@ import Data.Vec.Lazy qualified as Vec
 import HsBindgen.C.AST qualified as C (MFun(..))
 import HsBindgen.C.AST.Type qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro hiding ( IntegralType )
+import HsBindgen.ExtBindings (HsTypeClass)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
@@ -109,10 +110,10 @@ translateNewtype n = DNewtype $ Newtype
     , newtypeOrigin = Hs.newtypeOrigin n
     }
 
-translateDeriveInstance :: Hs.Strategy Hs.HsType -> Hs.TypeClass -> HsName NsTypeConstr -> SDecl
+translateDeriveInstance :: Hs.Strategy Hs.HsType -> HsTypeClass -> HsName NsTypeConstr -> SDecl
 translateDeriveInstance s tc n = DDerivingInstance (fmap translateType s) $ TApp (translateTypeClass tc) (TCon n)
 
-translateTypeClass :: Hs.TypeClass -> ClosedType
+translateTypeClass :: HsTypeClass -> ClosedType
 translateTypeClass Hs.Bits       = TGlobal Bits_class
 translateTypeClass Hs.Bounded    = TGlobal Bounded_class
 translateTypeClass Hs.Enum       = TGlobal Enum_class
@@ -125,11 +126,14 @@ translateTypeClass Hs.Ix         = TGlobal Ix_class
 translateTypeClass Hs.Num        = TGlobal Num_class
 translateTypeClass Hs.Ord        = TGlobal Ord_class
 translateTypeClass Hs.Read       = TGlobal Read_class
+translateTypeClass Hs.ReadRaw    = TGlobal ReadRaw_class
 translateTypeClass Hs.Real       = TGlobal Real_class
 translateTypeClass Hs.RealFloat  = TGlobal RealFloat_class
 translateTypeClass Hs.RealFrac   = TGlobal RealFrac_class
 translateTypeClass Hs.Show       = TGlobal Show_class
+translateTypeClass Hs.StaticSize = TGlobal StaticSize_class
 translateTypeClass Hs.Storable   = TGlobal Storable_class
+translateTypeClass Hs.WriteRaw   = TGlobal WriteRaw_class
 
 translateVarDecl :: Hs.VarDecl -> SDecl
 translateVarDecl Hs.VarDecl {..} = DVar

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -40,7 +40,7 @@ module HsBindgen.Lib (
   , Hs.TranslationOpts(..)
   , Hs.defaultTranslationOpts
   , Hs.Strategy(..)
-  , Hs.TypeClass(..)
+  , Hs.HsTypeClass(..)
 
     -- ** Predicates
   , Predicate.Predicate(..)

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -28,7 +28,7 @@ module HsBindgen.TH (
   , Hs.TranslationOpts(..)
   , Hs.defaultTranslationOpts
   , Hs.Strategy(..)
-  , Hs.TypeClass(..)
+  , Hs.HsTypeClass(..)
 
     -- ** Predicates
   , Predicate.Predicate(..)

--- a/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
@@ -117,6 +117,7 @@ instance ToExpr C.ReparseError where
 
 instance ToExpr HsModuleName
 instance ToExpr HsIdentifier
+instance ToExpr HsTypeClass
 instance ToExpr ExtIdentifier
 
 instance ToExpr C.TcMacroError where
@@ -222,7 +223,6 @@ instance ToExpr Hs.PatSynOrigin
 instance ToExpr Hs.StorableInstance
 instance ToExpr t => ToExpr (Hs.Strategy t)
 instance ToExpr Hs.StructOrigin
-instance ToExpr Hs.TypeClass
 instance ToExpr Hs.VarDecl
 
 instance ToExpr (Hs.PeekByteOff ctx)


### PR DESCRIPTION
By tracking which types have which instances, we are able to check which instances are available defining or deriving new instances.  For example, a `data` or `newtype` can only derive an `Eq` instance if all fields have `Eq` instances.

Currently a declaration is only generated when all required instances are available.  In a future PR, we will instead generate declarations that have constraints for any missing instances.  For example, a user may configure `hs-bindgen` to *not* generate a `Show` instance for some type `A` because they want to implement a custom instance.  Some type `B` that uses `A` can still have a generated `instance Show A => Show B`, however, so that the user can implement the `Show A` instance but not need to implement the `Show B` instance.

High-level notes:

* External bindings now include instances.  To support this, relevant `Hs` AST nodes now include a set of instances.

* Getter and setter functions for a union field are now only defined if the field type has a `Storable` instance.

* Optional instances for `newtype` wrappers translated from `typedef`s may now be generated with any wrapped type, not just primitives.

* For macros, we only generate a `newtype` for primitive types.  Experimenting with a non-primitive type (`#define I int64_t`) results in a parse error, and code is generated without a `newtype`.  I did not change this behavior.

* Type classes `StaticSize`, `ReadRaw`, and `WriteRaw` are added because the `base` and `hs-bindgen-runtime` external bindings use them.  Generation of instances during translation is *not* added yet, however.

Implementation notes:

* Aside from external bindings changes, this PR is almost entirely implemented within `HsBindgen.Hs.Translation`.

* The signature for top-level function `generateDeclarations` is unchanged, and the `State` monad is used to track instances internally.  The type of the state is as follows.

    ```haskell
    type InstanceMap = Map (HsName NsTypeConstr) (Set HsTypeClass)
    ```

    I initially used the `RWS` monad but decided against it because it complicated scoping.

* The implementation strictly separates code that does not depend on state, code that depends on state but cannot modify it, and code that may modify the state.  Example:

    ```haskell
    -- | Generate declarations for given C struct
    structDecs :: forall n m.
         (SNatI n, State.MonadState InstanceMap m)
      => TranslationOpts
      -> NameMangler
      -> C.Struct
      -> Vec n C.StructField
      -> m [Hs.Decl]
    structDecs opts nm struct fields = do
        (insts, decls) <- aux <$> State.get
        State.modify' $ Map.insert structName insts
        return decls
      where
        declPath :: C.DeclPath
        declPath = C.structDeclPath struct

        ...

        -- everything in aux is state-dependent
        aux :: InstanceMap -> (Set HsTypeClass, [Hs.Decl])
        aux instanceMap = (insts,) $
            structDecl : storableDecl ++ optDecls ++ hasFlamDecl
          where
            insts :: Set HsTypeClass
            insts = getInstances instanceMap structName candidateInsts $
              Hs.fieldType <$> Vec.toList structFields

        ...
    ```

    Everything in the `where` clause up until `aux` does not depend on state.  Everything defined under `aux` depends on state (exposed as `instanceMap`) but cannot modify it.  Only the (minimal) code in the `do` block makes use of the monad to get and modify the state.  I am *not* a fan of nested `where` clauses, but I think that this is a case where it is worthwhile.

* Auxiliary function `getInstances` computes intersections of sets of type classes, looking up type references in the current state.  It needs to know the type being processed in order to handle recursive types.

    ```haskell
    getInstances ::
       InstanceMap         -- ^ Current state
    -> HsName NsTypeConstr -- ^ Name of current type
    -> Set HsTypeClass     -- ^ Candidate instances
    -> [HsType]            -- ^ Dependencies
    -> Set HsTypeClass
    ```

    If a type is not found in the instance map, the function fails with `panicPure`.  This has not happened yet, across our existing tests.

I tested the example in #558 and confirmed that the `Eq` and `Show` instances are no longer derived.