### PR TITLE
Make empty a unit of SimplePrettyPrint.vsep

### DIFF
--- a/hs-bindgen/fixtures/headers.pp.hs
+++ b/hs-bindgen/fixtures/headers.pp.hs
@@ -1,4 +1,3 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Example where
-

--- a/hs-bindgen/fixtures/unnamed-struct.pp.hs
+++ b/hs-bindgen/fixtures/unnamed-struct.pp.hs
@@ -1,4 +1,3 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Example where
-

--- a/hs-bindgen/src-internal/Text/SimplePrettyPrint.hs
+++ b/hs-bindgen/src-internal/Text/SimplePrettyPrint.hs
@@ -183,7 +183,10 @@ vsep = \case
     ds -> CtxDoc $ \ctx -> foldl1 aux $ map (runCtxDoc ctx) ds
   where
     aux :: PP.Doc -> PP.Doc -> PP.Doc
-    aux dL dR = dL PP.$+$ "" PP.$+$ dR
+    aux dL dR
+        | PP.isEmpty dL = dR
+        | PP.isEmpty dR = dL
+        | otherwise     = dL PP.$+$ "" PP.$+$ dR
 
 -- | Horizontally /or/ vertically join documents, depending on if there is
 -- room on the line


### PR DESCRIPTION
So we don't get extra empty lines from vsep [empty, empty, empty]...