### PR TITLE
Nix development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+/.dir-locals.el
+/.direnv/
+
 .envrc
+.vscode/
+cabal.project.local
 dist-newstyle/
 unversioned
-cabal.project.local
-.vscode/
+
 *.dll
 *.log

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "hs-bindgen development environment";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    {
+      self,
+      flake-utils,
+      nixpkgs,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: {
+              # See ./test/internal/Test/Internal/Rust.hs::rustBindgenVersion.
+              rust-bindgen-unwrapped = prev.rust-bindgen-unwrapped.overrideAttrs (old: rec {
+                version = "0.70.1";
+                src = prev.fetchCrate {
+                  pname = "bindgen-cli";
+                  inherit version;
+                  hash = "sha256-6FRcW/VGqlmLjb64UYqk21HmQ8u0AdVD3S2F+9D/vQo=";
+                };
+                cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+                  pname = old.pname;
+                  inherit version src;
+                  hash = "sha256-r4ZI+uybK3MzJMYlRwmNhZMBO3aMKCIIznOOdQ0ReqU=";
+                };
+              });
+            })
+          ];
+        };
+        hpkgs = pkgs.haskellPackages;
+        lpkgs = pkgs.llvmPackages;
+      in
+      {
+        devShells.default = (pkgs.mkShell.override { stdenv = pkgs.clangStdenv; }) {
+          buildInputs = [ lpkgs.libclang ];
+          packages = [
+            # Haskell.
+            hpkgs.cabal-install
+            hpkgs.ghc
+            hpkgs.haskell-language-server
+
+            # Other.
+            lpkgs.clang
+            lpkgs.llvm
+            pkgs.rust-bindgen
+          ];
+          shellHook = ''
+            # When running `clang` during GHC compilation with Template Haskell,
+            # the Nixpkgs wrapper does not work, and so we need to set include
+            # paths manually.
+            C_INCLUDE_PATH="$(< ${lpkgs.clang}/nix-support/orig-libc-dev)/include:$(< ${pkgs.gcc}/nix-support/orig-cc)/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/include"
+            export C_INCLUDE_PATH
+            # `rust-bindgen` allows usage of environment variables to define
+            # clang arguments which seems a bit more elegant but does not work
+            # for `hs-bindgen`. See `rust-bindgen-hook.sh` in Nixpkgs.
+          '';
+        };
+      }
+    );
+}

--- a/hs-bindgen/test/internal/Test/Internal/Rust.hs
+++ b/hs-bindgen/test/internal/Test/Internal/Rust.hs
@@ -38,6 +38,10 @@ import System.Exit (ExitCode (..))
 
 import Test.Internal.Misc
 
+-- | The golden tests are tied to a specific version of @rust-bindgen@.
+rustBindgenVersion :: String
+rustBindgenVersion = "0.70.1"
+
 withRustBindgen :: (IO FilePath -> TestTree) -> TestTree
 withRustBindgen k = withResource getRustBindgen cleanupRustBindgen (k . fmap snd) -- TODO: unlink
 
@@ -65,7 +69,9 @@ getRustBindgen' = do
 
     callProcessCwd tmpDir' "curl"
         [ "-sLf", "-o", tmpDir' </> "bindgen.tar.xz"
-        , "https://github.com/rust-lang/rust-bindgen/releases/download/v0.70.1/bindgen-cli-x86_64-unknown-linux-gnu.tar.xz"
+        , "https://github.com/rust-lang/rust-bindgen/releases/download/v"
+          <> rustBindgenVersion
+          <> "/bindgen-cli-x86_64-unknown-linux-gnu.tar.xz"
         ]
 
     callProcessCwd tmpDir' "tar"


### PR DESCRIPTION
Build and tests pass in the Nix development shell. If you prefer to not have Nix-related code in the repo, I can amend the `.gitignore` file and use the files locally.

I also highlighted the version of `rust-bindgen` used by tests.

