### PR TITLE
readPrec for Read instances of `CEnum a`

### DIFF
--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -67,6 +67,7 @@ test-suite test-runtime
   other-modules:
       Test.HsBindgen.Runtime.Bitfield
       Test.HsBindgen.Runtime.CEnum
+      Test.HsBindgen.Runtime.CEnumArbitrary
       Test.Internal.Tasty
   build-depends:
       -- Internal dependencies
@@ -75,5 +76,6 @@ test-suite test-runtime
       -- External dependencies
     , QuickCheck        ^>=2.15.0.1
     , tasty             ^>=1.5
+    , tasty-expected-failure ^>= 0.12.3
     , tasty-hunit       ^>=0.10.2
     , tasty-quickcheck  ^>=0.11.1

--- a/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnumArbitrary.hs
+++ b/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnumArbitrary.hs
@@ -1,0 +1,19 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.HsBindgen.Runtime.CEnumArbitrary () where
+
+import Test.QuickCheck (Arbitrary (arbitrary), Small (Small), Gen)
+
+import HsBindgen.Runtime.CEnum (CEnum (CEnumZ, toCEnum),
+                                AsCEnum (WrapCEnum),
+                                AsSequentialCEnum (WrapSequentialCEnum))
+
+instance CEnum a => Arbitrary (AsCEnum a) where
+  arbitrary = do
+    (Small n) <- arbitrary :: Gen (Small (CEnumZ a))
+    pure $ WrapCEnum $ toCEnum n
+
+instance CEnum a => Arbitrary (AsSequentialCEnum a) where
+  arbitrary = do
+    (Small n) <- arbitrary :: Gen (Small (CEnumZ a))
+    pure $ WrapSequentialCEnum $ toCEnum n


### PR DESCRIPTION
See issue https://github.com/well-typed/hs-bindgen/issues/613; this implements the first part of the solution excluding code generation.

- Add a `readPrecUndeclared` method to the `CEnum` type class

- Add `readPrecWrappedUndeclared` wrapper function which allows easy definition of `readPrecUndeclared`

- Define `readPrecCEnum` in terms of `readPrecUndeclared`; `readPrecCEnum` allow easy definition of `Read` instances

- Add unit and property tests. The parsers either fails completely (i.e., does not consume input), or succeeds.

- Define and use proper `Show` instances of test cases.

