### PR TITLE
Simplify `DeclPath`

### DIFF
--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -367,8 +367,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S1")
-            DeclPathCtxtTop,
+            (CName "S1"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -446,8 +445,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S1")
-              DeclPathCtxtTop,
+              (CName "S1"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -530,8 +528,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -616,8 +613,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1335,8 +1331,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S2")
-            DeclPathCtxtTop,
+            (CName "S2"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -1416,8 +1411,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S2")
-              DeclPathCtxtTop,
+              (CName "S2"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -1502,8 +1496,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1590,8 +1583,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -2023,8 +2015,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S3")
-            DeclPathCtxtTop,
+            (CName "S3"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -2114,8 +2105,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S3")
-              DeclPathCtxtTop,
+              (CName "S3"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -2210,8 +2200,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S3")
-                      DeclPathCtxtTop,
+                      (CName "S3"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2308,8 +2297,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S3")
-                      DeclPathCtxtTop,
+                      (CName "S3"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -33,8 +33,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S1")
-          DeclPathCtxtTop,
+          (CName "S1"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -127,8 +126,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S2")
-          DeclPathCtxtTop,
+          (CName "S2"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -191,8 +189,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S3")
-          DeclPathCtxtTop,
+          (CName "S3"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -112,8 +112,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "flags")
-            DeclPathCtxtTop,
+            (CName "flags"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -287,8 +286,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "flags")
-              DeclPathCtxtTop,
+              (CName "flags"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -467,8 +465,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "flags")
-                      DeclPathCtxtTop,
+                      (CName "flags"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -653,8 +650,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "flags")
-                      DeclPathCtxtTop,
+                      (CName "flags"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -812,8 +808,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "overflow32")
-            DeclPathCtxtTop,
+            (CName "overflow32"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -907,8 +902,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "overflow32")
-              DeclPathCtxtTop,
+              (CName "overflow32"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -1007,8 +1001,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32")
-                      DeclPathCtxtTop,
+                      (CName "overflow32"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1110,8 +1103,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32")
-                      DeclPathCtxtTop,
+                      (CName "overflow32"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1234,8 +1226,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "overflow32b")
-            DeclPathCtxtTop,
+            (CName "overflow32b"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 8,
@@ -1329,8 +1320,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "overflow32b")
-              DeclPathCtxtTop,
+              (CName "overflow32b"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 8,
@@ -1429,8 +1419,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32b")
-                      DeclPathCtxtTop,
+                      (CName "overflow32b"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1532,8 +1521,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32b")
-                      DeclPathCtxtTop,
+                      (CName "overflow32b"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1656,8 +1644,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "overflow32c")
-            DeclPathCtxtTop,
+            (CName "overflow32c"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1751,8 +1738,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "overflow32c")
-              DeclPathCtxtTop,
+              (CName "overflow32c"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1851,8 +1837,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32c")
-                      DeclPathCtxtTop,
+                      (CName "overflow32c"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1954,8 +1939,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow32c")
-                      DeclPathCtxtTop,
+                      (CName "overflow32c"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2062,8 +2046,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "overflow64")
-            DeclPathCtxtTop,
+            (CName "overflow64"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -2133,8 +2116,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "overflow64")
-              DeclPathCtxtTop,
+              (CName "overflow64"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -2209,8 +2191,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow64")
-                      DeclPathCtxtTop,
+                      (CName "overflow64"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2287,8 +2268,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "overflow64")
-                      DeclPathCtxtTop,
+                      (CName "overflow64"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2383,8 +2363,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "alignA")
-            DeclPathCtxtTop,
+            (CName "alignA"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -2456,8 +2435,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "alignA")
-              DeclPathCtxtTop,
+              (CName "alignA"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -2534,8 +2512,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "alignA")
-                      DeclPathCtxtTop,
+                      (CName "alignA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -2614,8 +2591,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "alignA")
-                      DeclPathCtxtTop,
+                      (CName "alignA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -2711,8 +2687,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "alignB")
-            DeclPathCtxtTop,
+            (CName "alignB"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -2784,8 +2759,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "alignB")
-              DeclPathCtxtTop,
+              (CName "alignB"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -2862,8 +2836,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "alignB")
-                      DeclPathCtxtTop,
+                      (CName "alignB"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2942,8 +2915,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "alignB")
-                      DeclPathCtxtTop,
+                      (CName "alignB"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "flags")
-          DeclPathCtxtTop,
+          (CName "flags"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -67,8 +66,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "overflow32")
-          DeclPathCtxtTop,
+          (CName "overflow32"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -103,8 +101,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "overflow32b")
-          DeclPathCtxtTop,
+          (CName "overflow32b"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 8,
@@ -139,8 +136,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "overflow32c")
-          DeclPathCtxtTop,
+          (CName "overflow32c"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -175,8 +171,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "overflow64")
-          DeclPathCtxtTop,
+          (CName "overflow64"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -203,8 +198,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "alignA")
-          DeclPathCtxtTop,
+          (CName "alignA"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -232,8 +226,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "alignB")
-          DeclPathCtxtTop,
+          (CName "alignB"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -122,8 +122,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bools1")
-            DeclPathCtxtTop,
+            (CName "bools1"),
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -188,8 +187,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bools1")
-              DeclPathCtxtTop,
+              (CName "bools1"),
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -258,8 +256,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools1")
-                      DeclPathCtxtTop,
+                      (CName "bools1"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -331,8 +328,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools1")
-                      DeclPathCtxtTop,
+                      (CName "bools1"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -415,8 +411,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bools2")
-            DeclPathCtxtTop,
+            (CName "bools2"),
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -481,8 +476,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bools2")
-              DeclPathCtxtTop,
+              (CName "bools2"),
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -551,8 +545,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools2")
-                      DeclPathCtxtTop,
+                      (CName "bools2"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -624,8 +617,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools2")
-                      DeclPathCtxtTop,
+                      (CName "bools2"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -710,8 +702,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bools3")
-            DeclPathCtxtTop,
+            (CName "bools3"),
           structAliases = [],
           structSizeof = 2,
           structAlignment = 1,
@@ -781,8 +772,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bools3")
-              DeclPathCtxtTop,
+              (CName "bools3"),
             structAliases = [],
             structSizeof = 2,
             structAlignment = 1,
@@ -857,8 +847,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools3")
-                      DeclPathCtxtTop,
+                      (CName "bools3"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,
@@ -935,8 +924,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bools3")
-                      DeclPathCtxtTop,
+                      (CName "bools3"),
                     structAliases = [],
                     structSizeof = 2,
                     structAlignment = 1,

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -19,8 +19,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bools1")
-          DeclPathCtxtTop,
+          (CName "bools1"),
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,
@@ -43,8 +42,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bools2")
-          DeclPathCtxtTop,
+          (CName "bools2"),
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,
@@ -67,8 +65,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bools3")
-          DeclPathCtxtTop,
+          (CName "bools3"),
         structAliases = [],
         structSizeof = 2,
         structAlignment = 1,

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -1706,8 +1706,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "a_typedef_struct")
-            DeclPathCtxtTop,
+            (CName "a_typedef_struct"),
           structAliases = [],
           structSizeof = 140,
           structAlignment = 1,
@@ -2066,8 +2065,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "a_typedef_struct")
-              DeclPathCtxtTop,
+              (CName "a_typedef_struct"),
             structAliases = [],
             structSizeof = 140,
             structAlignment = 1,
@@ -2431,8 +2429,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "a_typedef_struct")
-                      DeclPathCtxtTop,
+                      (CName "a_typedef_struct"),
                     structAliases = [],
                     structSizeof = 140,
                     structAlignment = 1,
@@ -2807,8 +2804,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "a_typedef_struct")
-                      DeclPathCtxtTop,
+                      (CName "a_typedef_struct"),
                     structAliases = [],
                     structSizeof = 140,
                     structAlignment = 1,
@@ -2980,8 +2976,7 @@
             "a_typedef_struct_t",
           typedefType = TypeStruct
             (DeclPathName
-              (CName "a_typedef_struct")
-              DeclPathCtxtTop),
+              (CName "a_typedef_struct")),
           typedefSourceLoc =
           "distilled_lib_1.h:47:3"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -420,8 +420,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "a_typedef_struct")
-          DeclPathCtxtTop,
+          (CName "a_typedef_struct"),
         structAliases = [],
         structSizeof = 140,
         structAlignment = 1,
@@ -546,8 +545,7 @@ Header
           "a_typedef_struct_t",
         typedefType = TypeStruct
           (DeclPathName
-            (CName "a_typedef_struct")
-            DeclPathCtxtTop),
+            (CName "a_typedef_struct")),
         typedefSourceLoc =
         "distilled_lib_1.h:47:3"},
     DeclEnum

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -18,8 +18,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "first")
-            DeclPathCtxtTop,
+            (CName "first"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -56,8 +55,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "first")
-              DeclPathCtxtTop,
+              (CName "first"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -99,8 +97,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "first")
-                      DeclPathCtxtTop,
+                      (CName "first"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -142,8 +139,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "first")
-                      DeclPathCtxtTop,
+                      (CName "first"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -205,8 +201,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "first")
-              DeclPathCtxtTop,
+              (CName "first"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -249,8 +244,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "first")
-              DeclPathCtxtTop,
+              (CName "first"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -289,8 +283,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "first")
-              DeclPathCtxtTop,
+              (CName "first"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -365,8 +358,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "second")
-            DeclPathCtxtTop,
+            (CName "second"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Signed),
@@ -409,8 +401,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "second")
-              DeclPathCtxtTop,
+              (CName "second"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -458,8 +449,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "second")
-                      DeclPathCtxtTop,
+                      (CName "second"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -507,8 +497,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "second")
-                      DeclPathCtxtTop,
+                      (CName "second"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -576,8 +565,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "second")
-              DeclPathCtxtTop,
+              (CName "second"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -633,8 +621,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "second")
-              DeclPathCtxtTop,
+              (CName "second"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -681,8 +668,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "second")
-              DeclPathCtxtTop,
+              (CName "second"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -782,8 +768,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "same")
-            DeclPathCtxtTop,
+            (CName "same"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -822,8 +807,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "same")
-              DeclPathCtxtTop,
+              (CName "same"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -866,8 +850,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "same")
-                      DeclPathCtxtTop,
+                      (CName "same"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -911,8 +894,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "same")
-                      DeclPathCtxtTop,
+                      (CName "same"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -969,8 +951,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "same")
-              DeclPathCtxtTop,
+              (CName "same"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1016,8 +997,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "same")
-              DeclPathCtxtTop,
+              (CName "same"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1057,8 +1037,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "same")
-              DeclPathCtxtTop,
+              (CName "same"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1134,8 +1113,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "nonseq")
-            DeclPathCtxtTop,
+            (CName "nonseq"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1179,8 +1157,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "nonseq")
-              DeclPathCtxtTop,
+              (CName "nonseq"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1228,8 +1205,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "nonseq")
-                      DeclPathCtxtTop,
+                      (CName "nonseq"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1278,8 +1254,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "nonseq")
-                      DeclPathCtxtTop,
+                      (CName "nonseq"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1347,8 +1322,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "nonseq")
-              DeclPathCtxtTop,
+              (CName "nonseq"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1404,8 +1378,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "nonseq")
-              DeclPathCtxtTop,
+              (CName "nonseq"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1505,8 +1478,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "packad")
-            DeclPathCtxtTop,
+            (CName "packad"),
           enumAliases = [],
           enumType = TypePrim
             (PrimChar
@@ -1551,8 +1523,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "packad")
-              DeclPathCtxtTop,
+              (CName "packad"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -1601,8 +1572,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "packad")
-                      DeclPathCtxtTop,
+                      (CName "packad"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar
@@ -1652,8 +1622,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "packad")
-                      DeclPathCtxtTop,
+                      (CName "packad"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar
@@ -1722,8 +1691,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "packad")
-              DeclPathCtxtTop,
+              (CName "packad"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -1780,8 +1748,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "packad")
-              DeclPathCtxtTop,
+              (CName "packad"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -1829,8 +1796,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "packad")
-              DeclPathCtxtTop,
+              (CName "packad"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -2287,8 +2253,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "enumB")
-            DeclPathCtxtTop,
+            (CName "enumB"),
           enumAliases = [CName "enumB"],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -2327,8 +2292,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumB")
-              DeclPathCtxtTop,
+              (CName "enumB"),
             enumAliases = [CName "enumB"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2372,8 +2336,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumB")
-                      DeclPathCtxtTop,
+                      (CName "enumB"),
                     enumAliases = [CName "enumB"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2417,8 +2380,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumB")
-                      DeclPathCtxtTop,
+                      (CName "enumB"),
                     enumAliases = [CName "enumB"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2482,8 +2444,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumB")
-              DeclPathCtxtTop,
+              (CName "enumB"),
             enumAliases = [CName "enumB"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2528,8 +2489,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumB")
-              DeclPathCtxtTop,
+              (CName "enumB"),
             enumAliases = [CName "enumB"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2570,8 +2530,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumB")
-              DeclPathCtxtTop,
+              (CName "enumB"),
             enumAliases = [CName "enumB"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2647,8 +2606,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "enumC")
-            DeclPathCtxtTop,
+            (CName "enumC"),
           enumAliases = [CName "enumC"],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -2687,8 +2645,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumC")
-              DeclPathCtxtTop,
+              (CName "enumC"),
             enumAliases = [CName "enumC"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2731,8 +2688,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumC")
-                      DeclPathCtxtTop,
+                      (CName "enumC"),
                     enumAliases = [CName "enumC"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2776,8 +2732,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumC")
-                      DeclPathCtxtTop,
+                      (CName "enumC"),
                     enumAliases = [CName "enumC"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -2840,8 +2795,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumC")
-              DeclPathCtxtTop,
+              (CName "enumC"),
             enumAliases = [CName "enumC"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2885,8 +2839,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumC")
-              DeclPathCtxtTop,
+              (CName "enumC"),
             enumAliases = [CName "enumC"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -2926,8 +2879,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumC")
-              DeclPathCtxtTop,
+              (CName "enumC"),
             enumAliases = [CName "enumC"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -3003,8 +2955,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "enumD")
-            DeclPathCtxtTop,
+            (CName "enumD"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -3043,8 +2994,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumD")
-              DeclPathCtxtTop,
+              (CName "enumD"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -3087,8 +3037,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumD")
-                      DeclPathCtxtTop,
+                      (CName "enumD"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -3132,8 +3081,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumD")
-                      DeclPathCtxtTop,
+                      (CName "enumD"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -3196,8 +3144,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumD")
-              DeclPathCtxtTop,
+              (CName "enumD"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -3241,8 +3188,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumD")
-              DeclPathCtxtTop,
+              (CName "enumD"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -3282,8 +3228,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumD")
-              DeclPathCtxtTop,
+              (CName "enumD"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -3362,9 +3307,7 @@
         Typedef {
           typedefName = CName "enumD_t",
           typedefType = TypeEnum
-            (DeclPathName
-              (CName "enumD")
-              DeclPathCtxtTop),
+            (DeclPathName (CName "enumD")),
           typedefSourceLoc =
           "enums.h:38:20"}},
   DeclNewtypeInstance

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -18,8 +18,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "first")
-          DeclPathCtxtTop,
+          (CName "first"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -39,8 +38,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "second")
-          DeclPathCtxtTop,
+          (CName "second"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Signed),
@@ -66,8 +64,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "same")
-          DeclPathCtxtTop,
+          (CName "same"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -88,8 +85,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "nonseq")
-          DeclPathCtxtTop,
+          (CName "nonseq"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -115,8 +111,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "packad")
-          DeclPathCtxtTop,
+          (CName "packad"),
         enumAliases = [],
         enumType = TypePrim
           (PrimChar
@@ -165,8 +160,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "enumB")
-          DeclPathCtxtTop,
+          (CName "enumB"),
         enumAliases = [CName "enumB"],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -188,8 +182,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "enumC")
-          DeclPathCtxtTop,
+          (CName "enumC"),
         enumAliases = [CName "enumC"],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -210,8 +203,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "enumD")
-          DeclPathCtxtTop,
+          (CName "enumD"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -233,8 +225,6 @@ Header
       Typedef {
         typedefName = CName "enumD_t",
         typedefType = TypeEnum
-          (DeclPathName
-            (CName "enumD")
-            DeclPathCtxtTop),
+          (DeclPathName (CName "enumD")),
         typedefSourceLoc =
         "enums.h:38:20"}]

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -86,8 +86,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "Example")
-            DeclPathCtxtTop,
+            (CName "Example"),
           structAliases = [],
           structSizeof = 48,
           structAlignment = 4,
@@ -173,8 +172,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "Example")
-              DeclPathCtxtTop,
+              (CName "Example"),
             structAliases = [],
             structSizeof = 48,
             structAlignment = 4,
@@ -265,8 +263,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Example")
-                      DeclPathCtxtTop,
+                      (CName "Example"),
                     structAliases = [],
                     structSizeof = 48,
                     structAlignment = 4,
@@ -359,8 +356,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Example")
-                      DeclPathCtxtTop,
+                      (CName "Example"),
                     structAliases = [],
                     structSizeof = 48,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -12,8 +12,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "Example")
-          DeclPathCtxtTop,
+          (CName "Example"),
         structAliases = [],
         structSizeof = 48,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -252,8 +252,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -327,8 +326,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -407,8 +405,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -489,8 +486,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -19,8 +19,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -28,8 +28,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "pascal")
-            DeclPathCtxtTop,
+            (CName "pascal"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -83,8 +82,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "pascal")
-              DeclPathCtxtTop,
+              (CName "pascal"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -142,8 +140,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "pascal")
-                      DeclPathCtxtTop,
+                      (CName "pascal"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -202,8 +199,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "pascal")
-                      DeclPathCtxtTop,
+                      (CName "pascal"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -275,8 +271,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "pascal")
-              DeclPathCtxtTop,
+              (CName "pascal"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -649,8 +644,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -706,8 +700,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -767,8 +760,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -829,8 +821,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -900,8 +891,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -978,8 +968,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "diff")
-            DeclPathCtxtTop,
+            (CName "diff"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1061,8 +1050,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "diff")
-              DeclPathCtxtTop,
+              (CName "diff"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1149,8 +1137,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "diff")
-                      DeclPathCtxtTop,
+                      (CName "diff"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1239,8 +1226,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "diff")
-                      DeclPathCtxtTop,
+                      (CName "diff"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1338,8 +1324,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "diff")
-              DeclPathCtxtTop,
+              (CName "diff"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "pascal")
-          DeclPathCtxtTop,
+          (CName "pascal"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -59,8 +58,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -88,8 +86,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "diff")
-          DeclPathCtxtTop,
+          (CName "diff"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -28,8 +28,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S1")
-            DeclPathCtxtTop,
+            (CName "S1"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -75,8 +74,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S1")
-              DeclPathCtxtTop,
+              (CName "S1"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -127,8 +125,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -179,8 +176,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -231,9 +227,7 @@
         Typedef {
           typedefName = CName "S1_t",
           typedefType = TypeStruct
-            (DeclPathName
-              (CName "S1")
-              DeclPathCtxtTop),
+            (DeclPathName (CName "S1")),
           typedefSourceLoc =
           "forward_declaration.h:1:19"}},
   DeclNewtypeInstance
@@ -269,8 +263,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S2")
-            DeclPathCtxtTop,
+            (CName "S2"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -316,8 +309,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S2")
-              DeclPathCtxtTop,
+              (CName "S2"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -368,8 +360,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -420,8 +411,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S1")
-          DeclPathCtxtTop,
+          (CName "S1"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -24,16 +23,13 @@ Header
       Typedef {
         typedefName = CName "S1_t",
         typedefType = TypeStruct
-          (DeclPathName
-            (CName "S1")
-            DeclPathCtxtTop),
+          (DeclPathName (CName "S1")),
         typedefSourceLoc =
         "forward_declaration.h:1:19"},
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S2")
-          DeclPathCtxtTop,
+          (CName "S2"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -378,8 +378,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "struct1")
-              DeclPathCtxtTop)),
+              (CName "struct1"))),
         TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name1",
@@ -394,8 +393,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "struct1")
-                  DeclPathCtxtTop)),
+                  (CName "struct1"))),
             TypeTypedef (CName "MC")],
           functionRes = TypeVoid,
           functionHeader =
@@ -422,8 +420,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "struct3")
-              DeclPathCtxtTop)),
+              (CName "struct3"))),
         TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name2",
@@ -438,8 +435,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "struct3")
-                  DeclPathCtxtTop)),
+                  (CName "struct3"))),
             TypeTypedef (CName "MC")],
           functionRes = TypeVoid,
           functionHeader =
@@ -466,8 +462,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "struct4")
-              DeclPathCtxtTop)),
+              (CName "struct4"))),
         TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "struct_name3",
@@ -482,8 +477,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "struct4")
-                  DeclPathCtxtTop)),
+                  (CName "struct4"))),
             TypeTypedef (CName "MC")],
           functionRes = TypeVoid,
           functionHeader =
@@ -596,8 +590,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "struct1")
-            DeclPathCtxtTop,
+            (CName "struct1"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -643,8 +636,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "struct1")
-              DeclPathCtxtTop,
+              (CName "struct1"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -695,8 +687,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct1")
-                      DeclPathCtxtTop,
+                      (CName "struct1"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -747,8 +738,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct1")
-                      DeclPathCtxtTop,
+                      (CName "struct1"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -1028,8 +1018,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "struct3")
-            DeclPathCtxtTop,
+            (CName "struct3"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -1075,8 +1064,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "struct3")
-              DeclPathCtxtTop,
+              (CName "struct3"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -1127,8 +1115,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct3")
-                      DeclPathCtxtTop,
+                      (CName "struct3"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -1179,8 +1166,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct3")
-                      DeclPathCtxtTop,
+                      (CName "struct3"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -1238,8 +1224,7 @@
           typedefName = CName "struct3_t",
           typedefType = TypeStruct
             (DeclPathName
-              (CName "struct3")
-              DeclPathCtxtTop),
+              (CName "struct3")),
           typedefSourceLoc =
           "macro_in_fundecl_vs_typedef.h:20:35"}},
   DeclNewtypeInstance
@@ -1277,8 +1262,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "struct4")
-            DeclPathCtxtTop,
+            (CName "struct4"),
           structAliases = [
             CName "struct4"],
           structSizeof = 4,
@@ -1325,8 +1309,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "struct4")
-              DeclPathCtxtTop,
+              (CName "struct4"),
             structAliases = [
               CName "struct4"],
             structSizeof = 4,
@@ -1378,8 +1361,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct4")
-                      DeclPathCtxtTop,
+                      (CName "struct4"),
                     structAliases = [
                       CName "struct4"],
                     structSizeof = 4,
@@ -1431,8 +1413,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "struct4")
-                      DeclPathCtxtTop,
+                      (CName "struct4"),
                     structAliases = [
                       CName "struct4"],
                     structSizeof = 4,

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
@@ -122,8 +122,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "struct1")
-                DeclPathCtxtTop)),
+                (CName "struct1"))),
           TypeTypedef (CName "MC")],
         functionRes = TypeVoid,
         functionHeader =
@@ -138,8 +137,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "struct3")
-                DeclPathCtxtTop)),
+                (CName "struct3"))),
           TypeTypedef (CName "MC")],
         functionRes = TypeVoid,
         functionHeader =
@@ -154,8 +152,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "struct4")
-                DeclPathCtxtTop)),
+                (CName "struct4"))),
           TypeTypedef (CName "MC")],
         functionRes = TypeVoid,
         functionHeader =
@@ -174,8 +171,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "struct1")
-          DeclPathCtxtTop,
+          (CName "struct1"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -214,8 +210,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "struct3")
-          DeclPathCtxtTop,
+          (CName "struct3"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -236,15 +231,13 @@ Header
         typedefName = CName "struct3_t",
         typedefType = TypeStruct
           (DeclPathName
-            (CName "struct3")
-            DeclPathCtxtTop),
+            (CName "struct3")),
         typedefSourceLoc =
         "macro_in_fundecl_vs_typedef.h:20:35"},
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "struct4")
-          DeclPathCtxtTop,
+          (CName "struct4"),
         structAliases = [
           CName "struct4"],
         structSizeof = 4,

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -413,8 +413,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "triple")
-              DeclPathCtxtTop))],
+              (CName "triple")))],
       foreignImportOrigName =
       "mk_triple",
       foreignImportHeader =
@@ -434,8 +433,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "triple")
-                  DeclPathCtxtTop))],
+                  (CName "triple")))],
           functionRes = TypeVoid,
           functionHeader =
           "manual_examples.h",
@@ -464,12 +462,9 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "triple")
-              DeclPathCtxtTop)),
+              (CName "triple"))),
         TypeEnum
-          (DeclPathName
-            (CName "index")
-            DeclPathCtxtTop)],
+          (DeclPathName (CName "index"))],
       foreignImportOrigName =
       "index_triple",
       foreignImportHeader =
@@ -483,12 +478,9 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "triple")
-                  DeclPathCtxtTop)),
+                  (CName "triple"))),
             TypeEnum
-              (DeclPathName
-                (CName "index")
-                DeclPathCtxtTop)],
+              (DeclPathName (CName "index"))],
           functionRes = TypePrim
             (PrimIntegral PrimInt Signed),
           functionHeader =
@@ -517,8 +509,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "triple")
-              DeclPathCtxtTop))],
+              (CName "triple")))],
       foreignImportOrigName =
       "sum_triple",
       foreignImportHeader =
@@ -532,8 +523,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "triple")
-                  DeclPathCtxtTop))],
+                  (CName "triple")))],
           functionRes = TypeTypedef
             (CName "sum"),
           functionHeader =
@@ -562,8 +552,7 @@
         TypePointer
           (TypeStruct
             (DeclPathName
-              (CName "triple")
-              DeclPathCtxtTop))],
+              (CName "triple")))],
       foreignImportOrigName =
       "average_triple",
       foreignImportHeader =
@@ -577,8 +566,7 @@
             TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "triple")
-                  DeclPathCtxtTop))],
+                  (CName "triple")))],
           functionRes = TypeTypedef
             (CName "average"),
           functionHeader =
@@ -644,8 +632,7 @@
         TypePointer
           (TypeUnion
             (DeclPathName
-              (CName "occupation")
-              DeclPathCtxtTop))],
+              (CName "occupation")))],
       foreignImportOrigName =
       "print_occupation",
       foreignImportHeader =
@@ -661,8 +648,7 @@
             TypePointer
               (TypeUnion
                 (DeclPathName
-                  (CName "occupation")
-                  DeclPathCtxtTop))],
+                  (CName "occupation")))],
           functionRes = TypeVoid,
           functionHeader =
           "manual_examples.h",
@@ -798,8 +784,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "triple")
-            DeclPathCtxtTop,
+            (CName "triple"),
           structAliases = [
             CName "triple"],
           structSizeof = 12,
@@ -894,8 +879,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "triple")
-              DeclPathCtxtTop,
+              (CName "triple"),
             structAliases = [
               CName "triple"],
             structSizeof = 12,
@@ -995,8 +979,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "triple")
-                      DeclPathCtxtTop,
+                      (CName "triple"),
                     structAliases = [
                       CName "triple"],
                     structSizeof = 12,
@@ -1099,8 +1082,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "triple")
-                      DeclPathCtxtTop,
+                      (CName "triple"),
                     structAliases = [
                       CName "triple"],
                     structSizeof = 12,
@@ -1173,8 +1155,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "index")
-            DeclPathCtxtTop,
+            (CName "index"),
           enumAliases = [CName "index"],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -1218,8 +1199,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "index")
-              DeclPathCtxtTop,
+              (CName "index"),
             enumAliases = [CName "index"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1268,8 +1248,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "index")
-                      DeclPathCtxtTop,
+                      (CName "index"),
                     enumAliases = [CName "index"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1318,8 +1297,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "index")
-                      DeclPathCtxtTop,
+                      (CName "index"),
                     enumAliases = [CName "index"],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -1388,8 +1366,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "index")
-              DeclPathCtxtTop,
+              (CName "index"),
             enumAliases = [CName "index"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1440,8 +1417,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "index")
-              DeclPathCtxtTop,
+              (CName "index"),
             enumAliases = [CName "index"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1487,8 +1463,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "index")
-              DeclPathCtxtTop,
+              (CName "index"),
             enumAliases = [CName "index"],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -1802,8 +1777,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "date")
-            DeclPathCtxtTop,
+            (CName "date"),
           structAliases = [CName "date"],
           structSizeof = 12,
           structAlignment = 4,
@@ -1899,8 +1873,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "date")
-              DeclPathCtxtTop,
+              (CName "date"),
             structAliases = [CName "date"],
             structSizeof = 12,
             structAlignment = 4,
@@ -2001,8 +1974,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "date")
-                      DeclPathCtxtTop,
+                      (CName "date"),
                     structAliases = [CName "date"],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -2106,8 +2078,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "date")
-                      DeclPathCtxtTop,
+                      (CName "date"),
                     structAliases = [CName "date"],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -2204,11 +2175,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "student")
-            (DeclPathCtxtField
-              (Just (CName "occupation"))
-              (CName "student")
-              DeclPathCtxtTop),
+            (CName "student"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -2284,11 +2251,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "student")
-              (DeclPathCtxtField
-                (Just (CName "occupation"))
-                (CName "student")
-                DeclPathCtxtTop),
+              (CName "student"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -2369,11 +2332,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "student")
-                      (DeclPathCtxtField
-                        (Just (CName "occupation"))
-                        (CName "student")
-                        DeclPathCtxtTop),
+                      (CName "student"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2456,11 +2415,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "student")
-                      (DeclPathCtxtField
-                        (Just (CName "occupation"))
-                        (CName "student")
-                        DeclPathCtxtTop),
+                      (CName "student"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -2566,15 +2521,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "person")
-                    (DeclPathCtxtPtr
-                      (DeclPathCtxtField
-                        (Just (CName "employee"))
-                        (CName "supervisor")
-                        (DeclPathCtxtField
-                          (Just (CName "occupation"))
-                          (CName "employee")
-                          DeclPathCtxtTop))))),
+                    (CName "person"))),
               fieldSourceLoc =
               "manual_examples.h:77:20"}},
         Field {
@@ -2597,11 +2544,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "employee")
-            (DeclPathCtxtField
-              (Just (CName "occupation"))
-              (CName "employee")
-              DeclPathCtxtTop),
+            (CName "employee"),
           structAliases = [],
           structSizeof = 24,
           structAlignment = 8,
@@ -2624,15 +2567,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "person")
-                    (DeclPathCtxtPtr
-                      (DeclPathCtxtField
-                        (Just (CName "employee"))
-                        (CName "supervisor")
-                        (DeclPathCtxtField
-                          (Just (CName "occupation"))
-                          (CName "employee")
-                          DeclPathCtxtTop))))),
+                    (CName "person"))),
               fieldSourceLoc =
               "manual_examples.h:77:20"},
             StructField {
@@ -2693,15 +2628,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "person")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "employee"))
-                          (CName "supervisor")
-                          (DeclPathCtxtField
-                            (Just (CName "occupation"))
-                            (CName "employee")
-                            DeclPathCtxtTop))))),
+                      (CName "person"))),
                 fieldSourceLoc =
                 "manual_examples.h:77:20"}},
           Field {
@@ -2724,11 +2651,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "employee")
-              (DeclPathCtxtField
-                (Just (CName "occupation"))
-                (CName "employee")
-                DeclPathCtxtTop),
+              (CName "employee"),
             structAliases = [],
             structSizeof = 24,
             structAlignment = 8,
@@ -2751,15 +2674,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "person")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "employee"))
-                          (CName "supervisor")
-                          (DeclPathCtxtField
-                            (Just (CName "occupation"))
-                            (CName "employee")
-                            DeclPathCtxtTop))))),
+                      (CName "person"))),
                 fieldSourceLoc =
                 "manual_examples.h:77:20"},
               StructField {
@@ -2825,15 +2740,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "person")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "employee"))
-                                  (CName "supervisor")
-                                  (DeclPathCtxtField
-                                    (Just (CName "occupation"))
-                                    (CName "employee")
-                                    DeclPathCtxtTop))))),
+                              (CName "person"))),
                         fieldSourceLoc =
                         "manual_examples.h:77:20"}},
                   Field {
@@ -2856,11 +2763,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "employee")
-                      (DeclPathCtxtField
-                        (Just (CName "occupation"))
-                        (CName "employee")
-                        DeclPathCtxtTop),
+                      (CName "employee"),
                     structAliases = [],
                     structSizeof = 24,
                     structAlignment = 8,
@@ -2883,15 +2786,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "person")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "employee"))
-                                  (CName "supervisor")
-                                  (DeclPathCtxtField
-                                    (Just (CName "occupation"))
-                                    (CName "employee")
-                                    DeclPathCtxtTop))))),
+                              (CName "person"))),
                         fieldSourceLoc =
                         "manual_examples.h:77:20"},
                       StructField {
@@ -2960,15 +2855,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "person")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "employee"))
-                                  (CName "supervisor")
-                                  (DeclPathCtxtField
-                                    (Just (CName "occupation"))
-                                    (CName "employee")
-                                    DeclPathCtxtTop))))),
+                              (CName "person"))),
                         fieldSourceLoc =
                         "manual_examples.h:77:20"}},
                   Field {
@@ -2991,11 +2878,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "employee")
-                      (DeclPathCtxtField
-                        (Just (CName "occupation"))
-                        (CName "employee")
-                        DeclPathCtxtTop),
+                      (CName "employee"),
                     structAliases = [],
                     structSizeof = 24,
                     structAlignment = 8,
@@ -3018,15 +2901,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "person")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "employee"))
-                                  (CName "supervisor")
-                                  (DeclPathCtxtField
-                                    (Just (CName "occupation"))
-                                    (CName "employee")
-                                    DeclPathCtxtTop))))),
+                              (CName "person"))),
                         fieldSourceLoc =
                         "manual_examples.h:77:20"},
                       StructField {
@@ -3079,8 +2954,7 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathName
-            (CName "occupation")
-            DeclPathCtxtTop,
+            (CName "occupation"),
           unionAliases = [
             CName "occupation"],
           unionSizeof = 24,
@@ -3090,22 +2964,14 @@
               ufieldName = CName "student",
               ufieldType = TypeStruct
                 (DeclPathName
-                  (CName "student")
-                  (DeclPathCtxtField
-                    (Just (CName "occupation"))
-                    (CName "student")
-                    DeclPathCtxtTop)),
+                  (CName "student")),
               ufieldSourceLoc =
               "manual_examples.h:73:5"},
             UnionField {
               ufieldName = CName "employee",
               ufieldType = TypeStruct
                 (DeclPathName
-                  (CName "employee")
-                  (DeclPathCtxtField
-                    (Just (CName "occupation"))
-                    (CName "employee")
-                    DeclPathCtxtTop)),
+                  (CName "employee")),
               ufieldSourceLoc =
               "manual_examples.h:79:5"}],
           unionSourceLoc =
@@ -3864,8 +3730,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "rect")
-            DeclPathCtxtTop,
+            (CName "rect"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 4,
@@ -3955,8 +3820,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "rect")
-              DeclPathCtxtTop,
+              (CName "rect"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 4,
@@ -4051,8 +3915,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "rect")
-                      DeclPathCtxtTop,
+                      (CName "rect"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -4149,8 +4012,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "rect")
-                      DeclPathCtxtTop,
+                      (CName "rect"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -4850,8 +4712,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "signal")
-            DeclPathCtxtTop,
+            (CName "signal"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -4900,8 +4761,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "signal")
-              DeclPathCtxtTop,
+              (CName "signal"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -4955,8 +4815,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "signal")
-                      DeclPathCtxtTop,
+                      (CName "signal"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -5010,8 +4869,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "signal")
-                      DeclPathCtxtTop,
+                      (CName "signal"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -5085,8 +4943,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "signal")
-              DeclPathCtxtTop,
+              (CName "signal"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5143,8 +5000,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "signal")
-              DeclPathCtxtTop,
+              (CName "signal"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5195,8 +5051,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "signal")
-              DeclPathCtxtTop,
+              (CName "signal"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5320,8 +5175,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "HTTP_status")
-            DeclPathCtxtTop,
+            (CName "HTTP_status"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -5376,8 +5230,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "HTTP_status")
-              DeclPathCtxtTop,
+              (CName "HTTP_status"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5437,8 +5290,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "HTTP_status")
-                      DeclPathCtxtTop,
+                      (CName "HTTP_status"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -5498,8 +5350,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "HTTP_status")
-                      DeclPathCtxtTop,
+                      (CName "HTTP_status"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -5579,8 +5430,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "HTTP_status")
-              DeclPathCtxtTop,
+              (CName "HTTP_status"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5650,8 +5500,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "HTTP_status")
-              DeclPathCtxtTop,
+              (CName "HTTP_status"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5801,8 +5650,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "descending")
-            DeclPathCtxtTop,
+            (CName "descending"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -5851,8 +5699,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "descending")
-              DeclPathCtxtTop,
+              (CName "descending"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -5906,8 +5753,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "descending")
-                      DeclPathCtxtTop,
+                      (CName "descending"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -5961,8 +5807,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "descending")
-                      DeclPathCtxtTop,
+                      (CName "descending"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -6036,8 +5881,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "descending")
-              DeclPathCtxtTop,
+              (CName "descending"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -6095,8 +5939,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "descending")
-              DeclPathCtxtTop,
+              (CName "descending"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -6147,8 +5990,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "descending")
-              DeclPathCtxtTop,
+              (CName "descending"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -6272,8 +6114,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "result")
-            DeclPathCtxtTop,
+            (CName "result"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Signed),
@@ -6323,8 +6164,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "result")
-              DeclPathCtxtTop,
+              (CName "result"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -6379,8 +6219,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "result")
-                      DeclPathCtxtTop,
+                      (CName "result"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -6435,8 +6274,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "result")
-                      DeclPathCtxtTop,
+                      (CName "result"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Signed),
@@ -6511,8 +6349,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "result")
-              DeclPathCtxtTop,
+              (CName "result"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -6576,8 +6413,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "result")
-              DeclPathCtxtTop,
+              (CName "result"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -6631,8 +6467,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "result")
-              DeclPathCtxtTop,
+              (CName "result"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Signed),
@@ -6758,8 +6593,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "vote")
-            DeclPathCtxtTop,
+            (CName "vote"),
           enumAliases = [],
           enumType = TypePrim
             (PrimChar
@@ -6804,8 +6638,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "vote")
-              DeclPathCtxtTop,
+              (CName "vote"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -6855,8 +6688,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "vote")
-                      DeclPathCtxtTop,
+                      (CName "vote"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar
@@ -6906,8 +6738,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "vote")
-                      DeclPathCtxtTop,
+                      (CName "vote"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimChar
@@ -6971,8 +6802,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "vote")
-              DeclPathCtxtTop,
+              (CName "vote"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -7028,8 +6858,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "vote")
-              DeclPathCtxtTop,
+              (CName "vote"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -7076,8 +6905,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "vote")
-              DeclPathCtxtTop,
+              (CName "vote"),
             enumAliases = [],
             enumType = TypePrim
               (PrimChar
@@ -7178,8 +7006,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "CXCursorKind")
-            DeclPathCtxtTop,
+            (CName "CXCursorKind"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -7280,8 +7107,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "CXCursorKind")
-              DeclPathCtxtTop,
+              (CName "CXCursorKind"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -7387,8 +7213,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "CXCursorKind")
-                      DeclPathCtxtTop,
+                      (CName "CXCursorKind"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -7494,8 +7319,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "CXCursorKind")
-                      DeclPathCtxtTop,
+                      (CName "CXCursorKind"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -7621,8 +7445,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "CXCursorKind")
-              DeclPathCtxtTop,
+              (CName "CXCursorKind"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -7767,8 +7590,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "CXCursorKind")
-              DeclPathCtxtTop,
+              (CName "CXCursorKind"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/manual_examples.tree-diff.txt
+++ b/hs-bindgen/fixtures/manual_examples.tree-diff.txt
@@ -148,8 +148,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "triple")
-                DeclPathCtxtTop))],
+                (CName "triple")))],
         functionRes = TypeVoid,
         functionHeader =
         "manual_examples.h",
@@ -163,12 +162,9 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "triple")
-                DeclPathCtxtTop)),
+                (CName "triple"))),
           TypeEnum
-            (DeclPathName
-              (CName "index")
-              DeclPathCtxtTop)],
+            (DeclPathName (CName "index"))],
         functionRes = TypePrim
           (PrimIntegral PrimInt Signed),
         functionHeader =
@@ -183,8 +179,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "triple")
-                DeclPathCtxtTop))],
+                (CName "triple")))],
         functionRes = TypeTypedef
           (CName "sum"),
         functionHeader =
@@ -199,8 +194,7 @@ Header
           TypePointer
             (TypeStruct
               (DeclPathName
-                (CName "triple")
-                DeclPathCtxtTop))],
+                (CName "triple")))],
         functionRes = TypeTypedef
           (CName "average"),
         functionHeader =
@@ -229,8 +223,7 @@ Header
           TypePointer
             (TypeUnion
               (DeclPathName
-                (CName "occupation")
-                DeclPathCtxtTop))],
+                (CName "occupation")))],
         functionRes = TypeVoid,
         functionHeader =
         "manual_examples.h",
@@ -267,8 +260,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "triple")
-          DeclPathCtxtTop,
+          (CName "triple"),
         structAliases = [
           CName "triple"],
         structSizeof = 12,
@@ -304,8 +296,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "index")
-          DeclPathCtxtTop,
+          (CName "index"),
         enumAliases = [CName "index"],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -346,8 +337,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "date")
-          DeclPathCtxtTop,
+          (CName "date"),
         structAliases = [CName "date"],
         structSizeof = 12,
         structAlignment = 4,
@@ -382,11 +372,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "student")
-          (DeclPathCtxtField
-            (Just (CName "occupation"))
-            (CName "student")
-            DeclPathCtxtTop),
+          (CName "student"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -423,11 +409,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "employee")
-          (DeclPathCtxtField
-            (Just (CName "occupation"))
-            (CName "employee")
-            DeclPathCtxtTop),
+          (CName "employee"),
         structAliases = [],
         structSizeof = 24,
         structAlignment = 8,
@@ -450,15 +432,7 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "person")
-                  (DeclPathCtxtPtr
-                    (DeclPathCtxtField
-                      (Just (CName "employee"))
-                      (CName "supervisor")
-                      (DeclPathCtxtField
-                        (Just (CName "occupation"))
-                        (CName "employee")
-                        DeclPathCtxtTop))))),
+                  (CName "person"))),
             fieldSourceLoc =
             "manual_examples.h:77:20"},
           StructField {
@@ -475,8 +449,7 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathName
-          (CName "occupation")
-          DeclPathCtxtTop,
+          (CName "occupation"),
         unionAliases = [
           CName "occupation"],
         unionSizeof = 24,
@@ -486,22 +459,14 @@ Header
             ufieldName = CName "student",
             ufieldType = TypeStruct
               (DeclPathName
-                (CName "student")
-                (DeclPathCtxtField
-                  (Just (CName "occupation"))
-                  (CName "student")
-                  DeclPathCtxtTop)),
+                (CName "student")),
             ufieldSourceLoc =
             "manual_examples.h:73:5"},
           UnionField {
             ufieldName = CName "employee",
             ufieldType = TypeStruct
               (DeclPathName
-                (CName "employee")
-                (DeclPathCtxtField
-                  (Just (CName "occupation"))
-                  (CName "employee")
-                  DeclPathCtxtTop)),
+                (CName "employee")),
             ufieldSourceLoc =
             "manual_examples.h:79:5"}],
         unionSourceLoc =
@@ -569,8 +534,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "rect")
-          DeclPathCtxtTop,
+          (CName "rect"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 4,
@@ -667,8 +631,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "signal")
-          DeclPathCtxtTop,
+          (CName "signal"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -700,8 +663,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "HTTP_status")
-          DeclPathCtxtTop,
+          (CName "HTTP_status"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -739,8 +701,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "descending")
-          DeclPathCtxtTop,
+          (CName "descending"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -772,8 +733,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "result")
-          DeclPathCtxtTop,
+          (CName "result"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Signed),
@@ -806,8 +766,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "vote")
-          DeclPathCtxtTop,
+          (CName "vote"),
         enumAliases = [],
         enumType = TypePrim
           (PrimChar
@@ -835,8 +794,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "CXCursorKind")
-          DeclPathCtxtTop,
+          (CName "CXCursorKind"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -18,11 +18,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "enumA")
-            (DeclPathCtxtField
-              (Just (CName "exA"))
-              (CName "fieldA1")
-              DeclPathCtxtTop),
+            (CName "enumA"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -61,11 +57,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumA")
-              (DeclPathCtxtField
-                (Just (CName "exA"))
-                (CName "fieldA1")
-                DeclPathCtxtTop),
+              (CName "enumA"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -109,11 +101,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumA")
-                      (DeclPathCtxtField
-                        (Just (CName "exA"))
-                        (CName "fieldA1")
-                        DeclPathCtxtTop),
+                      (CName "enumA"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -157,11 +145,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "enumA")
-                      (DeclPathCtxtField
-                        (Just (CName "exA"))
-                        (CName "fieldA1")
-                        DeclPathCtxtTop),
+                      (CName "enumA"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -225,11 +209,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumA")
-              (DeclPathCtxtField
-                (Just (CName "exA"))
-                (CName "fieldA1")
-                DeclPathCtxtTop),
+              (CName "enumA"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -274,11 +254,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumA")
-              (DeclPathCtxtField
-                (Just (CName "exA"))
-                (CName "fieldA1")
-                DeclPathCtxtTop),
+              (CName "enumA"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -319,11 +295,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "enumA")
-              (DeclPathCtxtField
-                (Just (CName "exA"))
-                (CName "fieldA1")
-                DeclPathCtxtTop),
+              (CName "enumA"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -404,20 +376,14 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeEnum
-                (DeclPathName
-                  (CName "enumA")
-                  (DeclPathCtxtField
-                    (Just (CName "exA"))
-                    (CName "fieldA1")
-                    DeclPathCtxtTop)),
+                (DeclPathName (CName "enumA")),
               fieldSourceLoc =
               "nested_enums.h:5:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "exA")
-            DeclPathCtxtTop,
+            (CName "exA"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -427,12 +393,7 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeEnum
-                (DeclPathName
-                  (CName "enumA")
-                  (DeclPathCtxtField
-                    (Just (CName "exA"))
-                    (CName "fieldA1")
-                    DeclPathCtxtTop)),
+                (DeclPathName (CName "enumA")),
               fieldSourceLoc =
               "nested_enums.h:5:11"}],
           structFlam = Nothing,
@@ -463,20 +424,14 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeEnum
-                  (DeclPathName
-                    (CName "enumA")
-                    (DeclPathCtxtField
-                      (Just (CName "exA"))
-                      (CName "fieldA1")
-                      DeclPathCtxtTop)),
+                  (DeclPathName (CName "enumA")),
                 fieldSourceLoc =
                 "nested_enums.h:5:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "exA")
-              DeclPathCtxtTop,
+              (CName "exA"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -486,12 +441,7 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeEnum
-                  (DeclPathName
-                    (CName "enumA")
-                    (DeclPathCtxtField
-                      (Just (CName "exA"))
-                      (CName "fieldA1")
-                      DeclPathCtxtTop)),
+                  (DeclPathName (CName "enumA")),
                 fieldSourceLoc =
                 "nested_enums.h:5:11"}],
             structFlam = Nothing,
@@ -527,20 +477,14 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (DeclPathName
-                            (CName "enumA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "enumA")),
                         fieldSourceLoc =
                         "nested_enums.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exA")
-                      DeclPathCtxtTop,
+                      (CName "exA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -550,12 +494,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (DeclPathName
-                            (CName "enumA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "enumA")),
                         fieldSourceLoc =
                         "nested_enums.h:5:11"}],
                     structFlam = Nothing,
@@ -591,20 +530,14 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (DeclPathName
-                            (CName "enumA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "enumA")),
                         fieldSourceLoc =
                         "nested_enums.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exA")
-                      DeclPathCtxtTop,
+                      (CName "exA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -614,12 +547,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeEnum
-                          (DeclPathName
-                            (CName "enumA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "enumA")),
                         fieldSourceLoc =
                         "nested_enums.h:5:11"}],
                     structFlam = Nothing,
@@ -1049,8 +977,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "exB")
-            DeclPathCtxtTop,
+            (CName "exB"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -1106,8 +1033,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "exB")
-              DeclPathCtxtTop,
+              (CName "exB"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -1168,8 +1094,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exB")
-                      DeclPathCtxtTop,
+                      (CName "exB"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -1230,8 +1155,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exB")
-                      DeclPathCtxtTop,
+                      (CName "exB"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/nested_enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_enums.tree-diff.txt
@@ -3,11 +3,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "enumA")
-          (DeclPathCtxtField
-            (Just (CName "exA"))
-            (CName "fieldA1")
-            DeclPathCtxtTop),
+          (CName "enumA"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),
@@ -29,8 +25,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "exA")
-          DeclPathCtxtTop,
+          (CName "exA"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -40,12 +35,7 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeEnum
-              (DeclPathName
-                (CName "enumA")
-                (DeclPathCtxtField
-                  (Just (CName "exA"))
-                  (CName "fieldA1")
-                  DeclPathCtxtTop)),
+              (DeclPathName (CName "enumA")),
             fieldSourceLoc =
             "nested_enums.h:5:11"}],
         structFlam = Nothing,
@@ -79,8 +69,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "exB")
-          DeclPathCtxtTop,
+          (CName "exB"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -46,8 +46,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -121,8 +120,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -201,8 +199,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -283,8 +280,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -348,9 +344,7 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathName
-                  (CName "foo")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "foo")),
               fieldSourceLoc =
               "nested_types.h:7:16"}},
         Field {
@@ -366,17 +360,14 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathName
-                  (CName "foo")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "foo")),
               fieldSourceLoc =
               "nested_types.h:8:16"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bar")
-            DeclPathCtxtTop,
+            (CName "bar"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 4,
@@ -386,9 +377,7 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathName
-                  (CName "foo")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "foo")),
               fieldSourceLoc =
               "nested_types.h:7:16"},
             StructField {
@@ -396,9 +385,7 @@
               fieldOffset = 64,
               fieldWidth = Nothing,
               fieldType = TypeStruct
-                (DeclPathName
-                  (CName "foo")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "foo")),
               fieldSourceLoc =
               "nested_types.h:8:16"}],
           structFlam = Nothing,
@@ -427,9 +414,7 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop),
+                  (DeclPathName (CName "foo")),
                 fieldSourceLoc =
                 "nested_types.h:7:16"}},
           Field {
@@ -445,17 +430,14 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop),
+                  (DeclPathName (CName "foo")),
                 fieldSourceLoc =
                 "nested_types.h:8:16"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bar")
-              DeclPathCtxtTop,
+              (CName "bar"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 4,
@@ -465,9 +447,7 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop),
+                  (DeclPathName (CName "foo")),
                 fieldSourceLoc =
                 "nested_types.h:7:16"},
               StructField {
@@ -475,9 +455,7 @@
                 fieldOffset = 64,
                 fieldWidth = Nothing,
                 fieldType = TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop),
+                  (DeclPathName (CName "foo")),
                 fieldSourceLoc =
                 "nested_types.h:8:16"}],
             structFlam = Nothing,
@@ -511,9 +489,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:7:16"}},
                   Field {
@@ -529,17 +505,14 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop,
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -549,9 +522,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:7:16"},
                       StructField {
@@ -559,9 +530,7 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
@@ -597,9 +566,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:7:16"}},
                   Field {
@@ -615,17 +582,14 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop,
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -635,9 +599,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:7:16"},
                       StructField {
@@ -645,9 +607,7 @@
                         fieldOffset = 64,
                         fieldWidth = Nothing,
                         fieldType = TypeStruct
-                          (DeclPathName
-                            (CName "foo")
-                            DeclPathCtxtTop),
+                          (DeclPathName (CName "foo")),
                         fieldSourceLoc =
                         "nested_types.h:8:16"}],
                     structFlam = Nothing,
@@ -698,8 +658,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "ex3")
-            DeclPathCtxtTop,
+            (CName "ex3"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -745,8 +704,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "ex3")
-              DeclPathCtxtTop,
+              (CName "ex3"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -797,8 +755,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex3")
-                      DeclPathCtxtTop,
+                      (CName "ex3"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -849,8 +806,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex3")
-                      DeclPathCtxtTop,
+                      (CName "ex3"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -924,20 +880,14 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "ex4_odd")
-                    DeclPathCtxtTop)),
+                    (CName "ex4_odd"))),
               fieldSourceLoc =
               "nested_types.h:26:25"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "ex4_even")
-            (DeclPathCtxtPtr
-              (DeclPathCtxtField
-                (Just (CName "ex4_odd"))
-                (CName "next")
-                DeclPathCtxtTop)),
+            (CName "ex4_even"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -957,8 +907,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "ex4_odd")
-                    DeclPathCtxtTop)),
+                    (CName "ex4_odd"))),
               fieldSourceLoc =
               "nested_types.h:26:25"}],
           structFlam = Nothing,
@@ -1008,20 +957,14 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "ex4_odd")
-                      DeclPathCtxtTop)),
+                      (CName "ex4_odd"))),
                 fieldSourceLoc =
                 "nested_types.h:26:25"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "ex4_even")
-              (DeclPathCtxtPtr
-                (DeclPathCtxtField
-                  (Just (CName "ex4_odd"))
-                  (CName "next")
-                  DeclPathCtxtTop)),
+              (CName "ex4_even"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1041,8 +984,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "ex4_odd")
-                      DeclPathCtxtTop)),
+                      (CName "ex4_odd"))),
                 fieldSourceLoc =
                 "nested_types.h:26:25"}],
             structFlam = Nothing,
@@ -1097,20 +1039,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_odd")
-                              DeclPathCtxtTop)),
+                              (CName "ex4_odd"))),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex4_even")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "ex4_odd"))
-                          (CName "next")
-                          DeclPathCtxtTop)),
+                      (CName "ex4_even"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1130,8 +1066,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_odd")
-                              DeclPathCtxtTop)),
+                              (CName "ex4_odd"))),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
@@ -1188,20 +1123,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_odd")
-                              DeclPathCtxtTop)),
+                              (CName "ex4_odd"))),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex4_even")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "ex4_odd"))
-                          (CName "next")
-                          DeclPathCtxtTop)),
+                      (CName "ex4_even"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1221,8 +1150,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_odd")
-                              DeclPathCtxtTop)),
+                              (CName "ex4_odd"))),
                         fieldSourceLoc =
                         "nested_types.h:26:25"}],
                     structFlam = Nothing,
@@ -1291,20 +1219,14 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "ex4_even")
-                    (DeclPathCtxtPtr
-                      (DeclPathCtxtField
-                        (Just (CName "ex4_odd"))
-                        (CName "next")
-                        DeclPathCtxtTop)))),
+                    (CName "ex4_even"))),
               fieldSourceLoc =
               "nested_types.h:27:8"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "ex4_odd")
-            DeclPathCtxtTop,
+            (CName "ex4_odd"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1324,12 +1246,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "ex4_even")
-                    (DeclPathCtxtPtr
-                      (DeclPathCtxtField
-                        (Just (CName "ex4_odd"))
-                        (CName "next")
-                        DeclPathCtxtTop)))),
+                    (CName "ex4_even"))),
               fieldSourceLoc =
               "nested_types.h:27:8"}],
           structFlam = Nothing,
@@ -1379,20 +1296,14 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "ex4_even")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "ex4_odd"))
-                          (CName "next")
-                          DeclPathCtxtTop)))),
+                      (CName "ex4_even"))),
                 fieldSourceLoc =
                 "nested_types.h:27:8"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "ex4_odd")
-              DeclPathCtxtTop,
+              (CName "ex4_odd"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1412,12 +1323,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "ex4_even")
-                      (DeclPathCtxtPtr
-                        (DeclPathCtxtField
-                          (Just (CName "ex4_odd"))
-                          (CName "next")
-                          DeclPathCtxtTop)))),
+                      (CName "ex4_even"))),
                 fieldSourceLoc =
                 "nested_types.h:27:8"}],
             structFlam = Nothing,
@@ -1472,20 +1378,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_even")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "ex4_odd"))
-                                  (CName "next")
-                                  DeclPathCtxtTop)))),
+                              (CName "ex4_even"))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex4_odd")
-                      DeclPathCtxtTop,
+                      (CName "ex4_odd"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1505,12 +1405,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_even")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "ex4_odd"))
-                                  (CName "next")
-                                  DeclPathCtxtTop)))),
+                              (CName "ex4_even"))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,
@@ -1567,20 +1462,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_even")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "ex4_odd"))
-                                  (CName "next")
-                                  DeclPathCtxtTop)))),
+                              (CName "ex4_even"))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ex4_odd")
-                      DeclPathCtxtTop,
+                      (CName "ex4_odd"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1600,12 +1489,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "ex4_even")
-                              (DeclPathCtxtPtr
-                                (DeclPathCtxtField
-                                  (Just (CName "ex4_odd"))
-                                  (CName "next")
-                                  DeclPathCtxtTop)))),
+                              (CName "ex4_even"))),
                         fieldSourceLoc =
                         "nested_types.h:27:8"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -33,8 +32,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bar")
-          DeclPathCtxtTop,
+          (CName "bar"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 4,
@@ -44,9 +42,7 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathName
-                (CName "foo")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "foo")),
             fieldSourceLoc =
             "nested_types.h:7:16"},
           StructField {
@@ -54,9 +50,7 @@ Header
             fieldOffset = 64,
             fieldWidth = Nothing,
             fieldType = TypeStruct
-              (DeclPathName
-                (CName "foo")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "foo")),
             fieldSourceLoc =
             "nested_types.h:8:16"}],
         structFlam = Nothing,
@@ -65,8 +59,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "ex3")
-          DeclPathCtxtTop,
+          (CName "ex3"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -85,12 +78,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "ex4_even")
-          (DeclPathCtxtPtr
-            (DeclPathCtxtField
-              (Just (CName "ex4_odd"))
-              (CName "next")
-              DeclPathCtxtTop)),
+          (CName "ex4_even"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -110,8 +98,7 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "ex4_odd")
-                  DeclPathCtxtTop)),
+                  (CName "ex4_odd"))),
             fieldSourceLoc =
             "nested_types.h:26:25"}],
         structFlam = Nothing,
@@ -120,8 +107,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "ex4_odd")
-          DeclPathCtxtTop,
+          (CName "ex4_odd"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -141,12 +127,7 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "ex4_even")
-                  (DeclPathCtxtPtr
-                    (DeclPathCtxtField
-                      (Just (CName "ex4_odd"))
-                      (CName "next")
-                      DeclPathCtxtTop)))),
+                  (CName "ex4_even"))),
             fieldSourceLoc =
             "nested_types.h:27:8"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/nested_unions.hs
+++ b/hs-bindgen/fixtures/nested_unions.hs
@@ -17,11 +17,7 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathName
-            (CName "unionA")
-            (DeclPathCtxtField
-              (Just (CName "exA"))
-              (CName "fieldA1")
-              DeclPathCtxtTop),
+            (CName "unionA"),
           unionAliases = [],
           unionSizeof = 4,
           unionAlignment = 4,
@@ -105,20 +101,14 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathName
-                  (CName "unionA")
-                  (DeclPathCtxtField
-                    (Just (CName "exA"))
-                    (CName "fieldA1")
-                    DeclPathCtxtTop)),
+                (DeclPathName (CName "unionA")),
               fieldSourceLoc =
               "nested_unions.h:5:11"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "exA")
-            DeclPathCtxtTop,
+            (CName "exA"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -128,12 +118,7 @@
               fieldOffset = 0,
               fieldWidth = Nothing,
               fieldType = TypeUnion
-                (DeclPathName
-                  (CName "unionA")
-                  (DeclPathCtxtField
-                    (Just (CName "exA"))
-                    (CName "fieldA1")
-                    DeclPathCtxtTop)),
+                (DeclPathName (CName "unionA")),
               fieldSourceLoc =
               "nested_unions.h:5:11"}],
           structFlam = Nothing,
@@ -164,20 +149,14 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathName
-                    (CName "unionA")
-                    (DeclPathCtxtField
-                      (Just (CName "exA"))
-                      (CName "fieldA1")
-                      DeclPathCtxtTop)),
+                  (DeclPathName (CName "unionA")),
                 fieldSourceLoc =
                 "nested_unions.h:5:11"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "exA")
-              DeclPathCtxtTop,
+              (CName "exA"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -187,12 +166,7 @@
                 fieldOffset = 0,
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
-                  (DeclPathName
-                    (CName "unionA")
-                    (DeclPathCtxtField
-                      (Just (CName "exA"))
-                      (CName "fieldA1")
-                      DeclPathCtxtTop)),
+                  (DeclPathName (CName "unionA")),
                 fieldSourceLoc =
                 "nested_unions.h:5:11"}],
             structFlam = Nothing,
@@ -228,20 +202,14 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathName
-                            (CName "unionA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "unionA")),
                         fieldSourceLoc =
                         "nested_unions.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exA")
-                      DeclPathCtxtTop,
+                      (CName "exA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -251,12 +219,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathName
-                            (CName "unionA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "unionA")),
                         fieldSourceLoc =
                         "nested_unions.h:5:11"}],
                     structFlam = Nothing,
@@ -292,20 +255,14 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathName
-                            (CName "unionA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "unionA")),
                         fieldSourceLoc =
                         "nested_unions.h:5:11"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exA")
-                      DeclPathCtxtTop,
+                      (CName "exA"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -315,12 +272,7 @@
                         fieldOffset = 0,
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
-                          (DeclPathName
-                            (CName "unionA")
-                            (DeclPathCtxtField
-                              (Just (CName "exA"))
-                              (CName "fieldA1")
-                              DeclPathCtxtTop)),
+                          (DeclPathName (CName "unionA")),
                         fieldSourceLoc =
                         "nested_unions.h:5:11"}],
                     structFlam = Nothing,
@@ -457,8 +409,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "exB")
-            DeclPathCtxtTop,
+            (CName "exB"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -514,8 +465,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "exB")
-              DeclPathCtxtTop,
+              (CName "exB"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -576,8 +526,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exB")
-                      DeclPathCtxtTop,
+                      (CName "exB"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -638,8 +587,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "exB")
-                      DeclPathCtxtTop,
+                      (CName "exB"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/nested_unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_unions.tree-diff.txt
@@ -3,11 +3,7 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathName
-          (CName "unionA")
-          (DeclPathCtxtField
-            (Just (CName "exA"))
-            (CName "fieldA1")
-            DeclPathCtxtTop),
+          (CName "unionA"),
         unionAliases = [],
         unionSizeof = 4,
         unionAlignment = 4,
@@ -31,8 +27,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "exA")
-          DeclPathCtxtTop,
+          (CName "exA"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -42,12 +37,7 @@ Header
             fieldOffset = 0,
             fieldWidth = Nothing,
             fieldType = TypeUnion
-              (DeclPathName
-                (CName "unionA")
-                (DeclPathCtxtField
-                  (Just (CName "exA"))
-                  (CName "fieldA1")
-                  DeclPathCtxtTop)),
+              (DeclPathName (CName "unionA")),
             fieldSourceLoc =
             "nested_unions.h:5:11"}],
         structFlam = Nothing,
@@ -83,8 +73,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "exB")
-          DeclPathCtxtTop,
+          (CName "exB"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -35,9 +35,7 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop)),
+                  (DeclPathName (CName "foo"))),
               fieldSourceLoc =
               "opaque_declaration.h:5:17"}},
         Field {
@@ -55,17 +53,14 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathName
-                    (CName "bar")
-                    DeclPathCtxtTop)),
+                  (DeclPathName (CName "bar"))),
               fieldSourceLoc =
               "opaque_declaration.h:6:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bar")
-            DeclPathCtxtTop,
+            (CName "bar"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -76,9 +71,7 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathName
-                    (CName "foo")
-                    DeclPathCtxtTop)),
+                  (DeclPathName (CName "foo"))),
               fieldSourceLoc =
               "opaque_declaration.h:5:17"},
             StructField {
@@ -87,9 +80,7 @@
               fieldWidth = Nothing,
               fieldType = TypePointer
                 (TypeStruct
-                  (DeclPathName
-                    (CName "bar")
-                    DeclPathCtxtTop)),
+                  (DeclPathName (CName "bar"))),
               fieldSourceLoc =
               "opaque_declaration.h:6:17"}],
           structFlam = Nothing,
@@ -120,9 +111,7 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop)),
+                    (DeclPathName (CName "foo"))),
                 fieldSourceLoc =
                 "opaque_declaration.h:5:17"}},
           Field {
@@ -140,17 +129,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop)),
+                    (DeclPathName (CName "bar"))),
                 fieldSourceLoc =
                 "opaque_declaration.h:6:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bar")
-              DeclPathCtxtTop,
+              (CName "bar"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -161,9 +147,7 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop)),
+                    (DeclPathName (CName "foo"))),
                 fieldSourceLoc =
                 "opaque_declaration.h:5:17"},
               StructField {
@@ -172,9 +156,7 @@
                 fieldWidth = Nothing,
                 fieldType = TypePointer
                   (TypeStruct
-                    (DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop)),
+                    (DeclPathName (CName "bar"))),
                 fieldSourceLoc =
                 "opaque_declaration.h:6:17"}],
             structFlam = Nothing,
@@ -210,9 +192,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "foo")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "foo"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"}},
                   Field {
@@ -230,17 +210,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "bar")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "bar"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop,
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -251,9 +228,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "foo")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "foo"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"},
                       StructField {
@@ -262,9 +237,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "bar")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "bar"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
@@ -302,9 +275,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "foo")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "foo"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"}},
                   Field {
@@ -322,17 +293,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "bar")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "bar"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      DeclPathCtxtTop,
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -343,9 +311,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "foo")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "foo"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:5:17"},
                       StructField {
@@ -354,9 +320,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypePointer
                           (TypeStruct
-                            (DeclPathName
-                              (CName "bar")
-                              DeclPathCtxtTop)),
+                            (DeclPathName (CName "bar"))),
                         fieldSourceLoc =
                         "opaque_declaration.h:6:17"}],
                     structFlam = Nothing,
@@ -391,8 +355,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "baz")
-            DeclPathCtxtTop,
+            (CName "baz"),
           structAliases = [],
           structSizeof = 0,
           structAlignment = 1,
@@ -414,8 +377,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "baz")
-              DeclPathCtxtTop,
+              (CName "baz"),
             structAliases = [],
             structSizeof = 0,
             structAlignment = 1,
@@ -442,8 +404,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "baz")
-                      DeclPathCtxtTop,
+                      (CName "baz"),
                     structAliases = [],
                     structSizeof = 0,
                     structAlignment = 1,
@@ -470,8 +431,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "baz")
-                      DeclPathCtxtTop,
+                      (CName "baz"),
                     structAliases = [],
                     structSizeof = 0,
                     structAlignment = 1,

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -9,8 +9,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bar")
-          DeclPathCtxtTop,
+          (CName "bar"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -21,9 +20,7 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathName
-                  (CName "foo")
-                  DeclPathCtxtTop)),
+                (DeclPathName (CName "foo"))),
             fieldSourceLoc =
             "opaque_declaration.h:5:17"},
           StructField {
@@ -32,9 +29,7 @@ Header
             fieldWidth = Nothing,
             fieldType = TypePointer
               (TypeStruct
-                (DeclPathName
-                  (CName "bar")
-                  DeclPathCtxtTop)),
+                (DeclPathName (CName "bar"))),
             fieldSourceLoc =
             "opaque_declaration.h:6:17"}],
         structFlam = Nothing,
@@ -43,8 +38,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "baz")
-          DeclPathCtxtTop,
+          (CName "baz"),
         structAliases = [],
         structSizeof = 0,
         structAlignment = 1,

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -484,8 +484,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "primitive")
-            DeclPathCtxtTop,
+            (CName "primitive"),
           structAliases = [],
           structSizeof = 152,
           structAlignment = 8,
@@ -1227,8 +1226,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "primitive")
-              DeclPathCtxtTop,
+              (CName "primitive"),
             structAliases = [],
             structSizeof = 152,
             structAlignment = 8,
@@ -1975,8 +1973,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "primitive")
-                      DeclPathCtxtTop,
+                      (CName "primitive"),
                     structAliases = [],
                     structSizeof = 152,
                     structAlignment = 8,
@@ -2751,8 +2748,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "primitive")
-                      DeclPathCtxtTop,
+                      (CName "primitive"),
                     structAliases = [],
                     structSizeof = 152,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "primitive")
-          DeclPathCtxtTop,
+          (CName "primitive"),
         structAliases = [],
         structSizeof = 152,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -42,16 +42,14 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "linked_list_A_s")
-                    DeclPathCtxtTop)),
+                    (CName "linked_list_A_s"))),
               fieldSourceLoc =
               "recursive_struct.h:3:27"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "linked_list_A_s")
-            DeclPathCtxtTop,
+            (CName "linked_list_A_s"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -71,8 +69,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "linked_list_A_s")
-                    DeclPathCtxtTop)),
+                    (CName "linked_list_A_s"))),
               fieldSourceLoc =
               "recursive_struct.h:3:27"}],
           structFlam = Nothing,
@@ -122,16 +119,14 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "linked_list_A_s")
-                      DeclPathCtxtTop)),
+                      (CName "linked_list_A_s"))),
                 fieldSourceLoc =
                 "recursive_struct.h:3:27"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "linked_list_A_s")
-              DeclPathCtxtTop,
+              (CName "linked_list_A_s"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -151,8 +146,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "linked_list_A_s")
-                      DeclPathCtxtTop)),
+                      (CName "linked_list_A_s"))),
                 fieldSourceLoc =
                 "recursive_struct.h:3:27"}],
             structFlam = Nothing,
@@ -207,16 +201,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_A_s")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_A_s"))),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "linked_list_A_s")
-                      DeclPathCtxtTop,
+                      (CName "linked_list_A_s"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -236,8 +228,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_A_s")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_A_s"))),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
@@ -294,16 +285,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_A_s")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_A_s"))),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "linked_list_A_s")
-                      DeclPathCtxtTop,
+                      (CName "linked_list_A_s"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -323,8 +312,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_A_s")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_A_s"))),
                         fieldSourceLoc =
                         "recursive_struct.h:3:27"}],
                     structFlam = Nothing,
@@ -374,8 +362,7 @@
             "linked_list_A_t",
           typedefType = TypeStruct
             (DeclPathName
-              (CName "linked_list_A_s")
-              DeclPathCtxtTop),
+              (CName "linked_list_A_s")),
           typedefSourceLoc =
           "recursive_struct.h:4:3"}},
   DeclNewtypeInstance
@@ -427,16 +414,14 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "linked_list_B_t")
-                    DeclPathCtxtTop)),
+                    (CName "linked_list_B_t"))),
               fieldSourceLoc =
               "recursive_struct.h:11:20"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "linked_list_B_t")
-            DeclPathCtxtTop,
+            (CName "linked_list_B_t"),
           structAliases = [
             CName "linked_list_B_t"],
           structSizeof = 16,
@@ -457,8 +442,7 @@
               fieldType = TypePointer
                 (TypeStruct
                   (DeclPathName
-                    (CName "linked_list_B_t")
-                    DeclPathCtxtTop)),
+                    (CName "linked_list_B_t"))),
               fieldSourceLoc =
               "recursive_struct.h:11:20"}],
           structFlam = Nothing,
@@ -508,16 +492,14 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "linked_list_B_t")
-                      DeclPathCtxtTop)),
+                      (CName "linked_list_B_t"))),
                 fieldSourceLoc =
                 "recursive_struct.h:11:20"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "linked_list_B_t")
-              DeclPathCtxtTop,
+              (CName "linked_list_B_t"),
             structAliases = [
               CName "linked_list_B_t"],
             structSizeof = 16,
@@ -538,8 +520,7 @@
                 fieldType = TypePointer
                   (TypeStruct
                     (DeclPathName
-                      (CName "linked_list_B_t")
-                      DeclPathCtxtTop)),
+                      (CName "linked_list_B_t"))),
                 fieldSourceLoc =
                 "recursive_struct.h:11:20"}],
             structFlam = Nothing,
@@ -594,16 +575,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_B_t")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_B_t"))),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "linked_list_B_t")
-                      DeclPathCtxtTop,
+                      (CName "linked_list_B_t"),
                     structAliases = [
                       CName "linked_list_B_t"],
                     structSizeof = 16,
@@ -624,8 +603,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_B_t")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_B_t"))),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,
@@ -682,16 +660,14 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_B_t")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_B_t"))),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "linked_list_B_t")
-                      DeclPathCtxtTop,
+                      (CName "linked_list_B_t"),
                     structAliases = [
                       CName "linked_list_B_t"],
                     structSizeof = 16,
@@ -712,8 +688,7 @@
                         fieldType = TypePointer
                           (TypeStruct
                             (DeclPathName
-                              (CName "linked_list_B_t")
-                              DeclPathCtxtTop)),
+                              (CName "linked_list_B_t"))),
                         fieldSourceLoc =
                         "recursive_struct.h:11:20"}],
                     structFlam = Nothing,

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "linked_list_A_s")
-          DeclPathCtxtTop,
+          (CName "linked_list_A_s"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -24,8 +23,7 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "linked_list_A_s")
-                  DeclPathCtxtTop)),
+                  (CName "linked_list_A_s"))),
             fieldSourceLoc =
             "recursive_struct.h:3:27"}],
         structFlam = Nothing,
@@ -37,15 +35,13 @@ Header
           "linked_list_A_t",
         typedefType = TypeStruct
           (DeclPathName
-            (CName "linked_list_A_s")
-            DeclPathCtxtTop),
+            (CName "linked_list_A_s")),
         typedefSourceLoc =
         "recursive_struct.h:4:3"},
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "linked_list_B_t")
-          DeclPathCtxtTop,
+          (CName "linked_list_B_t"),
         structAliases = [
           CName "linked_list_B_t"],
         structSizeof = 16,
@@ -66,8 +62,7 @@ Header
             fieldType = TypePointer
               (TypeStruct
                 (DeclPathName
-                  (CName "linked_list_B_t")
-                  DeclPathCtxtTop)),
+                  (CName "linked_list_B_t"))),
             fieldSourceLoc =
             "recursive_struct.h:11:20"}],
         structFlam = Nothing,

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -46,8 +46,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S1")
-            DeclPathCtxtTop,
+            (CName "S1"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -121,8 +120,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S1")
-              DeclPathCtxtTop,
+              (CName "S1"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -201,8 +199,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -283,8 +280,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S1")
-                      DeclPathCtxtTop,
+                      (CName "S1"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -389,8 +385,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S2")
-            DeclPathCtxtTop,
+            (CName "S2"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -488,8 +483,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S2")
-              DeclPathCtxtTop,
+              (CName "S2"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -592,8 +586,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -699,8 +692,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S2")
-                      DeclPathCtxtTop,
+                      (CName "S2"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -771,9 +763,7 @@
         Typedef {
           typedefName = CName "S2_t",
           typedefType = TypeStruct
-            (DeclPathName
-              (CName "S2")
-              DeclPathCtxtTop),
+            (DeclPathName (CName "S2")),
           typedefSourceLoc =
           "simple_structs.h:12:3"}},
   DeclNewtypeInstance
@@ -1072,8 +1062,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S4")
-            DeclPathCtxtTop,
+            (CName "S4"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 8,
@@ -1173,8 +1162,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S4")
-              DeclPathCtxtTop,
+              (CName "S4"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 8,
@@ -1279,8 +1267,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S4")
-                      DeclPathCtxtTop,
+                      (CName "S4"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1388,8 +1375,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S4")
-                      DeclPathCtxtTop,
+                      (CName "S4"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 8,
@@ -1488,8 +1474,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S5")
-            DeclPathCtxtTop,
+            (CName "S5"),
           structAliases = [CName "S5"],
           structSizeof = 8,
           structAlignment = 4,
@@ -1563,8 +1548,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S5")
-              DeclPathCtxtTop,
+              (CName "S5"),
             structAliases = [CName "S5"],
             structSizeof = 8,
             structAlignment = 4,
@@ -1643,8 +1627,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S5")
-                      DeclPathCtxtTop,
+                      (CName "S5"),
                     structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1725,8 +1708,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S5")
-                      DeclPathCtxtTop,
+                      (CName "S5"),
                     structAliases = [CName "S5"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -1815,8 +1797,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "S6")
-            DeclPathCtxtTop,
+            (CName "S6"),
           structAliases = [CName "S6"],
           structSizeof = 8,
           structAlignment = 4,
@@ -1890,8 +1871,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "S6")
-              DeclPathCtxtTop,
+              (CName "S6"),
             structAliases = [CName "S6"],
             structSizeof = 8,
             structAlignment = 4,
@@ -1970,8 +1950,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S6")
-                      DeclPathCtxtTop,
+                      (CName "S6"),
                     structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -2052,8 +2031,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "S6")
-                      DeclPathCtxtTop,
+                      (CName "S6"),
                     structAliases = [CName "S6"],
                     structSizeof = 8,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S1")
-          DeclPathCtxtTop,
+          (CName "S1"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -33,8 +32,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S2")
-          DeclPathCtxtTop,
+          (CName "S2"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -72,9 +70,7 @@ Header
       Typedef {
         typedefName = CName "S2_t",
         typedefType = TypeStruct
-          (DeclPathName
-            (CName "S2")
-            DeclPathCtxtTop),
+          (DeclPathName (CName "S2")),
         typedefSourceLoc =
         "simple_structs.h:12:3"},
     DeclStruct
@@ -102,8 +98,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S4")
-          DeclPathCtxtTop,
+          (CName "S4"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 8,
@@ -141,8 +136,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S5")
-          DeclPathCtxtTop,
+          (CName "S5"),
         structAliases = [CName "S5"],
         structSizeof = 8,
         structAlignment = 4,
@@ -171,8 +165,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "S6")
-          DeclPathCtxtTop,
+          (CName "S6"),
         structAliases = [CName "S6"],
         structSizeof = 8,
         structAlignment = 4,

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -544,8 +544,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "ExampleStruct")
-            DeclPathCtxtTop,
+            (CName "ExampleStruct"),
           structAliases = [],
           structSizeof = 16,
           structAlignment = 4,
@@ -663,8 +662,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "ExampleStruct")
-              DeclPathCtxtTop,
+              (CName "ExampleStruct"),
             structAliases = [],
             structSizeof = 16,
             structAlignment = 4,
@@ -787,8 +785,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ExampleStruct")
-                      DeclPathCtxtTop,
+                      (CName "ExampleStruct"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -915,8 +912,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "ExampleStruct")
-                      DeclPathCtxtTop,
+                      (CName "ExampleStruct"),
                     structAliases = [],
                     structSizeof = 16,
                     structAlignment = 4,
@@ -1011,8 +1007,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 8,
@@ -1063,8 +1058,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 8,
@@ -1120,8 +1114,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,
@@ -1177,8 +1170,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 8,

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -166,8 +166,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "ExampleStruct")
-          DeclPathCtxtTop,
+          (CName "ExampleStruct"),
         structAliases = [],
         structSizeof = 16,
         structAlignment = 4,
@@ -210,8 +209,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 8,

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -18,8 +18,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -58,8 +57,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -103,8 +101,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -148,8 +145,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -207,8 +203,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -253,8 +248,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -295,8 +289,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -44,8 +44,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "Dim2")
-            DeclPathCtxtTop,
+            (CName "Dim2"),
           structAliases = [],
           structSizeof = 8,
           structAlignment = 4,
@@ -115,8 +114,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "Dim2")
-              DeclPathCtxtTop,
+              (CName "Dim2"),
             structAliases = [],
             structSizeof = 8,
             structAlignment = 4,
@@ -191,8 +189,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim2")
-                      DeclPathCtxtTop,
+                      (CName "Dim2"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -269,8 +266,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim2")
-                      DeclPathCtxtTop,
+                      (CName "Dim2"),
                     structAliases = [],
                     structSizeof = 8,
                     structAlignment = 4,
@@ -371,8 +367,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "Dim3")
-            DeclPathCtxtTop,
+            (CName "Dim3"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -466,8 +461,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "Dim3")
-              DeclPathCtxtTop,
+              (CName "Dim3"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -566,8 +560,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim3")
-                      DeclPathCtxtTop,
+                      (CName "Dim3"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -669,8 +662,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim3")
-                      DeclPathCtxtTop,
+                      (CName "Dim3"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -737,8 +729,7 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathName
-            (CName "DimPayload")
-            DeclPathCtxtTop,
+            (CName "DimPayload"),
           unionAliases = [],
           unionSizeof = 8,
           unionAlignment = 4,
@@ -746,17 +737,13 @@
             UnionField {
               ufieldName = CName "dim2",
               ufieldType = TypeStruct
-                (DeclPathName
-                  (CName "Dim2")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "Dim2")),
               ufieldSourceLoc =
               "unions.h:13:17"},
             UnionField {
               ufieldName = CName "dim3",
               ufieldType = TypeStruct
-                (DeclPathName
-                  (CName "Dim2")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "Dim2")),
               ufieldSourceLoc =
               "unions.h:14:17"}],
           unionSourceLoc =
@@ -845,16 +832,14 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathName
-                  (CName "DimPayload")
-                  DeclPathCtxtTop),
+                  (CName "DimPayload")),
               fieldSourceLoc =
               "unions.h:19:22"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "Dim")
-            DeclPathCtxtTop,
+            (CName "Dim"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -873,8 +858,7 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathName
-                  (CName "DimPayload")
-                  DeclPathCtxtTop),
+                  (CName "DimPayload")),
               fieldSourceLoc =
               "unions.h:19:22"}],
           structFlam = Nothing,
@@ -922,16 +906,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathName
-                    (CName "DimPayload")
-                    DeclPathCtxtTop),
+                    (CName "DimPayload")),
                 fieldSourceLoc =
                 "unions.h:19:22"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "Dim")
-              DeclPathCtxtTop,
+              (CName "Dim"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -950,8 +932,7 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathName
-                    (CName "DimPayload")
-                    DeclPathCtxtTop),
+                    (CName "DimPayload")),
                 fieldSourceLoc =
                 "unions.h:19:22"}],
             structFlam = Nothing,
@@ -1004,16 +985,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayload")
-                            DeclPathCtxtTop),
+                            (CName "DimPayload")),
                         fieldSourceLoc =
                         "unions.h:19:22"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim")
-                      DeclPathCtxtTop,
+                      (CName "Dim"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1032,8 +1011,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayload")
-                            DeclPathCtxtTop),
+                            (CName "DimPayload")),
                         fieldSourceLoc =
                         "unions.h:19:22"}],
                     structFlam = Nothing,
@@ -1088,16 +1066,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayload")
-                            DeclPathCtxtTop),
+                            (CName "DimPayload")),
                         fieldSourceLoc =
                         "unions.h:19:22"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "Dim")
-                      DeclPathCtxtTop,
+                      (CName "Dim"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1116,8 +1092,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayload")
-                            DeclPathCtxtTop),
+                            (CName "DimPayload")),
                         fieldSourceLoc =
                         "unions.h:19:22"}],
                     structFlam = Nothing,
@@ -1157,8 +1132,7 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathName
-            (CName "DimPayloadB")
-            DeclPathCtxtTop,
+            (CName "DimPayloadB"),
           unionAliases = [
             CName "DimPayloadB"],
           unionSizeof = 8,
@@ -1167,17 +1141,13 @@
             UnionField {
               ufieldName = CName "dim2",
               ufieldType = TypeStruct
-                (DeclPathName
-                  (CName "Dim2")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "Dim2")),
               ufieldSourceLoc =
               "unions.h:24:17"},
             UnionField {
               ufieldName = CName "dim3",
               ufieldType = TypeStruct
-                (DeclPathName
-                  (CName "Dim2")
-                  DeclPathCtxtTop),
+                (DeclPathName (CName "Dim2")),
               ufieldSourceLoc =
               "unions.h:25:17"}],
           unionSourceLoc =
@@ -1266,16 +1236,14 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathName
-                  (CName "DimPayloadB")
-                  DeclPathCtxtTop),
+                  (CName "DimPayloadB")),
               fieldSourceLoc =
               "unions.h:30:17"}}],
       structOrigin =
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "DimB")
-            DeclPathCtxtTop,
+            (CName "DimB"),
           structAliases = [],
           structSizeof = 12,
           structAlignment = 4,
@@ -1294,8 +1262,7 @@
               fieldWidth = Nothing,
               fieldType = TypeUnion
                 (DeclPathName
-                  (CName "DimPayloadB")
-                  DeclPathCtxtTop),
+                  (CName "DimPayloadB")),
               fieldSourceLoc =
               "unions.h:30:17"}],
           structFlam = Nothing,
@@ -1343,16 +1310,14 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathName
-                    (CName "DimPayloadB")
-                    DeclPathCtxtTop),
+                    (CName "DimPayloadB")),
                 fieldSourceLoc =
                 "unions.h:30:17"}}],
         structOrigin =
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "DimB")
-              DeclPathCtxtTop,
+              (CName "DimB"),
             structAliases = [],
             structSizeof = 12,
             structAlignment = 4,
@@ -1371,8 +1336,7 @@
                 fieldWidth = Nothing,
                 fieldType = TypeUnion
                   (DeclPathName
-                    (CName "DimPayloadB")
-                    DeclPathCtxtTop),
+                    (CName "DimPayloadB")),
                 fieldSourceLoc =
                 "unions.h:30:17"}],
             structFlam = Nothing,
@@ -1425,16 +1389,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayloadB")
-                            DeclPathCtxtTop),
+                            (CName "DimPayloadB")),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "DimB")
-                      DeclPathCtxtTop,
+                      (CName "DimB"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1453,8 +1415,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayloadB")
-                            DeclPathCtxtTop),
+                            (CName "DimPayloadB")),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,
@@ -1509,16 +1470,14 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayloadB")
-                            DeclPathCtxtTop),
+                            (CName "DimPayloadB")),
                         fieldSourceLoc =
                         "unions.h:30:17"}}],
                 structOrigin =
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "DimB")
-                      DeclPathCtxtTop,
+                      (CName "DimB"),
                     structAliases = [],
                     structSizeof = 12,
                     structAlignment = 4,
@@ -1537,8 +1496,7 @@
                         fieldWidth = Nothing,
                         fieldType = TypeUnion
                           (DeclPathName
-                            (CName "DimPayloadB")
-                            DeclPathCtxtTop),
+                            (CName "DimPayloadB")),
                         fieldSourceLoc =
                         "unions.h:30:17"}],
                     structFlam = Nothing,
@@ -2224,8 +2182,7 @@
       NewtypeOriginUnion
         Union {
           unionDeclPath = DeclPathName
-            (CName "AnonA")
-            DeclPathCtxtTop,
+            (CName "AnonA"),
           unionAliases = [],
           unionSizeof = 16,
           unionAlignment = 8,

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -3,8 +3,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "Dim2")
-          DeclPathCtxtTop,
+          (CName "Dim2"),
         structAliases = [],
         structSizeof = 8,
         structAlignment = 4,
@@ -31,8 +30,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "Dim3")
-          DeclPathCtxtTop,
+          (CName "Dim3"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -67,8 +65,7 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathName
-          (CName "DimPayload")
-          DeclPathCtxtTop,
+          (CName "DimPayload"),
         unionAliases = [],
         unionSizeof = 8,
         unionAlignment = 4,
@@ -76,17 +73,13 @@ Header
           UnionField {
             ufieldName = CName "dim2",
             ufieldType = TypeStruct
-              (DeclPathName
-                (CName "Dim2")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "Dim2")),
             ufieldSourceLoc =
             "unions.h:13:17"},
           UnionField {
             ufieldName = CName "dim3",
             ufieldType = TypeStruct
-              (DeclPathName
-                (CName "Dim2")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "Dim2")),
             ufieldSourceLoc =
             "unions.h:14:17"}],
         unionSourceLoc =
@@ -94,8 +87,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "Dim")
-          DeclPathCtxtTop,
+          (CName "Dim"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -114,8 +106,7 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeUnion
               (DeclPathName
-                (CName "DimPayload")
-                DeclPathCtxtTop),
+                (CName "DimPayload")),
             fieldSourceLoc =
             "unions.h:19:22"}],
         structFlam = Nothing,
@@ -124,8 +115,7 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathName
-          (CName "DimPayloadB")
-          DeclPathCtxtTop,
+          (CName "DimPayloadB"),
         unionAliases = [
           CName "DimPayloadB"],
         unionSizeof = 8,
@@ -134,17 +124,13 @@ Header
           UnionField {
             ufieldName = CName "dim2",
             ufieldType = TypeStruct
-              (DeclPathName
-                (CName "Dim2")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "Dim2")),
             ufieldSourceLoc =
             "unions.h:24:17"},
           UnionField {
             ufieldName = CName "dim3",
             ufieldType = TypeStruct
-              (DeclPathName
-                (CName "Dim2")
-                DeclPathCtxtTop),
+              (DeclPathName (CName "Dim2")),
             ufieldSourceLoc =
             "unions.h:25:17"}],
         unionSourceLoc =
@@ -152,8 +138,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "DimB")
-          DeclPathCtxtTop,
+          (CName "DimB"),
         structAliases = [],
         structSizeof = 12,
         structAlignment = 4,
@@ -172,8 +157,7 @@ Header
             fieldWidth = Nothing,
             fieldType = TypeUnion
               (DeclPathName
-                (CName "DimPayloadB")
-                DeclPathCtxtTop),
+                (CName "DimPayloadB")),
             fieldSourceLoc =
             "unions.h:30:17"}],
         structFlam = Nothing,
@@ -242,8 +226,7 @@ Header
     DeclUnion
       Union {
         unionDeclPath = DeclPathName
-          (CName "AnonA")
-          DeclPathCtxtTop,
+          (CName "AnonA"),
         unionAliases = [],
         unionSizeof = 16,
         unionAlignment = 8,

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -18,8 +18,7 @@
       NewtypeOriginEnum
         Enu {
           enumDeclPath = DeclPathName
-            (CName "MyEnum")
-            DeclPathCtxtTop,
+            (CName "MyEnum"),
           enumAliases = [],
           enumType = TypePrim
             (PrimIntegral PrimInt Unsigned),
@@ -60,8 +59,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "MyEnum")
-              DeclPathCtxtTop,
+              (CName "MyEnum"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -107,8 +105,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "MyEnum")
-                      DeclPathCtxtTop,
+                      (CName "MyEnum"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -154,8 +151,7 @@
                 structOrigin = StructOriginEnum
                   Enu {
                     enumDeclPath = DeclPathName
-                      (CName "MyEnum")
-                      DeclPathCtxtTop,
+                      (CName "MyEnum"),
                     enumAliases = [],
                     enumType = TypePrim
                       (PrimIntegral PrimInt Unsigned),
@@ -221,8 +217,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "MyEnum")
-              DeclPathCtxtTop,
+              (CName "MyEnum"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -275,8 +270,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "MyEnum")
-              DeclPathCtxtTop,
+              (CName "MyEnum"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),
@@ -323,8 +317,7 @@
         structOrigin = StructOriginEnum
           Enu {
             enumDeclPath = DeclPathName
-              (CName "MyEnum")
-              DeclPathCtxtTop,
+              (CName "MyEnum"),
             enumAliases = [],
             enumType = TypePrim
               (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -18,8 +18,7 @@ Header
     DeclEnum
       Enu {
         enumDeclPath = DeclPathName
-          (CName "MyEnum")
-          DeclPathCtxtTop,
+          (CName "MyEnum"),
         enumAliases = [],
         enumType = TypePrim
           (PrimIntegral PrimInt Unsigned),

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -13,10 +13,7 @@
       foreignImportCArgs = [
         TypePointer
           (TypeStruct
-            (DeclPathName
-              (CName "bar")
-              (DeclPathCtxtPtr
-                DeclPathCtxtTop)))],
+            (DeclPathName (CName "bar")))],
       foreignImportOrigName = "func",
       foreignImportHeader =
       "weird01.h",
@@ -27,10 +24,7 @@
           functionArgs = [
             TypePointer
               (TypeStruct
-                (DeclPathName
-                  (CName "bar")
-                  (DeclPathCtxtPtr
-                    DeclPathCtxtTop)))],
+                (DeclPathName (CName "bar")))],
           functionRes = TypeVoid,
           functionHeader = "weird01.h",
           functionSourceLoc =
@@ -64,8 +58,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "foo")
-            DeclPathCtxtTop,
+            (CName "foo"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -111,8 +104,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "foo")
-              DeclPathCtxtTop,
+              (CName "foo"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -163,8 +155,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -215,8 +206,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "foo")
-                      DeclPathCtxtTop,
+                      (CName "foo"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -276,9 +266,7 @@
       StructOriginStruct
         Struct {
           structDeclPath = DeclPathName
-            (CName "bar")
-            (DeclPathCtxtPtr
-              DeclPathCtxtTop),
+            (CName "bar"),
           structAliases = [],
           structSizeof = 4,
           structAlignment = 4,
@@ -324,9 +312,7 @@
         StructOriginStruct
           Struct {
             structDeclPath = DeclPathName
-              (CName "bar")
-              (DeclPathCtxtPtr
-                DeclPathCtxtTop),
+              (CName "bar"),
             structAliases = [],
             structSizeof = 4,
             structAlignment = 4,
@@ -377,9 +363,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      (DeclPathCtxtPtr
-                        DeclPathCtxtTop),
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,
@@ -430,9 +414,7 @@
                 StructOriginStruct
                   Struct {
                     structDeclPath = DeclPathName
-                      (CName "bar")
-                      (DeclPathCtxtPtr
-                        DeclPathCtxtTop),
+                      (CName "bar"),
                     structAliases = [],
                     structSizeof = 4,
                     structAlignment = 4,

--- a/hs-bindgen/fixtures/weird01.tree-diff.txt
+++ b/hs-bindgen/fixtures/weird01.tree-diff.txt
@@ -6,10 +6,7 @@ Header
         functionArgs = [
           TypePointer
             (TypeStruct
-              (DeclPathName
-                (CName "bar")
-                (DeclPathCtxtPtr
-                  DeclPathCtxtTop)))],
+              (DeclPathName (CName "bar")))],
         functionRes = TypeVoid,
         functionHeader = "weird01.h",
         functionSourceLoc =
@@ -17,8 +14,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "foo")
-          DeclPathCtxtTop,
+          (CName "foo"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,
@@ -37,9 +33,7 @@ Header
     DeclStruct
       Struct {
         structDeclPath = DeclPathName
-          (CName "bar")
-          (DeclPathCtxtPtr
-            DeclPathCtxtTop),
+          (CName "bar"),
         structAliases = [],
         structSizeof = 4,
         structAlignment = 4,

--- a/hs-bindgen/src-internal/HsBindgen/C/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST.hs
@@ -62,7 +62,6 @@ module HsBindgen.C.AST (
     -- * DeclPath
   , DeclPath(..)
   , DeclPathCtxt(..)
-  , topLevel
   , declPathName
     -- * Source locations
   , SingleLoc(..)

--- a/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/AST/Type.hs
@@ -27,7 +27,6 @@ module HsBindgen.C.AST.Type (
     -- * DeclPath
   , DeclPath(..)
   , DeclPathCtxt(..)
-  , topLevel
   , declPathName
   ) where
 
@@ -100,8 +99,8 @@ showsType x (TypeExtBinding _ t)    = showsType x t
 -- | by "construction" function arguments (where showsType is used), cannot be anonymous, so DeclPathAnon is shown as <anon>.
 -- FWIW, that's similar to how libclang show types referencing anonymous structs.
 showDeclPath :: DeclPath -> ShowS
-showDeclPath (DeclPathName n _) = showString (T.unpack (getCName n))
-showDeclPath (DeclPathAnon _)   = showString "<anon>"
+showDeclPath (DeclPathName n) = showString (T.unpack (getCName n))
+showDeclPath (DeclPathAnon _) = showString "<anon>"
 
 showsFunctionType
   :: ShowS   -- ^ function name
@@ -377,7 +376,7 @@ data Typedef = Typedef {
 -- generation.
 data DeclPath =
     -- | Named type
-    DeclPathName CName DeclPathCtxt
+    DeclPathName CName
 
     -- | Anonymous type
     --
@@ -430,10 +429,7 @@ data DeclPathCtxt =
   | DeclPathCtxtField (Maybe CName) CName DeclPathCtxt
   deriving stock (Eq, Ord, Generic, Show)
 
-topLevel :: CName -> DeclPath
-topLevel cname = DeclPathName cname DeclPathCtxtTop
-
 -- | Name of the declared type, or 'Nothing' if anonymous
 declPathName :: DeclPath -> Maybe CName
-declPathName (DeclPathName name _ctxt) = Just name
+declPathName (DeclPathName name)  = Just name
 declPathName (DeclPathAnon _ctxt) = Nothing

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -149,19 +149,19 @@ processTypeDecl' ctxt extBindings unit declCursor ty = case fromSimpleEnum $ cxt
                     -- If names match, skip.
                     -- Note: this is not the same as clang_Type_isTransparentTagTypedef,
                     -- in typedef struct { ... } foo; the typedef does not have transparent tag.
-                    TypeStruct (DeclPathName declName _ctxt) | declName == tag -> do
+                    TypeStruct (DeclPathName declName) | declName == tag -> do
                             updateDeclAddAlias ty' tag
                             addAlias ty use
                     TypeStruct (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
                             addAlias ty use
 
-                    TypeEnum (DeclPathName declName _ctxt) | declName == tag -> do
+                    TypeEnum (DeclPathName declName) | declName == tag -> do
                             updateDeclAddAlias ty' tag
                             addAlias ty use
                     TypeEnum (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
                             addAlias ty use
 
-                    TypeUnion (DeclPathName declName _ctxt) | declName == tag -> do
+                    TypeUnion (DeclPathName declName) | declName == tag -> do
                             updateDeclAddAlias ty' tag
                             addAlias ty use
                     TypeUnion (DeclPathAnon (DeclPathCtxtTypedef typedefName)) | typedefName == tag ->
@@ -580,7 +580,7 @@ classifyTypeDecl ctxt extBindings (ty, decl, ki, sloc) = do
     mkDeclPath :: Text -> Maybe CName -> DeclPath
     mkDeclPath spelling mTag =
         case mTag of
-          Just tag -> DeclPathName tag ctxt
+          Just tag -> DeclPathName tag
           Nothing  -> DeclPathAnon (DeclPathCtxtTypedef (CName spelling))
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Decl.hs
@@ -388,11 +388,11 @@ declarationSpecifiersType specs =
                   { structOrUnion = su, structOrUnionIdentifier = i }
                  -> Just $
                       case su of
-                        IsStruct -> TypeStruct $ DeclPathName i DeclPathCtxtTop
-                        IsUnion  -> TypeUnion  $ DeclPathName i DeclPathCtxtTop
+                        IsStruct -> TypeStruct $ DeclPathName i
+                        IsUnion  -> TypeUnion  $ DeclPathName i
               EnumTypeSpecifier
                 EnumSpecifier { enumSpecifierIdentifier = i } ->
-                  Just $ TypeEnum $ DeclPathName i DeclPathCtxtTop
+                  Just $ TypeEnum $ DeclPathName i
 
 declaratorTypeAndName
   :: Type -> DirectDeclarator abs

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -110,7 +110,7 @@ getNewtypeExtBindings hsNewtype = fmap (, hsId) . catMaybes $
     hsId = HsIdentifier $ getHsName (Hs.newtypeName hsNewtype)
 
 getCNS :: Text -> C.DeclPath -> Maybe CNameSpelling
-getCNS prefix (C.DeclPathName cname _ctxt) =
+getCNS prefix (C.DeclPathName cname) =
     Just $ CNameSpelling (prefix <> getCName cname)
 getCNS _prefix (C.DeclPathAnon ctxt) =
     case ctxt of

--- a/hs-bindgen/src-internal/HsBindgen/GenTests/C.hs
+++ b/hs-bindgen/src-internal/HsBindgen/GenTests/C.hs
@@ -107,7 +107,7 @@ getStructCTypeSpelling = \case
             Just $ T.unpack (C.getCName typedefName)
           _otherwise ->
             Nothing
-      C.DeclPathName cName _ctxt ->
+      C.DeclPathName cName ->
           Just $ "struct " ++ T.unpack (C.getCName cName)
     Hs.StructOriginEnum{} -> Nothing
 

--- a/hs-bindgen/src-internal/HsBindgen/Hs/NameMangler/DSL/ProduceCandidate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/NameMangler/DSL/ProduceCandidate.hs
@@ -124,8 +124,8 @@ fromCName prod = processCName prod . getCName
 
 fromDeclPath :: ProduceCandidate -> DeclPath -> Text
 fromDeclPath prod = \case
-    DeclPathAnon ctxt    -> concatParts prod $ aux ctxt
-    DeclPathName n _ctxt -> fromCName prod n
+    DeclPathName n    -> fromCName prod n
+    DeclPathAnon ctxt -> concatParts prod $ aux ctxt
   where
     aux :: DeclPathCtxt -> [Text]
     aux DeclPathCtxtTop =

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -226,7 +226,7 @@ opaqueStructDecs ::
   -> [Hs.Decl]
 opaqueStructDecs _opts nm o =
     [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.topLevel (C.opaqueStructTag o)
+          emptyDataName   = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueStructTag o)
         , emptyDataOrigin = Hs.EmptyDataOriginOpaqueStruct o
         }
     ]
@@ -234,7 +234,7 @@ opaqueStructDecs _opts nm o =
 opaqueEnumDecs :: TranslationOpts -> NameMangler -> C.OpaqueEnum -> [Hs.Decl]
 opaqueEnumDecs _opts nm o =
     [ Hs.DeclEmpty Hs.EmptyData {
-          emptyDataName   = mangle nm $ NameTycon $ C.topLevel (C.opaqueEnumTag o)
+          emptyDataName   = mangle nm $ NameTycon $ C.DeclPathName (C.opaqueEnumTag o)
         , emptyDataOrigin = Hs.EmptyDataOriginOpaqueEnum o
         }
     ]
@@ -319,7 +319,7 @@ enumDecs opts nm e = concat [
     valueDecls :: [Hs.Decl]
     valueDecls =
         [ Hs.DeclPatSyn Hs.PatSyn
-          { patSynName   = mangle nm $ NameDatacon (C.topLevel valueName)
+          { patSynName   = mangle nm $ NameDatacon (C.DeclPathName valueName)
           , patSynType   = newtypeName
           , patSynConstr = newtypeConstr
           , patSynValue  = valueValue
@@ -368,10 +368,10 @@ typedefDecs opts nm d = concat [
     ]
   where
     cName         = C.typedefName d
-    newtypeName   = mangle nm $ NameTycon (C.topLevel cName)
-    newtypeConstr = mangle nm $ NameDatacon (C.topLevel cName)
+    newtypeName   = mangle nm $ NameTycon (C.DeclPathName cName)
+    newtypeConstr = mangle nm $ NameDatacon (C.DeclPathName cName)
     newtypeField  = Hs.Field {
-        fieldName   = mangle nm $ NameDecon (C.topLevel cName)
+        fieldName   = mangle nm $ NameDecon (C.DeclPathName cName)
       , fieldType   = typ nm (C.typedefType d)
       , fieldOrigin = Hs.FieldOriginNone
       }
@@ -443,13 +443,13 @@ macroDecsTypedef opts nm m =
         []
   where
     cName         = C.macroName m
-    newtypeName   = mangle nm $ NameTycon (C.topLevel cName)
-    newtypeConstr = mangle nm $ NameDatacon (C.topLevel cName)
+    newtypeName   = mangle nm $ NameTycon (C.DeclPathName cName)
+    newtypeConstr = mangle nm $ NameDatacon (C.DeclPathName cName)
     newtypeOrigin = Hs.NewtypeOriginMacro m
 
     mkField :: C.Type -> Hs.Field
     mkField ty = Hs.Field {
-          fieldName   = mangle nm $ NameDecon (C.topLevel cName)
+          fieldName   = mangle nm $ NameDecon (C.DeclPathName cName)
         , fieldType   = typ nm ty
         , fieldOrigin = Hs.FieldOriginNone
         }
@@ -473,7 +473,7 @@ typ' ctx nm = go ctx
   where
     go :: TypeContext -> C.Type -> Hs.HsType
     go _ (C.TypeTypedef c) =
-        Hs.HsTypRef (mangle nm $ NameTycon (C.topLevel c)) -- wrong
+        Hs.HsTypRef (mangle nm $ NameTycon (C.DeclPathName c)) -- wrong
     go _ (C.TypeStruct declPath) =
         Hs.HsTypRef (mangle nm $ NameTycon declPath)
     go _ (C.TypeUnion declPath) =


### PR DESCRIPTION
We don't need the context for named types, we only need it for anonymous ones (both in order to name them, and also in order to distinguish them from one another).