### PR TITLE
Tracers: Custom log levels and tracking log levels

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -39,7 +39,7 @@ data GlobalOpts = GlobalOpts {
     , globalOptsClangArgs   :: ClangArgs
     , globalOptsExtBindings :: [FilePath]
     }
-  deriving (Show)
+  deriving stock (Show)
 
 parseGlobalOpts :: Parser GlobalOpts
 parseGlobalOpts =

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -19,7 +19,7 @@ import HsBindgen.Lib
 main :: IO ()
 main = handle exceptionHandler $ do
     cli@Cli{..} <- getCli
-    withTracerStdOut (globalOptsTracerConf cliGlobalOpts) $ \tracer ->
+    withTracerStdOut (globalOptsTracerConf cliGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode cli tracer cliMode
 
 data LiterateFileException = LiterateFileException FilePath String

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -15,7 +15,7 @@ import HsBindgen.Pipeline qualified as Pipeline
 main :: IO ()
 main = do
     dev@Dev{..} <- getDev
-    withTracerStdOut (globalOptsTracerConf devGlobalOpts) $ \tracer ->
+    withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode dev tracer devMode
 
 execMode :: HasCallStack

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -23,9 +23,9 @@ import Clang.LowLevel.Doxygen
 import Clang.Paths
 import HsBindgen.Clang.Args (withExtraClangArgs)
 import HsBindgen.Resolve (resolveHeader)
-import HsBindgen.Util.Tracer (Level (Warning), TracerConf (tVerbosity),
-                              Verbosity (Verbosity), defaultTracerConf,
-                              withTracerStdOut)
+import HsBindgen.Util.Tracer (CustomLogLevel (DefaultLogLevel), Level (Warning),
+                              TracerConf (tVerbosity), Verbosity (Verbosity),
+                              defaultTracerConf, withTracerStdOut)
 
 {-------------------------------------------------------------------------------
   Options
@@ -52,7 +52,7 @@ clangAstDump opts@Options{..} = do
     putStrLn $ "## `" ++ renderCHeaderIncludePath optFile ++ "`"
     putStrLn ""
 
-    withTracerStdOut tracerConf $ \tracer ->
+    withTracerStdOut tracerConf DefaultLogLevel $ \tracer ->
       withExtraClangArgs tracer cArgs $ \cArgs' -> do
         src <- resolveHeader tracer cArgs' optFile
         HighLevel.withIndex DontDisplayDiagnostics $ \index ->
@@ -67,7 +67,7 @@ clangAstDump opts@Options{..} = do
                   | otherwise                             -> foldDecls opts cursor
   where
     tracerConf :: TracerConf
-    tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning}
+    tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }
 
     cArgs :: ClangArgs
     cArgs = defaultClangArgs {

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -275,8 +275,9 @@ test-suite test-internal
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        test-internal.hs
-  hs-source-dirs: test/internal
+  hs-source-dirs: test/internal, test/common
   other-modules:
+      -- Internal
       Test.HsBindgen.C.Parser
       Test.HsBindgen.Clang.Args
       Test.Internal.Misc
@@ -284,6 +285,8 @@ test-suite test-internal
       Test.Internal.TastyGolden
       Test.Internal.TH
       Test.Internal.TreeDiff.Orphans
+      -- Common
+      Test.Internal.Trace
   build-depends:
       -- Internal dependencies
     , c-expr
@@ -317,16 +320,20 @@ test-suite test-internal
 test-suite test-th
   type:           exitcode-stdio-1.0
   main-is:        test-th.hs
-  hs-source-dirs: test/th
+  hs-source-dirs: test/th, test/common
   include-dirs:   examples
 
   other-modules:
+      -- TH
       Test01
       Test02
+      -- Common
+      Test.Internal.Trace
 
   default-language: Haskell2010
   build-depends:
       -- Internal dependencies
+    , clang
     , hs-bindgen
     , hs-bindgen-runtime
   build-depends:
@@ -342,12 +349,15 @@ test-suite test-th
 test-suite test-pp
   type:           exitcode-stdio-1.0
   main-is:        ../th/test-th.hs
-  hs-source-dirs: test/pp
+  hs-source-dirs: test/pp, test/common
   include-dirs:   examples
 
   other-modules:
+      -- PP
       Test01
       Test02
+      -- Common
+      Test.Internal.Trace
 
   default-language: Haskell2010
 
@@ -361,6 +371,8 @@ test-suite test-pp
   build-depends:
       -- Internal dependencies
     , c-expr
+    , clang
+    , hs-bindgen
     , hs-bindgen-runtime
   build-depends:
       -- Inherited dependencies

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
@@ -29,6 +29,7 @@ data ExtraClangArgsLog =
     ExtraClangArgsNone
   | ExtraClangArgsParsed { envName    :: String
                          , envArgs    :: [String] }
+  deriving stock (Show)
 
 instance PrettyTrace ExtraClangArgsLog where
   prettyTrace = \case

--- a/hs-bindgen/test/common/Test/Internal/Trace.hs
+++ b/hs-bindgen/test/common/Test/Internal/Trace.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Internal.Trace
+  ( degradeKnownTraces
+  ) where
+
+import Clang.HighLevel.Types (Diagnostic (diagnosticCategory))
+import HsBindgen.Lib
+
+-- | Degrade log levels of known traces in tests.
+degradeKnownTraces :: CustomLogLevel Trace
+degradeKnownTraces = CustomLogLevel $ \case
+  -- "Sematic Issue": "declaration does not declare anything".
+  TraceDiagnostic x | diagnosticCategory x == 2 -> Debug
+  -- "Nullability Issue": "pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)".
+  TraceDiagnostic x | diagnosticCategory x == 26 -> Debug
+  TraceExtraClangArgs _ -> Debug
+  TraceSkipped _        -> Debug
+  x                     -> getDefaultLogLevel x

--- a/hs-bindgen/test/internal/Test/Internal/TH.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TH.hs
@@ -19,13 +19,14 @@ import HsBindgen.Guasi
 import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 import Test.Internal.Misc
+import Test.Internal.Trace (degradeKnownTraces)
 
 goldenTh :: HasCallStack => FilePath -> TestName -> TestTree
 goldenTh packageRoot name = goldenVsStringDiff_ "th" ("fixtures" </> (name ++ ".th.txt")) $ \report -> do
     -- -<.> does weird stuff for filenames with multiple dots;
     -- I usually simply avoid using it.
     let headerIncludePath = CHeaderQuoteIncludePath $ name ++ ".h"
-        tracer = mkTracer EnableAnsiColor defaultTracerConf report
+        tracer = mkTracer EnableAnsiColor defaultTracerConf degradeKnownTraces report
         opts = Pipeline.defaultOpts {
             Pipeline.optsClangArgs  = clangArgs packageRoot
           , Pipeline.optsTracer = tracer

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -24,6 +24,7 @@ import Test.HsBindgen.Clang.Args qualified
 import Test.Internal.Misc
 import Test.Internal.Rust
 import Test.Internal.TastyGolden (goldenTestSteps)
+import Test.Internal.Trace (degradeKnownTraces)
 import Test.Internal.TreeDiff.Orphans ()
 
 #if __GLASGOW_HASKELL__ >=904
@@ -37,7 +38,7 @@ import Test.Internal.TH
 main :: IO ()
 main = do
     packageRoot <- findPackageDirectory "hs-bindgen"
-    withTracerStdOut defaultTracerConf $ \tracer ->
+    withTracerStdOut defaultTracerConf degradeKnownTraces $ \tracer ->
       defaultMain . withRustBindgen $ tests tracer packageRoot
 
 {-------------------------------------------------------------------------------
@@ -173,8 +174,8 @@ tests tracer packageRoot rustBindgen = testGroup "test-internal" [
 
     mkOpts :: (String -> IO ()) -> Pipeline.Opts
     mkOpts report =
-      let tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }
-          tracerGolden     = mkTracer EnableAnsiColor tracerConf report
+      let tracerConf   = defaultTracerConf { tVerbosity = Verbosity Warning }
+          tracerGolden = mkTracer EnableAnsiColor tracerConf degradeKnownTraces report
       in  opts {
               Pipeline.optsTracer = tracerGolden
             }

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -8,6 +8,8 @@ module Test02 where
 
 import HsBindgen.TH
 
+import Test.Internal.Trace (degradeKnownTraces)
+
 -- Used by generated code
 import Data.Word qualified
 import HsBindgen.Runtime.LibC qualified
@@ -17,7 +19,7 @@ $(do
     let args = defaultClangArgs {
             clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
-    extBindings <- snd <$> (withTracerQ defaultTracerConf $
+    extBindings <- snd <$> (withTracerQ defaultTracerConf degradeKnownTraces $
       \tracer -> loadExtBindings tracer args [
         joinPath [dir, "bindings", "base.yaml"]
       , joinPath [dir, "bindings", "hs-bindgen-runtime.yaml"]


### PR DESCRIPTION
Closes #662.

### Support tracers with custom log levels
- Use the machinery to suppress some known traces in tests.
- The tests are now trace-free (but we do still show quite some other putStrLn log messages).

### Track and return maximum log level of traces