### PR TITLE
CEnum: Read instance with code generation

### DIFF
--- a/clang/src/Clang/Paths.hs
+++ b/clang/src/Clang/Paths.hs
@@ -119,7 +119,7 @@ renderCHeaderIncludePath = \case
 -- | C include path directory
 --
 -- A C include path is an ordered list of directories that is used to resolve a
--- 'CHeaderIncludePath'.  The name cames from environment variables
+-- 'CHeaderIncludePath'.  The name comes from environment variables
 -- @C_INCLUDE_PATH@ and @CPATH@.  It is unforuntaly confusing terminology that a
 -- /search/ path is a list of /filesystem/ paths.
 --

--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -68,6 +68,7 @@ test-suite test-runtime
   other-modules:
       Test.HsBindgen.Runtime.Bitfield
       Test.HsBindgen.Runtime.CEnum
+      Test.HsBindgen.Runtime.CEnumArbitrary
       Test.Internal.Tasty
   build-depends:
       -- Internal dependencies
@@ -76,5 +77,6 @@ test-suite test-runtime
       -- External dependencies
     , QuickCheck        ^>=2.15.0.1
     , tasty             ^>=1.5
+    , tasty-expected-failure ^>= 0.12.3
     , tasty-hunit       ^>=0.10.2
     , tasty-quickcheck  ^>=0.11.1

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/CEnum.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/CEnum.hs
@@ -16,6 +16,8 @@ module HsBindgen.Runtime.CEnum (
   , showCEnum
   , showsCEnum
   , showsWrappedUndeclared
+  , readPrecCEnum
+  , readPrecWrappedUndeclared
   , seqIsDeclared
   , seqMkDeclared
     -- * Deriving via support
@@ -34,7 +36,12 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy(Proxy))
-import GHC.Show (appPrec1, showSpace)
+import GHC.Show (appPrec1, showSpace, appPrec)
+import Text.Read (ReadPrec, (+++))
+import Text.Read.Lex (Lexeme (..), expect)
+import Text.Read qualified as Read
+import Text.ParserCombinators.ReadP qualified as ReadP
+import Text.ParserCombinators.ReadPrec qualified as ReadPrec
 
 {-------------------------------------------------------------------------------
   Type classes
@@ -94,7 +101,7 @@ class Integral (CEnumZ a) => CEnum a where
   -- valid if the Haskell wrapper has a 'Num' instance. If the Haskell type is
   -- simply a newtype wrapper around the underlying C type, you can use
   -- 'showsWrappedUndeclared'. Finally, if the Haskell type /cannot/ represent
-  -- undeclared values, this can be defined using @error@
+  -- undeclared values, this can be defined using @error@.
   --
   -- > showsUndeclared _ = \_ x ->
   -- >   error $ "Unexpected value " ++ show x ++ " for type Foo"
@@ -104,20 +111,26 @@ class Integral (CEnumZ a) => CEnum a where
             => proxy a -> Int -> CEnumZ a -> ShowS
   showsUndeclared _ = showsPrec
 
+  -- | Read undeclared value
+  --
+  -- See 'showsUndeclared', 'showsWrappedUndeclared', and
+  -- 'readPrecWrappedUndeclared'.
+  readPrecUndeclared :: ReadPrec a
+
   -- | Determine if the specified value is declared
   --
   -- This has a default definition in terms of 'getDeclaredValues', but you may
   -- wish to override this with a more efficient implementation (in particular,
   -- see 'seqIsDeclared').
   isDeclared :: a -> Bool
-  isDeclared x = (fromCEnum x) `Map.member` getDeclaredValues (Proxy :: Proxy a)
+  isDeclared x = (fromCEnum x) `Map.member` getIntegralToDeclaredValues (Proxy :: Proxy a)
 
   -- | Construct a value only if it is declared
   --
   -- See also 'seqMkDeclared'.
   mkDeclared :: CEnumZ a -> Maybe a
   mkDeclared i
-    | i `Map.member` getDeclaredValues (Proxy :: Proxy a) = Just (toCEnum i)
+    | i `Map.member` getIntegralToDeclaredValues (Proxy :: Proxy a) = Just (toCEnum i)
     | otherwise = Nothing
 
 -- | C enumeration with sequential values
@@ -151,15 +164,16 @@ class CEnum a => SequentialCEnum a where
 -- An empty list is returned when the specified value is not declared.
 getNames :: forall a. CEnum a => a -> [String]
 getNames x = maybe [] NonEmpty.toList $
-    Map.lookup (fromCEnum x) (getDeclaredValues (Proxy :: Proxy a))
+    Map.lookup (fromCEnum x) (getIntegralToDeclaredValues (Proxy :: Proxy a))
 
 {-------------------------------------------------------------------------------
   Instance support
 -------------------------------------------------------------------------------}
 
--- | Declared values and associated names (opaque)
-newtype DeclaredValues a = DeclaredValues
-    { unDeclaredValues :: Map (CEnumZ a) (NonEmpty String)
+-- | Declared values (opaque)
+data DeclaredValues a = DeclaredValues
+    { integralToDeclaredValues :: !(Map (CEnumZ a) (NonEmpty String))
+    , declaredValueToIntegral :: !(Map String (CEnumZ a))
     }
 
 -- | Construct 'DeclaredValues' from a list of values and associated names
@@ -167,7 +181,14 @@ declaredValuesFromList ::
      Ord (CEnumZ a)
   => [(CEnumZ a, NonEmpty String)]
   -> DeclaredValues a
-declaredValuesFromList = DeclaredValues . Map.fromList
+declaredValuesFromList xs =
+  DeclaredValues
+    { integralToDeclaredValues = Map.fromList xs
+    , declaredValueToIntegral =
+        Map.fromList [ (n, i) | (i, ns) <-  xs , n <- NonEmpty.toList ns ] }
+
+declaredValuesList :: DeclaredValues a -> [String]
+declaredValuesList = Map.keys . declaredValueToIntegral
 
 -- | Show the specified value
 --
@@ -175,20 +196,20 @@ declaredValuesFromList = DeclaredValues . Map.fromList
 -- @newtype@ representation of a C enumeration.
 --
 -- When the value is declared, a corresponding name is returned.  Otherwise,
--- 'showUndeclared' is called.
+-- 'showsUndeclared' is called.
 --
 -- Examples for a hypothetical enumeration type, using generated defaults:
 --
--- > showName "StatusCode" StatusOK == "StatusOK"
+-- > showCEnum StatusOK == "StatusOK"
 --
--- > showName "StatusCode" (StatusCode 418) == "StatusCode 418"
+-- > showCEnum (StatusCode 418) == "StatusCode 418"
 showCEnum :: forall a. CEnum a => a -> String
 showCEnum x = showsCEnum 0 x ""
 
 -- | Generalization of 'showsCEnum' (akin to 'showsPrec').
 showsCEnum :: forall a. CEnum a => Int -> a -> ShowS
 showsCEnum prec x =
-    case Map.lookup i (getDeclaredValues (Proxy :: Proxy a)) of
+    case Map.lookup i (getIntegralToDeclaredValues (Proxy :: Proxy a)) of
       Just (name :| _names) -> showString name
       Nothing -> showsUndeclared (Proxy :: Proxy a) prec i
   where
@@ -206,6 +227,39 @@ showsWrappedUndeclared constructorName _ p x = showParen (p >= appPrec1) $
      showString constructorName
    . showSpace
    . showsPrec appPrec1 x
+
+-- | Read a declared 'CEnum' value
+readPrecDeclaredValue :: forall proxy a. CEnum a => proxy a -> ReadPrec a
+readPrecDeclaredValue proxy = Read.parens $ ReadPrec.prec appPrec1 $ do
+  declaredValue <- ReadPrec.lift $ ReadP.choice $
+                     map ReadP.string $ declaredValuesList $ declaredValues proxy
+  pure $ toCEnum $ (declaredValueToIntegral $ declaredValues proxy) Map.! declaredValue
+
+-- | Helper function for defining 'readPrecUndeclared'
+--
+-- This helper can be used in the case where @a@ is a newtype wrapper around
+-- the underlying @CEnumZ a@.
+readPrecWrappedUndeclared
+  :: forall a. (CEnum a, Read (CEnumZ a)) => String -> ReadPrec a
+readPrecWrappedUndeclared constructorName = Read.parens $ ReadPrec.prec appPrec $ do
+  ReadPrec.lift $ expect $ Ident constructorName
+  n <- Read.step (Read.readPrec :: ReadPrec (CEnumZ a))
+  pure $ toCEnum n
+
+-- | Read a 'CEnum' from string
+--
+-- This function may be used in the definition of a 'Read' instance for a
+-- @newtype@ representation of a C enumeration.
+--
+-- Examples for a hypothetical enumeration type, using generated defaults:
+--
+-- > (read "StatusCode 200" :: StatusCode) == StatusOK
+--
+-- > (read "StatusOK" :: StatusCode) == StatusOK
+--
+-- > (read "StatusCode 123" :: StatusCode) == StatusCode 123
+readPrecCEnum :: forall a. (CEnum a, Read (CEnumZ a)) => ReadPrec a
+readPrecCEnum = readPrecDeclaredValue (Proxy :: Proxy a) +++ readPrecUndeclared
 
 -- | Determine if the specified value is declared
 --
@@ -341,7 +395,7 @@ instance Exception CEnumException where
 -------------------------------------------------------------------------------}
 
 minBoundGen :: forall a. CEnum a => a
-minBoundGen = case Map.lookupMin (getDeclaredValues (Proxy :: Proxy a)) of
+minBoundGen = case Map.lookupMin (getIntegralToDeclaredValues (Proxy :: Proxy a)) of
     Just (i, _names) -> toCEnum i
     Nothing -> throw CEnumEmpty
 
@@ -349,7 +403,7 @@ minBoundSeq :: SequentialCEnum a => a
 minBoundSeq = minDeclaredValue
 
 maxBoundGen :: forall a. CEnum a => a
-maxBoundGen = case Map.lookupMax (getDeclaredValues (Proxy :: Proxy a)) of
+maxBoundGen = case Map.lookupMax (getIntegralToDeclaredValues (Proxy :: Proxy a)) of
     Just (k, _names) -> toCEnum k
     Nothing -> throw CEnumEmpty
 
@@ -362,7 +416,7 @@ maxBoundSeq = maxDeclaredValue
 
 succGen :: forall a. CEnum a => a -> a
 succGen x = either (throw . CEnumNotDeclared) id $ do
-    (_ltMap, gtMap) <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+    (_ltMap, gtMap) <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
     case Map.lookupMin gtMap of
       Just (j, _names) -> return $ toCEnum j
       Nothing -> throw $ CEnumNoSuccessor (toInteger i)
@@ -383,7 +437,7 @@ succSeq x
 
 predGen :: forall a. CEnum a => a -> a
 predGen y = either (throw . CEnumNotDeclared) id $ do
-    (ltMap, _gtMap) <- splitMap j (getDeclaredValues (Proxy :: Proxy a))
+    (ltMap, _gtMap) <- splitMap j (getIntegralToDeclaredValues (Proxy :: Proxy a))
     case Map.lookupMax ltMap of
       Just (i, _names) -> return $ toCEnum i
       Nothing -> throw $ CEnumNoPredecessor (toInteger j)
@@ -419,7 +473,7 @@ toEnumSeq n
 
 fromEnumGen :: forall a. CEnum a => a -> Int
 fromEnumGen x
-    | i `Map.member` getDeclaredValues (Proxy :: Proxy a) = fromIntegral i
+    | i `Map.member` getIntegralToDeclaredValues (Proxy :: Proxy a) = fromIntegral i
     | otherwise = throw $ CEnumNotDeclared (toInteger i)
   where
     i :: CEnumZ a
@@ -437,7 +491,7 @@ fromEnumSeq x
 
 enumFromGen :: forall a. CEnum a => a -> [a]
 enumFromGen x = either (throw . CEnumNotDeclared) id $ do
-    (_ltMap, gtMap) <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+    (_ltMap, gtMap) <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
     return $ x : map toCEnum (Map.keys gtMap)
   where
     i :: CEnumZ a
@@ -456,13 +510,13 @@ enumFromSeq x
 enumFromThenGen :: forall a. CEnum a => a -> a -> [a]
 enumFromThenGen x y = case compare i j of
     LT -> either (throw . CEnumNotDeclared) id $ do
-      (_ltIMap, gtIMap) <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+      (_ltIMap, gtIMap) <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
       (ltJMap,  gtJMap) <- splitMap j gtIMap
       let w  = Map.size ltJMap + 1
           js = j : Map.keys gtJMap
       return $ x : map (toCEnum . NonEmpty.head) (nonEmptyChunksOf w js)
     GT -> either (throw . CEnumNotDeclared) id $ do
-      (ltIMap, _gtIMap) <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+      (ltIMap, _gtIMap) <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
       (ltJMap, gtJMap)  <- splitMap j ltIMap
       let w  = Map.size gtJMap + 1
           js = j : reverse (Map.keys ltJMap)
@@ -489,7 +543,7 @@ enumFromThenSeq x y
 
 enumFromToGen :: forall a. CEnum a => a -> a -> [a]
 enumFromToGen x z = either (throw . CEnumNotDeclared) id $ do
-    (_ltIMap, gtIMap)  <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+    (_ltIMap, gtIMap)  <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
     if i == k
       then return [x]
       else do
@@ -515,14 +569,14 @@ enumFromToSeq x z
 enumFromThenToGen :: forall a. CEnum a => a -> a -> a -> [a]
 enumFromThenToGen x y z = case compare i j of
     LT -> either (throw . CEnumNotDeclared) id $ do
-      (_ltIMap, gtIMap)  <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+      (_ltIMap, gtIMap)  <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
       (ltJMap,  gtJMap)  <- splitMap j gtIMap
       (ltKMap,  _gtKMap) <- splitMap k gtJMap
       let w  = Map.size ltJMap + 1
           js = j : Map.keys ltKMap ++ [k]
       return $ x : map (toCEnum . NonEmpty.head) (nonEmptyChunksOf w js)
     GT -> either (throw . CEnumNotDeclared) id $ do
-      (ltIMap,  _gtIMap) <- splitMap i (getDeclaredValues (Proxy :: Proxy a))
+      (ltIMap,  _gtIMap) <- splitMap i (getIntegralToDeclaredValues (Proxy :: Proxy a))
       (ltJMap,  gtJMap)  <- splitMap j ltIMap
       (_ltKMap, gtKMap)  <- splitMap k ltJMap
       let w  = Map.size gtJMap + 1
@@ -554,8 +608,8 @@ enumFromThenToSeq x y z
   Auxiliary Functions
 -------------------------------------------------------------------------------}
 
-getDeclaredValues :: CEnum a => proxy a -> Map (CEnumZ a) (NonEmpty String)
-getDeclaredValues = unDeclaredValues . declaredValues
+getIntegralToDeclaredValues :: CEnum a => proxy a -> Map (CEnumZ a) (NonEmpty String)
+getIntegralToDeclaredValues = integralToDeclaredValues . declaredValues
 
 nonEmptyChunksOf :: Int -> [a] -> [NonEmpty a]
 nonEmptyChunksOf n xs

--- a/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnumArbitrary.hs
+++ b/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CEnumArbitrary.hs
@@ -1,0 +1,19 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.HsBindgen.Runtime.CEnumArbitrary () where
+
+import Test.QuickCheck (Arbitrary (arbitrary), Small (Small), Gen)
+
+import HsBindgen.Runtime.CEnum (CEnum (CEnumZ, toCEnum),
+                                AsCEnum (WrapCEnum),
+                                AsSequentialCEnum (WrapSequentialCEnum))
+
+instance CEnum a => Arbitrary (AsCEnum a) where
+  arbitrary = do
+    (Small n) <- arbitrary :: Gen (Small (CEnumZ a))
+    pure $ WrapCEnum $ toCEnum n
+
+instance CEnum a => Arbitrary (AsSequentialCEnum a) where
+  arbitrary = do
+    (Small n) <- arbitrary :: Gen (Small (CEnumZ a))
+    pure $ WrapSequentialCEnum $ toCEnum n

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -1019,12 +1019,6 @@
     (HsName
       "@NsTypeConstr"
       "Another_typedef_enum_e"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Another_typedef_enum_e"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -1121,6 +1115,54 @@
       (HsName "@NsConstr" "BAR")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Another_typedef_enum_e",
+        structConstr = HsName
+          "@NsConstr"
+          "Another_typedef_enum_e",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Another_typedef_enum_e",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName
+                  "another_typedef_enum_e")),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "FOO",
+                valueValue = 0,
+                valueSourceLoc =
+                "distilled_lib_1.h:9:16"},
+              EnumValue {
+                valueName = CName "BAR",
+                valueValue = 1,
+                valueSourceLoc =
+                "distilled_lib_1.h:9:21"}],
+            enumSourceLoc =
+            "distilled_lib_1.h:9:9"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -3578,12 +3620,6 @@
     (HsName
       "@NsTypeConstr"
       "A_typedef_enum_e"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "A_typedef_enum_e"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -3714,6 +3750,64 @@
         "ENUM_CASE_3")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "A_typedef_enum_e",
+        structConstr = HsName
+          "@NsConstr"
+          "A_typedef_enum_e",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_A_typedef_enum_e",
+            fieldType = HsPrimType
+              HsPrimCUChar,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "a_typedef_enum_e")),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
+            enumSizeof = 1,
+            enumAlignment = 1,
+            enumValues = [
+              EnumValue {
+                valueName = CName "ENUM_CASE_0",
+                valueValue = 0,
+                valueSourceLoc =
+                "distilled_lib_1.h:62:3"},
+              EnumValue {
+                valueName = CName "ENUM_CASE_1",
+                valueValue = 1,
+                valueSourceLoc =
+                "distilled_lib_1.h:63:3"},
+              EnumValue {
+                valueName = CName "ENUM_CASE_2",
+                valueValue = 2,
+                valueSourceLoc =
+                "distilled_lib_1.h:64:3"},
+              EnumValue {
+                valueName = CName "ENUM_CASE_3",
+                valueValue = 3,
+                valueSourceLoc =
+                "distilled_lib_1.h:65:3"}],
+            enumSourceLoc =
+            "distilled_lib_1.h:60:9"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -21,6 +21,7 @@ import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
 import qualified HsBindgen.Runtime.ConstantArray
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
+import qualified Text.Read
 
 -- #include "distilled_lib_1.h"
 
@@ -199,8 +200,6 @@ deriving stock instance Eq Another_typedef_enum_e
 
 deriving stock instance Ord Another_typedef_enum_e
 
-deriving stock instance Read Another_typedef_enum_e
-
 instance HsBindgen.Runtime.CEnum.CEnum Another_typedef_enum_e where
 
   type CEnumZ Another_typedef_enum_e = FC.CUInt
@@ -216,6 +215,9 @@ instance HsBindgen.Runtime.CEnum.CEnum Another_typedef_enum_e where
   showsUndeclared =
     HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Another_typedef_enum_e"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Another_typedef_enum_e"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -229,6 +231,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Another_typedef_enum_e where
 instance Show Another_typedef_enum_e where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Another_typedef_enum_e where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern FOO :: Another_typedef_enum_e
 pattern FOO = Another_typedef_enum_e 0
@@ -420,8 +430,6 @@ deriving stock instance Eq A_typedef_enum_e
 
 deriving stock instance Ord A_typedef_enum_e
 
-deriving stock instance Read A_typedef_enum_e
-
 instance HsBindgen.Runtime.CEnum.CEnum A_typedef_enum_e where
 
   type CEnumZ A_typedef_enum_e = FC.CUChar
@@ -441,6 +449,9 @@ instance HsBindgen.Runtime.CEnum.CEnum A_typedef_enum_e where
   showsUndeclared =
     HsBindgen.Runtime.CEnum.showsWrappedUndeclared "A_typedef_enum_e"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "A_typedef_enum_e"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -454,6 +465,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum A_typedef_enum_e where
 instance Show A_typedef_enum_e where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read A_typedef_enum_e where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern ENUM_CASE_0 :: A_typedef_enum_e
 pattern ENUM_CASE_0 = A_typedef_enum_e 0

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -82,7 +82,6 @@ instance Storable Another_typedef_enum_e
                                     {Another_typedef_enum_e un_Another_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_Another_typedef_enum_e_3}}
 deriving stock instance Eq Another_typedef_enum_e
 deriving stock instance Ord Another_typedef_enum_e
-deriving stock instance Read Another_typedef_enum_e
 instance CEnum Another_typedef_enum_e
     where {type CEnumZ Another_typedef_enum_e = CUInt;
            toCEnum = Another_typedef_enum_e;
@@ -91,12 +90,17 @@ instance CEnum Another_typedef_enum_e
                                                            singleton "FOO"),
                                                           (1, singleton "BAR")];
            showsUndeclared = showsWrappedUndeclared "Another_typedef_enum_e";
+           readPrecUndeclared = readPrecWrappedUndeclared "Another_typedef_enum_e";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Another_typedef_enum_e
     where {minDeclaredValue = FOO; maxDeclaredValue = BAR}
 instance Show Another_typedef_enum_e
     where {showsPrec = showsCEnum}
+instance Read Another_typedef_enum_e
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern FOO :: Another_typedef_enum_e
 pattern FOO = Another_typedef_enum_e 0
 pattern BAR :: Another_typedef_enum_e
@@ -191,7 +195,6 @@ instance Storable A_typedef_enum_e
                                     {A_typedef_enum_e un_A_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_A_typedef_enum_e_3}}
 deriving stock instance Eq A_typedef_enum_e
 deriving stock instance Ord A_typedef_enum_e
-deriving stock instance Read A_typedef_enum_e
 instance CEnum A_typedef_enum_e
     where {type CEnumZ A_typedef_enum_e = CUChar;
            toCEnum = A_typedef_enum_e;
@@ -202,6 +205,7 @@ instance CEnum A_typedef_enum_e
                                                           (2, singleton "ENUM_CASE_2"),
                                                           (3, singleton "ENUM_CASE_3")];
            showsUndeclared = showsWrappedUndeclared "A_typedef_enum_e";
+           readPrecUndeclared = readPrecWrappedUndeclared "A_typedef_enum_e";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum A_typedef_enum_e
@@ -209,6 +213,10 @@ instance SequentialCEnum A_typedef_enum_e
            maxDeclaredValue = ENUM_CASE_3}
 instance Show A_typedef_enum_e
     where {showsPrec = showsCEnum}
+instance Read A_typedef_enum_e
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern ENUM_CASE_0 :: A_typedef_enum_e
 pattern ENUM_CASE_0 = A_typedef_enum_e 0
 pattern ENUM_CASE_1 :: A_typedef_enum_e

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -193,12 +193,6 @@
     (HsName
       "@NsTypeConstr"
       "First"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "First"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -287,6 +281,50 @@
       (HsName "@NsConstr" "FIRST2")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "First",
+        structConstr = HsName
+          "@NsConstr"
+          "First",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_First",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "first"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "FIRST1",
+                valueValue = 0,
+                valueSourceLoc = "enums.h:5:5"},
+              EnumValue {
+                valueName = CName "FIRST2",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:6:5"}],
+            enumSourceLoc = "enums.h:4:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -585,12 +623,6 @@
     (HsName
       "@NsTypeConstr"
       "Second"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Second"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -700,6 +732,56 @@
         "SECOND_C")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Second",
+        structConstr = HsName
+          "@NsConstr"
+          "Second",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Second",
+            fieldType = HsPrimType
+              HsPrimCInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "second"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "SECOND_A",
+                valueValue = `-1`,
+                valueSourceLoc =
+                "enums.h:10:5"},
+              EnumValue {
+                valueName = CName "SECOND_B",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:11:5"},
+              EnumValue {
+                valueName = CName "SECOND_C",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:12:5"}],
+            enumSourceLoc = "enums.h:9:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -999,10 +1081,6 @@
     DeriveStock
     Ord
     (HsName "@NsTypeConstr" "Same"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName "@NsTypeConstr" "Same"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -1095,6 +1173,51 @@
       (HsName "@NsConstr" "SAME_A")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Same",
+        structConstr = HsName
+          "@NsConstr"
+          "Same",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Same",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "same"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "SAME_A",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:16:5"},
+              EnumValue {
+                valueName = CName "SAME_B",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:17:5"}],
+            enumSourceLoc = "enums.h:15:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -1394,12 +1517,6 @@
     (HsName
       "@NsTypeConstr"
       "Nonseq"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Nonseq"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -1460,6 +1577,56 @@
       False),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Nonseq",
+        structConstr = HsName
+          "@NsConstr"
+          "Nonseq",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Nonseq",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "nonseq"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "NONSEQ_A",
+                valueValue = 200,
+                valueSourceLoc =
+                "enums.h:21:5"},
+              EnumValue {
+                valueName = CName "NONSEQ_B",
+                valueValue = 301,
+                valueSourceLoc =
+                "enums.h:22:5"},
+              EnumValue {
+                valueName = CName "NONSEQ_C",
+                valueValue = 404,
+                valueSourceLoc =
+                "enums.h:23:5"}],
+            enumSourceLoc = "enums.h:20:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -1787,12 +1954,6 @@
     (HsName
       "@NsTypeConstr"
       "Packad"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Packad"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -1904,6 +2065,57 @@
         "PACKED_C")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Packad",
+        structConstr = HsName
+          "@NsConstr"
+          "Packad",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Packad",
+            fieldType = HsPrimType
+              HsPrimCUChar,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "packad"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
+            enumSizeof = 1,
+            enumAlignment = 1,
+            enumValues = [
+              EnumValue {
+                valueName = CName "PACKED_A",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:27:5"},
+              EnumValue {
+                valueName = CName "PACKED_B",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:27:15"},
+              EnumValue {
+                valueName = CName "PACKED_C",
+                valueValue = 2,
+                valueSourceLoc =
+                "enums.h:27:25"}],
+            enumSourceLoc = "enums.h:26:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -2212,12 +2424,6 @@
     (HsName
       "@NsTypeConstr"
       "EnumA"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "EnumA"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -2310,6 +2516,52 @@
       (HsName "@NsConstr" "A_BAR")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "EnumA",
+        structConstr = HsName
+          "@NsConstr"
+          "EnumA",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_EnumA",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtTypedef
+                (CName "enumA")),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "A_FOO",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:30:16"},
+              EnumValue {
+                valueName = CName "A_BAR",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:30:23"}],
+            enumSourceLoc = "enums.h:30:9"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -2594,12 +2846,6 @@
     (HsName
       "@NsTypeConstr"
       "EnumB"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "EnumB"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -2692,6 +2938,52 @@
       (HsName "@NsConstr" "B_BAR")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "EnumB",
+        structConstr = HsName
+          "@NsConstr"
+          "EnumB",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_EnumB",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "enumB"),
+            enumAliases = [CName "enumB"],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "B_FOO",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:32:22"},
+              EnumValue {
+                valueName = CName "B_BAR",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:32:29"}],
+            enumSourceLoc =
+            "enums.h:32:14"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -2972,12 +3264,6 @@
     (HsName
       "@NsTypeConstr"
       "EnumC"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "EnumC"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -3068,6 +3354,51 @@
       (HsName "@NsConstr" "C_BAR")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "EnumC",
+        structConstr = HsName
+          "@NsConstr"
+          "EnumC",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_EnumC",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "enumC"),
+            enumAliases = [CName "enumC"],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "C_FOO",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:34:14"},
+              EnumValue {
+                valueName = CName "C_BAR",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:34:21"}],
+            enumSourceLoc = "enums.h:34:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -3347,12 +3678,6 @@
     (HsName
       "@NsTypeConstr"
       "EnumD"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "EnumD"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -3443,6 +3768,51 @@
       (HsName "@NsConstr" "D_BAR")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "EnumD",
+        structConstr = HsName
+          "@NsConstr"
+          "EnumD",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_EnumD",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "enumD"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "D_FOO",
+                valueValue = 0,
+                valueSourceLoc =
+                "enums.h:37:14"},
+              EnumValue {
+                valueName = CName "D_BAR",
+                valueValue = 1,
+                valueSourceLoc =
+                "enums.h:37:21"}],
+            enumSourceLoc = "enums.h:37:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -13,6 +13,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
+import qualified Text.Read
 
 newtype First = First
   { un_First :: FC.CUInt
@@ -39,8 +40,6 @@ deriving stock instance Eq First
 
 deriving stock instance Ord First
 
-deriving stock instance Read First
-
 instance HsBindgen.Runtime.CEnum.CEnum First where
 
   type CEnumZ First = FC.CUInt
@@ -55,6 +54,8 @@ instance HsBindgen.Runtime.CEnum.CEnum First where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "First"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "First"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -68,6 +69,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum First where
 instance Show First where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read First where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern FIRST1 :: First
 pattern FIRST1 = First 0
@@ -100,8 +109,6 @@ deriving stock instance Eq Second
 
 deriving stock instance Ord Second
 
-deriving stock instance Read Second
-
 instance HsBindgen.Runtime.CEnum.CEnum Second where
 
   type CEnumZ Second = FC.CInt
@@ -119,6 +126,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Second where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Second"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Second"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -132,6 +141,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Second where
 instance Show Second where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Second where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern SECOND_A :: Second
 pattern SECOND_A = Second (-1)
@@ -167,8 +184,6 @@ deriving stock instance Eq Same
 
 deriving stock instance Ord Same
 
-deriving stock instance Read Same
-
 instance HsBindgen.Runtime.CEnum.CEnum Same where
 
   type CEnumZ Same = FC.CUInt
@@ -183,6 +198,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Same where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Same"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Same"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -196,6 +213,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Same where
 instance Show Same where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Same where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern SAME_A :: Same
 pattern SAME_A = Same 1
@@ -228,8 +253,6 @@ deriving stock instance Eq Nonseq
 
 deriving stock instance Ord Nonseq
 
-deriving stock instance Read Nonseq
-
 instance HsBindgen.Runtime.CEnum.CEnum Nonseq where
 
   type CEnumZ Nonseq = FC.CUInt
@@ -247,9 +270,19 @@ instance HsBindgen.Runtime.CEnum.CEnum Nonseq where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Nonseq"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Nonseq"
+
 instance Show Nonseq where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Nonseq where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern NONSEQ_A :: Nonseq
 pattern NONSEQ_A = Nonseq 200
@@ -285,8 +318,6 @@ deriving stock instance Eq Packad
 
 deriving stock instance Ord Packad
 
-deriving stock instance Read Packad
-
 instance HsBindgen.Runtime.CEnum.CEnum Packad where
 
   type CEnumZ Packad = FC.CUChar
@@ -304,6 +335,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Packad where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Packad"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Packad"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -317,6 +350,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Packad where
 instance Show Packad where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Packad where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern PACKED_A :: Packad
 pattern PACKED_A = Packad 0
@@ -352,8 +393,6 @@ deriving stock instance Eq EnumA
 
 deriving stock instance Ord EnumA
 
-deriving stock instance Read EnumA
-
 instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   type CEnumZ EnumA = FC.CUInt
@@ -368,6 +407,8 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "EnumA"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "EnumA"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -381,6 +422,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumA where
 instance Show EnumA where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read EnumA where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
@@ -413,8 +462,6 @@ deriving stock instance Eq EnumB
 
 deriving stock instance Ord EnumB
 
-deriving stock instance Read EnumB
-
 instance HsBindgen.Runtime.CEnum.CEnum EnumB where
 
   type CEnumZ EnumB = FC.CUInt
@@ -429,6 +476,8 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumB where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "EnumB"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "EnumB"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -442,6 +491,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumB where
 instance Show EnumB where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read EnumB where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
@@ -474,8 +531,6 @@ deriving stock instance Eq EnumC
 
 deriving stock instance Ord EnumC
 
-deriving stock instance Read EnumC
-
 instance HsBindgen.Runtime.CEnum.CEnum EnumC where
 
   type CEnumZ EnumC = FC.CUInt
@@ -490,6 +545,8 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumC where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "EnumC"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "EnumC"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -503,6 +560,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumC where
 instance Show EnumC where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read EnumC where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
@@ -535,8 +600,6 @@ deriving stock instance Eq EnumD
 
 deriving stock instance Ord EnumD
 
-deriving stock instance Read EnumD
-
 instance HsBindgen.Runtime.CEnum.CEnum EnumD where
 
   type CEnumZ EnumD = FC.CUInt
@@ -551,6 +614,8 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumD where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "EnumD"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "EnumD"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -564,6 +629,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumD where
 instance Show EnumD where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read EnumD where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern D_FOO :: EnumD
 pattern D_FOO = EnumD 0

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -8,7 +8,6 @@ instance Storable First
                                     {First un_First_3 -> pokeByteOff ptr_1 (0 :: Int) un_First_3}}
 deriving stock instance Eq First
 deriving stock instance Ord First
-deriving stock instance Read First
 instance CEnum First
     where {type CEnumZ First = CUInt;
            toCEnum = First;
@@ -17,12 +16,17 @@ instance CEnum First
                                                            singleton "FIRST1"),
                                                           (1, singleton "FIRST2")];
            showsUndeclared = showsWrappedUndeclared "First";
+           readPrecUndeclared = readPrecWrappedUndeclared "First";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum First
     where {minDeclaredValue = FIRST1; maxDeclaredValue = FIRST2}
 instance Show First
     where {showsPrec = showsCEnum}
+instance Read First
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern FIRST1 :: First
 pattern FIRST1 = First 0
 pattern FIRST2 :: First
@@ -36,7 +40,6 @@ instance Storable Second
                                     {Second un_Second_3 -> pokeByteOff ptr_1 (0 :: Int) un_Second_3}}
 deriving stock instance Eq Second
 deriving stock instance Ord Second
-deriving stock instance Read Second
 instance CEnum Second
     where {type CEnumZ Second = CInt;
            toCEnum = Second;
@@ -46,12 +49,17 @@ instance CEnum Second
                                                           (0, singleton "SECOND_B"),
                                                           (1, singleton "SECOND_C")];
            showsUndeclared = showsWrappedUndeclared "Second";
+           readPrecUndeclared = readPrecWrappedUndeclared "Second";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Second
     where {minDeclaredValue = SECOND_A; maxDeclaredValue = SECOND_C}
 instance Show Second
     where {showsPrec = showsCEnum}
+instance Read Second
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern SECOND_A :: Second
 pattern SECOND_A = Second (-1)
 pattern SECOND_B :: Second
@@ -67,7 +75,6 @@ instance Storable Same
                                     {Same un_Same_3 -> pokeByteOff ptr_1 (0 :: Int) un_Same_3}}
 deriving stock instance Eq Same
 deriving stock instance Ord Same
-deriving stock instance Read Same
 instance CEnum Same
     where {type CEnumZ Same = CUInt;
            toCEnum = Same;
@@ -75,12 +82,17 @@ instance CEnum Same
            declaredValues = \_ -> declaredValuesFromList [(1,
                                                            "SAME_A" :| ["SAME_B"])];
            showsUndeclared = showsWrappedUndeclared "Same";
+           readPrecUndeclared = readPrecWrappedUndeclared "Same";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Same
     where {minDeclaredValue = SAME_A; maxDeclaredValue = SAME_A}
 instance Show Same
     where {showsPrec = showsCEnum}
+instance Read Same
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern SAME_A :: Same
 pattern SAME_A = Same 1
 pattern SAME_B :: Same
@@ -94,7 +106,6 @@ instance Storable Nonseq
                                     {Nonseq un_Nonseq_3 -> pokeByteOff ptr_1 (0 :: Int) un_Nonseq_3}}
 deriving stock instance Eq Nonseq
 deriving stock instance Ord Nonseq
-deriving stock instance Read Nonseq
 instance CEnum Nonseq
     where {type CEnumZ Nonseq = CUInt;
            toCEnum = Nonseq;
@@ -103,9 +114,14 @@ instance CEnum Nonseq
                                                            singleton "NONSEQ_A"),
                                                           (301, singleton "NONSEQ_B"),
                                                           (404, singleton "NONSEQ_C")];
-           showsUndeclared = showsWrappedUndeclared "Nonseq"}
+           showsUndeclared = showsWrappedUndeclared "Nonseq";
+           readPrecUndeclared = readPrecWrappedUndeclared "Nonseq"}
 instance Show Nonseq
     where {showsPrec = showsCEnum}
+instance Read Nonseq
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern NONSEQ_A :: Nonseq
 pattern NONSEQ_A = Nonseq 200
 pattern NONSEQ_B :: Nonseq
@@ -121,7 +137,6 @@ instance Storable Packad
                                     {Packad un_Packad_3 -> pokeByteOff ptr_1 (0 :: Int) un_Packad_3}}
 deriving stock instance Eq Packad
 deriving stock instance Ord Packad
-deriving stock instance Read Packad
 instance CEnum Packad
     where {type CEnumZ Packad = CUChar;
            toCEnum = Packad;
@@ -131,12 +146,17 @@ instance CEnum Packad
                                                           (1, singleton "PACKED_B"),
                                                           (2, singleton "PACKED_C")];
            showsUndeclared = showsWrappedUndeclared "Packad";
+           readPrecUndeclared = readPrecWrappedUndeclared "Packad";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Packad
     where {minDeclaredValue = PACKED_A; maxDeclaredValue = PACKED_C}
 instance Show Packad
     where {showsPrec = showsCEnum}
+instance Read Packad
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern PACKED_A :: Packad
 pattern PACKED_A = Packad 0
 pattern PACKED_B :: Packad
@@ -152,7 +172,6 @@ instance Storable EnumA
                                     {EnumA un_EnumA_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumA_3}}
 deriving stock instance Eq EnumA
 deriving stock instance Ord EnumA
-deriving stock instance Read EnumA
 instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            toCEnum = EnumA;
@@ -161,12 +180,17 @@ instance CEnum EnumA
                                                            singleton "A_FOO"),
                                                           (1, singleton "A_BAR")];
            showsUndeclared = showsWrappedUndeclared "EnumA";
+           readPrecUndeclared = readPrecWrappedUndeclared "EnumA";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
     where {minDeclaredValue = A_FOO; maxDeclaredValue = A_BAR}
 instance Show EnumA
     where {showsPrec = showsCEnum}
+instance Read EnumA
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
@@ -180,7 +204,6 @@ instance Storable EnumB
                                     {EnumB un_EnumB_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumB_3}}
 deriving stock instance Eq EnumB
 deriving stock instance Ord EnumB
-deriving stock instance Read EnumB
 instance CEnum EnumB
     where {type CEnumZ EnumB = CUInt;
            toCEnum = EnumB;
@@ -189,12 +212,17 @@ instance CEnum EnumB
                                                            singleton "B_FOO"),
                                                           (1, singleton "B_BAR")];
            showsUndeclared = showsWrappedUndeclared "EnumB";
+           readPrecUndeclared = readPrecWrappedUndeclared "EnumB";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumB
     where {minDeclaredValue = B_FOO; maxDeclaredValue = B_BAR}
 instance Show EnumB
     where {showsPrec = showsCEnum}
+instance Read EnumB
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
@@ -208,7 +236,6 @@ instance Storable EnumC
                                     {EnumC un_EnumC_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumC_3}}
 deriving stock instance Eq EnumC
 deriving stock instance Ord EnumC
-deriving stock instance Read EnumC
 instance CEnum EnumC
     where {type CEnumZ EnumC = CUInt;
            toCEnum = EnumC;
@@ -217,12 +244,17 @@ instance CEnum EnumC
                                                            singleton "C_FOO"),
                                                           (1, singleton "C_BAR")];
            showsUndeclared = showsWrappedUndeclared "EnumC";
+           readPrecUndeclared = readPrecWrappedUndeclared "EnumC";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumC
     where {minDeclaredValue = C_FOO; maxDeclaredValue = C_BAR}
 instance Show EnumC
     where {showsPrec = showsCEnum}
+instance Read EnumC
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
 pattern C_BAR :: EnumC
@@ -236,7 +268,6 @@ instance Storable EnumD
                                     {EnumD un_EnumD_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumD_3}}
 deriving stock instance Eq EnumD
 deriving stock instance Ord EnumD
-deriving stock instance Read EnumD
 instance CEnum EnumD
     where {type CEnumZ EnumD = CUInt;
            toCEnum = EnumD;
@@ -245,12 +276,17 @@ instance CEnum EnumD
                                                            singleton "D_FOO"),
                                                           (1, singleton "D_BAR")];
            showsUndeclared = showsWrappedUndeclared "EnumD";
+           readPrecUndeclared = readPrecWrappedUndeclared "EnumD";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumD
     where {minDeclaredValue = D_FOO; maxDeclaredValue = D_BAR}
 instance Show EnumD
     where {showsPrec = showsCEnum}
+instance Read EnumD
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern D_FOO :: EnumD
 pattern D_FOO = EnumD 0
 pattern D_BAR :: EnumD

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -698,12 +698,6 @@
     (HsName
       "@NsTypeConstr"
       "Index"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Index"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -807,6 +801,57 @@
       (HsName "@NsConstr" "C")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Index",
+        structConstr = HsName
+          "@NsConstr"
+          "Index",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Index",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "index"),
+            enumAliases = [CName "index"],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "A",
+                valueValue = 0,
+                valueSourceLoc =
+                "manual_examples.h:27:5"},
+              EnumValue {
+                valueName = CName "B",
+                valueValue = 1,
+                valueSourceLoc =
+                "manual_examples.h:28:5"},
+              EnumValue {
+                valueName = CName "C",
+                valueValue = 2,
+                valueSourceLoc =
+                "manual_examples.h:29:5"}],
+            enumSourceLoc =
+            "manual_examples.h:26:14"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -5187,12 +5232,6 @@
     (HsName
       "@NsTypeConstr"
       "Signal"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Signal"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -5307,6 +5346,62 @@
       (HsName "@NsConstr" "Stop")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Signal",
+        structConstr = HsName
+          "@NsConstr"
+          "Signal",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Signal",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "signal"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "start",
+                valueValue = 1,
+                valueSourceLoc =
+                "manual_examples.h:121:3"},
+              EnumValue {
+                valueName = CName "pause",
+                valueValue = 2,
+                valueSourceLoc =
+                "manual_examples.h:122:3"},
+              EnumValue {
+                valueName = CName "resume",
+                valueValue = 3,
+                valueSourceLoc =
+                "manual_examples.h:123:3"},
+              EnumValue {
+                valueName = CName "stop",
+                valueValue = 4,
+                valueSourceLoc =
+                "manual_examples.h:124:3"}],
+            enumSourceLoc =
+            "manual_examples.h:120:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -5703,12 +5798,6 @@
     (HsName
       "@NsTypeConstr"
       "HTTP_status"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "HTTP_status"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -5783,6 +5872,68 @@
       False),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "HTTP_status",
+        structConstr = HsName
+          "@NsConstr"
+          "HTTP_status",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_HTTP_status",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "HTTP_status"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "ok",
+                valueValue = 200,
+                valueSourceLoc =
+                "manual_examples.h:128:3"},
+              EnumValue {
+                valueName = CName "moved",
+                valueValue = 301,
+                valueSourceLoc =
+                "manual_examples.h:129:3"},
+              EnumValue {
+                valueName = CName "bad_request",
+                valueValue = 400,
+                valueSourceLoc =
+                "manual_examples.h:130:3"},
+              EnumValue {
+                valueName = CName
+                  "unauthorized",
+                valueValue = 401,
+                valueSourceLoc =
+                "manual_examples.h:131:3"},
+              EnumValue {
+                valueName = CName "not_found",
+                valueValue = 404,
+                valueSourceLoc =
+                "manual_examples.h:132:3"}],
+            enumSourceLoc =
+            "manual_examples.h:127:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -6181,12 +6332,6 @@
     (HsName
       "@NsTypeConstr"
       "Descending"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Descending"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -6302,6 +6447,62 @@
       (HsName "@NsConstr" "X")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Descending",
+        structConstr = HsName
+          "@NsConstr"
+          "Descending",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Descending",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "descending"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "X",
+                valueValue = 100,
+                valueSourceLoc =
+                "manual_examples.h:136:3"},
+              EnumValue {
+                valueName = CName "Y",
+                valueValue = 99,
+                valueSourceLoc =
+                "manual_examples.h:137:3"},
+              EnumValue {
+                valueName = CName "Y_alias",
+                valueValue = 99,
+                valueSourceLoc =
+                "manual_examples.h:138:3"},
+              EnumValue {
+                valueName = CName "Z",
+                valueValue = 98,
+                valueSourceLoc =
+                "manual_examples.h:139:3"}],
+            enumSourceLoc =
+            "manual_examples.h:135:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -6678,12 +6879,6 @@
     (HsName
       "@NsTypeConstr"
       "Result"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "Result"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -6808,6 +7003,63 @@
         "Already_done")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Result",
+        structConstr = HsName
+          "@NsConstr"
+          "Result",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Result",
+            fieldType = HsPrimType
+              HsPrimCInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "result"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Signed),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "failed",
+                valueValue = `-1`,
+                valueSourceLoc =
+                "manual_examples.h:143:3"},
+              EnumValue {
+                valueName = CName "success",
+                valueValue = 0,
+                valueSourceLoc =
+                "manual_examples.h:144:3"},
+              EnumValue {
+                valueName = CName "postponed",
+                valueValue = 1,
+                valueSourceLoc =
+                "manual_examples.h:145:3"},
+              EnumValue {
+                valueName = CName
+                  "already_done",
+                valueValue = 2,
+                valueSourceLoc =
+                "manual_examples.h:146:3"}],
+            enumSourceLoc =
+            "manual_examples.h:142:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -7162,10 +7414,6 @@
     DeriveStock
     Ord
     (HsName "@NsTypeConstr" "Vote"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName "@NsTypeConstr" "Vote"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -7275,6 +7523,58 @@
       (HsName "@NsConstr" "Abstain")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Vote",
+        structConstr = HsName
+          "@NsConstr"
+          "Vote",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Vote",
+            fieldType = HsPrimType
+              HsPrimCUChar,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "vote"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimChar
+                (PrimSignExplicit Unsigned)),
+            enumSizeof = 1,
+            enumAlignment = 1,
+            enumValues = [
+              EnumValue {
+                valueName = CName "infavour",
+                valueValue = 0,
+                valueSourceLoc =
+                "manual_examples.h:150:3"},
+              EnumValue {
+                valueName = CName "against",
+                valueValue = 1,
+                valueSourceLoc =
+                "manual_examples.h:151:3"},
+              EnumValue {
+                valueName = CName "abstain",
+                valueValue = 2,
+                valueSourceLoc =
+                "manual_examples.h:152:3"}],
+            enumSourceLoc =
+            "manual_examples.h:149:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -7832,12 +8132,6 @@
     (HsName
       "@NsTypeConstr"
       "CXCursorKind"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "CXCursorKind"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -7987,6 +8281,114 @@
       False),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "CXCursorKind",
+        structConstr = HsName
+          "@NsConstr"
+          "CXCursorKind",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_CXCursorKind",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "CXCursorKind"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName
+                  "CXCursor_FirstExpr",
+                valueValue = 100,
+                valueSourceLoc =
+                "manual_examples.h:158:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_UnexposedExpr",
+                valueValue = 100,
+                valueSourceLoc =
+                "manual_examples.h:159:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_DeclRefExpr",
+                valueValue = 101,
+                valueSourceLoc =
+                "manual_examples.h:160:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_MemberRefExpr",
+                valueValue = 102,
+                valueSourceLoc =
+                "manual_examples.h:161:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_PackIndexingExpr",
+                valueValue = 156,
+                valueSourceLoc =
+                "manual_examples.h:163:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_LastExpr",
+                valueValue = 156,
+                valueSourceLoc =
+                "manual_examples.h:164:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_FirstStmt",
+                valueValue = 200,
+                valueSourceLoc =
+                "manual_examples.h:166:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_UnexposedStmt",
+                valueValue = 200,
+                valueSourceLoc =
+                "manual_examples.h:167:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_LabelStmt",
+                valueValue = 201,
+                valueSourceLoc =
+                "manual_examples.h:168:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_CompoundStmt",
+                valueValue = 202,
+                valueSourceLoc =
+                "manual_examples.h:169:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_OpenACCUpdateConstruct",
+                valueValue = 331,
+                valueSourceLoc =
+                "manual_examples.h:171:3"},
+              EnumValue {
+                valueName = CName
+                  "CXCursor_LastStmt",
+                valueValue = 331,
+                valueSourceLoc =
+                "manual_examples.h:172:3"}],
+            enumSourceLoc =
+            "manual_examples.h:157:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -27,6 +27,7 @@ import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CEnum
 import qualified HsBindgen.Runtime.SizedByteArray
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Floating, Fractional, IO, Int, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show, pure, showsPrec)
+import qualified Text.Read
 
 -- #include "manual_examples.h"
 
@@ -91,8 +92,6 @@ deriving stock instance Eq Index
 
 deriving stock instance Ord Index
 
-deriving stock instance Read Index
-
 instance HsBindgen.Runtime.CEnum.CEnum Index where
 
   type CEnumZ Index = FC.CUInt
@@ -107,6 +106,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Index where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Index"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Index"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -120,6 +121,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Index where
 instance Show Index where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Index where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern A :: Index
 pattern A = Index 0
@@ -675,8 +684,6 @@ deriving stock instance Eq Signal
 
 deriving stock instance Ord Signal
 
-deriving stock instance Read Signal
-
 instance HsBindgen.Runtime.CEnum.CEnum Signal where
 
   type CEnumZ Signal = FC.CUInt
@@ -695,6 +702,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Signal where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Signal"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Signal"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -708,6 +717,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Signal where
 instance Show Signal where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Signal where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern Start :: Signal
 pattern Start = Signal 1
@@ -746,8 +763,6 @@ deriving stock instance Eq HTTP_status
 
 deriving stock instance Ord HTTP_status
 
-deriving stock instance Read HTTP_status
-
 instance HsBindgen.Runtime.CEnum.CEnum HTTP_status where
 
   type CEnumZ HTTP_status = FC.CUInt
@@ -767,9 +782,20 @@ instance HsBindgen.Runtime.CEnum.CEnum HTTP_status where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "HTTP_status"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "HTTP_status"
+
 instance Show HTTP_status where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read HTTP_status where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern Ok :: HTTP_status
 pattern Ok = HTTP_status 200
@@ -811,8 +837,6 @@ deriving stock instance Eq Descending
 
 deriving stock instance Ord Descending
 
-deriving stock instance Read Descending
-
 instance HsBindgen.Runtime.CEnum.CEnum Descending where
 
   type CEnumZ Descending = FC.CUInt
@@ -830,6 +854,9 @@ instance HsBindgen.Runtime.CEnum.CEnum Descending where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Descending"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Descending"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -843,6 +870,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Descending where
 instance Show Descending where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Descending where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern X :: Descending
 pattern X = Descending 100
@@ -881,8 +916,6 @@ deriving stock instance Eq Result
 
 deriving stock instance Ord Result
 
-deriving stock instance Read Result
-
 instance HsBindgen.Runtime.CEnum.CEnum Result where
 
   type CEnumZ Result = FC.CInt
@@ -901,6 +934,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Result where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Result"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Result"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -914,6 +949,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Result where
 instance Show Result where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Result where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern Failed :: Result
 pattern Failed = Result (-1)
@@ -952,8 +995,6 @@ deriving stock instance Eq Vote
 
 deriving stock instance Ord Vote
 
-deriving stock instance Read Vote
-
 instance HsBindgen.Runtime.CEnum.CEnum Vote where
 
   type CEnumZ Vote = FC.CUChar
@@ -971,6 +1012,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Vote where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Vote"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Vote"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -984,6 +1027,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Vote where
 instance Show Vote where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Vote where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern Infavour :: Vote
 pattern Infavour = Vote 0
@@ -1019,8 +1070,6 @@ deriving stock instance Eq CXCursorKind
 
 deriving stock instance Ord CXCursorKind
 
-deriving stock instance Read CXCursorKind
-
 instance HsBindgen.Runtime.CEnum.CEnum CXCursorKind where
 
   type CEnumZ CXCursorKind = FC.CUInt
@@ -1043,9 +1092,20 @@ instance HsBindgen.Runtime.CEnum.CEnum CXCursorKind where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "CXCursorKind"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "CXCursorKind"
+
 instance Show CXCursorKind where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read CXCursorKind where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern CXCursor_FirstExpr :: CXCursorKind
 pattern CXCursor_FirstExpr = CXCursorKind 100

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -24,7 +24,6 @@ instance Storable Index
                                     {Index un_Index_3 -> pokeByteOff ptr_1 (0 :: Int) un_Index_3}}
 deriving stock instance Eq Index
 deriving stock instance Ord Index
-deriving stock instance Read Index
 instance CEnum Index
     where {type CEnumZ Index = CUInt;
            toCEnum = Index;
@@ -33,12 +32,17 @@ instance CEnum Index
                                                           (1, singleton "B"),
                                                           (2, singleton "C")];
            showsUndeclared = showsWrappedUndeclared "Index";
+           readPrecUndeclared = readPrecWrappedUndeclared "Index";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Index
     where {minDeclaredValue = A; maxDeclaredValue = C}
 instance Show Index
     where {showsPrec = showsCEnum}
+instance Read Index
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern A :: Index
 pattern A = Index 0
 pattern B :: Index
@@ -286,7 +290,6 @@ instance Storable Signal
                                     {Signal un_Signal_3 -> pokeByteOff ptr_1 (0 :: Int) un_Signal_3}}
 deriving stock instance Eq Signal
 deriving stock instance Ord Signal
-deriving stock instance Read Signal
 instance CEnum Signal
     where {type CEnumZ Signal = CUInt;
            toCEnum = Signal;
@@ -297,12 +300,17 @@ instance CEnum Signal
                                                           (3, singleton "Resume"),
                                                           (4, singleton "Stop")];
            showsUndeclared = showsWrappedUndeclared "Signal";
+           readPrecUndeclared = readPrecWrappedUndeclared "Signal";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Signal
     where {minDeclaredValue = Start; maxDeclaredValue = Stop}
 instance Show Signal
     where {showsPrec = showsCEnum}
+instance Read Signal
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern Start :: Signal
 pattern Start = Signal 1
 pattern Pause :: Signal
@@ -320,7 +328,6 @@ instance Storable HTTP_status
                                     {HTTP_status un_HTTP_status_3 -> pokeByteOff ptr_1 (0 :: Int) un_HTTP_status_3}}
 deriving stock instance Eq HTTP_status
 deriving stock instance Ord HTTP_status
-deriving stock instance Read HTTP_status
 instance CEnum HTTP_status
     where {type CEnumZ HTTP_status = CUInt;
            toCEnum = HTTP_status;
@@ -331,9 +338,14 @@ instance CEnum HTTP_status
                                                           (400, singleton "Bad_request"),
                                                           (401, singleton "Unauthorized"),
                                                           (404, singleton "Not_found")];
-           showsUndeclared = showsWrappedUndeclared "HTTP_status"}
+           showsUndeclared = showsWrappedUndeclared "HTTP_status";
+           readPrecUndeclared = readPrecWrappedUndeclared "HTTP_status"}
 instance Show HTTP_status
     where {showsPrec = showsCEnum}
+instance Read HTTP_status
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern Ok :: HTTP_status
 pattern Ok = HTTP_status 200
 pattern Moved :: HTTP_status
@@ -353,7 +365,6 @@ instance Storable Descending
                                     {Descending un_Descending_3 -> pokeByteOff ptr_1 (0 :: Int) un_Descending_3}}
 deriving stock instance Eq Descending
 deriving stock instance Ord Descending
-deriving stock instance Read Descending
 instance CEnum Descending
     where {type CEnumZ Descending = CUInt;
            toCEnum = Descending;
@@ -362,12 +373,17 @@ instance CEnum Descending
                                                           (99, "Y" :| ["Y_alias"]),
                                                           (100, singleton "X")];
            showsUndeclared = showsWrappedUndeclared "Descending";
+           readPrecUndeclared = readPrecWrappedUndeclared "Descending";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Descending
     where {minDeclaredValue = Z; maxDeclaredValue = X}
 instance Show Descending
     where {showsPrec = showsCEnum}
+instance Read Descending
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern X :: Descending
 pattern X = Descending 100
 pattern Y :: Descending
@@ -385,7 +401,6 @@ instance Storable Result
                                     {Result un_Result_3 -> pokeByteOff ptr_1 (0 :: Int) un_Result_3}}
 deriving stock instance Eq Result
 deriving stock instance Ord Result
-deriving stock instance Read Result
 instance CEnum Result
     where {type CEnumZ Result = CInt;
            toCEnum = Result;
@@ -396,12 +411,17 @@ instance CEnum Result
                                                           (1, singleton "Postponed"),
                                                           (2, singleton "Already_done")];
            showsUndeclared = showsWrappedUndeclared "Result";
+           readPrecUndeclared = readPrecWrappedUndeclared "Result";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Result
     where {minDeclaredValue = Failed; maxDeclaredValue = Already_done}
 instance Show Result
     where {showsPrec = showsCEnum}
+instance Read Result
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern Failed :: Result
 pattern Failed = Result (-1)
 pattern Success :: Result
@@ -419,7 +439,6 @@ instance Storable Vote
                                     {Vote un_Vote_3 -> pokeByteOff ptr_1 (0 :: Int) un_Vote_3}}
 deriving stock instance Eq Vote
 deriving stock instance Ord Vote
-deriving stock instance Read Vote
 instance CEnum Vote
     where {type CEnumZ Vote = CUChar;
            toCEnum = Vote;
@@ -429,12 +448,17 @@ instance CEnum Vote
                                                           (1, singleton "Against"),
                                                           (2, singleton "Abstain")];
            showsUndeclared = showsWrappedUndeclared "Vote";
+           readPrecUndeclared = readPrecWrappedUndeclared "Vote";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Vote
     where {minDeclaredValue = Infavour; maxDeclaredValue = Abstain}
 instance Show Vote
     where {showsPrec = showsCEnum}
+instance Read Vote
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern Infavour :: Vote
 pattern Infavour = Vote 0
 pattern Against :: Vote
@@ -450,7 +474,6 @@ instance Storable CXCursorKind
                                     {CXCursorKind un_CXCursorKind_3 -> pokeByteOff ptr_1 (0 :: Int) un_CXCursorKind_3}}
 deriving stock instance Eq CXCursorKind
 deriving stock instance Ord CXCursorKind
-deriving stock instance Read CXCursorKind
 instance CEnum CXCursorKind
     where {type CEnumZ CXCursorKind = CUInt;
            toCEnum = CXCursorKind;
@@ -467,9 +490,14 @@ instance CEnum CXCursorKind
                                                           (202, singleton "CXCursor_CompoundStmt"),
                                                           (331,
                                                            "CXCursor_OpenACCUpdateConstruct" :| ["CXCursor_LastStmt"])];
-           showsUndeclared = showsWrappedUndeclared "CXCursorKind"}
+           showsUndeclared = showsWrappedUndeclared "CXCursorKind";
+           readPrecUndeclared = readPrecWrappedUndeclared "CXCursorKind"}
 instance Show CXCursorKind
     where {showsPrec = showsCEnum}
+instance Read CXCursorKind
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern CXCursor_FirstExpr :: CXCursorKind
 pattern CXCursor_FirstExpr = CXCursorKind 100
 pattern CXCursor_UnexposedExpr :: CXCursorKind

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -201,12 +201,6 @@
     (HsName
       "@NsTypeConstr"
       "EnumA"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "EnumA"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -299,6 +293,52 @@
       (HsName "@NsConstr" "VALA_2")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "EnumA",
+        structConstr = HsName
+          "@NsConstr"
+          "EnumA",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_EnumA",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "enumA"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "VALA_1",
+                valueValue = 0,
+                valueSourceLoc =
+                "nested_enums.h:3:17"},
+              EnumValue {
+                valueName = CName "VALA_2",
+                valueValue = 1,
+                valueSourceLoc =
+                "nested_enums.h:4:17"}],
+            enumSourceLoc =
+            "nested_enums.h:2:14"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"
@@ -819,12 +859,6 @@
     (HsName
       "@NsTypeConstr"
       "ExB_fieldB1"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "ExB_fieldB1"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -923,6 +957,55 @@
       (HsName "@NsConstr" "VALB_2")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "ExB_fieldB1",
+        structConstr = HsName
+          "@NsConstr"
+          "ExB_fieldB1",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_ExB_fieldB1",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathAnon
+              (DeclPathCtxtField
+                (Just (CName "exB"))
+                (CName "fieldB1")
+                DeclPathCtxtTop),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "VALB_1",
+                valueValue = 0,
+                valueSourceLoc =
+                "nested_enums.h:10:17"},
+              EnumValue {
+                valueName = CName "VALB_2",
+                valueValue = 1,
+                valueSourceLoc =
+                "nested_enums.h:11:17"}],
+            enumSourceLoc =
+            "nested_enums.h:9:9"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/nested_enums.pp.hs
+++ b/hs-bindgen/fixtures/nested_enums.pp.hs
@@ -12,6 +12,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
+import qualified Text.Read
 
 newtype EnumA = EnumA
   { un_EnumA :: FC.CUInt
@@ -38,8 +39,6 @@ deriving stock instance Eq EnumA
 
 deriving stock instance Ord EnumA
 
-deriving stock instance Read EnumA
-
 instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   type CEnumZ EnumA = FC.CUInt
@@ -54,6 +53,8 @@ instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "EnumA"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "EnumA"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -67,6 +68,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum EnumA where
 instance Show EnumA where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read EnumA where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern VALA_1 :: EnumA
 pattern VALA_1 = EnumA 0
@@ -124,8 +133,6 @@ deriving stock instance Eq ExB_fieldB1
 
 deriving stock instance Ord ExB_fieldB1
 
-deriving stock instance Read ExB_fieldB1
-
 instance HsBindgen.Runtime.CEnum.CEnum ExB_fieldB1 where
 
   type CEnumZ ExB_fieldB1 = FC.CUInt
@@ -140,6 +147,9 @@ instance HsBindgen.Runtime.CEnum.CEnum ExB_fieldB1 where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "ExB_fieldB1"
 
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "ExB_fieldB1"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -153,6 +163,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum ExB_fieldB1 where
 instance Show ExB_fieldB1 where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read ExB_fieldB1 where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern VALB_1 :: ExB_fieldB1
 pattern VALB_1 = ExB_fieldB1 0

--- a/hs-bindgen/fixtures/nested_enums.th.txt
+++ b/hs-bindgen/fixtures/nested_enums.th.txt
@@ -8,7 +8,6 @@ instance Storable EnumA
                                     {EnumA un_EnumA_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumA_3}}
 deriving stock instance Eq EnumA
 deriving stock instance Ord EnumA
-deriving stock instance Read EnumA
 instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            toCEnum = EnumA;
@@ -17,12 +16,17 @@ instance CEnum EnumA
                                                            singleton "VALA_1"),
                                                           (1, singleton "VALA_2")];
            showsUndeclared = showsWrappedUndeclared "EnumA";
+           readPrecUndeclared = readPrecWrappedUndeclared "EnumA";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum EnumA
     where {minDeclaredValue = VALA_1; maxDeclaredValue = VALA_2}
 instance Show EnumA
     where {showsPrec = showsCEnum}
+instance Read EnumA
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern VALA_1 :: EnumA
 pattern VALA_1 = EnumA 0
 pattern VALA_2 :: EnumA
@@ -45,7 +49,6 @@ instance Storable ExB_fieldB1
                                     {ExB_fieldB1 un_ExB_fieldB1_3 -> pokeByteOff ptr_1 (0 :: Int) un_ExB_fieldB1_3}}
 deriving stock instance Eq ExB_fieldB1
 deriving stock instance Ord ExB_fieldB1
-deriving stock instance Read ExB_fieldB1
 instance CEnum ExB_fieldB1
     where {type CEnumZ ExB_fieldB1 = CUInt;
            toCEnum = ExB_fieldB1;
@@ -54,12 +57,17 @@ instance CEnum ExB_fieldB1
                                                            singleton "VALB_1"),
                                                           (1, singleton "VALB_2")];
            showsUndeclared = showsWrappedUndeclared "ExB_fieldB1";
+           readPrecUndeclared = readPrecWrappedUndeclared "ExB_fieldB1";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum ExB_fieldB1
     where {minDeclaredValue = VALB_1; maxDeclaredValue = VALB_2}
 instance Show ExB_fieldB1
     where {showsPrec = showsCEnum}
+instance Read ExB_fieldB1
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern VALB_1 :: ExB_fieldB1
 pattern VALB_1 = ExB_fieldB1 0
 pattern VALB_2 :: ExB_fieldB1

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -197,10 +197,6 @@
     DeriveStock
     Ord
     (HsName "@NsTypeConstr" "Foo"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName "@NsTypeConstr" "Foo"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -293,6 +289,52 @@
       (HsName "@NsConstr" "FOO2")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "Foo",
+        structConstr = HsName
+          "@NsConstr"
+          "Foo",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_Foo",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "foo"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName "FOO1",
+                valueValue = 0,
+                valueSourceLoc =
+                "typenames.h:15:2"},
+              EnumValue {
+                valueName = CName "FOO2",
+                valueValue = 1,
+                valueSourceLoc =
+                "typenames.h:16:2"}],
+            enumSourceLoc =
+            "typenames.h:14:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/typenames.pp.hs
+++ b/hs-bindgen/fixtures/typenames.pp.hs
@@ -13,6 +13,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
 import Prelude ((<*>), Enum, Eq, Floating, Fractional, Int, Num, Ord, Read, Real, RealFloat, RealFrac, Show, pure, showsPrec)
+import qualified Text.Read
 
 newtype Foo = Foo
   { un_Foo :: FC.CUInt
@@ -39,8 +40,6 @@ deriving stock instance Eq Foo
 
 deriving stock instance Ord Foo
 
-deriving stock instance Read Foo
-
 instance HsBindgen.Runtime.CEnum.CEnum Foo where
 
   type CEnumZ Foo = FC.CUInt
@@ -55,6 +54,8 @@ instance HsBindgen.Runtime.CEnum.CEnum Foo where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Foo"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Foo"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -68,6 +69,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum Foo where
 instance Show Foo where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Foo where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern FOO1 :: Foo
 pattern FOO1 = Foo 0

--- a/hs-bindgen/fixtures/typenames.th.txt
+++ b/hs-bindgen/fixtures/typenames.th.txt
@@ -8,7 +8,6 @@ instance Storable Foo
                                     {Foo un_Foo_3 -> pokeByteOff ptr_1 (0 :: Int) un_Foo_3}}
 deriving stock instance Eq Foo
 deriving stock instance Ord Foo
-deriving stock instance Read Foo
 instance CEnum Foo
     where {type CEnumZ Foo = CUInt;
            toCEnum = Foo;
@@ -17,12 +16,17 @@ instance CEnum Foo
                                                            singleton "FOO1"),
                                                           (1, singleton "FOO2")];
            showsUndeclared = showsWrappedUndeclared "Foo";
+           readPrecUndeclared = readPrecWrappedUndeclared "Foo";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum Foo
     where {minDeclaredValue = FOO1; maxDeclaredValue = FOO2}
 instance Show Foo
     where {showsPrec = showsCEnum}
+instance Read Foo
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern FOO1 :: Foo
 pattern FOO1 = Foo 0
 pattern FOO2 :: Foo

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -209,12 +209,6 @@
     (HsName
       "@NsTypeConstr"
       "MyEnum"),
-  DeclNewtypeInstance
-    DeriveStock
-    Read
-    (HsName
-      "@NsTypeConstr"
-      "MyEnum"),
   DeclInstance
     (InstanceCEnum
       Struct {
@@ -321,6 +315,54 @@
         "Say\25308\25308")),
   DeclInstance
     (InstanceCEnumShow
+      Struct {
+        structName = HsName
+          "@NsTypeConstr"
+          "MyEnum",
+        structConstr = HsName
+          "@NsConstr"
+          "MyEnum",
+        structFields = [
+          Field {
+            fieldName = HsName
+              "@NsVar"
+              "un_MyEnum",
+            fieldType = HsPrimType
+              HsPrimCUInt,
+            fieldOrigin = FieldOriginNone}],
+        structOrigin = StructOriginEnum
+          Enu {
+            enumDeclPath = DeclPathName
+              (CName "MyEnum"),
+            enumAliases = [],
+            enumType = TypePrim
+              (PrimIntegral PrimInt Unsigned),
+            enumSizeof = 4,
+            enumAlignment = 4,
+            enumValues = [
+              EnumValue {
+                valueName = CName
+                  "Say\20320\22909",
+                valueValue = 0,
+                valueSourceLoc =
+                "uses_utf8.h:5:9"},
+              EnumValue {
+                valueName = CName
+                  "Say\25308\25308",
+                valueValue = 1,
+                valueSourceLoc =
+                "uses_utf8.h:6:9"}],
+            enumSourceLoc =
+            "uses_utf8.h:4:6"},
+        structInstances = Set.fromList
+          [
+            Eq,
+            Ord,
+            Read,
+            Show,
+            Storable]}),
+  DeclInstance
+    (InstanceCEnumRead
       Struct {
         structName = HsName
           "@NsTypeConstr"

--- a/hs-bindgen/fixtures/uses_utf8.pp.hs
+++ b/hs-bindgen/fixtures/uses_utf8.pp.hs
@@ -12,6 +12,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified HsBindgen.Runtime.CEnum
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
+import qualified Text.Read
 
 newtype MyEnum = MyEnum
   { un_MyEnum :: FC.CUInt
@@ -38,8 +39,6 @@ deriving stock instance Eq MyEnum
 
 deriving stock instance Ord MyEnum
 
-deriving stock instance Read MyEnum
-
 instance HsBindgen.Runtime.CEnum.CEnum MyEnum where
 
   type CEnumZ MyEnum = FC.CUInt
@@ -54,6 +53,8 @@ instance HsBindgen.Runtime.CEnum.CEnum MyEnum where
 
   showsUndeclared = HsBindgen.Runtime.CEnum.showsWrappedUndeclared "MyEnum"
 
+  readPrecUndeclared = HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "MyEnum"
+
   isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
 
   mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
@@ -67,6 +68,14 @@ instance HsBindgen.Runtime.CEnum.SequentialCEnum MyEnum where
 instance Show MyEnum where
 
   showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read MyEnum where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
 
 pattern Say你好 :: MyEnum
 pattern Say你好 = MyEnum 0

--- a/hs-bindgen/fixtures/uses_utf8.th.txt
+++ b/hs-bindgen/fixtures/uses_utf8.th.txt
@@ -8,7 +8,6 @@ instance Storable MyEnum
                                     {MyEnum un_MyEnum_3 -> pokeByteOff ptr_1 (0 :: Int) un_MyEnum_3}}
 deriving stock instance Eq MyEnum
 deriving stock instance Ord MyEnum
-deriving stock instance Read MyEnum
 instance CEnum MyEnum
     where {type CEnumZ MyEnum = CUInt;
            toCEnum = MyEnum;
@@ -17,12 +16,17 @@ instance CEnum MyEnum
                                                            singleton "Say\20320\22909"),
                                                           (1, singleton "Say\25308\25308")];
            showsUndeclared = showsWrappedUndeclared "MyEnum";
+           readPrecUndeclared = readPrecWrappedUndeclared "MyEnum";
            isDeclared = seqIsDeclared;
            mkDeclared = seqMkDeclared}
 instance SequentialCEnum MyEnum
     where {minDeclaredValue = Say你好; maxDeclaredValue = Say拜拜}
 instance Show MyEnum
     where {showsPrec = showsCEnum}
+instance Read MyEnum
+    where {readPrec = readPrecCEnum;
+           readList = readListDefault;
+           readListPrec = readListPrecDefault}
 pattern Say你好 :: MyEnum
 pattern Say你好 = MyEnum 0
 pattern Say拜拜 :: MyEnum

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -209,6 +209,7 @@ data InstanceDecl where
       -> HsName NsConstr
       -> InstanceDecl
     InstanceCEnumShow :: Struct (S Z) -> InstanceDecl
+    InstanceCEnumRead :: Struct (S Z) -> InstanceDecl
 
 deriving instance Show InstanceDecl
 

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -79,6 +79,9 @@ data Global =
   | Num_class
   | Ord_class
   | Read_class
+  | Read_readPrec
+  | Read_readList
+  | Read_readListPrec
   | Real_class
   | RealFloat_class
   | RealFrac_class
@@ -146,6 +149,8 @@ data Global =
   | NonEmpty_constructor
   | NonEmpty_singleton
   | Map_fromList
+  | Read_readListDefault
+  | Read_readListPrecDefault
 
   | CEnum_class
   | CEnumZ_tycon
@@ -153,6 +158,7 @@ data Global =
   | CEnum_fromCEnum
   | CEnum_declaredValues
   | CEnum_showsUndeclared
+  | CEnum_readPrecUndeclared
   | CEnum_isDeclared
   | CEnum_mkDeclared
   | SequentialCEnum_class
@@ -161,6 +167,8 @@ data Global =
   | CEnum_declaredValuesFromList
   | CEnum_showsCEnum
   | CEnum_showsWrappedUndeclared
+  | CEnum_readPrecCEnum
+  | CEnum_readPrecWrappedUndeclared
   | CEnum_seqIsDeclared
   | CEnum_seqMkDeclared
   | AsCEnum_type

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -75,6 +75,8 @@ translateDefineInstanceDecl (Hs.InstanceSequentialCEnum struct nameMin nameMax) 
     DInst $ translateSequentialCEnum struct nameMin nameMax
 translateDefineInstanceDecl (Hs.InstanceCEnumShow struct) =
     DInst $ translateCEnumInstanceShow struct
+translateDefineInstanceDecl (Hs.InstanceCEnumRead struct) =
+    DInst $ translateCEnumInstanceRead struct
 
 translateDeclData :: Hs.Struct n -> SDecl
 translateDeclData struct = DRecord $ Record
@@ -404,6 +406,7 @@ translateCEnumInstance struct fTyp vMap isSequential = Instance {
         , (CEnum_fromCEnum, EFree fname)
         , (CEnum_declaredValues, EUnusedLam declaredValuesE)
         , (CEnum_showsUndeclared, EApp (EGlobal CEnum_showsWrappedUndeclared) dconStrE)
+        , (CEnum_readPrecUndeclared, EApp (EGlobal CEnum_readPrecWrappedUndeclared) dconStrE)
         ] ++ seqDecs
     }
   where
@@ -467,6 +470,23 @@ translateCEnumInstanceShow struct = Instance {
     , instanceTypes = []
     , instanceDecs  = [
           (Show_showsPrec, EGlobal CEnum_showsCEnum)
+        ]
+    }
+  where
+    tcon :: ClosedType
+    tcon = TCon $ Hs.structName struct
+
+translateCEnumInstanceRead ::
+     Hs.Struct (S Z)
+  -> Instance
+translateCEnumInstanceRead struct = Instance {
+      instanceClass = Read_class
+    , instanceArgs  = [tcon]
+    , instanceTypes = []
+    , instanceDecs  = [
+          (Read_readPrec, EGlobal CEnum_readPrecCEnum)
+        , (Read_readList, EGlobal Read_readListDefault)
+        , (Read_readListPrec, EGlobal Read_readListPrecDefault)
         ]
     }
   where

--- a/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TreeDiff/Orphans.hs
@@ -282,6 +282,8 @@ instance ToExpr Hs.InstanceDecl where
       Expr.App "InstanceSequentialCEnum" [toExpr struct, toExpr minV, toExpr maxV]
     Hs.InstanceCEnumShow struct ->
       Expr.App "InstanceCEnumShow" [toExpr struct]
+    Hs.InstanceCEnumRead struct ->
+      Expr.App "InstanceCEnumRead" [toExpr struct]
 
 instance ToExpr (t (S ctx)) => ToExpr (Hs.Lambda t ctx) where
   toExpr (Hs.Lambda name body) = Expr.App "Lambda" [toExpr name, toExpr body]


### PR DESCRIPTION
Closes #613.

CEnum:
- Add a `readPrecUndeclared` method to the `CEnum` type class
- Add `readPrecWrappedUndeclared` wrapper function which allows easy definition of `readPrecUndeclared`
- Define `readPrecCEnum` in terms of `readPrecUndeclared`; `readPrecCEnum` allow easy definition of `Read` instances
- Add unit and property tests. The parsers either fails completely (i.e., does not consume input), or succeeds.
- Define and use proper `Show` instances of test cases.

Code generation:
- Generate relevant code in `hs-bindgen`.
- `Text.Read` now maps to `Text.Read` (although TH resolves it to `GHC.Read`). Only the `Read` type class resolves to the Prelude.
- Accept golden tests (please review!).
- I can not guarantee that the generated code works, but I checked it manually (the `Text.Read` imports seem to be OK).

This PR does not yet add Read-related stuff to the manual.
