### PR TITLE
Unify tracing and logging

### DIFF
--- a/clang/src/Clang/HighLevel/Diagnostics.hs
+++ b/clang/src/Clang/HighLevel/Diagnostics.hs
@@ -85,6 +85,7 @@ data FixIt = FixIt {
     }
   deriving stock (Show)
 
+-- TODO: Probably separate into Info/Warning/Error (issue #175).
 diagnosticIsError :: Diagnostic -> Bool
 diagnosticIsError diag =
     case fromSimpleEnum (diagnosticSeverity diag) of

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -121,6 +121,7 @@ library internal
       HsBindgen.SHs.Translation
       HsBindgen.Util.Parsec
       HsBindgen.Util.TestEquality
+      HsBindgen.Util.Trace
       HsBindgen.Util.Tracer
       HsBindgen.ModuleUnique
       Text.SimplePrettyPrint
@@ -140,6 +141,7 @@ library internal
   build-depends:
       -- External dependencies
     , aeson              >= 2         && < 2.3
+    , ansi-terminal      >= 1.0.0     && < 1.2
     , array              >= 0.5.4.0   && < 0.6
     , base-compat        >= 0.13.1    && < 0.15
     , bytestring         >= 0.11.4.0  && < 0.13
@@ -159,6 +161,7 @@ library internal
     , some
     , template-haskell   >= 2.18      && < 2.24
     , text               >= 1.2       && < 2.2
+    , time               >= 1.11      && < 1.15
     , unliftio-core      ^>=0.2.1.0
     , vec                >= 0.5       && < 0.6
     , yaml               >= 0.11.11.1 && < 0.12
@@ -210,6 +213,7 @@ executable hs-bindgen-cli
     , hs-bindgen
   build-depends:
       -- Inherited dependencies
+    , contra-tracer
     , data-default
   build-depends:
       -- External dependencies
@@ -234,6 +238,9 @@ executable hs-bindgen-dev
       -- Internal dependencies
     , hs-bindgen
     , hs-bindgen:internal
+  build-depends:
+      -- Inherited dependencies
+    , contra-tracer
   build-depends:
       -- External dependencies
     , optparse-applicative >= 0.18 && < 0.19

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Decl.hs
@@ -6,6 +6,7 @@ module HsBindgen.C.Fold.Decl (
   ) where
 
 import Control.Monad.State
+import Control.Tracer (Tracer)
 import Data.List.Compat ((!?))
 import Data.Vec.Lazy qualified as Vec
 
@@ -21,12 +22,12 @@ import HsBindgen.C.Fold.Type
 import HsBindgen.C.Predicate (Predicate)
 import HsBindgen.C.Reparse
 import HsBindgen.C.Tc.Macro (tcMacro)
+import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Eff
 import HsBindgen.Errors
 import HsBindgen.ExtBindings
 import HsBindgen.Imports
-import HsBindgen.Util.Tracer
-import HsBindgen.C.Tc.Macro qualified as Macro
+import HsBindgen.Util.Tracer (TraceWithCallStack)
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -34,7 +35,7 @@ import HsBindgen.C.Tc.Macro qualified as Macro
 
 foldDecls ::
      HasCallStack
-  => Tracer IO Skipped
+  => Tracer IO (TraceWithCallStack Skipped)
   -> Predicate
   -> ExtBindings
   -> [CHeaderIncludePath]

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -7,7 +7,7 @@ module HsBindgen.C.Fold.Type (
     processTypeDecl,
 ) where
 
-import Control.Monad.State (State, get, put, gets)
+import Control.Monad.State (State, get, gets, put)
 import Data.Map.Ordered.Strict qualified as OMap
 import Data.Text qualified as T
 import Foreign.C

--- a/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Fold/Type.hs
@@ -27,7 +27,7 @@ import HsBindgen.Eff
 import HsBindgen.Errors
 import HsBindgen.ExtBindings
 import HsBindgen.Imports
-import HsBindgen.Util.Tracer (prettyLogMsg)
+import HsBindgen.Util.Tracer (prettyTrace)
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -155,7 +155,7 @@ processTypeDecl' ctxt extBindings unit declLoc declCursor ty = case fromSimpleEn
                                 , "Proceeding with macros expanded."
                                 , ""
                                 , "Parse error:"
-                                , prettyLogMsg err
+                                , prettyTrace err
                                 , ""
                                 ]
                               return Nothing
@@ -416,7 +416,7 @@ processTypeDecl' ctxt extBindings unit declLoc declCursor ty = case fromSimpleEn
                       , "Proceeding with macros expanded."
                       , ""
                       , "Parse error:"
-                      , prettyLogMsg err
+                      , prettyTrace err
                       , ""
                       ]
                     return Nothing
@@ -669,7 +669,7 @@ mkStructField extBindings unit mkCtxt current = do
                   , "Proceeding with macros expanded."
                   , ""
                   , "Parse error:"
-                  , prettyLogMsg err
+                  , prettyTrace err
                   , ""
                   ]
                 return Nothing
@@ -760,7 +760,7 @@ mkUnionField extBindings unit mkCtxt current = do
                   , "Proceeding with macros expanded."
                   , ""
                   , "Parse error:"
-                  , prettyLogMsg err
+                  , prettyTrace err
                   , ""
                   ]
                 return Nothing

--- a/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
@@ -30,8 +30,8 @@ import Clang.HighLevel qualified as HighLevel
 import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 import Clang.Paths
-import Data.DynGraph qualified as DynGraph
 import Data.DynGraph (DynGraph)
+import Data.DynGraph qualified as DynGraph
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Fold qualified as C
 import HsBindgen.C.Fold.DeclState qualified as C

--- a/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
@@ -12,6 +12,7 @@ module HsBindgen.C.Parser (
   ) where
 
 import Control.Exception
+import Control.Tracer (Tracer)
 import Data.List qualified as List
 import Data.List.Compat ((!?))
 import Data.Map.Strict qualified as Map
@@ -20,6 +21,7 @@ import Data.Ord (comparing)
 import Data.Text qualified as Text
 import Data.Tree (Tree)
 import Data.Tree qualified as Tree
+import GHC.Stack (callStack)
 
 import Clang.Args
 import Clang.Enum.Bitfield
@@ -38,7 +40,7 @@ import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Errors
 import HsBindgen.ExtBindings
 import HsBindgen.Imports
-import HsBindgen.Util.Tracer
+import HsBindgen.Util.Tracer (TraceWithCallStack, traceWithCallStack)
 
 {-------------------------------------------------------------------------------
   Parsing
@@ -73,8 +75,9 @@ instance Exception ParseCHeadersException where
       "unknown error parsing C headers: " ++ show errCode
 
 parseCHeaders ::
-     Tracer IO Diagnostic  -- ^ Tracer for warnings
-  -> Tracer IO C.Skipped
+     HasCallStack =>
+     Tracer IO (TraceWithCallStack Diagnostic)  -- ^ Tracer for warnings
+  -> Tracer IO (TraceWithCallStack C.Skipped)
   -> ClangArgs
   -> Predicate
   -> ExtBindings
@@ -90,9 +93,7 @@ parseCHeaders diagTracer skipTracer args p extBindings headerIncludePaths =
               (errors, warnings) <- List.partition diagnosticIsError
                 <$> HighLevel.clang_getDiagnostics unit Nothing
               unless (null errors) $ throwIO (getError errors)
-              -- TODO: <https://github.com/well-typed/hs-bindgen/issues/175>
-              -- We should print warnings only optionally.
-              forM_ warnings $ traceWith diagTracer Warning
+              forM_ warnings $ traceWithCallStack diagTracer callStack
               rootCursor <- clang_getTranslationUnitCursor unit
               (decls, finalDeclState) <-
                 C.runFoldState C.initDeclState $

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Infra.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Infra.hs
@@ -35,7 +35,7 @@ import Clang.LowLevel.Core
 import Clang.Paths
 import HsBindgen.Errors
 import HsBindgen.Imports
-import HsBindgen.Util.Tracer (PrettyLogMsg(..))
+import HsBindgen.Util.Tracer (PrettyTrace (..))
 
 {-------------------------------------------------------------------------------
   Parser type
@@ -81,8 +81,8 @@ data ReparseError = ReparseError {
   deriving stock (Show, Eq, Generic)
   deriving anyclass (Exception)
 
-instance PrettyLogMsg ReparseError where
-  prettyLogMsg ReparseError{
+instance PrettyTrace ReparseError where
+  prettyTrace ReparseError{
           reparseError
         , reparseErrorTokens
         } = unlines [

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -41,14 +41,14 @@ import Language.Haskell.TH qualified as TH
 import Clang.Args
 import Clang.Paths
 import HsBindgen.Backend.Extensions
-import HsBindgen.Backend.PP.Render (HsRenderOpts(..))
+import HsBindgen.Backend.PP.Render (HsRenderOpts (..))
 import HsBindgen.Backend.PP.Render qualified as Backend.PP
-import HsBindgen.Backend.PP.Translation (HsModuleOpts(..))
+import HsBindgen.Backend.PP.Translation (HsModuleOpts (..))
 import HsBindgen.Backend.PP.Translation qualified as Backend.PP
 import HsBindgen.Backend.TH.Translation qualified as Backend.TH
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Parser qualified as C
-import HsBindgen.C.Predicate (Predicate(..))
+import HsBindgen.C.Predicate (Predicate (..))
 import HsBindgen.Errors
 import HsBindgen.ExtBindings
 import HsBindgen.ExtBindings.Gen qualified as GenExtBindings

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -33,6 +33,7 @@ module HsBindgen.Pipeline (
   ) where
 
 import Control.Monad ((<=<))
+import Control.Tracer (Tracer, nullTracer)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Language.Haskell.TH qualified as TH
@@ -52,17 +53,18 @@ import HsBindgen.Errors
 import HsBindgen.ExtBindings
 import HsBindgen.ExtBindings.Gen qualified as GenExtBindings
 import HsBindgen.GenTests qualified as GenTests
+import HsBindgen.Guasi
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.NameMangler (NameMangler)
 import HsBindgen.Hs.NameMangler qualified as NameMangler
 import HsBindgen.Hs.NameMangler.DSL qualified as NameMangler.DSL
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports
+import HsBindgen.ModuleUnique
 import HsBindgen.SHs.AST qualified as SHs
 import HsBindgen.SHs.Translation qualified as SHs
-import HsBindgen.Util.Tracer
-import HsBindgen.Guasi
-import HsBindgen.ModuleUnique
+import HsBindgen.Util.Trace (Trace (TraceDiagnostic, TraceSkipped))
+import HsBindgen.Util.Tracer (TraceWithCallStack, useTrace)
 
 {-------------------------------------------------------------------------------
   Options
@@ -75,8 +77,7 @@ data Opts = Opts {
     , optsTranslation :: Hs.TranslationOpts
     , optsNameMangler :: NameMangler
     , optsPredicate   :: Predicate
-    , optsDiagTracer  :: Tracer IO String
-    , optsSkipTracer  :: Tracer IO String
+    , optsTracer      :: Tracer IO (TraceWithCallStack Trace)
     }
 
 -- | Default 'Opts'
@@ -87,8 +88,7 @@ defaultOpts = Opts {
     , optsTranslation = Hs.defaultTranslationOpts
     , optsNameMangler = nameMangler
     , optsPredicate   = SelectFromMainFile
-    , optsDiagTracer  = nullTracer
-    , optsSkipTracer  = nullTracer
+    , optsTracer      = nullTracer
     }
   where
     -- TODO: Make it possible to specify overrides through the CLI
@@ -115,11 +115,11 @@ defaultPPOpts = PPOpts {
 -------------------------------------------------------------------------------}
 
 -- | Parse a C header
-parseCHeader :: Opts -> CHeaderIncludePath -> IO ([SourcePath], C.Header)
+parseCHeader :: HasCallStack => Opts -> CHeaderIncludePath -> IO ([SourcePath], C.Header)
 parseCHeader Opts{..} headerIncludePath =
     C.parseCHeaders
-      (contramap show optsDiagTracer)
-      (contramap prettyLogMsg optsSkipTracer)
+      (useTrace TraceDiagnostic optsTracer)
+      (useTrace TraceSkipped optsTracer)
       optsClangArgs
       optsPredicate
       optsExtBindings
@@ -158,7 +158,8 @@ genExtensions = foldMap requiredExtensions
 -------------------------------------------------------------------------------}
 
 -- | Parse a C header and generate @Hs@ declarations
-translateCHeader :: ModuleUnique -> Opts -> CHeaderIncludePath -> IO [Hs.Decl]
+translateCHeader :: HasCallStack
+  => ModuleUnique -> Opts -> CHeaderIncludePath -> IO [Hs.Decl]
 translateCHeader mu opts headerIncludePath = do
     (_depPaths, header) <- parseCHeader opts headerIncludePath
     return $ genHsDecls mu opts header
@@ -180,7 +181,7 @@ preprocessIO ppOpts fp = genPP ppOpts fp . genModule ppOpts . genSHsDecls
 -------------------------------------------------------------------------------}
 
 -- | Generate bindings for the given C header
-genBindings ::
+genBindings :: HasCallStack =>
      Opts
   -> FilePath -- ^ Input header, as written in C @#include@
   -> TH.Q [TH.Dec]

--- a/hs-bindgen/src-internal/HsBindgen/Resolve.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Resolve.hs
@@ -6,7 +6,7 @@ module HsBindgen.Resolve (
   , resolveHeader
   ) where
 
-import Control.Exception (Exception(displayException))
+import Control.Exception (Exception (displayException))
 import Control.Monad ((<=<))
 import Control.Monad.Except (runExceptT, throwError)
 import Data.Maybe (listToMaybe)

--- a/hs-bindgen/src-internal/HsBindgen/Resolve.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Resolve.hs
@@ -21,6 +21,9 @@ import Clang.LowLevel.Core
 import Clang.Paths
 import HsBindgen.Errors
 import HsBindgen.Imports
+import HsBindgen.Util.Tracer (HasDefaultLogLevel (getDefaultLogLevel),
+                              HasSource (getSource), Level (..),
+                              PrettyTrace (prettyTrace), Source (HsBindgen))
 
 {-------------------------------------------------------------------------------
   Error type
@@ -35,6 +38,15 @@ instance Exception ResolveHeaderException where
   displayException = \case
     ResolveHeaderNotFound headerIncludePath ->
       "header not found: " ++ getCHeaderIncludePath headerIncludePath
+
+instance PrettyTrace ResolveHeaderException where
+  prettyTrace = displayException
+
+instance HasDefaultLogLevel ResolveHeaderException where
+  getDefaultLogLevel = const Error
+
+instance HasSource ResolveHeaderException where
+  getSource = const HsBindgen
 
 {-------------------------------------------------------------------------------
   API

--- a/hs-bindgen/src-internal/HsBindgen/Util/Trace.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Trace.hs
@@ -1,0 +1,43 @@
+module HsBindgen.Util.Trace (
+    Trace (..)
+  ) where
+
+import Clang.HighLevel.Types (Diagnostic, diagnosticIsError)
+
+import Control.Exception (Exception (displayException))
+import HsBindgen.C.Fold.Common (Skipped)
+import HsBindgen.Resolve (ResolveHeaderException)
+import HsBindgen.Util.Tracer (HasDefaultLogLevel (getDefaultLogLevel),
+                              HasSource (getSource), Level (Error, Warning),
+                              PrettyTrace (prettyTrace), Source (Libclang))
+
+{-------------------------------------------------------------------------------
+  HsBindgen traces
+-------------------------------------------------------------------------------}
+
+-- | Traces supported by @hs-bindgen@.
+--
+-- Lazy on purpose to avoid evaluation when traces are not reported.
+data Trace = TraceDiagnostic Diagnostic
+           | TraceResolveHeader ResolveHeaderException
+           | TraceSkipped Skipped
+
+instance PrettyTrace Trace where
+  prettyTrace = \case
+    TraceDiagnostic x    -> show x
+    TraceResolveHeader x -> displayException x
+    TraceSkipped x       -> prettyTrace x
+
+instance HasDefaultLogLevel Trace where
+  getDefaultLogLevel = \case
+    -- We must evluate the diagnostic here to determine if it is an error.
+    TraceDiagnostic x | diagnosticIsError x -> Error
+    TraceDiagnostic _                       -> Warning
+    TraceResolveHeader x                    -> getDefaultLogLevel x
+    TraceSkipped x                          -> getDefaultLogLevel x
+
+instance HasSource Trace where
+  getSource = \case
+    TraceDiagnostic _    -> Libclang
+    TraceResolveHeader x -> getSource x
+    TraceSkipped x       -> getSource x

--- a/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
@@ -4,114 +4,251 @@
 --
 -- Indended for unqualified import.
 module HsBindgen.Util.Tracer (
-    Tracer -- opaque
-  , nullTracer
-  , PrettyLogMsg(..)
-    -- * Using the tracer
-  , Level(..)
-  , traceWith
-  , contramap
-    -- * Constructing tracers
+  -- | Data types and typeclasses useful for tracing
+    Level (..)
+  , PrettyTrace (..)
+  , HasDefaultLogLevel (..)
+  , Source (..)
+  , HasSource (..)
+  , Verbosity (..)
+  -- | Tracer configuration
+  , AnsiColor (..)
+  , ShowTimeStamp (..)
+  , ShowCallStack (..)
+  , TracerConf (..)
+  , defaultTracerConf
+  -- | Trace with call stack
+  , TraceWithCallStack (..)
+  , traceWithCallStack
+  , useTrace
+  -- | Tracers
   , mkTracer
-  , mkTracerIO
-  , mkTracerQ
-  , traceThrow
+  , withTracerStdOut
+  , withTracerFile
+  , withTracerQ
   ) where
 
-import Control.Tracer qualified as Contra
-import Control.Tracer.Arrow
-import Data.Bifunctor
-import Data.Functor.Contravariant
-
-import Language.Haskell.TH.Syntax
-import Control.Exception
-
-{-------------------------------------------------------------------------------
-  Definition
--------------------------------------------------------------------------------}
-
-newtype Tracer m a = Wrap {
-      unwrap :: Contra.Tracer m (Level, a)
-    }
-
-instance Monad m => Contravariant (Tracer m) where
-  contramap f = Wrap . contramap (second f) . unwrap
-
-data Level = Error | Warning | Info
-
-traceWith :: Monad m => Tracer m a -> Level -> a -> m ()
-traceWith t l a = Contra.traceWith (unwrap t) (l, a)
+import Control.Applicative (ZipList (ZipList, getZipList))
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Tracer (Contravariant (contramap), Tracer (Tracer), emit,
+                       squelchUnless, traceWith)
+import Data.Time (UTCTime, defaultTimeLocale, formatTime, getCurrentTime)
+import Data.Time.Format (FormatTime)
+import GHC.Stack (CallStack, prettyCallStack)
+import Language.Haskell.TH.Syntax (Quasi)
+import System.Console.ANSI (Color (..), ColorIntensity (Vivid),
+                            ConsoleIntensity (BoldIntensity),
+                            ConsoleLayer (Foreground),
+                            SGR (SetColor, SetConsoleIntensity),
+                            hSupportsANSIColor, setSGRCode)
+import System.IO (IOMode (AppendMode), hPutStrLn, stdout, withFile)
 
 {-------------------------------------------------------------------------------
-  Internal: general tracer construction
+  Data types and type classes useful for tracing
 -------------------------------------------------------------------------------}
 
-nullTracer :: Monad m => Tracer m a
-nullTracer = Wrap Contra.nullTracer
+-- | Log or verbosity level.
+--
+-- Careful, the derived 'Ord' instance is used when determining if a trace
+-- should be emitted, or not.
+data Level = Debug | Info | Warning | Error
+  deriving stock (Show, Eq, Ord)
 
-mkTracer :: forall m a.
-     Monad m
-  => (a -> m ())  -- ^ Output error
-  -> (a -> m ())  -- ^ Output warning
-  -> (a -> m ())  -- ^ Output info
-  -> Bool         -- ^ Enable 'Info' (verbose mode)
-  -> Tracer m a
-mkTracer outputError outputWarning outputInfo verbose =
-    Wrap $ Contra.arrow aux
+alignLevel :: Level -> String
+alignLevel = \case
+  Debug   -> "Debug  "
+  Info    -> "Info   "
+  Warning -> "Warning"
+  Error   -> "Error  "
+
+getColorForLevel :: Level -> Color
+getColorForLevel = \case
+  Debug   -> White
+  Info    -> Green
+  Warning -> Yellow
+  Error   -> Red
+
+-- | Convert values to textual representations used in traces.
+class PrettyTrace a where
+  -- TODO: Use 'Text' (issue #650).
+  prettyTrace :: a -> String
+
+-- | Get default (or suggested) log level of values used in traces.
+class HasDefaultLogLevel a where
+  getDefaultLogLevel :: a -> Level
+
+-- | Possible sources of traces. The 'Source' is shown by default in traces, and
+-- so should be useful to users of @hs-bindgen@.
+data Source = Libclang | HsBindgen
+  deriving stock (Show, Eq)
+
+alignSource :: Source -> String
+alignSource = \case
+  Libclang  -> "Libclang "
+  HsBindgen -> "HsBindgen"
+
+-- | Get source or context of values used in traces.
+class HasSource a where
+  getSource :: a -> Source
+
+data Verbosity = Verbosity !Level | Quiet
+  deriving stock (Show, Eq)
+
+{-------------------------------------------------------------------------------
+  Tracer configuration
+-------------------------------------------------------------------------------}
+
+data AnsiColor = EnableAnsiColor | DisableAnsiColor
+  deriving stock (Show, Eq)
+
+data ShowTimeStamp = EnableTimeStamp | DisableTimeStamp
+  deriving stock (Show, Eq)
+
+data ShowCallStack = EnableCallStack | DisableCallStack
+  deriving stock (Show, Eq)
+
+-- | Configuration of tracer.
+data TracerConf = TracerConf {
+    tVerbosity     :: !Verbosity
+  , tShowTimeStamp :: !ShowTimeStamp
+  , tShowCallStack :: !ShowCallStack
+  }
+  deriving stock (Show, Eq)
+
+defaultTracerConf :: TracerConf
+defaultTracerConf = TracerConf (Verbosity Info) DisableTimeStamp DisableCallStack
+
+{-------------------------------------------------------------------------------
+  Tracers
+-------------------------------------------------------------------------------}
+
+-- | Create a tracer emitting traces to a provided function @report@.
+--
+-- The traces provide additional information about
+-- - the time,
+-- - the log level, and
+-- - the source.
+mkTracer :: forall m a. (MonadIO m, PrettyTrace a, HasDefaultLogLevel a, HasSource a)
+  => AnsiColor -> TracerConf -> (String -> m ()) -> Tracer m (TraceWithCallStack a)
+mkTracer ansiColor (TracerConf {..}) report =
+  squelchUnless (isLogLevelHighEnough . tTrace) $ Tracer $ emit prettyReport
   where
-    aux :: TracerA m (Level, a) ()
-    aux = proc (level, msg) -> do
-        case level of
-          Error   -> emit outputError   -< msg
-          Warning -> emit outputWarning -< msg
-          Info    -> if verbose
-                       then emit outputInfo -< msg
-                       else squelch         -< msg
+    isLogLevelHighEnough :: a -> Bool
+    isLogLevelHighEnough x = case tVerbosity of
+      Quiet -> False
+      Verbosity v -> getDefaultLogLevel x >= v
+
+    showTime :: FormatTime t => t -> String
+    showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%3QZ"
+
+    prependTime :: FormatTime t => t -> String -> String
+    prependTime time x = '[' : showTime time <> "] " <> x
+
+    prependLevel :: Level -> String -> String
+    prependLevel level x =
+      withColor ansiColor level ('[' : alignLevel level <> "] ") <> x
+
+    prependSource :: Level -> Source -> String -> String
+    prependSource level source x =
+      withColor ansiColor level ('[' : alignSource source <> "] ") <> x
+
+    prependLabels :: Maybe UTCTime -> Level -> Source -> String -> String
+    prependLabels mTime level source =
+      maybePrependTime . prependLevel level . prependSource level source
+      where maybePrependTime = case mTime of
+              Nothing   -> id
+              Just time -> prependTime time
+
+    formatLines :: Maybe UTCTime -> Level -> Source -> ZipList (String -> String)
+    formatLines mTime level source = ZipList $
+      prependLabels mTime level source : repeat indent
+
+    indent :: String -> String
+    indent = ("  " <>)
+
+    -- Log format:
+    -- [OPTIONAL TIMESTAMP] [LEVEL] [SOURCE] Message.
+    --   Indent subsequent lines.
+    --   OPTION CALL STACK.
+    prettyReport :: TraceWithCallStack a -> m ()
+    prettyReport TraceWithCallStack {..} = do
+      time <- case tShowTimeStamp of
+        DisableTimeStamp -> pure Nothing
+        EnableTimeStamp -> Just <$> liftIO getCurrentTime
+      mapM_ report $ getZipList $ formatLines time level source <*> traces
+      when (tShowCallStack == EnableCallStack) $
+        mapM_ (report . indent) $ lines $ prettyCallStack tCallStack
+      where level = getDefaultLogLevel tTrace
+            source = getSource tTrace
+            traces = ZipList $ lines $ prettyTrace tTrace
+
+-- | Run an action with a tracer writing to 'stdout'. Use ANSI colors, if available.
+withTracerStdOut :: (PrettyTrace a, HasDefaultLogLevel a, HasSource a)
+  => TracerConf -> (Tracer IO (TraceWithCallStack a) -> IO b) -> IO b
+withTracerStdOut tracerConf action = do
+  supportsAnsiColor <- hSupportsANSIColor stdout
+  let ansiColor = if supportsAnsiColor then EnableAnsiColor else DisableAnsiColor
+  action $ mkTracer ansiColor tracerConf putStrLn
+
+-- | Run an action with a tracer writing to a file. Do not use ANSI colors.
+withTracerFile
+  :: (PrettyTrace a, HasDefaultLogLevel a, HasSource a)
+  => FilePath -> TracerConf -> (Tracer IO (TraceWithCallStack a) -> IO b) -> IO b
+withTracerFile file tracerConf action = withFile file AppendMode $ \handle ->
+  let tracer = mkTracer DisableAnsiColor tracerConf (hPutStrLn handle)
+  in action tracer
+
+-- | Run an action with a tracer in TH mode. Do not use ANSI colors.
+withTracerQ :: forall m a b. (Quasi m, PrettyTrace a, HasDefaultLogLevel a, HasSource a)
+  => TracerConf -> (Tracer m (TraceWithCallStack a) -> m b) -> m b
+withTracerQ tracerConf action = action $ mkTracer DisableAnsiColor tracerConf report
+  where
+    report :: String -> m ()
+    -- Use 'putStrLn' instead of 'qReport', to avoid the "Template Haskell
+    -- error:" prefix. We are not exclusively reporting errors.
+    report = liftIO . putStrLn
 
 {-------------------------------------------------------------------------------
-  Specific tracers
+  Trace with call stack
 -------------------------------------------------------------------------------}
 
--- | Standard tracer for use in the 'IO' monad
---
--- Intended for use preprocessor mode.
---
--- TODO: <https://github.com/well-typed/hs-bindgen/issues/84>
--- We should support some ANSI colors here.
-mkTracerIO ::
-     Bool -- ^ Verbose
-  -> Tracer IO String
-mkTracerIO =
-    mkTracer
-      (putStrLn . ("Error: "   ++))
-      (putStrLn . ("Warning: " ++))
-      (putStrLn . ("Info: "    ++))
+data TraceWithCallStack a = TraceWithCallStack { tTrace     :: a
+                                               , tCallStack :: CallStack }
 
--- | Tracer intended for use in TH mode
-mkTracerQ ::
-     Quasi m
-  => Bool -- ^ Verbose
-  -> Tracer m String
-mkTracerQ  =
-    mkTracer
-      (qReport True)
-      (qReport False)
-      (qReport False . ("Info: " ++))
+instance Functor TraceWithCallStack where
+  fmap f trace = trace { tTrace = f (tTrace trace) }
 
--- | Throw any messages that aren't suppressed by the verbosity level
-traceThrow ::
-     Exception a
-  => Bool  -- ^ Verbose
-  -> Tracer IO a
-traceThrow =
-    mkTracer
-      throwIO
-      throwIO
-      throwIO
+traceWithCallStack :: Monad m
+  => Tracer m (TraceWithCallStack a) -> CallStack -> a -> m ()
+traceWithCallStack tracer stack trace =
+  traceWith tracer (TraceWithCallStack trace stack)
+
+-- | Use, for example, to specialize a tracer with a call stack.
+--
+-- > useDiagnostic :: Tracer IO (TraceWithCallStack Trace)
+-- >               -> Tracer IO (TraceWithCallStack Diagnostic)
+-- > useDiagnsotic = useTrace TraceDiagnostic
+useTrace :: (Contravariant c, Functor f)  => (b -> a) -> c (f a) -> c (f b)
+useTrace = contramap . fmap
 
 {-------------------------------------------------------------------------------
-  Type class intended for rendering log messages
+  Helpers
 -------------------------------------------------------------------------------}
 
-class PrettyLogMsg a where
-  prettyLogMsg :: a -> String
+-- | Render a string in bold and a specified color.
+--
+-- Careful, the applied ANSI code suffix also resets all other activated formatting.
+withColor :: AnsiColor -> Level -> String -> String
+withColor DisableAnsiColor _     = id
+withColor EnableAnsiColor    level = withColor' (getColorForLevel level)
+  where
+    withColor' :: Color -> String -> String
+    withColor' color x = setColor <> x <> resetColor
+      where
+        setColor :: String
+        setColor = setSGRCode [ SetColor Foreground Vivid color
+                              , SetConsoleIntensity BoldIntensity ]
+
+        resetColor :: String
+        resetColor = setSGRCode []

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -35,6 +35,7 @@ module HsBindgen.Lib (
   , ExtBindings.ExtBindings
   , ExtBindings.emptyExtBindings
   , ExtBindings.loadExtBindings
+  , Resolve.ResolveHeaderException(..)
 
     -- ** Translation options
   , Hs.TranslationOpts(..)
@@ -47,14 +48,8 @@ module HsBindgen.Lib (
   , Predicate.Regex -- opaque
 
     -- ** Logging
-  , Tracer.Tracer
-  , Tracer.Level(..)
-  , Tracer.nullTracer
-  , Tracer.mkTracerIO
-  , Tracer.mkTracerQ
-  , Tracer.mkTracer
-  , Tracer.contramap
-  , Tracer.traceWith
+  , Trace.Trace (..)
+  , module HsBindgen.Util.Tracer
 
     -- ** Preprocessor
   , Pipeline.PPOpts(..)
@@ -70,6 +65,7 @@ module HsBindgen.Lib (
   , FilePath.joinPath
   ) where
 
+import GHC.Stack (HasCallStack)
 import System.FilePath qualified as FilePath
 
 import Clang.Args qualified as Args
@@ -80,9 +76,11 @@ import HsBindgen.C.Predicate qualified as Predicate
 import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
-import HsBindgen.Pipeline qualified as Pipeline
-import HsBindgen.Util.Tracer qualified as Tracer
 import HsBindgen.ModuleUnique
+import HsBindgen.Pipeline qualified as Pipeline
+import HsBindgen.Resolve qualified as Resolve
+import HsBindgen.Util.Trace qualified as Trace
+import HsBindgen.Util.Tracer hiding (withTracerQ)
 
 {-------------------------------------------------------------------------------
   Parsing and translating
@@ -96,7 +94,8 @@ newtype HsDecls = WrapHsDecls {
       unwrapHsDecls :: [Hs.Decl]
     }
 
-translateCHeader :: ModuleUnique -> Pipeline.Opts -> Paths.CHeaderIncludePath -> IO HsDecls
+translateCHeader :: HasCallStack
+  => ModuleUnique -> Pipeline.Opts -> Paths.CHeaderIncludePath -> IO HsDecls
 translateCHeader mu opts = fmap WrapHsDecls . Pipeline.translateCHeader mu opts
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -35,12 +35,8 @@ module HsBindgen.TH (
   , Predicate.Regex -- opaque
 
     -- ** Logging
-  , Tracer.Tracer
-  , Tracer.nullTracer
-  , Tracer.mkTracerIO
-  , Tracer.mkTracerQ
-  , Tracer.mkTracer
-  , Tracer.contramap
+  , Trace.Trace (..)
+  , module HsBindgen.Util.Tracer
 
     -- * Paths
   , Paths.CIncludePathDir(..)
@@ -61,7 +57,8 @@ import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
-import HsBindgen.Util.Tracer qualified as Tracer
+import HsBindgen.Util.Trace qualified as Trace
+import HsBindgen.Util.Tracer hiding (withTracerFile, withTracerStdOut)
 
 #ifdef MIN_VERSION_th_compat
 import Language.Haskell.TH.Syntax.Compat qualified as THSyntax

--- a/hs-bindgen/test/internal/Test/Internal/TH.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TH.hs
@@ -11,12 +11,12 @@ import Data.Generics qualified as SYB
 import GHC.Stack (HasCallStack)
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
-import Test.Tasty (TestTree, TestName)
 import System.FilePath (makeRelative)
+import Test.Tasty (TestName, TestTree)
 
 import Clang.Paths
-import HsBindgen.Lib
 import HsBindgen.Guasi
+import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 import Test.Internal.Misc
 

--- a/hs-bindgen/test/internal/Test/Internal/TH.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TH.hs
@@ -8,6 +8,7 @@ module Test.Internal.TH (
 
 import Control.Monad.State.Strict (State, get, put, runState)
 import Data.Generics qualified as SYB
+import GHC.Stack (HasCallStack)
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
 import Test.Tasty (TestTree, TestName)
@@ -19,16 +20,15 @@ import HsBindgen.Guasi
 import HsBindgen.Pipeline qualified as Pipeline
 import Test.Internal.Misc
 
-goldenTh :: FilePath -> TestName -> TestTree
+goldenTh :: HasCallStack => FilePath -> TestName -> TestTree
 goldenTh packageRoot name = goldenVsStringDiff_ "th" ("fixtures" </> (name ++ ".th.txt")) $ \report -> do
     -- -<.> does weird stuff for filenames with multiple dots;
     -- I usually simply avoid using it.
     let headerIncludePath = CHeaderQuoteIncludePath $ name ++ ".h"
-        tracer = mkTracer report report report False
+        tracer = mkTracer EnableAnsiColor defaultTracerConf report
         opts = Pipeline.defaultOpts {
             Pipeline.optsClangArgs  = clangArgs packageRoot
-          , Pipeline.optsDiagTracer = tracer
-          , Pipeline.optsSkipTracer = tracer
+          , Pipeline.optsTracer = tracer
           }
     (depPaths, cheader) <- Pipeline.parseCHeader opts headerIncludePath
 

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -169,10 +169,10 @@ tests packageRoot rustBindgen = testGroup "test-internal" [
 
     mkOpts :: (String -> IO ()) -> Pipeline.Opts
     mkOpts report =
-      let tracer = mkTracer report report report False
+      let tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }
+          tracer = mkTracer EnableAnsiColor tracerConf report
       in  opts {
-              Pipeline.optsDiagTracer = tracer
-            , Pipeline.optsSkipTracer = tracer
+              Pipeline.optsTracer = tracer
             }
 
     ppOpts :: Pipeline.PPOpts

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -2,19 +2,19 @@
 module Main (main) where
 
 import Control.DeepSeq (force)
-import Control.Exception (try, displayException, evaluate)
+import Control.Exception (displayException, evaluate, try)
 import Data.ByteString.UTF8 qualified as UTF8
 import Data.List qualified as List
 import Data.TreeDiff.Golden (ediffGolden1)
-import Test.Tasty (TestTree, TestName, defaultMain, testGroup)
+import Test.Tasty (TestName, TestTree, defaultMain, testGroup)
 import Text.Regex.Applicative qualified as R
 import Text.Regex.Applicative.Common qualified as R
 
 import Clang.Paths
-import HsBindgen.Imports
 import HsBindgen.Errors
 import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.ExtBindings.Gen qualified as ExtBindings
+import HsBindgen.Imports
 import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 

--- a/hs-bindgen/test/th/Test01.hs
+++ b/hs-bindgen/test/th/Test01.hs
@@ -13,8 +13,9 @@
 
 module Test01 where
 
+ -- TODO: GHC issue, we need to import this
+import HsBindgen.Runtime.SizedByteArray (SizedByteArray (..))
 import HsBindgen.TH
-import HsBindgen.Runtime.SizedByteArray (SizedByteArray (..)) -- TODO: GHC issue, we need to import this
 
 -- Used by generated code
 import Foreign.C.Types

--- a/hs-bindgen/test/th/test-th.hs
+++ b/hs-bindgen/test/th/test-th.hs
@@ -10,10 +10,10 @@ module Main (main) where
 
 import Control.Exception (bracket)
 import Data.Vector.Storable qualified as VS
-import Foreign (Storable (..), Ptr, nullPtr)
+import Foreign (Ptr, Storable (..), nullPtr)
 import Foreign.C.Types (CLong)
 import Foreign.Marshal.Alloc (alloca)
-import Test.Tasty (TestTree, testGroup, defaultMain)
+import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
 import HsBindgen.Runtime.CEnum qualified as CEnum


### PR DESCRIPTION
- Provide a centralized `Trace` data type collecting all possible traces.

- However, ensure decoupling of domain-specific code by consistently using contravariant tracers.

- Improve trace output by prefixing traces with time stamps, log level, and a source.

- Provide tracers to `stdout` and files, as well as generalized tracers using a `report` function.

- Color warnings and errors with ANSI codes when desired (e.g., when printing to `stdout` and if `stdout` supports ANSI colors).

Closes #647, and #84.

May close #175 (depending on if we want to separate `Diagnostic`s into Info/Warning/Error levels, or not).

### Notes

Key modules are [Tracer](https://github.com/well-typed/hs-bindgen/pull/651/files#diff-2e84a03ffcc37880a8115799d9b04e603e8f19ba7d3e94465c05edbe24299ed3) and [Trace](https://github.com/well-typed/hs-bindgen/pull/651/files#diff-eead051cdf4b9bbf8d2858fa0ed56415ddd37f645824f9388c840d5e6b91be2d).

### Questions/Todos

- [x] ~~Maybe unify the type classes `PrettyTrace`, `HasLogLevel`, and `HasSource` into `IsTrace`.~~
- [x] ~~We apply the prefix line-wise. I prefer this behavior, but do you agree?~~ -> We use indentation with whitespace.
- [x] Extract import changes to separate commit.
- [x] ~~Should we use TH to define a default implementation of `getSource` (e.g., using the module name)?~~ -> We use an ADT as `Source`.

Meeting with Edsko:
- [x] Default log level.
- [X] Source returns ADT (Libclang and Bindgen for now).
- [X] Clients should have flags for printing time and callstacks.
- [X] Only one prefix, indent follow-up log messages by 2.
- [x] Attach call stack of report site.
