### PR TITLE
Add showsType

### DIFF
--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -6,6 +6,8 @@
         "c\978",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName = "\978",
       foreignImportHeader = "adios.h",
       foreignImportDeclOrigin =
@@ -24,6 +26,8 @@
         "\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "\25308\25308",
       foreignImportHeader = "adios.h",
@@ -44,6 +48,8 @@
         "say\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "Say\25308\25308",
       foreignImportHeader = "adios.h",

--- a/hs-bindgen/fixtures/adios.pp.hs
+++ b/hs-bindgen/fixtures/adios.pp.hs
@@ -13,9 +13,15 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
+-- void ϒ (void)
+
 foreign import capi safe "adios.h ϒ" cϒ :: IO ()
 
+-- void 拜拜 (void)
+
 foreign import capi safe "adios.h 拜拜" 拜拜 :: IO ()
+
+-- void Say拜拜 (void)
 
 foreign import capi safe "adios.h Say拜拜" say拜拜 :: IO ()
 

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -225,6 +225,16 @@
                 (HsName
                   "@NsTypeConstr"
                   "Int32_t"))))),
+      foreignImportCRes = TypeTypedef
+        (CName "int32_t"),
+      foreignImportCArgs = [
+        TypePointer
+          (TypeTypedef
+            (CName "a_type_t")),
+        TypeTypedef (CName "uint32_t"),
+        TypeIncompleteArray
+          (TypeTypedef
+            (CName "uint8_t"))],
       foreignImportOrigName =
       "some_fun",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -42,6 +42,8 @@ a_DEFINE_2 = (2 :: FC.CInt)
 tWO_ARGS :: ((,) FC.CInt) FC.CInt
 tWO_ARGS = (,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 
+-- int32_t some_fun (a_type_t *arg1, uint32_t arg2, uint8_t arg3[])
+
 foreign import capi safe "distilled_lib_1.h some_fun" some_fun :: (F.Ptr A_type_t) -> Uint32_t -> (F.Ptr Uint8_t) -> IO Int32_t
 
 data Another_typedef_struct_t = Another_typedef_struct_t

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -424,6 +424,14 @@
           (HsPrimType HsPrimCChar)
           (HsIO
             (HsPrimType HsPrimCChar))),
+      foreignImportCRes = TypePrim
+        (PrimChar
+          (PrimSignImplicit Nothing)),
+      foreignImportCArgs = [
+        TypeTypedef (CName "F"),
+        TypePrim
+          (PrimChar
+            (PrimSignImplicit Nothing))],
       foreignImportOrigName = "quux",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -460,6 +468,13 @@
                 (HsName
                   "@NsTypeConstr"
                   "C"))))),
+      foreignImportCRes = TypePointer
+        (TypeTypedef (CName "C")),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimFloat),
+        TypePointer
+          (TypeTypedef (CName "C"))],
       foreignImportOrigName = "wam",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -493,6 +508,23 @@
           (HsIO
             (HsPtr
               (HsPrimType HsPrimCChar)))),
+      foreignImportCRes = TypePointer
+        (TypePrim
+          (PrimChar
+            (PrimSignImplicit
+              (Just Signed)))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimFloat),
+        TypePointer
+          (TypeFun
+            [
+              TypePrim
+                (PrimIntegral PrimInt Signed)]
+            (TypePrim
+              (PrimIntegral
+                PrimInt
+                Signed)))],
       foreignImportOrigName = "foo1",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -537,6 +569,21 @@
           (HsIO
             (HsPtr
               (HsPrimType HsPrimCChar)))),
+      foreignImportCRes = TypePointer
+        (TypePrim
+          (PrimChar
+            (PrimSignImplicit Nothing))),
+      foreignImportCArgs = [
+        TypeTypedef (CName "F"),
+        TypePointer
+          (TypeFun
+            [
+              TypePrim
+                (PrimIntegral PrimInt Signed)]
+            (TypePrim
+              (PrimIntegral
+                PrimInt
+                Signed)))],
       foreignImportOrigName = "foo2",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -581,6 +628,20 @@
                 (HsName
                   "@NsTypeConstr"
                   "C"))))),
+      foreignImportCRes = TypePointer
+        (TypeTypedef (CName "C")),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimFloat),
+        TypePointer
+          (TypeFun
+            [
+              TypePrim
+                (PrimIntegral PrimInt Signed)]
+            (TypePrim
+              (PrimIntegral
+                PrimInt
+                Signed)))],
       foreignImportOrigName = "foo3",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -619,6 +680,16 @@
               (HsPrimType HsPrimCShort)
               (HsIO
                 (HsPrimType HsPrimCInt))))),
+      foreignImportCRes = TypePointer
+        (TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimShort Signed)]
+          (TypePrim
+            (PrimIntegral PrimInt Signed))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName = "bar1",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -654,6 +725,15 @@
               (HsPrimType HsPrimCShort)
               (HsIO
                 (HsPrimType HsPrimCInt))))),
+      foreignImportCRes = TypePointer
+        (TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimShort Signed)]
+          (TypePrim
+            (PrimIntegral PrimInt Signed))),
+      foreignImportCArgs = [
+        TypeTypedef (CName "L")],
       foreignImportOrigName = "bar2",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -688,6 +768,14 @@
                 (HsName "@NsTypeConstr" "S"))
               (HsIO
                 (HsPrimType HsPrimCInt))))),
+      foreignImportCRes = TypePointer
+        (TypeFun
+          [TypeTypedef (CName "S")]
+          (TypePrim
+            (PrimIntegral PrimInt Signed))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName = "bar3",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -723,6 +811,15 @@
                   (HsName
                     "@NsTypeConstr"
                     "I")))))),
+      foreignImportCRes = TypePointer
+        (TypeFun
+          [
+            TypePrim
+              (PrimIntegral PrimShort Signed)]
+          (TypeTypedef (CName "I"))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName = "bar4",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -757,6 +854,18 @@
               (HsConstArray
                 3
                 (HsPrimType HsPrimCInt))))),
+      foreignImportCRes = TypePointer
+        (TypeConstArray
+          2
+          (TypeConstArray
+            3
+            (TypePrim
+              (PrimIntegral
+                PrimInt
+                Signed)))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimInt Signed)],
       foreignImportOrigName = "baz1",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -795,6 +904,17 @@
               (HsConstArray
                 3
                 (HsPrimType HsPrimCInt))))),
+      foreignImportCRes = TypePointer
+        (TypeConstArray
+          2
+          (TypeConstArray
+            3
+            (TypePrim
+              (PrimIntegral
+                PrimInt
+                Signed)))),
+      foreignImportCArgs = [
+        TypeTypedef (CName "I")],
       foreignImportOrigName = "baz2",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -834,6 +954,15 @@
                   (HsName
                     "@NsTypeConstr"
                     "I")))))),
+      foreignImportCRes = TypePointer
+        (TypeConstArray
+          2
+          (TypeConstArray
+            3
+            (TypeTypedef (CName "I")))),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimInt Signed)],
       foreignImportOrigName = "baz3",
       foreignImportHeader =
       "macro_in_fundecl.h",
@@ -862,6 +991,9 @@
       foreignImportType = HsIO
         (HsTypRef
           (HsName "@NsTypeConstr" "I")),
+      foreignImportCRes = TypeTypedef
+        (CName "I"),
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "no_args_no_void",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
@@ -162,28 +162,54 @@ deriving newtype instance Num S
 
 deriving newtype instance Real S
 
+-- char quux (F arg1, char arg2)
+
 foreign import capi safe "macro_in_fundecl.h quux" quux :: F -> FC.CChar -> IO FC.CChar
+
+-- C *wam (float arg1, C *arg2)
 
 foreign import capi safe "macro_in_fundecl.h wam" wam :: FC.CFloat -> (F.Ptr C) -> IO (F.Ptr C)
 
+-- char *foo1 (float arg1, signed int (*arg2) (signed int arg1))
+
 foreign import capi safe "macro_in_fundecl.h foo1" foo1 :: FC.CFloat -> (F.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (F.Ptr FC.CChar)
+
+-- char *foo2 (F arg1, signed int (*arg2) (signed int arg1))
 
 foreign import capi safe "macro_in_fundecl.h foo2" foo2 :: F -> (F.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (F.Ptr FC.CChar)
 
+-- C *foo3 (float arg1, signed int (*arg2) (signed int arg1))
+
 foreign import capi safe "macro_in_fundecl.h foo3" foo3 :: FC.CFloat -> (F.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (F.Ptr C)
+
+-- signed int (*bar1) (signed short arg1) (signed long arg1)
 
 foreign import capi safe "macro_in_fundecl.h bar1" bar1 :: FC.CLong -> IO (F.FunPtr (FC.CShort -> IO FC.CInt))
 
+-- signed int (*bar2) (signed short arg1) (L arg1)
+
 foreign import capi safe "macro_in_fundecl.h bar2" bar2 :: L -> IO (F.FunPtr (FC.CShort -> IO FC.CInt))
+
+-- signed int (*bar3) (S arg1) (signed long arg1)
 
 foreign import capi safe "macro_in_fundecl.h bar3" bar3 :: FC.CLong -> IO (F.FunPtr (S -> IO FC.CInt))
 
+-- I (*bar4) (signed short arg1) (signed long arg1)
+
 foreign import capi safe "macro_in_fundecl.h bar4" bar4 :: FC.CLong -> IO (F.FunPtr (FC.CShort -> IO I))
+
+-- signed int *baz1[2][3] (signed int arg1)
 
 foreign import capi safe "macro_in_fundecl.h baz1" baz1 :: FC.CInt -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
+-- signed int *baz2[2][3] (I arg1)
+
 foreign import capi safe "macro_in_fundecl.h baz2" baz2 :: I -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
+-- I *baz3[2][3] (signed int arg1)
+
 foreign import capi safe "macro_in_fundecl.h baz3" baz3 :: FC.CInt -> IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) I)))
+
+-- I no_args_no_void (void)
 
 foreign import capi safe "macro_in_fundecl.h no_args_no_void" no_args_no_void :: IO I

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -95,6 +95,12 @@
             (HsName "@NsTypeConstr" "TC"))
           (HsIO
             (HsPrimType HsPrimCChar))),
+      foreignImportCRes = TypePrim
+        (PrimChar
+          (PrimSignImplicit Nothing)),
+      foreignImportCArgs = [
+        TypeTypedef (CName "MC"),
+        TypeTypedef (CName "TC")],
       foreignImportOrigName = "quux1",
       foreignImportHeader =
       "macro_in_fundecl_vs_typedef.h",
@@ -127,6 +133,13 @@
               (HsName
                 "@NsTypeConstr"
                 "TC")))),
+      foreignImportCRes = TypeTypedef
+        (CName "TC"),
+      foreignImportCArgs = [
+        TypeTypedef (CName "MC"),
+        TypePrim
+          (PrimChar
+            (PrimSignImplicit Nothing))],
       foreignImportOrigName = "quux2",
       foreignImportHeader =
       "macro_in_fundecl_vs_typedef.h",
@@ -162,6 +175,13 @@
                 (HsName
                   "@NsTypeConstr"
                   "MC"))))),
+      foreignImportCRes = TypePointer
+        (TypeTypedef (CName "MC")),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimFloat),
+        TypePointer
+          (TypeTypedef (CName "TC"))],
       foreignImportOrigName = "wam1",
       foreignImportHeader =
       "macro_in_fundecl_vs_typedef.h",
@@ -197,6 +217,13 @@
                 (HsName
                   "@NsTypeConstr"
                   "TC"))))),
+      foreignImportCRes = TypePointer
+        (TypeTypedef (CName "TC")),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimFloat),
+        TypePointer
+          (TypeTypedef (CName "MC"))],
       foreignImportOrigName = "wam2",
       foreignImportHeader =
       "macro_in_fundecl_vs_typedef.h",
@@ -230,6 +257,11 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeTypedef (CName "struct2")),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_typedef1",
       foreignImportHeader =
@@ -263,6 +295,12 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeTypedef
+            (CName "struct3_t")),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_typedef2",
       foreignImportHeader =
@@ -297,6 +335,11 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeTypedef (CName "struct4")),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_typedef3",
       foreignImportHeader =
@@ -330,6 +373,14 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "struct1")
+              DeclPathCtxtTop)),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name1",
       foreignImportHeader =
@@ -366,6 +417,14 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "struct3")
+              DeclPathCtxtTop)),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name2",
       foreignImportHeader =
@@ -402,6 +461,14 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "struct4")
+              DeclPathCtxtTop)),
+        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name3",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
@@ -43,23 +43,43 @@ deriving newtype instance Num MC
 
 deriving newtype instance Real MC
 
+-- char quux1 (MC arg1, TC arg2)
+
 foreign import capi safe "macro_in_fundecl_vs_typedef.h quux1" quux1 :: MC -> TC -> IO FC.CChar
+
+-- TC quux2 (MC arg1, char arg2)
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h quux2" quux2 :: MC -> FC.CChar -> IO TC
 
+-- MC *wam1 (float arg1, TC *arg2)
+
 foreign import capi safe "macro_in_fundecl_vs_typedef.h wam1" wam1 :: FC.CFloat -> (F.Ptr TC) -> IO (F.Ptr MC)
+
+-- TC *wam2 (float arg1, MC *arg2)
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h wam2" wam2 :: FC.CFloat -> (F.Ptr MC) -> IO (F.Ptr TC)
 
+-- void struct_typedef1 (struct2 *arg1, MC arg2)
+
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef1" struct_typedef1 :: (F.Ptr Struct2) -> MC -> IO ()
+
+-- void struct_typedef2 (struct3_t *arg1, MC arg2)
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef2" struct_typedef2 :: (F.Ptr Struct3_t) -> MC -> IO ()
 
+-- void struct_typedef3 (struct4 *arg1, MC arg2)
+
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_typedef3" struct_typedef3 :: (F.Ptr Struct4) -> MC -> IO ()
+
+-- void struct_name1 (struct struct1 *arg1, MC arg2)
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name1" struct_name1 :: (F.Ptr Struct1) -> MC -> IO ()
 
+-- void struct_name2 (struct struct3 *arg1, MC arg2)
+
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name2" struct_name2 :: (F.Ptr Struct3) -> MC -> IO ()
+
+-- void struct_name3 (struct struct4 *arg1, MC arg2)
 
 foreign import capi safe "macro_in_fundecl_vs_typedef.h struct_name3" struct_name3 :: (F.Ptr Struct4) -> MC -> IO ()
 

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -402,6 +402,19 @@
                     "Triple")))
               (HsIO
                 (HsPrimType HsPrimUnit))))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimInt Signed),
+        TypePrim
+          (PrimIntegral PrimInt Signed),
+        TypePrim
+          (PrimIntegral PrimInt Signed),
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "triple")
+              DeclPathCtxtTop))],
       foreignImportOrigName =
       "mk_triple",
       foreignImportHeader =
@@ -445,6 +458,18 @@
               "@NsTypeConstr"
               "Index"))
           (HsIO (HsPrimType HsPrimCInt))),
+      foreignImportCRes = TypePrim
+        (PrimIntegral PrimInt Signed),
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "triple")
+              DeclPathCtxtTop)),
+        TypeEnum
+          (DeclPathName
+            (CName "index")
+            DeclPathCtxtTop)],
       foreignImportOrigName =
       "index_triple",
       foreignImportHeader =
@@ -486,6 +511,14 @@
             (HsName
               "@NsTypeConstr"
               "Sum"))),
+      foreignImportCRes = TypeTypedef
+        (CName "sum"),
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "triple")
+              DeclPathCtxtTop))],
       foreignImportOrigName =
       "sum_triple",
       foreignImportHeader =
@@ -523,6 +556,14 @@
             (HsName
               "@NsTypeConstr"
               "Average"))),
+      foreignImportCRes = TypeTypedef
+        (CName "average"),
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "triple")
+              DeclPathCtxtTop))],
       foreignImportOrigName =
       "average_triple",
       foreignImportHeader =
@@ -560,6 +601,11 @@
             (HsName
               "@NsTypeConstr"
               "YEAR"))),
+      foreignImportCRes = TypeTypedef
+        (CName "YEAR"),
+      foreignImportCArgs = [
+        TypePointer
+          (TypeTypedef (CName "date"))],
       foreignImportOrigName =
       "getYear",
       foreignImportHeader =
@@ -591,6 +637,15 @@
                 "@NsTypeConstr"
                 "Occupation")))
           (HsIO (HsPrimType HsPrimUnit))),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePrim
+          (PrimIntegral PrimInt Signed),
+        TypePointer
+          (TypeUnion
+            (DeclPathName
+              (CName "occupation")
+              DeclPathCtxtTop))],
       foreignImportOrigName =
       "print_occupation",
       foreignImportHeader =
@@ -620,6 +675,8 @@
         "\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "\25308\25308",
       foreignImportHeader =
@@ -642,6 +699,8 @@
         "c\978",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName = "\978",
       foreignImportHeader =
       "manual_examples.h",
@@ -662,6 +721,8 @@
         "import'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "import",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -126,21 +126,39 @@ deriving newtype instance Num DAY
 
 deriving newtype instance Real DAY
 
+-- void mk_triple (signed int arg1, signed int arg2, signed int arg3, struct triple *arg4)
+
 foreign import capi safe "manual_examples.h mk_triple" mk_triple :: FC.CInt -> FC.CInt -> FC.CInt -> (F.Ptr Triple) -> IO ()
+
+-- signed int index_triple (struct triple *arg1, enum index arg2)
 
 foreign import capi safe "manual_examples.h index_triple" index_triple :: (F.Ptr Triple) -> Index -> IO FC.CInt
 
+-- sum sum_triple (struct triple *arg1)
+
 foreign import capi safe "manual_examples.h sum_triple" sum_triple :: (F.Ptr Triple) -> IO Sum
+
+-- average average_triple (struct triple *arg1)
 
 foreign import capi safe "manual_examples.h average_triple" average_triple :: (F.Ptr Triple) -> IO Average
 
+-- YEAR getYear (date *arg1)
+
 foreign import capi safe "manual_examples.h getYear" getYear :: (F.Ptr Date) -> IO YEAR
+
+-- void print_occupation (signed int arg1, union occupation *arg2)
 
 foreign import capi safe "manual_examples.h print_occupation" print_occupation :: FC.CInt -> (F.Ptr Occupation) -> IO ()
 
+-- void 拜拜 (void)
+
 foreign import capi safe "manual_examples.h 拜拜" 拜拜 :: IO ()
 
+-- void ϒ (void)
+
 foreign import capi safe "manual_examples.h ϒ" cϒ :: IO ()
+
+-- void import (void)
 
 foreign import capi safe "manual_examples.h import" import' :: IO ()
 

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -8,6 +8,11 @@
         (HsPrimType HsPrimCDouble)
         (HsIO
           (HsPrimType HsPrimCDouble)),
+      foreignImportCRes = TypePrim
+        (PrimFloating PrimDouble),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimDouble)],
       foreignImportOrigName = "erf",
       foreignImportHeader =
       "simple_func.h",
@@ -37,6 +42,15 @@
             (HsPrimType HsPrimCDouble)
             (HsIO
               (HsPrimType HsPrimCDouble)))),
+      foreignImportCRes = TypePrim
+        (PrimFloating PrimDouble),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimFloating PrimDouble),
+        TypePrim
+          (PrimFloating PrimDouble),
+        TypePrim
+          (PrimFloating PrimDouble)],
       foreignImportOrigName =
       "bad_fma",
       foreignImportHeader =
@@ -65,6 +79,8 @@
         "no_args",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "no_args",
       foreignImportHeader =
@@ -86,6 +102,8 @@
         "no_args_no_void",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [],
       foreignImportOrigName =
       "no_args_no_void",
       foreignImportHeader =
@@ -111,6 +129,15 @@
         (HsFun
           (HsPrimType HsPrimCDouble)
           (HsIO (HsPrimType HsPrimCInt))),
+      foreignImportCRes = TypePrim
+        (PrimIntegral PrimInt Signed),
+      foreignImportCArgs = [
+        TypePrim
+          (PrimChar
+            (PrimSignImplicit
+              (Just Signed))),
+        TypePrim
+          (PrimFloating PrimDouble)],
       foreignImportOrigName = "fun",
       foreignImportHeader =
       "simple_func.h",

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -6,12 +6,22 @@ module Example where
 import qualified Foreign.C as FC
 import Prelude (IO)
 
+-- double erf (double arg1)
+
 foreign import capi safe "simple_func.h erf" erf :: FC.CDouble -> IO FC.CDouble
+
+-- double bad_fma (double arg1, double arg2, double arg3)
 
 foreign import capi safe "simple_func.h bad_fma" bad_fma :: FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDouble
 
+-- void no_args (void)
+
 foreign import capi safe "simple_func.h no_args" no_args :: IO ()
 
+-- void no_args_no_void (void)
+
 foreign import capi safe "simple_func.h no_args_no_void" no_args_no_void :: IO ()
+
+-- signed int fun (char arg1, double arg2)
 
 foreign import capi safe "simple_func.h fun" fun :: FC.CChar -> FC.CDouble -> IO FC.CInt

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -9,6 +9,14 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "Bar")))
         (HsIO (HsPrimType HsPrimUnit)),
+      foreignImportCRes = TypeVoid,
+      foreignImportCArgs = [
+        TypePointer
+          (TypeStruct
+            (DeclPathName
+              (CName "bar")
+              (DeclPathCtxtPtr
+                DeclPathCtxtTop)))],
       foreignImportOrigName = "func",
       foreignImportHeader =
       "weird01.h",

--- a/hs-bindgen/fixtures/weird01.pp.hs
+++ b/hs-bindgen/fixtures/weird01.pp.hs
@@ -9,6 +9,8 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import Prelude ((<*>), Eq, IO, Int, Show, pure)
 
+-- void func (struct bar *arg1)
+
 foreign import capi safe "weird01.h func" func :: (F.Ptr Bar) -> IO ()
 
 data Foo = Foo

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -12,6 +12,8 @@ import HsBindgen.Hs.AST (Strategy (..))
 -- | Which GHC language extensions this declarations needs.
 requiredExtensions :: SDecl -> Set TH.Extension
 requiredExtensions = \case
+    DComment {} ->
+        Set.empty
     DVar _name ty _expr ->
         foldMap typeExtensions ty
     DInst x -> Set.fromList $ catMaybes [

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -103,6 +103,7 @@ instance Pretty ImportListItem where
 
 instance Pretty SDecl where
   pretty = \case
+    DComment s -> "--" <+> string s
     DVar name mbTy expr ->
       fsep
         [ pretty name <+> string "::" <+> pretty ty

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
@@ -136,6 +136,7 @@ instance Monoid ImportAcc where
 -- | Resolve imports in a declaration
 resolveDeclImports :: SDecl -> ImportAcc
 resolveDeclImports = \case
+    DComment {} -> mempty
     DVar _name mbTy e ->
       maybe mempty resolveTypeImports mbTy <> resolveExprImports e
     DInst Instance{..} -> mconcat $

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -452,6 +452,7 @@ mkPrimType = TH.conT . mkGlobalP
 
 mkDecl :: forall q. Quote q => SDecl -> q [TH.Dec]
 mkDecl = \case
+      DComment {} -> return []
       DVar x Nothing   f -> singleton <$> simpleDecl (hsNameToTH x) f
       DVar x (Just ty) f -> sequence
           [ TH.sigD (hsNameToTH x) (mkType EmptyEnv ty)

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -58,7 +58,6 @@ module HsBindgen.Hs.AST (
   , PatSynOrigin(..)
   ) where
 
-import Data.List.NonEmpty (NonEmpty)
 import Data.Type.Nat (SNat, SNatI, snat)
 import Data.Type.Nat qualified as Nat
 
@@ -134,6 +133,8 @@ data NewtypeOrigin =
 data ForeignImportDecl = ForeignImportDecl
     { foreignImportName       :: HsName NsVar
     , foreignImportType       :: HsType
+    , foreignImportCRes       :: C.Type
+    , foreignImportCArgs      :: [C.Type]
     , foreignImportOrigName   :: Text
     , foreignImportHeader     :: FilePath -- TODO: https://github.com/well-typed/hs-bindgen/issues/333
     , foreignImportDeclOrigin :: ForeignImportDeclOrigin

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -555,6 +555,8 @@ functionDecs _opts typedefs nm f
     [ Hs.DeclForeignImport $ Hs.ForeignImportDecl
         { foreignImportName       = mangle nm $ NameVar $ C.functionName f
         , foreignImportType       = ty
+        , foreignImportCRes       = C.functionRes f
+        , foreignImportCArgs      = C.functionArgs f
         , foreignImportOrigName   = C.getCName $ C.functionName f
         , foreignImportHeader     = getCHeaderIncludePath $ C.functionHeader f
         , foreignImportDeclOrigin = Hs.ForeignImportDeclOriginFunction f

--- a/hs-bindgen/src-internal/HsBindgen/Imports.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Imports.hs
@@ -28,6 +28,7 @@ import Numeric.Natural as X (Natural)
 -- types
 import Data.IntMap.Strict as X (IntMap)
 import Data.IntSet as X (IntSet)
+import Data.List.NonEmpty as X (NonEmpty (..))
 import Data.Map.Strict as X (Map)
 import Data.Nat as X (Nat (Z, S))
 import Data.Set as X (Set)

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -130,7 +130,7 @@ genHsDecls Opts{..} = Hs.generateDeclarations optsTranslation optsNameMangler
 
 -- | Generate @SHs@ declarations
 genSHsDecls :: [Hs.Decl] -> [SHs.SDecl]
-genSHsDecls = map SHs.translateDecl
+genSHsDecls = concatMap SHs.translateDecl
 
 -- | Generate a preprocessor 'Backend.PP.HsModule'
 genModule :: PPOpts -> [SHs.SDecl] -> Backend.PP.HsModule

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -228,6 +228,7 @@ data SDecl =
   | DDerivingInstance (Hs.Strategy ClosedType) ClosedType
   | DForeignImport ForeignImport
   | DPatternSynonym PatternSynonym
+  | DComment String
   deriving stock (Show)
 
 type ClosedType = SType EmptyCtx


### PR DESCRIPTION
... and use it to print original C signatures for now Later we'll use that to make our own C wrappers.

The implementation does a bit of non-sense with function pointers (and arrays). I'll fix up those later, those examples can be fixed independently of further userland-capi work.