### PR TITLE
Make `clang` bindings polymorphic over `m`

### DIFF
--- a/clang/clang.cabal
+++ b/clang/clang.cabal
@@ -97,10 +97,11 @@ library
       Clang.HighLevel.Wrappers
   build-depends:
       -- External dependencies
-    , filepath      >= 1.4     && < 1.6
-    , mtl           >= 2.2     && < 2.4
-    , text          >= 1.2     && < 2.2
-    , unliftio-core ^>=0.2.1.0
+    , exceptions    >= 0.10  && < 0.11
+    , filepath      >= 1.4   && < 1.6
+    , mtl           >= 2.2   && < 2.4
+    , text          >= 1.2   && < 2.2
+    , unliftio-core >= 0.2.1 && < 0.3
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >=0.1.0.1 && <0.2

--- a/clang/src/Clang/Backtrace.hs
+++ b/clang/src/Clang/Backtrace.hs
@@ -9,6 +9,7 @@ module Clang.Backtrace (
   ) where
 
 import Control.Exception
+import Control.Monad.IO.Class
 import Data.Typeable
 import GHC.Stack
 
@@ -34,8 +35,8 @@ instance Show Backtrace where
 prettyBacktrace :: Backtrace -> String
 prettyBacktrace = displayBacktraces . unwrapStack
 
-collectBacktrace :: HasCallStack => IO Backtrace
-collectBacktrace = WrapStack <$> collectBacktraces
+collectBacktrace :: (MonadIO m, HasCallStack) => m Backtrace
+collectBacktrace = liftIO $ WrapStack <$> collectBacktraces
 
 #else
 
@@ -51,7 +52,7 @@ instance Show Backtrace where
 prettyBacktrace :: Backtrace -> String
 prettyBacktrace = prettyCallStack . unwrapStack
 
-collectBacktrace :: HasCallStack => IO Backtrace
+collectBacktrace :: (MonadIO m, HasCallStack) => m Backtrace
 collectBacktrace = return $ WrapStack callStack
 
 #endif

--- a/clang/src/Clang/HighLevel/Declaration.hs
+++ b/clang/src/Clang/HighLevel/Declaration.hs
@@ -4,6 +4,8 @@ module Clang.HighLevel.Declaration (
   , classifyDeclaration
   ) where
 
+import Control.Monad.IO.Class
+
 import Clang.LowLevel.Core
 
 {-------------------------------------------------------------------------------
@@ -23,8 +25,9 @@ data Declaration =
 
 -- | Classify a declaration
 classifyDeclaration ::
-     CXCursor  -- ^ Declaration
-  -> IO Declaration
+     MonadIO m
+  => CXCursor  -- ^ Declaration
+  -> m Declaration
 classifyDeclaration cursor = do
     defnCursor <- clang_getCursorDefinition cursor
     isDefnNull <- clang_equalCursors defnCursor nullCursor

--- a/clang/src/Clang/HighLevel/Fold.hs
+++ b/clang/src/Clang/HighLevel/Fold.hs
@@ -145,7 +145,9 @@ popUntil someStack newParent = do
 --
 -- * visitors can return results
 -- * we can specify different visitors at different levels of the AST
-clang_visitChildren :: forall m a. MonadUnliftIO m => CXCursor -> Fold m a -> m [a]
+clang_visitChildren :: forall m a.
+     MonadUnliftIO m
+  => CXCursor -> Fold m a -> m [a]
 clang_visitChildren root topLevelFold = withRunInIO $ \support -> do
     stack     <- initStack root topLevelFold
     someStack <- newIORef $ SomeStack stack

--- a/clang/src/Clang/HighLevel/UserProvided.hs
+++ b/clang/src/Clang/HighLevel/UserProvided.hs
@@ -5,6 +5,7 @@ module Clang.HighLevel.UserProvided (
   , clang_getCursorSpelling
   ) where
 
+import Control.Monad.IO.Class
 import Data.Text (Text)
 
 import Clang.LowLevel.Core hiding (clang_getCursorSpelling)
@@ -32,7 +33,7 @@ getUserProvided (LibclangProvided _) = Nothing
 -- @libclang@ fills in a name (\"spelling\") for the struct tag, even though the
 -- user did not provide one; recent versions of @llvm@ fill in @S3_t@ (@""@ in
 -- older versions).
-clang_getCursorSpelling :: CXCursor -> IO (UserProvided Text)
+clang_getCursorSpelling :: MonadIO m => CXCursor -> m (UserProvided Text)
 clang_getCursorSpelling cursor = do
     nameSpelling <- Core.clang_getCursorSpelling cursor
 

--- a/clang/src/Clang/HighLevel/Wrappers.hs
+++ b/clang/src/Clang/HighLevel/Wrappers.hs
@@ -7,7 +7,8 @@ module Clang.HighLevel.Wrappers (
   , withUnsavedFile
   ) where
 
-import Control.Exception (bracket)
+import Control.Monad.Catch
+import Control.Monad.IO.Class
 import Foreign.C.String (withCString, withCStringLen)
 import GHC.Stack (HasCallStack)
 
@@ -19,22 +20,23 @@ import Clang.Paths
 
 -- | Brackets 'clang_createIndex' with 'clang_disposeIndex'
 withIndex ::
-     DisplayDiagnostics
-  -> (CXIndex -> IO a)
-  -> IO a
+     (MonadIO m, MonadMask m)
+  => DisplayDiagnostics
+  -> (CXIndex -> m a)
+  -> m a
 withIndex diagnostics =
     bracket (clang_createIndex diagnostics) clang_disposeIndex
 
 -- | Brackets 'clang_parseTranslationUnit' with 'clang_disposeTranslationUnit'
 withTranslationUnit ::
-     HasCallStack
+     (MonadIO m, MonadMask m, HasCallStack)
   => CXIndex
   -> SourcePath
   -> ClangArgs
   -> [CXUnsavedFile]
   -> BitfieldEnum CXTranslationUnit_Flags
-  -> (CXTranslationUnit -> IO a)
-  -> IO a
+  -> (CXTranslationUnit -> m a)
+  -> m a
 withTranslationUnit index src args unsavedFiles options =
     bracket
       (clang_parseTranslationUnit index src args unsavedFiles options)
@@ -42,14 +44,14 @@ withTranslationUnit index src args unsavedFiles options =
 
 -- | Brackets 'clang_parseTranslationUnit2' with 'clang_disposeTranslationUnit'
 withTranslationUnit2 ::
-     HasCallStack
+     (MonadIO m, MonadMask m, HasCallStack)
   => CXIndex
   -> SourcePath
   -> ClangArgs
   -> [CXUnsavedFile]
   -> BitfieldEnum CXTranslationUnit_Flags
-  -> (Either (SimpleEnum CXErrorCode) CXTranslationUnit -> IO a)
-  -> IO a
+  -> (Either (SimpleEnum CXErrorCode) CXTranslationUnit -> m a)
+  -> m a
 withTranslationUnit2 index src args unsavedFiles options =
     bracket (clang_parseTranslationUnit2 index src args unsavedFiles options) $
       \case

--- a/clang/src/Clang/Internal/Results.hs
+++ b/clang/src/Clang/Internal/Results.hs
@@ -15,6 +15,7 @@ module Clang.Internal.Results (
   ) where
 
 import Control.Exception
+import Control.Monad.IO.Class
 import Data.Coerce
 import Foreign
 import GHC.Stack
@@ -36,10 +37,10 @@ data CallFailed = CallFailed String Backtrace
   deriving stock (Show)
   deriving Exception via CollectedBacktrace CallFailed
 
-callFailed :: (Show hint, HasCallStack) => hint -> IO a
+callFailed :: (MonadIO m, Show hint, HasCallStack) => hint -> m a
 callFailed hint = do
     stack <- collectBacktrace
-    throwIO $ CallFailed (show hint) stack
+    liftIO $ throwIO $ CallFailed (show hint) stack
 
 {-------------------------------------------------------------------------------
   Specific conditions

--- a/clang/src/Clang/LowLevel/Doxygen.hs
+++ b/clang/src/Clang/LowLevel/Doxygen.hs
@@ -58,6 +58,7 @@ module Clang.LowLevel.Doxygen (
   , clang_FullComment_getAsXML
   ) where
 
+import Control.Monad.IO.Class
 import Data.Text (Text)
 import Foreign.C
 
@@ -101,8 +102,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_InlineContentComment_hasTrai
 -- return the associated parsed comment as a 'CXComment_FullComment' AST node.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gab4f95ae3b2e0bd63b10cecc3727a391e>
-clang_Cursor_getParsedComment :: CXCursor -> IO CXComment
-clang_Cursor_getParsedComment cursor =
+clang_Cursor_getParsedComment :: MonadIO m => CXCursor -> m CXComment
+clang_Cursor_getParsedComment cursor = liftIO $
     onHaskellHeap cursor $ \cursor' ->
       preallocate_ $ wrap_Cursor_getParsedComment cursor'
 
@@ -110,9 +111,10 @@ clang_Cursor_getParsedComment cursor =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gad7f2a27ab2f69abcb9442e05a21a130f>
 clang_Comment_getKind ::
-     CXComment -- ^ AST node of any kind
-  -> IO (SimpleEnum CXCommentKind)
-clang_Comment_getKind comment =
+     MonadIO m
+  => CXComment -- ^ AST node of any kind
+  -> m (SimpleEnum CXCommentKind)
+clang_Comment_getKind comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_Comment_getKind comment'
 
@@ -120,9 +122,10 @@ clang_Comment_getKind comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaad4eba69493735a4db462bb4b5bed97a>
 clang_Comment_getNumChildren ::
-     CXComment -- ^ AST node of any kind
-  -> IO CUInt
-clang_Comment_getNumChildren comment =
+     MonadIO m
+  => CXComment -- ^ AST node of any kind
+  -> m CUInt
+clang_Comment_getNumChildren comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_Comment_getNumChildren comment'
 
@@ -130,10 +133,11 @@ clang_Comment_getNumChildren comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gad5567ecc26b083562e42b83170c105aa>
 clang_Comment_getChild ::
-     CXComment -- ^ AST node of any kind
+     MonadIO m
+  => CXComment -- ^ AST node of any kind
   -> CUInt     -- ^ child index (zero-based)
-  -> IO CXComment
-clang_Comment_getChild comment childIdx =
+  -> m CXComment
+clang_Comment_getChild comment childIdx = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_Comment_getChild comment' childIdx
 
@@ -146,8 +150,8 @@ clang_Comment_getChild comment childIdx =
 -- never considered whitespace.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga1193c1dc798aecad92cb30cea78bf71e>
-clang_Comment_isWhitespace :: CXComment -> IO Bool
-clang_Comment_isWhitespace comment =
+clang_Comment_isWhitespace :: MonadIO m => CXComment -> m Bool
+clang_Comment_isWhitespace comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_Comment_isWhitespace comment'
 
@@ -157,8 +161,10 @@ clang_Comment_isWhitespace comment =
 -- Newlines between paragraphs do not count.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gacbc2924271ca86226c024e859e0a75c8>
-clang_InlineContentComment_hasTrailingNewline :: CXComment -> IO Bool
-clang_InlineContentComment_hasTrailingNewline comment =
+clang_InlineContentComment_hasTrailingNewline ::
+     MonadIO m
+  => CXComment -> m Bool
+clang_InlineContentComment_hasTrailingNewline comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_InlineContentComment_hasTrailingNewline comment'
 
@@ -172,8 +178,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_TextComment_getText"
 -- | Get the text contained in the AST node.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gae9a27e851356181beac36bbff6e638e2>
-clang_TextComment_getText :: CXComment -> IO Text
-clang_TextComment_getText comment =
+clang_TextComment_getText :: MonadIO m => CXComment -> m Text
+clang_TextComment_getText comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_TextComment_getText comment'
 
@@ -205,8 +211,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_InlineCommandComment_getArgT
 -- | Get the name of the inline command.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga77f5b160e7d73190ac518298c1e79d05>
-clang_InlineCommandComment_getCommandName :: CXComment -> IO Text
-clang_InlineCommandComment_getCommandName comment =
+clang_InlineCommandComment_getCommandName :: MonadIO m => CXComment -> m Text
+clang_InlineCommandComment_getCommandName comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_InlineCommandComment_getCommandName comment'
 
@@ -215,17 +221,18 @@ clang_InlineCommandComment_getCommandName comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga3dd54ce1288d09c408cac8c887da2ebd>
 clang_InlineCommandComment_getRenderKind ::
-     CXComment
-  -> IO (SimpleEnum CXCommentInlineCommandRenderKind)
-clang_InlineCommandComment_getRenderKind comment =
+     MonadIO m
+  => CXComment
+  -> m (SimpleEnum CXCommentInlineCommandRenderKind)
+clang_InlineCommandComment_getRenderKind comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_InlineCommandComment_getRenderKind comment'
 
 -- | Get the number of command arguments.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga78db1049239be9649c2829cdeb83c544>
-clang_InlineCommandComment_getNumArgs :: CXComment -> IO CUInt
-clang_InlineCommandComment_getNumArgs comment =
+clang_InlineCommandComment_getNumArgs :: MonadIO m => CXComment -> m CUInt
+clang_InlineCommandComment_getNumArgs comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_InlineCommandComment_getNumArgs comment'
 
@@ -233,10 +240,11 @@ clang_InlineCommandComment_getNumArgs comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga6824f3cdcb42edbd143db77a657fe888>
 clang_InlineCommandComment_getArgText ::
-     CXComment
+     MonadIO m
+  => CXComment
   -> CUInt -- ^ argument index (zero-based)
-  -> IO Text
-clang_InlineCommandComment_getArgText comment argIdx =
+  -> m Text
+clang_InlineCommandComment_getArgText comment argIdx = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_InlineCommandComment_getArgText comment' argIdx
 
@@ -270,10 +278,11 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_HTMLTagComment_getAsString"
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga55b84483c67c0629260b1534d4b3f80e>
 clang_HTMLTagComment_getTagName ::
-     CXComment
+     MonadIO m
+  => CXComment
   -- ^ a 'CXComment_HTMLStartTag' or 'CXComment_HTMLEndTag' AST node
-  -> IO Text
-clang_HTMLTagComment_getTagName comment =
+  -> m Text
+clang_HTMLTagComment_getTagName comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_HTMLTagComment_getTagName comment'
 
@@ -283,9 +292,10 @@ clang_HTMLTagComment_getTagName comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga052be5f208a0ef2f76e3e9923a96ef19>
 clang_HTMLStartTagComment_isSelfClosing ::
-     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
-  -> IO Bool
-clang_HTMLStartTagComment_isSelfClosing comment =
+     MonadIO m
+  => CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> m Bool
+clang_HTMLStartTagComment_isSelfClosing comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_HTMLStartTagComment_isSelfClosing comment'
 
@@ -293,9 +303,10 @@ clang_HTMLStartTagComment_isSelfClosing comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaffb8098debd5b99c2345840a5f0e63e0>
 clang_HTMLStartTag_getNumAttrs ::
-     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
-  -> IO CUInt
-clang_HTMLStartTag_getNumAttrs comment =
+     MonadIO m
+  => CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+  -> m CUInt
+clang_HTMLStartTag_getNumAttrs comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_HTMLStartTag_getNumAttrs comment'
 
@@ -303,10 +314,11 @@ clang_HTMLStartTag_getNumAttrs comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga4bdf958af343477fc70eb2b4822cd006>
 clang_HTMLStartTag_getAttrName ::
-     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+     MonadIO m
+  => CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
   -> CUInt     -- ^ attribute index (zero-based)
-  -> IO Text
-clang_HTMLStartTag_getAttrName comment attrIdx =
+  -> m Text
+clang_HTMLStartTag_getAttrName comment attrIdx = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_HTMLStartTag_getAttrName comment' attrIdx
 
@@ -314,10 +326,11 @@ clang_HTMLStartTag_getAttrName comment attrIdx =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gae674a07af38d28d67941c1c54909c5e8>
 clang_HTMLStartTag_getAttrValue ::
-     CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
+     MonadIO m
+  => CXComment -- ^ a 'CXComment_HTMLStartTag' AST node
   -> CUInt     -- ^ attribute index (zero-based)
-  -> IO Text
-clang_HTMLStartTag_getAttrValue comment attrIdx =
+  -> m Text
+clang_HTMLStartTag_getAttrValue comment attrIdx = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_HTMLStartTag_getAttrValue comment' attrIdx
 
@@ -325,10 +338,11 @@ clang_HTMLStartTag_getAttrValue comment attrIdx =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga684a46f5993fe907016aba5dbe9d1d9e>
 clang_HTMLTagComment_getAsString ::
-     CXComment
+     MonadIO m
+  => CXComment
   -- ^ a 'CXComment_HTMLStartTag' or 'CXComment_HTMLEndTag' AST node
-  -> IO Text
-clang_HTMLTagComment_getAsString comment =
+  -> m Text
+clang_HTMLTagComment_getAsString comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_HTMLTagComment_getAsString comment'
 
@@ -358,16 +372,16 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_BlockCommandComment_getParag
 -- | Get the name of the block command.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga8fdde998537370477362a4f84bc03420>
-clang_BlockCommandComment_getCommandName :: CXComment -> IO Text
-clang_BlockCommandComment_getCommandName comment =
+clang_BlockCommandComment_getCommandName :: MonadIO m => CXComment -> m Text
+clang_BlockCommandComment_getCommandName comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_BlockCommandComment_getCommandName comment'
 
 -- | Get the number of word-like arguments.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gacb447968ce9efdfdabbfca8918540cdf>
-clang_BlockCommandComment_getNumArgs :: CXComment -> IO CUInt
-clang_BlockCommandComment_getNumArgs comment =
+clang_BlockCommandComment_getNumArgs :: MonadIO m => CXComment -> m CUInt
+clang_BlockCommandComment_getNumArgs comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_BlockCommandComment_getNumArgs comment'
 
@@ -375,10 +389,11 @@ clang_BlockCommandComment_getNumArgs comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga9faf08601d88c809a9a97a9826051990>
 clang_BlockCommandComment_getArgText ::
-     CXComment
+     MonadIO m
+  => CXComment
   -> CUInt -- ^ argument index (zero-based)
-  -> IO Text
-clang_BlockCommandComment_getArgText comment argIdx =
+  -> m Text
+clang_BlockCommandComment_getArgText comment argIdx = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_BlockCommandComment_getArgText comment' argIdx
 
@@ -386,10 +401,11 @@ clang_BlockCommandComment_getArgText comment argIdx =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gac6f2ffc8fdbe9394bd4bb7d54327c968>
 clang_BlockCommandComment_getParagraph ::
-     CXComment
+     MonadIO m
+  => CXComment
   -- ^ a @CXComment_BlockCommand@ or @CXComment_VerbatimBlockCommand@ AST node
-  -> IO CXComment
-clang_BlockCommandComment_getParagraph comment =
+  -> m CXComment
+clang_BlockCommandComment_getParagraph comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_BlockCommandComment_getParagraph comment'
 
@@ -417,8 +433,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_ParamCommandComment_getDirec
 -- | Get the parameter name.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaffd7aaf697c5eb3a3d2b508b5d806763>
-clang_ParamCommandComment_getParamName :: CXComment -> IO Text
-clang_ParamCommandComment_getParamName comment =
+clang_ParamCommandComment_getParamName :: MonadIO m => CXComment -> m Text
+clang_ParamCommandComment_getParamName comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_ParamCommandComment_getParamName comment'
 
@@ -427,16 +443,16 @@ clang_ParamCommandComment_getParamName comment =
 -- will return a meaningful value.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga92e6422da2a3e428b4452a3e8955ff76>
-clang_ParamCommandComment_isParamIndexValid :: CXComment -> IO Bool
-clang_ParamCommandComment_isParamIndexValid comment =
+clang_ParamCommandComment_isParamIndexValid :: MonadIO m => CXComment -> m Bool
+clang_ParamCommandComment_isParamIndexValid comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_ParamCommandComment_isParamIndexValid comment'
 
 -- | Get the zero-based parameter index in function prototype.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gad9d1dc9ebb52dcc9cb7da8ca4c23332a>
-clang_ParamCommandComment_getParamIndex :: CXComment -> IO CUInt
-clang_ParamCommandComment_getParamIndex comment =
+clang_ParamCommandComment_getParamIndex :: MonadIO m => CXComment -> m CUInt
+clang_ParamCommandComment_getParamIndex comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_ParamCommandComment_getParamIndex comment'
 
@@ -444,8 +460,10 @@ clang_ParamCommandComment_getParamIndex comment =
 -- in the comment.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gaf68f19e83ca9b27aec7eb22b065620bd>
-clang_ParamCommandComment_isDirectionExplicit :: CXComment -> IO Bool
-clang_ParamCommandComment_isDirectionExplicit comment =
+clang_ParamCommandComment_isDirectionExplicit ::
+     MonadIO m
+  => CXComment -> m Bool
+clang_ParamCommandComment_isDirectionExplicit comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_ParamCommandComment_isDirectionExplicit comment'
 
@@ -453,9 +471,10 @@ clang_ParamCommandComment_isDirectionExplicit comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gac78b84734e9e6040a001a0036e6aa15c>
 clang_ParamCommandComment_getDirection ::
-     CXComment
-  -> IO (SimpleEnum CXCommentParamPassDirection)
-clang_ParamCommandComment_getDirection comment =
+     MonadIO m
+  => CXComment
+  -> m (SimpleEnum CXCommentParamPassDirection)
+clang_ParamCommandComment_getDirection comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_ParamCommandComment_getDirection comment'
 
@@ -478,8 +497,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_TParamCommandComment_getInde
 -- | Get the template parameter name.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga01f61f1d0dabcaf806eb1b9f21e5e340>
-clang_TParamCommandComment_getParamName :: CXComment -> IO Text
-clang_TParamCommandComment_getParamName comment =
+clang_TParamCommandComment_getParamName :: MonadIO m => CXComment -> m Text
+clang_TParamCommandComment_getParamName comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_TParamCommandComment_getParamName comment'
 
@@ -489,8 +508,10 @@ clang_TParamCommandComment_getParamName comment =
 -- value.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga1f6e7538a646824f3dde65d634de753f>
-clang_TParamCommandComment_isParamPositionValid :: CXComment -> IO Bool
-clang_TParamCommandComment_isParamPositionValid comment =
+clang_TParamCommandComment_isParamPositionValid ::
+     MonadIO m
+  => CXComment -> m Bool
+clang_TParamCommandComment_isParamPositionValid comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       cToBool <$> wrap_TParamCommandComment_isParamPositionValid comment'
 
@@ -498,8 +519,8 @@ clang_TParamCommandComment_isParamPositionValid comment =
 -- parameter list.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga88371156eeeb768d0d14eb5630b7c726>
-clang_TParamCommandComment_getDepth :: CXComment -> IO CUInt
-clang_TParamCommandComment_getDepth comment =
+clang_TParamCommandComment_getDepth :: MonadIO m => CXComment -> m CUInt
+clang_TParamCommandComment_getDepth comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_TParamCommandComment_getDepth comment'
 
@@ -508,10 +529,11 @@ clang_TParamCommandComment_getDepth comment =
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga0b91d26f02a476076b6dc5b5eea59a8f>
 clang_TParamCommandComment_getIndex ::
-     CXComment
+     MonadIO m
+  => CXComment
   -> CUInt -- ^ depth
-  -> IO CUInt
-clang_TParamCommandComment_getIndex comment depth =
+  -> m CUInt
+clang_TParamCommandComment_getIndex comment depth = liftIO $
     onHaskellHeap comment $ \comment' ->
       wrap_TParamCommandComment_getIndex comment' depth
 
@@ -525,8 +547,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_VerbatimBlockLineComment_get
 -- | Get the text contained in the AST node.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga599fad38a1c52917a2458ac10412969f>
-clang_VerbatimBlockLineComment_getText :: CXComment -> IO Text
-clang_VerbatimBlockLineComment_getText comment =
+clang_VerbatimBlockLineComment_getText :: MonadIO m => CXComment -> m Text
+clang_VerbatimBlockLineComment_getText comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_VerbatimBlockLineComment_getText comment'
 
@@ -540,8 +562,8 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_VerbatimLineComment_getText"
 -- | Get the text contained in the AST node.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#ga4eb1de9012b525f14051409427bd8eb2>
-clang_VerbatimLineComment_getText :: CXComment -> IO Text
-clang_VerbatimLineComment_getText comment =
+clang_VerbatimLineComment_getText :: MonadIO m => CXComment -> m Text
+clang_VerbatimLineComment_getText comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_VerbatimLineComment_getText comment'
 
@@ -558,15 +580,15 @@ foreign import capi unsafe "doxygen_wrappers.h wrap_FullComment_getAsXML"
 -- | Convert a given full parsed comment to an HTML fragment.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gafdfc03bbfdddd06c380a2644f16ccba9>
-clang_FullComment_getAsHTML :: CXComment -> IO Text
-clang_FullComment_getAsHTML comment =
+clang_FullComment_getAsHTML :: MonadIO m => CXComment -> m Text
+clang_FullComment_getAsHTML comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_FullComment_getAsHTML comment'
 
 -- | Convert a given full parsed comment to an XML document.
 --
 -- <https://clang.llvm.org/doxygen/group__CINDEX__COMMENT.html#gac877b07be05f591fdfea05f466ed9395>
-clang_FullComment_getAsXML :: CXComment -> IO Text
-clang_FullComment_getAsXML comment =
+clang_FullComment_getAsXML :: MonadIO m => CXComment -> m Text
+clang_FullComment_getAsXML comment = liftIO $
     onHaskellHeap comment $ \comment' ->
       preallocate_ $ wrap_FullComment_getAsXML comment'

--- a/clang/src/Clang/Version.hsc
+++ b/clang/src/Clang/Version.hsc
@@ -9,6 +9,7 @@ module Clang.Version (
   ) where
 
 import Control.Monad (unless)
+import Control.Monad.IO.Class
 import Foreign.C
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
@@ -139,5 +140,5 @@ newtype Requires a = Requires a
 -- @'Clang.Internal.Results.CallFailed' ('Requires' 'ClangVersion')@ exception
 -- if the current Clang version is not greater than or equal to the specified
 -- Clang version
-requireClangVersion :: HasCallStack => ClangVersion -> IO ()
+requireClangVersion :: (MonadIO m, HasCallStack) => ClangVersion -> m ()
 requireClangVersion v = unless (clangVersion >= v) $ callFailed (Requires v)

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Common.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Common.hs
@@ -75,13 +75,13 @@ whenPredicateMatches ::
 whenPredicateMatches tracer p mMainHeader current sloc k =
     case mMainHeader of
       Just (mainHeaderIncludePath, mainSourcePath) -> do
-        isMatch <- liftIO $ Predicate.match mainSourcePath current sloc p
+        isMatch <- Predicate.match mainSourcePath current sloc p
         case isMatch of
           Right ()     -> k mainHeaderIncludePath
-          Left  reason -> liftIO $ do
+          Left  reason -> do
             name <- clang_getCursorSpelling current
             loc  <- HighLevel.clang_getCursorLocation current
-            traceWith tracer Info $ Skipped name loc reason
+            liftIO $ traceWith tracer Info $ Skipped name loc reason
             return $ Continue Nothing
       Nothing -> return $ Continue Nothing
 
@@ -110,11 +110,11 @@ unrecognizedCursor ::
      (MonadIO m, HasCallStack)
   => CXCursor
   -> m a
-unrecognizedCursor cursor = liftIO $ do
+unrecognizedCursor cursor = do
     unrecognizedCursorKind  <- clang_getCursorKind cursor
     unrecognizedCursorLoc   <- HighLevel.clang_getCursorLocation cursor
     unrecognizedCursorTrace <- collectBacktrace
-    throwIO UnrecognizedCursor{
+    liftIO $ throwIO UnrecognizedCursor{
         unrecognizedCursorKind
       , unrecognizedCursorLoc
       , unrecognizedCursorTrace
@@ -123,11 +123,11 @@ unrecognizedCursor cursor = liftIO $ do
 unrecognizedType ::
      (MonadIO m, HasCallStack)
   => CXType -> Maybe SingleLoc -> m a
-unrecognizedType typ unrecognizedTypeLocation = liftIO $ do
+unrecognizedType typ unrecognizedTypeLocation = do
     let unrecognizedTypeKind = cxtKind typ
     unrecognizedTypeTrace    <- collectBacktrace
     unrecognizedTypeSpelling <- clang_getTypeSpelling typ
-    throwIO UnrecognizedType{
+    liftIO $ throwIO UnrecognizedType{
         unrecognizedTypeKind
       , unrecognizedTypeSpelling
       , unrecognizedTypeLocation

--- a/hs-bindgen/src-internal/HsBindgen/Resolve.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Resolve.hs
@@ -61,7 +61,7 @@ resolveHeader' args headerIncludePath =
   where
     visit :: CXCursor -> IO (Next IO SourcePath)
     visit cursor = either return return <=< runExceptT $ do
-      srcPath <- liftIO $
+      srcPath <-
             fmap singleLocPath . HighLevel.clang_getExpansionLocation
         =<< clang_getCursorLocation cursor
       -- skip builtin macros
@@ -70,13 +70,13 @@ resolveHeader' args headerIncludePath =
       unless (srcPath == headerSourcePath) $
         throwError (Break Nothing)
       -- only parse the inclusion directive
-      eCursorKind <- liftIO $ fromSimpleEnum <$> clang_getCursorKind cursor
+      eCursorKind <- fromSimpleEnum <$> clang_getCursorKind cursor
       unless (eCursorKind == Right CXCursor_InclusionDirective) $
         throwError (Break Nothing)
       -- check that the inclusion directive is for the specified header
-      displayName <- liftIO $ clang_getCursorDisplayName cursor
+      displayName <- clang_getCursorDisplayName cursor
       unless (displayName == headerIncludePath') $ throwError (Break Nothing)
-      path <- liftIO $ clang_getFileName =<< clang_getIncludedFile cursor
+      path <- clang_getFileName =<< clang_getIncludedFile cursor
       -- check that the included header was found
       when (Text.null path) $ throwError (Break Nothing)
       return $ Break (Just (SourcePath path))


### PR DESCRIPTION
All of the `clang` functions worked in the concrete `IO` monad, but we never actually _use_ it in `IO`, resulting in a lot of unnecessary visual noise.