### PR TITLE
Fix running the manual with shared library `vector`

### DIFF
--- a/manual/c/Makefile
+++ b/manual/c/Makefile
@@ -17,7 +17,7 @@ manual_examples.o: manual_examples.c ${PROJECT_ROOT}/hs-bindgen/examples/manual_
 # Example for external bindings
 
 libvector.so: vector.o vector_length.o vector_rotate.o
-	gcc -Wall -o libvector.so -shared vector.o vector_length.o vector_rotate.o
+	gcc -Wall -o libvector.so -shared vector.o vector_length.o vector_rotate.o -lm
 
 vector.o: vector.c vector.h
 	gcc -Wall -o vector.o -c -fPIC vector.c

--- a/manual/hs/hs-vector/hs-vector.cabal
+++ b/manual/hs/hs-vector/hs-vector.cabal
@@ -27,4 +27,3 @@ library
 
   extra-libraries:
       vector
-      m


### PR DESCRIPTION
I was getting segmentation faults when running `cd manual/hs; cabal run manual`.`

The reason was that the vector library did not link against `libm`, but rather the Haskell project linked against `libm`.

Then, when running `cabal run manual`, the dynamic linker relinked the library to `libm`, causing a segmentation fault (even without using any functionality of `libvector` or the generated Haskell bindings thereof).