### PR TITLE
Add --with-compiler to configure script

### DIFF
--- a/clang/configure
+++ b/clang/configure
@@ -700,6 +700,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_compiler
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1324,6 +1325,11 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of clang 0.1.0:";;
    esac
   cat <<\_ACEOF
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-compiler         Haskell compiler
 
 Some influential environment variables:
   CC          C compiler command
@@ -2214,7 +2220,6 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
 
 
 
@@ -3212,6 +3217,14 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+# Check whether --with-compiler was given.
+if test ${with_compiler+y}
+then :
+  withval=$with_compiler;
+fi
 
 
 

--- a/clang/configure.ac
+++ b/clang/configure.ac
@@ -1,8 +1,14 @@
 AC_PREREQ([2.69])
 AC_INIT([clang],[0.1.0])
-AC_CONFIG_MACRO_DIRS([m4])
+dnl AC_CONFIG_MACRO_DIRS([m4])
 
 AC_PROG_CC
+
+dnl we get --with-compiler warnings without this
+dnl this is not great, as really it should be --with-ghc or --with-readline
+dnl i.e. pointing to the external software by name
+AC_ARG_WITH([compiler],
+  [AS_HELP_STRING([--with-compiler], [Haskell compiler])])
 
 dnl The discovery logic is following
 dnl * look for llvm-config (LLVM_CONFIG if set, in PATH otherwise)


### PR DESCRIPTION
Even if we don't use the setting for anything (yet?). this removes

```
configure: WARNING: unrecognized options: --with-compiler
```

warning, as Cabal calls configure script with `--with-compiler` flag.