### PR TITLE
More informative `UnrecognizedType` exception

### DIFF
--- a/clang/src/Clang/HighLevel/SourceLoc.hs
+++ b/clang/src/Clang/HighLevel/SourceLoc.hs
@@ -97,7 +97,7 @@ data MultiLoc = MultiLoc {
       -- If the location refers into a macro instantiation, this corresponds to
       -- the /original/ location of the spelling in the source file.
       --
-      -- /WARNING/: This field is only populated correctly from @llvm >= 191.0@;
+      -- /WARNING/: This field is only populated correctly from @llvm >= 19.1.0@;
       -- prior to that this is equal to 'multiLocFile'.
       -- See <https://github.com/llvm/llvm-project/pull/72400>.
       --

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -341,9 +341,8 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
         return (TypeIncompleteArray e')
 
     _ -> do
-      name <- CName <$> liftIO (clang_getTypeSpelling ty)
-      liftIO $ print name
-      unrecognizedType ty
+      mLoc <- liftIO $ traverse HighLevel.clang_getCursorLocation declCursor
+      unrecognizedType ty (multiLocExpansion <$> mLoc)
 
   where
     processFun :: Eff (State DeclState) Type


### PR DESCRIPTION
For example, when we remove the case for `CXType_FunctionNoProto`, then if we run this on `examples/simple_func.h`, we get

```
hs-bindgen-dev: UnrecognizedType {
    unrecognizedTypeKind = simpleEnum CXType_FunctionNoProto
  , unrecognizedTypeSpelling = "void ()"
  , unrecognizedTypeLocation = Just "./examples/simple_func.h:9:6"
  , unrecognizedTypeTrace = CallStack (from HasCallStack):
      collectBacktrace, called at src-internal/HsBindgen/C/Fold/Common.hs:128:33 in hs-bindgen-0.1.0-inplace-internal:HsBindgen.C.Fold.Common
      unrecognizedType, called at src-internal/HsBindgen/C/Fold/Type.hs:345:7 in hs-bindgen-0.1.0-inplace-internal:HsBindgen.C.Fold.Type
}
```