### PR TITLE
Poke with FLAM

### DIFF
--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/FlexibleArrayMember.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/FlexibleArrayMember.hs
@@ -4,8 +4,12 @@ module HsBindgen.Runtime.FlexibleArrayMember (
     HasFlexibleArrayLength (..),
     WithFlexibleArrayMember (..),
     peekWithFLAM,
+    FLAMLengthMismatch (..),
+    pokeWithFLAM,
 ) where
 
+import Control.Exception (Exception, throwIO)
+import Control.Monad (unless)
 import Data.Vector.Storable qualified as VS
 import Data.Vector.Storable.Mutable qualified as VSM
 import Foreign
@@ -23,7 +27,7 @@ data WithFlexibleArrayMember element struct = WithFlexibleArrayMember
     }
   deriving Show
 
--- | Peek structure together with contents of flexible array member.
+-- | Peek structure with flexible array member.
 peekWithFLAM :: forall struct element. (Storable struct, Storable element, HasFlexibleArrayLength element struct)
     => Ptr struct -> IO (WithFlexibleArrayMember element struct)
 peekWithFLAM ptr = do
@@ -35,3 +39,28 @@ peekWithFLAM ptr = do
         copyBytes ptr' (plusPtr ptr (flexibleArrayMemberOffset (proxy# @struct))) bytesN
     vector' <- VS.unsafeFreeze vector
     return (WithFlexibleArrayMember struct vector')
+
+data FLAMLengthMismatch = FLAMLengthMismatch { flamLengthStruct :: Int
+                                             , flamLengthProvided :: Int }
+  deriving (Show)
+
+instance Exception FLAMLengthMismatch
+
+-- | Poke structure with flexible array member.
+pokeWithFLAM
+  :: forall struct elem.
+     (Storable struct, Storable elem, HasFlexibleArrayLength elem struct)
+  => Ptr struct -> WithFlexibleArrayMember elem struct -> IO ()
+pokeWithFLAM ptrToStruct (WithFlexibleArrayMember struct' vector')  = do
+  struct <- peek ptrToStruct
+  let !lenFLAM = flexibleArrayMemberLength struct
+      !lenVector' = VS.length vector'
+  unless (lenFLAM == lenVector') $ throwIO $ FLAMLengthMismatch lenFLAM lenVector'
+  poke ptrToStruct struct'
+  mVector' <- VS.unsafeThaw vector'
+  withForeignPtr (fst (VSM.unsafeToForeignPtr0 mVector')) $ \ptrToVec -> do
+    let !ptrToFLAM = plusPtr ptrToStruct (flexibleArrayMemberOffset (proxy# @struct))
+        !bytesN = lenFLAM * sizeOf (undefined :: elem)
+    copyBytes ptrToFLAM ptrToVec bytesN
+  _ <- VS.unsafeFreeze mVector'
+  pure ()

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/FlexibleArrayMember.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/FlexibleArrayMember.hs
@@ -6,10 +6,10 @@ module HsBindgen.Runtime.FlexibleArrayMember (
     peekWithFLAM,
 ) where
 
-import GHC.Exts (Proxy#, proxy#)
-import Foreign
 import Data.Vector.Storable qualified as VS
 import Data.Vector.Storable.Mutable qualified as VSM
+import Foreign
+import GHC.Exts (Proxy#, proxy#)
 
 class HasFlexibleArrayMember element struct | struct -> element where
   flexibleArrayMemberOffset :: Proxy# struct -> Int


### PR DESCRIPTION
Closes #490 

- [x] `assert` does not work well with Tastt HUnit tests, so we use `throwIO`.
- [x] We use `AssertionFailed`. Let me know if you prefer to use a separate exception type