### PR TITLE
Include `DeclPath` in `OpaqueStruct` / `OpaqueEnum`

### DIFF
--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -2515,8 +2515,17 @@
       emptyDataOrigin =
       EmptyDataOriginOpaqueStruct
         OpaqueStruct {
-          opaqueStructTag = CName
-            "person",
+          opaqueStructDeclPath =
+          DeclPathName
+            (CName "person")
+            (DeclPathCtxtPtr
+              (DeclPathCtxtField
+                (Just (CName "employee"))
+                (CName "supervisor")
+                (DeclPathCtxtField
+                  (Just (CName "occupation"))
+                  (CName "employee")
+                  DeclPathCtxtTop))),
           opaqueStructAliases = [],
           opaqueStructSourceLoc =
           "manual_examples.h:77:12"}},

--- a/hs-bindgen/fixtures/manual_examples.tree-diff.txt
+++ b/hs-bindgen/fixtures/manual_examples.tree-diff.txt
@@ -415,8 +415,17 @@ Header
         "manual_examples.h:70:10"},
     DeclOpaqueStruct
       OpaqueStruct {
-        opaqueStructTag = CName
-          "person",
+        opaqueStructDeclPath =
+        DeclPathName
+          (CName "person")
+          (DeclPathCtxtPtr
+            (DeclPathCtxtField
+              (Just (CName "employee"))
+              (CName "supervisor")
+              (DeclPathCtxtField
+                (Just (CName "occupation"))
+                (CName "employee")
+                DeclPathCtxtTop))),
         opaqueStructAliases = [],
         opaqueStructSourceLoc =
         "manual_examples.h:77:12"},

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -7,7 +7,10 @@
       emptyDataOrigin =
       EmptyDataOriginOpaqueStruct
         OpaqueStruct {
-          opaqueStructTag = CName "foo",
+          opaqueStructDeclPath =
+          DeclPathName
+            (CName "foo")
+            DeclPathCtxtTop,
           opaqueStructAliases = [],
           opaqueStructSourceLoc =
           "opaque_declaration.h:1:8"}},
@@ -497,7 +500,10 @@
       emptyDataOrigin =
       EmptyDataOriginOpaqueEnum
         OpaqueEnum {
-          opaqueEnumTag = CName "quu",
+          opaqueEnumDeclPath =
+          DeclPathName
+            (CName "quu")
+            DeclPathCtxtTop,
           opaqueEnumAliases = [],
           opaqueEnumSourceLoc =
           "opaque_declaration.h:11:6"}},
@@ -509,8 +515,10 @@
       emptyDataOrigin =
       EmptyDataOriginOpaqueStruct
         OpaqueStruct {
-          opaqueStructTag = CName
-            "opaque_union",
+          opaqueStructDeclPath =
+          DeclPathName
+            (CName "opaque_union")
+            DeclPathCtxtTop,
           opaqueStructAliases = [],
           opaqueStructSourceLoc =
           "opaque_declaration.h:13:7"}}]

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -2,7 +2,10 @@ Header
   [
     DeclOpaqueStruct
       OpaqueStruct {
-        opaqueStructTag = CName "foo",
+        opaqueStructDeclPath =
+        DeclPathName
+          (CName "foo")
+          DeclPathCtxtTop,
         opaqueStructAliases = [],
         opaqueStructSourceLoc =
         "opaque_declaration.h:1:8"},
@@ -54,14 +57,19 @@ Header
         "opaque_declaration.h:9:8"},
     DeclOpaqueEnum
       OpaqueEnum {
-        opaqueEnumTag = CName "quu",
+        opaqueEnumDeclPath =
+        DeclPathName
+          (CName "quu")
+          DeclPathCtxtTop,
         opaqueEnumAliases = [],
         opaqueEnumSourceLoc =
         "opaque_declaration.h:11:6"},
     DeclOpaqueStruct
       OpaqueStruct {
-        opaqueStructTag = CName
-          "opaque_union",
+        opaqueStructDeclPath =
+        DeclPathName
+          (CName "opaque_union")
+          DeclPathCtxtTop,
         opaqueStructAliases = [],
         opaqueStructSourceLoc =
         "opaque_declaration.h:13:7"}]

--- a/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
@@ -292,7 +292,7 @@ data StructField = StructField {
 --
 -- > struct foo;
 data OpaqueStruct = OpaqueStruct {
-      opaqueStructTag       :: CName
+      opaqueStructDeclPath  :: DeclPath
     , opaqueStructAliases   :: [CName]
     , opaqueStructSourceLoc :: SingleLoc
     }
@@ -349,7 +349,7 @@ data EnumValue = EnumValue {
 --
 -- > enum foo;
 data OpaqueEnum = OpaqueEnum {
-      opaqueEnumTag       :: CName
+      opaqueEnumDeclPath  :: DeclPath
     , opaqueEnumAliases   :: [CName]
     , opaqueEnumSourceLoc :: SingleLoc
     }

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -198,9 +198,9 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     case flavour of
                       TypeDeclExternal extId ->
                         addAlias ty $ TypeExtBinding extId ctype
-                      TypeDeclOpaque name -> do
+                      TypeDeclOpaque _name -> do
                         addDecl ty $ DeclOpaqueStruct OpaqueStruct {
-                            opaqueStructTag       = name
+                            opaqueStructDeclPath  = declPath
                           , opaqueStructAliases   = []
                           , opaqueStructSourceLoc = sloc
                           }
@@ -235,10 +235,10 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     case flavour of
                       TypeDeclExternal _extId ->
                         panicIO "external bindings for unions not implemented #537"
-                      TypeDeclOpaque name ->
+                      TypeDeclOpaque _name ->
                         -- opaque struct and opaque union look the same.
                         addDecl ty $ DeclOpaqueStruct OpaqueStruct {
-                              opaqueStructTag       = name
+                              opaqueStructDeclPath  = declPath
                             , opaqueStructAliases   = []
                             , opaqueStructSourceLoc = sloc
                             }
@@ -281,9 +281,9 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     case flavour of
                       TypeDeclExternal extId ->
                         addAlias ty $ TypeExtBinding extId ctype
-                      TypeDeclOpaque name ->
+                      TypeDeclOpaque _name ->
                         addDecl ty $ DeclOpaqueEnum OpaqueEnum {
-                            opaqueEnumTag       = name
+                            opaqueEnumDeclPath  = declPath
                           , opaqueEnumAliases   = []
                           , opaqueEnumSourceLoc = sloc
                           }

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -85,10 +85,10 @@ getEmptyDataExtBindings :: Hs.EmptyData -> [(CNameSpelling, HsIdentifier)]
 getEmptyDataExtBindings edata = fmap (, hsId) . catMaybes $
     case Hs.emptyDataOrigin edata of
       Hs.EmptyDataOriginOpaqueStruct C.OpaqueStruct{..} ->
-        Just (CNameSpelling ("struct " <> getCName opaqueStructTag))
+        getCNS "struct " opaqueStructDeclPath
           : map (Just . getCNS_alias) opaqueStructAliases
       Hs.EmptyDataOriginOpaqueEnum C.OpaqueEnum{..} ->
-        Just (CNameSpelling ("enum " <> getCName opaqueEnumTag))
+        getCNS "enum " opaqueEnumDeclPath
           : map (Just . getCNS_alias) opaqueEnumAliases
   where
     hsId :: HsIdentifier

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -226,7 +226,7 @@ opaqueStructDecs ::
   -> [Hs.Decl]
 opaqueStructDecs _opts nm o =
     [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.topLevel (C.opaqueStructTag o)
+          emptyDataName   = mangle nm $ NameTycon $ C.opaqueStructDeclPath o
         , emptyDataOrigin = Hs.EmptyDataOriginOpaqueStruct o
         }
     ]
@@ -234,7 +234,7 @@ opaqueStructDecs _opts nm o =
 opaqueEnumDecs :: TranslationOpts -> NameMangler -> C.OpaqueEnum -> [Hs.Decl]
 opaqueEnumDecs _opts nm o =
     [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.topLevel (C.opaqueEnumTag o)
+          emptyDataName   = mangle nm $ NameTycon $ C.opaqueEnumDeclPath o
         , emptyDataOrigin = Hs.EmptyDataOriginOpaqueEnum o
         }
     ]


### PR DESCRIPTION
Opaque types `OpaqueStruct` and `OpaqueEnum` only included the `CName` because there was no need for a full `DeclPath`.  When taking dependencies into account when sorting (#620), however, we need the full `DeclPath` for dependency type resolution.