### PR TITLE
Clang extra args: `withExtraClangArgs`  (#640)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.dir-locals.el
 /.direnv/
+/.stylish-haskell.yaml
 
 .envrc
 .vscode/

--- a/hs-bindgen/app/HsBindgen/App/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cli.hs
@@ -26,6 +26,7 @@ getCli = customExecParser p opts
     opts = info (parseCli <**> helper) $
       mconcat [
           header "hs-bindgen - generate Haskell bindings from C headers"
+        , footerDoc (Just $ environmentVariablesFooter p)
         ]
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/app/HsBindgen/App/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/App/Dev.hs
@@ -22,6 +22,7 @@ getDev = customExecParser p opts
     opts = info (parseDev <**> helper) $
       mconcat [
           header "hs-bindgen development utilities"
+        , footerDoc (Just $ environmentVariablesFooter p)
         ]
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -34,7 +34,7 @@ instance Exception LiterateFileException where
 execMode :: HasCallStack => Cli -> Tracer IO (TraceWithCallStack Trace) -> Mode -> IO ()
 execMode Cli{..} tracer = \case
     ModePreprocess{..} -> do
-      extBindings <- loadExtBindings' resolveHeaderTracer cliGlobalOpts
+      extBindings <- loadExtBindings' tracer cliGlobalOpts
       let opts = cmdOpts {
               optsExtBindings = extBindings
             , optsTranslation = preprocessTranslationOpts
@@ -55,7 +55,7 @@ execMode Cli{..} tracer = \case
         Just path -> genExtBindings ppOpts preprocessInput path decls
 
     ModeGenTests{..} -> do
-      extBindings <- loadExtBindings' resolveHeaderTracer cliGlobalOpts
+      extBindings <- loadExtBindings' tracer cliGlobalOpts
       let opts = defaultOpts {
               optsExtBindings = extBindings
             }
@@ -68,9 +68,6 @@ execMode Cli{..} tracer = \case
 
     ModeLiterate input output -> execLiterate input output tracer
   where
-    resolveHeaderTracer :: Tracer IO (TraceWithCallStack ResolveHeaderException)
-    resolveHeaderTracer = useTrace TraceResolveHeader tracer
-
     cmdOpts :: Opts
     cmdOpts = defaultOpts {
         optsClangArgs  = globalOptsClangArgs cliGlobalOpts

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -22,15 +22,12 @@ execMode :: HasCallStack
   => Dev -> Tracer IO (TraceWithCallStack Trace) -> Mode -> IO ()
 execMode Dev{..} tracer = \case
     ModeParse{..} -> do
-      extBindings <- loadExtBindings' resolveHeaderTracer devGlobalOpts
+      extBindings <- loadExtBindings' tracer devGlobalOpts
       let opts = cmdOpts {
               optsExtBindings = extBindings
             }
       print . snd =<< Pipeline.parseCHeader opts parseInputPath
   where
-    resolveHeaderTracer :: Tracer IO (TraceWithCallStack ResolveHeaderException)
-    resolveHeaderTracer = useTrace TraceResolveHeader tracer
-
     cmdOpts :: Opts
     cmdOpts = defaultOpts {
         optsClangArgs  = globalOptsClangArgs devGlobalOpts

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -90,6 +90,7 @@ library internal
       HsBindgen.C.Reparse.Type
       HsBindgen.C.Tc.Macro
       HsBindgen.C.Tc.Macro.Type
+      HsBindgen.Clang.Args
       HsBindgen.Debug
       HsBindgen.Eff
       HsBindgen.Errors
@@ -189,6 +190,7 @@ library
   build-depends:
       -- Inherited dependencies
     , containers
+    , contra-tracer
     , filepath
     , template-haskell
 
@@ -217,7 +219,9 @@ executable hs-bindgen-cli
     , data-default
   build-depends:
       -- External dependencies
-    , optparse-applicative >= 0.18 && < 0.19
+    , optparse-applicative >= 0.18      && < 0.19
+    , prettyprinter        ^>=1.7.1
+    , text                 >= 1.2       && < 2.2
 
 executable hs-bindgen-dev
   import:         lang
@@ -243,7 +247,9 @@ executable hs-bindgen-dev
     , contra-tracer
   build-depends:
       -- External dependencies
-    , optparse-applicative >= 0.18 && < 0.19
+    , optparse-applicative >= 0.18      && < 0.19
+    , prettyprinter        ^>=1.7.1
+    , text                 >= 1.2       && < 2.2
 
 executable clang-ast-dump
   import:         lang
@@ -272,6 +278,7 @@ test-suite test-internal
   hs-source-dirs: test/internal
   other-modules:
       Test.HsBindgen.C.Parser
+      Test.HsBindgen.Clang.Args
       Test.Internal.Misc
       Test.Internal.Rust
       Test.Internal.TastyGolden
@@ -286,6 +293,7 @@ test-suite test-internal
     , deepseq
   build-depends:
       -- Inherited dependencies
+    , contra-tracer
     , bytestring
     , debruijn
     , mtl
@@ -296,7 +304,7 @@ test-suite test-internal
     , ansi-diff
     , deepseq
     , directory     ^>=1.3.6.2
-    , filepath      ^>=1.4.2.2 || ^>=1.5.2.0
+    , filepath      ^>=1.4.2.2   || ^>=1.5.2.0
     , process
     , syb           ^>=0.7.2.4
     , tasty         ^>=1.5

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
@@ -1,0 +1,105 @@
+-- | Handle `libclang`-specific environment variables.
+
+module HsBindgen.Clang.Args (
+    withExtraClangArgs
+  , ExtraClangArgsLog
+  -- Exported for tests.
+  , splitArguments
+  , getExtraClangArgs
+  ) where
+
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import System.Environment (lookupEnv)
+
+import Clang.Args
+import Control.Tracer (Tracer)
+import Data.Maybe (isJust)
+import GHC.ResponseFile (unescapeArgs)
+import GHC.Stack (HasCallStack, callStack)
+import HsBindgen.Util.Tracer (HasDefaultLogLevel (getDefaultLogLevel),
+                              HasSource (getSource), Level (Debug, Info),
+                              PrettyTrace (prettyTrace), Source (HsBindgen),
+                              TraceWithCallStack, traceWithCallStack)
+
+extraClangArgsEnvNameBase :: String
+extraClangArgsEnvNameBase = "BINDGEN_EXTRA_CLANG_ARGS"
+
+data ExtraClangArgsLog =
+    ExtraClangArgsNone
+  | ExtraClangArgsParsed { envName    :: String
+                         , envArgs    :: [String] }
+
+instance PrettyTrace ExtraClangArgsLog where
+  prettyTrace = \case
+    ExtraClangArgsNone ->
+      "No " <> extraClangArgsEnvNameBase <> " environment variables"
+    ExtraClangArgsParsed {..} ->
+      "Picked up evironment variable " <> envName <>
+      "; parsed 'libclang' arguments: " <> show envArgs
+
+instance HasDefaultLogLevel ExtraClangArgsLog where
+  getDefaultLogLevel = \case
+    ExtraClangArgsNone -> Debug
+    ExtraClangArgsParsed {} -> Info
+
+instance HasSource ExtraClangArgsLog where
+  getSource = const HsBindgen
+
+-- | Run a continuation honoring @libclang@-specific environment variables.
+--
+-- Extra arguments to `libclang`:
+--
+-- - If compiling natively, and without a target, use @BINDGEN_EXTRA_CLANG_ARGS@.
+--
+-- - If cross-compiling to a given target, use
+--   @BINDGEN_EXTRA_CLANG_ARGS_<TARGET>@, where @<TARGET>@ is a
+--   'Args.targetTriple'. Fall back to @BINDGEN_EXTRA_CLANG_ARGS@ if the
+--   target-specific environment variable is unset or empty. In particular, if
+--   cross-compiling to a given target, a provided, non-empty, target-specific
+--   environment variable takes precedence over `BINDGEN_EXTRA_CLANG_ARGS`,
+--   which is unused.
+--
+-- The values are split into separate command line arguments using
+-- 'splitArguments'.
+withExtraClangArgs :: (HasCallStack, MonadIO m)
+  => Tracer m (TraceWithCallStack ExtraClangArgsLog)
+  -> ClangArgs -> (ClangArgs -> m a) -> m a
+withExtraClangArgs tracer args k = do
+  extraClangArgs <- getExtraClangArgs tracer (fst <$> clangTarget args)
+  k $ args { clangOtherArgs = clangOtherArgs args <> extraClangArgs }
+
+{-------------------------------------------------------------------------------
+  Auxiliary functions.
+-------------------------------------------------------------------------------}
+
+getExtraClangArgsEnvName :: Maybe Target -> String
+getExtraClangArgsEnvName Nothing       = extraClangArgsEnvNameBase
+getExtraClangArgsEnvName (Just target) = extraClangArgsEnvNameBase <> "_"
+                                           <> targetTriple target TargetEnvDefault
+
+-- | Split string into command line arguments honoring shell escapes.
+--
+-- For expectations, see 'Test.HsBindgen.C.Environment.splitArgumentTests'.
+splitArguments :: String -> [String]
+splitArguments = unescapeArgs
+
+-- | Get extra `clang` arguments from system environment.
+--
+-- For expectations, see 'Test.HsNindgen.C.Environment.envTests'.
+getExtraClangArgs :: (HasCallStack, MonadIO m)
+  => Tracer m (TraceWithCallStack ExtraClangArgsLog) -> Maybe Target -> m [String]
+getExtraClangArgs tracer mtarget = do
+  extraClangArgsStr <- liftIO $ lookupEnv extraClangArgsEnvName
+  case extraClangArgsStr of
+    Nothing ->
+      if isJust mtarget
+      then getExtraClangArgs tracer Nothing -- Always fall back to no target.
+      else traceWithCallStack tracer callStack ExtraClangArgsNone >> pure []
+    Just content -> do
+      let args = splitArguments content
+      traceWithCallStack tracer callStack
+        (ExtraClangArgsParsed extraClangArgsEnvName args)
+      pure args
+  where
+    extraClangArgsEnvName = getExtraClangArgsEnvName mtarget

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings.hs
@@ -33,7 +33,7 @@ module HsBindgen.ExtBindings (
   ) where
 
 import Control.Applicative
-import Control.Exception (Exception(displayException))
+import Control.Exception (Exception (displayException))
 import Control.Monad ((<=<))
 import Control.Tracer (Tracer)
 import Data.Aeson ((.!=), (.:), (.:?), (.=))

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -63,8 +63,8 @@ import HsBindgen.Imports
 import HsBindgen.ModuleUnique
 import HsBindgen.SHs.AST qualified as SHs
 import HsBindgen.SHs.Translation qualified as SHs
-import HsBindgen.Util.Trace (Trace (TraceDiagnostic, TraceSkipped))
-import HsBindgen.Util.Tracer (TraceWithCallStack, useTrace)
+import HsBindgen.Util.Trace (Trace)
+import HsBindgen.Util.Tracer (TraceWithCallStack)
 
 {-------------------------------------------------------------------------------
   Options
@@ -118,8 +118,7 @@ defaultPPOpts = PPOpts {
 parseCHeader :: HasCallStack => Opts -> CHeaderIncludePath -> IO ([SourcePath], C.Header)
 parseCHeader Opts{..} headerIncludePath =
     C.parseCHeaders
-      (useTrace TraceDiagnostic optsTracer)
-      (useTrace TraceSkipped optsTracer)
+      optsTracer
       optsClangArgs
       optsPredicate
       optsExtBindings

--- a/hs-bindgen/src-internal/HsBindgen/Util/Parsec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Parsec.hs
@@ -8,11 +8,13 @@ module HsBindgen.Util.Parsec (
   , foldTokens
   ) where
 
-import Control.Monad
+import Control.Monad (guard)
 import Data.Char (toLower)
-import Text.Parsec.Error
-import Text.Parsec.Pos
-import Text.Parsec.Prim
+import Text.Parsec (Consumed (..), ParseError, ParsecT, Reply (..), SourcePos,
+                    State (..), Stream (..), mkPT, tokenPrim, unknownError,
+                    (<?>))
+import Text.Parsec.Error (Message (..), newErrorMessage)
+import Text.Parsec.Pos (updatePosChar, updatePosString)
 
 {-------------------------------------------------------------------------------
   Character streams

--- a/hs-bindgen/src-internal/HsBindgen/Util/Trace.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Trace.hs
@@ -6,6 +6,7 @@ import Clang.HighLevel.Types (Diagnostic, diagnosticIsError)
 
 import Control.Exception (Exception (displayException))
 import HsBindgen.C.Fold.Common (Skipped)
+import HsBindgen.Clang.Args (ExtraClangArgsLog)
 import HsBindgen.Resolve (ResolveHeaderException)
 import HsBindgen.Util.Tracer (HasDefaultLogLevel (getDefaultLogLevel),
                               HasSource (getSource), Level (Error, Warning),
@@ -19,12 +20,14 @@ import HsBindgen.Util.Tracer (HasDefaultLogLevel (getDefaultLogLevel),
 --
 -- Lazy on purpose to avoid evaluation when traces are not reported.
 data Trace = TraceDiagnostic Diagnostic
+           | TraceExtraClangArgs ExtraClangArgsLog
            | TraceResolveHeader ResolveHeaderException
            | TraceSkipped Skipped
 
 instance PrettyTrace Trace where
   prettyTrace = \case
     TraceDiagnostic x    -> show x
+    TraceExtraClangArgs x -> prettyTrace x
     TraceResolveHeader x -> displayException x
     TraceSkipped x       -> prettyTrace x
 
@@ -33,11 +36,13 @@ instance HasDefaultLogLevel Trace where
     -- We must evluate the diagnostic here to determine if it is an error.
     TraceDiagnostic x | diagnosticIsError x -> Error
     TraceDiagnostic _                       -> Warning
+    TraceExtraClangArgs x                   -> getDefaultLogLevel x
     TraceResolveHeader x                    -> getDefaultLogLevel x
     TraceSkipped x                          -> getDefaultLogLevel x
 
 instance HasSource Trace where
   getSource = \case
-    TraceDiagnostic _    -> Libclang
-    TraceResolveHeader x -> getSource x
-    TraceSkipped x       -> getSource x
+    TraceDiagnostic _     -> Libclang
+    TraceExtraClangArgs x -> getSource x
+    TraceResolveHeader x  -> getSource x
+    TraceSkipped x        -> getSource x

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -94,6 +94,7 @@ newtype HsDecls = WrapHsDecls {
       unwrapHsDecls :: [Hs.Decl]
     }
 
+-- | Translate C header to Haskell declarations
 translateCHeader :: HasCallStack
   => ModuleUnique -> Pipeline.Opts -> Paths.CHeaderIncludePath -> IO HsDecls
 translateCHeader mu opts = fmap WrapHsDecls . Pipeline.translateCHeader mu opts

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -45,6 +45,7 @@ module HsBindgen.TH (
   , THSyntax.getPackageRoot
   ) where
 
+import Control.Tracer (Tracer, natTracer)
 import Data.Set (Set)
 import Language.Haskell.TH qualified as TH
 import System.FilePath qualified as FilePath
@@ -52,6 +53,7 @@ import System.FilePath qualified as FilePath
 import Clang.Args qualified as Args
 import Clang.Paths qualified as Paths
 import HsBindgen.C.Predicate qualified as Predicate
+import HsBindgen.Clang.Args (ExtraClangArgsLog)
 import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
@@ -78,7 +80,11 @@ import Language.Haskell.TH.Syntax qualified as THSyntax
 -- * YAML (@.yaml@ extension)
 -- * JSON (@.json@ extension)
 loadExtBindings ::
-     Args.ClangArgs
+     Tracer TH.Q (TraceWithCallStack Trace.Trace)
+  -> Args.ClangArgs
   -> [FilePath]
   -> TH.Q (Set Resolve.ResolveHeaderException, ExtBindings.ExtBindings)
-loadExtBindings args = TH.runIO . ExtBindings.loadExtBindings args
+loadExtBindings tracer args = TH.runIO . ExtBindings.loadExtBindings tracer' args
+  where
+    tracer' :: Tracer IO (TraceWithCallStack ExtraClangArgsLog)
+    tracer' = useTrace Trace.TraceExtraClangArgs $ natTracer TH.runQ tracer

--- a/hs-bindgen/test/internal/Test/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/C/Parser.hs
@@ -2,7 +2,7 @@ module Test.HsBindgen.C.Parser (tests) where
 
 import Control.Tracer (Tracer)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit ((@?=), testCase)
+import Test.Tasty.HUnit (testCase, (@?=))
 
 import HsBindgen.C.Parser (getTargetTriple)
 import HsBindgen.Lib

--- a/hs-bindgen/test/internal/Test/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/C/Parser.hs
@@ -1,5 +1,6 @@
 module Test.HsBindgen.C.Parser (tests) where
 
+import Control.Tracer (Tracer)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@?=), testCase)
 
@@ -10,14 +11,14 @@ import HsBindgen.Lib
   Tests
 -------------------------------------------------------------------------------}
 
-tests :: ClangArgs -> TestTree
-tests args = testGroup "HsBindgen.C.Parser"
-    [ testGetTargetTriple args
+tests :: Tracer IO (TraceWithCallStack Trace) -> ClangArgs -> TestTree
+tests tracer args = testGroup "HsBindgen.C.Parser"
+    [ testGetTargetTriple tracer args
     ]
 
-testGetTargetTriple :: ClangArgs -> TestTree
-testGetTargetTriple args = testCase "getTargetTriple" $ do
-    triple <- getTargetTriple args
+testGetTargetTriple :: Tracer IO (TraceWithCallStack Trace) -> ClangArgs -> TestTree
+testGetTargetTriple tracer args = testCase "getTargetTriple" $ do
+    triple <- getTargetTriple (useTrace TraceExtraClangArgs tracer) args
 
     -- macos-latest (macos-14) returns "arm64-apple-macosx14.0.0"
     -- windows-latest (???) returns "x86_64-pc-windows-msvc19.41.34120"

--- a/hs-bindgen/test/internal/Test/HsBindgen/Clang/Args.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/Clang/Args.hs
@@ -1,0 +1,78 @@
+module Test.HsBindgen.Clang.Args (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+
+import Control.Tracer (Tracer)
+import System.Environment (setEnv, unsetEnv)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+import HsBindgen.Clang.Args
+import HsBindgen.Lib
+
+type EnvVar = String
+type Content = String
+
+eDef, eLnx :: String
+eDef = "BINDGEN_EXTRA_CLANG_ARGS"
+eLnx = eDef <> "_x86_64-pc-linux"
+
+withEnv :: [(EnvVar, Content)] -> IO a -> IO a
+withEnv xs k = do
+  mapM_ unsetEnv [eDef, eLnx]
+  mapM_ (uncurry setEnv) xs
+  r <- k
+  mapM_ (unsetEnv . fst) xs
+  pure r
+
+assertWithEnv :: (Eq a, Show a) => [(EnvVar, Content)] -> IO a -> a -> Assertion
+assertWithEnv xs k x = withEnv xs k >>= \r -> r @?= x
+
+tests :: Tracer IO (TraceWithCallStack Trace) -> TestTree
+tests tracer = testGroup "HsBindgen.Clang.Args" [ getExtraClangArgsTests (useTrace TraceExtraClangArgs tracer)
+                                                , splitArgumentsTests
+                                                ]
+
+splitArgumentsTests :: TestTree
+splitArgumentsTests = testGroup "splitStringArguments"
+    [ testCase "simple"       $ splitArguments "a b"                   @?= ["a", "b"]
+    , testCase "spacesPre"    $ splitArguments " \targ"                @?= ["arg"]
+    , testCase "spacesSuf1"   $ splitArguments "arg\t "                @?= ["arg"]
+    , testCase "spacesSuf2"   $ splitArguments "arg "                  @?= ["arg"]
+    , testCase "spaces1"      $ splitArguments "  \t  "                @?= []
+    , testCase "spaces2"      $ splitArguments " \t a b \t\n "         @?= ["a", "b"]
+    , testCase "escape1"      $ splitArguments "a\\ b"                 @?= ["a b"]
+    , testCase "escape2"      $ splitArguments "a1 arg\\ two a3"       @?= ["a1", "arg two", "a3"]
+    , testCase "escapedEsape" $ splitArguments "c\\\\d"                @?= ["c\\d"]
+    , testCase "escapedQuote" $ splitArguments "e\\\"f"                @?= ["e\"f"]
+    , testCase "escaped^2"    $ splitArguments "c\\\\d e\\\"f"         @?= ["c\\d", "e\"f"]
+    , testCase "escaped^3"    $ splitArguments " a\\ b c\\\\d e\\\"f " @?= ["a b", "c\\d", "e\"f"]
+    , testCase "quote1"       $ splitArguments "\"a b\""               @?= ["a b"]
+    , testCase "quote2"       $ splitArguments "a1 \"arg two\" a3"     @?= ["a1", "arg two", "a3"]
+    , testCase "escape&quote" $ splitArguments "a\\ \"b c\"\\ d"       @?= ["a b c d"]
+    ]
+
+getExtraClangArgsTests :: Tracer IO (TraceWithCallStack ExtraClangArgsLog) -> TestTree
+getExtraClangArgsTests tracer = testGroup "getExtraClangArgs" [
+          testCase "!target" $
+            assertWithEnv [(eDef, "native")]
+              (getExtraClangArgs tracer Nothing) ["native"]
+        , -- Without target, we ignore target-specific `clang` arguments.
+          testCase "!target+other" $
+            assertWithEnv [(eDef, "native"), (eLnx, "cross")]
+              (getExtraClangArgs tracer Nothing) ["native"]
+        , testCase "target" $
+            assertWithEnv [(eLnx, "cross")]
+              (getExtraClangArgs tracer (Just Target_Linux_X86_64)) ["cross"]
+        , -- With target, we exclusively use target-specific `clang` arguments,
+          -- if present.
+          testCase "target+other" $
+            assertWithEnv [(eDef, "native"), (eLnx, "cross")]
+              (getExtraClangArgs tracer (Just Target_Linux_X86_64)) ["cross"]
+        , -- With target, we fall back to the default `clang` arguments.
+          testCase "target+!other" $
+            assertWithEnv [(eDef, "native")]
+              (getExtraClangArgs tracer (Just Target_Linux_X86_64)) ["native"]
+        , testCase "target+otherEmpty" $
+            assertWithEnv [(eDef, "native"), (eLnx, "")]
+              (getExtraClangArgs tracer (Just Target_Linux_X86_64)) ["native"]
+        ]

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -17,10 +17,11 @@ $(do
     let args = defaultClangArgs {
             clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
-    extBindings <- snd <$> loadExtBindings args [
+    extBindings <- snd <$> (withTracerQ defaultTracerConf $
+      \tracer -> loadExtBindings tracer args [
         joinPath [dir, "bindings", "base.yaml"]
       , joinPath [dir, "bindings", "hs-bindgen-runtime.yaml"]
-      ]
+      ])
     let opts = defaultOpts {
             optsClangArgs   = args
           , optsExtBindings = extBindings

--- a/manual/LowLevel/Invocation.md
+++ b/manual/LowLevel/Invocation.md
@@ -13,3 +13,46 @@ For which C names do we want to generate Haskell definitions?
 ## `hs-bindgen`-as-a-library
 
 ## Cross-compilation
+
+## Environment variables
+
+A small set of environment variables affects the behavior of `hs-bindgen`.
+
+Users can provide extra command-line arguments to `libclang`:
+
+- __When compiling natively (i.e., without specifying a target)__: `hs-bindgen`
+  reads
+  `BINDGEN_EXTRA_CLANG_ARGS` and splits its string value into command-line
+  arguments, respecting shell escapes. For example,
+
+  ```sh
+  BINDGEN_EXTRA_CLANG_ARGS="arg1\ with\ whitespace\ endOfArg1 arg2"
+  BINDGEN_EXTRA_CLANG_ARGS="\"arg1 with whitespace endOfArg1\" arg2"
+  ```
+
+- __When cross-compiling to a given target__: `hs-bindgen` uses
+  `BINDGEN_EXTRA_CLANG_ARGS_<TARGET>` instead of `BINDGEN_EXTRA_CLANG_ARGS`.
+  Supported `<TARGET>`s: `x86_64-pc-linux`, `i386-pc-linux`, `aarch64-pc-linux`,
+  `x86_64-pc-windows`, `x86_64-apple-macosx`, `aarch64-apple-macosx`.
+  `hs-bindgen` falls back to `BINDGEN_EXTRA_CLANG_ARGS` if the target-specific
+  environment variable is unset or empty. Therefore, a non-empty,
+  target-specific variable takes precedence, and `hs-bindgen` ignores
+  `BINDGEN_EXTRA_CLANG_ARGS`.
+
+This behavior is consistent with that of
+[`rust-bindgen`](https://github.com/rust-lang/rust-bindgen?tab=readme-ov-file#environment-variables).
+
+Configuration of `libclang` via environment variables is important because:
+
+- Software distribution maintainers (e.g., for NixOS) may want to configure
+  `hs-bindgen`'s behavior for packages that use it.
+
+- Users may want to configure `hs-bindgen`'s behavior when it is invoked via
+  Template Haskell (using `genBindings`), without modifying the source code.
+
+Note that when using `hs-bindgen-cli`, users can fully configure `libclang`
+with command-line arguments. For instance, they can set:
+
+- `--system-include-path DIR`,
+- `--include-path DIR`, and
+- `--clang-option OPTION` (for other options passed directly to `libclang`).


### PR DESCRIPTION
Implement and use `withExtraClangArgs` honoring `BINDGEN_EXTRA_CLANG_ARGS` and `BINDGEN_EXTRA_CLANG_ARGS_<TARGET>`.

The environment variables are documented in the optparse-applicative help footer, and the "Invocation" section in the manual.

This was a bit of a rabbit hole. Since we use `libclang` directly, we need to parse the extra arguments and split them honoring shell-escape syntax. (However, `unescapeArgs` in `base` can do that for us).

There are still some open questions:
- [x] Logging. (Right now when reading `BINDGEN_EXTRA_CLANG_ARGS`, we print to `stdout` which is suboptimal, especially when `hs-bindgen` is used as a library). However, I was not sure if I should re-use one of the tracers, or if we still setup a proper logger. -> Seprate issue/PR (#647).
- [x] ~~I tested the parser well, but there may be more edge cases I have missed. (I was surprised I coulnd't find a library function on Hackage doing this for us; do you know one?)~~ We use `unescapeArgs` from `base`.
- [x] Should we add an integration-like test, checking if `BINDGEN_EXTRA_CLANG_ARGS` is acutally used? (It does work here, but in the long run this is desirable). This may also be especially relevant when using other targets. -> Done.
- [x] We document the behavior in the manual, and in the footer of the client(s).
- [x] Rebase on #651.
- [x] Use tracer in `withExtraClangArgs`.

Closes #640
