### PR TITLE
Tracers log level improvements

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -56,16 +56,24 @@ parseTracerConf = TracerConf <$> parseVerbosity
 
 parseVerbosity :: Parser Verbosity
 parseVerbosity =
-  countToVerbosity . length <$> many (flag' () $
-          mconcat [ short 'v'
-                  , long "verbose"
-                  , help "Verbose output (-v for verbose, -vv for debug)"
-                  ])
+  nToVerbosity <$>
+    (option auto $
+      mconcat [ short 'v'
+              , long "verbosity"
+              , metavar "INT"
+              , value 1
+              , help "Specify verbosity (0: error, 1: warning, 2: info, 3: debug);"
+              , showDefault
+              ])
 
-  where countToVerbosity x = case x `compare` 1 of
-          LT -> Verbosity Warning
-          EQ -> Verbosity Info
-          GT -> Verbosity Debug
+  where
+    nToVerbosity :: Int -> Verbosity
+    nToVerbosity = Verbosity . \case
+      n | n <= 0 -> Error
+      1          -> Warning
+      2          -> Info
+      -- n | n >= 3 -- (But exhaustive checker complains).
+      _nGe3      -> Debug
 
 parseShowTimeStamp :: Parser ShowTimeStamp
 parseShowTimeStamp = flag DisableTimeStamp EnableTimeStamp $ mconcat [

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -39,7 +39,7 @@ data GlobalOpts = GlobalOpts {
     , globalOptsClangArgs   :: ClangArgs
     , globalOptsExtBindings :: [FilePath]
     }
-  deriving (Show)
+  deriving stock (Show)
 
 parseGlobalOpts :: Parser GlobalOpts
 parseGlobalOpts =

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -20,7 +20,7 @@ import HsBindgen.Lib
 main :: IO ()
 main = handle exceptionHandler $ do
     cli@Cli{..} <- getCli
-    withTracerStdOut (globalOptsTracerConf cliGlobalOpts) $ \tracer ->
+    withTracerStdOut (globalOptsTracerConf cliGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode cli tracer cliMode
 
 data LiterateFileException = LiterateFileException FilePath String

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -20,8 +20,9 @@ import HsBindgen.Lib
 main :: IO ()
 main = handle exceptionHandler $ do
     cli@Cli{..} <- getCli
-    withTracerStdOut (globalOptsTracerConf cliGlobalOpts) DefaultLogLevel $ \tracer ->
+    _ <- withTracerStdOut (globalOptsTracerConf cliGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode cli tracer cliMode
+    pure ()
 
 data LiterateFileException = LiterateFileException FilePath String
   deriving Show

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -15,7 +15,7 @@ import HsBindgen.Pipeline qualified as Pipeline
 main :: IO ()
 main = do
     dev@Dev{..} <- getDev
-    withTracerStdOut (globalOptsTracerConf devGlobalOpts) $ \tracer ->
+    withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode dev tracer devMode
 
 execMode :: HasCallStack

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -15,8 +15,9 @@ import HsBindgen.Pipeline qualified as Pipeline
 main :: IO ()
 main = do
     dev@Dev{..} <- getDev
-    withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $ \tracer ->
+    _ <- withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $ \tracer ->
       execMode dev tracer devMode
+    pure ()
 
 execMode :: HasCallStack
   => Dev -> Tracer IO (TraceWithCallStack Trace) -> Mode -> IO ()

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -52,7 +52,7 @@ clangAstDump opts@Options{..} = do
     putStrLn $ "## `" ++ renderCHeaderIncludePath optFile ++ "`"
     putStrLn ""
 
-    withTracerStdOut tracerConf DefaultLogLevel $ \tracer ->
+    _ <- withTracerStdOut tracerConf DefaultLogLevel $ \tracer ->
       withExtraClangArgs tracer cArgs $ \cArgs' -> do
         src <- resolveHeader tracer cArgs' optFile
         HighLevel.withIndex DontDisplayDiagnostics $ \index ->
@@ -65,6 +65,7 @@ clangAstDump opts@Options{..} = do
                   | optSameFile && SourcePath file /= src -> pure $ Continue Nothing
                   | not optBuiltin && isBuiltIn file      -> pure $ Continue Nothing
                   | otherwise                             -> foldDecls opts cursor
+    pure ()
   where
     tracerConf :: TracerConf
     tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -23,9 +23,9 @@ import Clang.LowLevel.Doxygen
 import Clang.Paths
 import HsBindgen.Clang.Args (withExtraClangArgs)
 import HsBindgen.Resolve (resolveHeader)
-import HsBindgen.Util.Tracer (Level (Warning), TracerConf (tVerbosity),
-                              Verbosity (Verbosity), defaultTracerConf,
-                              withTracerStdOut)
+import HsBindgen.Util.Tracer (CustomLogLevel (DefaultLogLevel), Level (Warning),
+                              TracerConf (tVerbosity), Verbosity (Verbosity),
+                              defaultTracerConf, withTracerStdOut)
 
 {-------------------------------------------------------------------------------
   Options
@@ -52,7 +52,7 @@ clangAstDump opts@Options{..} = do
     putStrLn $ "## `" ++ renderCHeaderIncludePath optFile ++ "`"
     putStrLn ""
 
-    withTracerStdOut tracerConf $ \tracer ->
+    withTracerStdOut tracerConf DefaultLogLevel $ \tracer ->
       withExtraClangArgs tracer cArgs $ \cArgs' -> do
         src <- resolveHeader tracer cArgs' optFile
         HighLevel.withIndex DontDisplayDiagnostics $ \index ->
@@ -67,7 +67,7 @@ clangAstDump opts@Options{..} = do
                   | otherwise                             -> foldDecls opts cursor
   where
     tracerConf :: TracerConf
-    tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning}
+    tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }
 
     cArgs :: ClangArgs
     cArgs = defaultClangArgs {

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -275,8 +275,9 @@ test-suite test-internal
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        test-internal.hs
-  hs-source-dirs: test/internal
+  hs-source-dirs: test/internal, test/common
   other-modules:
+      -- Internal
       Test.HsBindgen.C.Parser
       Test.HsBindgen.Clang.Args
       Test.Internal.Misc
@@ -284,6 +285,8 @@ test-suite test-internal
       Test.Internal.TastyGolden
       Test.Internal.TH
       Test.Internal.TreeDiff.Orphans
+      -- Common
+      Test.Internal.Trace
   build-depends:
       -- Internal dependencies
     , c-expr
@@ -317,16 +320,20 @@ test-suite test-internal
 test-suite test-th
   type:           exitcode-stdio-1.0
   main-is:        test-th.hs
-  hs-source-dirs: test/th
+  hs-source-dirs: test/th, test/common
   include-dirs:   examples
 
   other-modules:
+      -- TH
       Test01
       Test02
+      -- Common
+      Test.Internal.Trace
 
   default-language: Haskell2010
   build-depends:
       -- Internal dependencies
+    , clang
     , hs-bindgen
     , hs-bindgen-runtime
   build-depends:
@@ -342,12 +349,15 @@ test-suite test-th
 test-suite test-pp
   type:           exitcode-stdio-1.0
   main-is:        ../th/test-th.hs
-  hs-source-dirs: test/pp
+  hs-source-dirs: test/pp, test/common
   include-dirs:   examples
 
   other-modules:
+      -- PP
       Test01
       Test02
+      -- Common
+      Test.Internal.Trace
 
   default-language: Haskell2010
 
@@ -361,6 +371,8 @@ test-suite test-pp
   build-depends:
       -- Internal dependencies
     , c-expr
+    , clang
+    , hs-bindgen
     , hs-bindgen-runtime
   build-depends:
       -- Inherited dependencies

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -280,6 +280,7 @@ test-suite test-internal
       -- Internal
       Test.HsBindgen.C.Parser
       Test.HsBindgen.Clang.Args
+      Test.HsBindgen.Util.Tracer
       Test.Internal.Misc
       Test.Internal.Rust
       Test.Internal.TastyGolden

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Args.hs
@@ -29,6 +29,7 @@ data ExtraClangArgsLog =
     ExtraClangArgsNone
   | ExtraClangArgsParsed { envName    :: String
                          , envArgs    :: [String] }
+  deriving stock (Show)
 
 instance PrettyTrace ExtraClangArgsLog where
   prettyTrace = \case

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -80,7 +80,7 @@ import HsBindgen.ModuleUnique
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.Util.Trace qualified as Trace
-import HsBindgen.Util.Tracer hiding (withTracerQ)
+import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
   Parsing and translating

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -60,7 +60,7 @@ import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.Util.Trace qualified as Trace
-import HsBindgen.Util.Tracer hiding (withTracerFile, withTracerStdOut)
+import HsBindgen.Util.Tracer hiding (withTracerFile)
 
 #ifdef MIN_VERSION_th_compat
 import Language.Haskell.TH.Syntax.Compat qualified as THSyntax

--- a/hs-bindgen/test/common/Test/Internal/Trace.hs
+++ b/hs-bindgen/test/common/Test/Internal/Trace.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Internal.Trace
+  ( degradeKnownTraces
+  ) where
+
+import Clang.HighLevel.Types (Diagnostic (diagnosticCategory))
+import HsBindgen.Lib
+
+-- | Degrade log levels of known traces in tests.
+degradeKnownTraces :: CustomLogLevel Trace
+degradeKnownTraces = CustomLogLevel $ \case
+  -- "Sematic Issue": "declaration does not declare anything".
+  TraceDiagnostic x | diagnosticCategory x == 2 -> Debug
+  -- "Nullability Issue": "pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)".
+  TraceDiagnostic x | diagnosticCategory x == 26 -> Debug
+  TraceExtraClangArgs _ -> Debug
+  TraceSkipped _        -> Debug
+  x                     -> getDefaultLogLevel x

--- a/hs-bindgen/test/internal/Test/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/Util/Tracer.hs
@@ -1,0 +1,74 @@
+module Test.HsBindgen.Util.Tracer
+  ( tests
+  ) where
+
+import GHC.Stack (callStack)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+import HsBindgen.Lib
+
+data TestTrace = TestDebug String | TestWarning String | TestError String
+
+instance PrettyTrace TestTrace where
+  prettyTrace = \case
+    TestDebug x   -> x
+    TestWarning x -> x
+    TestError x   -> x
+
+instance HasDefaultLogLevel TestTrace where
+  getDefaultLogLevel = \case
+    TestDebug   _ -> Debug
+    TestWarning _ -> Warning
+    TestError   _ -> Error
+
+instance HasSource TestTrace where
+  getSource = const HsBindgen
+
+assertMaxLevel :: [TestTrace] -> Level -> Assertion
+assertMaxLevel = assertMaxLevelWithCustomLogLevel DefaultLogLevel
+
+assertMaxLevelWithDegrade :: [TestTrace] -> Level -> Assertion
+assertMaxLevelWithDegrade =
+  assertMaxLevelWithCustomLogLevel (CustomLogLevel $ const Info)
+
+assertMaxLevelWithCustomLogLevel
+  :: CustomLogLevel TestTrace -> [TestTrace] -> Level -> Assertion
+assertMaxLevelWithCustomLogLevel customLogLevel traces expectedLevel = do
+  lvl <- testTracerIO customLogLevel traces
+  lvl @?= expectedLevel
+
+testTracerIO :: CustomLogLevel TestTrace -> [TestTrace] -> IO Level
+testTracerIO customLogLevel traces = do
+  let noOutput _ = pure ()
+      tracerConf = defaultTracerConf { tVerbosity = Verbosity Debug }
+      withTracer = withTracerCustom DisableAnsiColor tracerConf customLogLevel noOutput
+  (_, maxLogLevel) <- withTracer $ \tracer -> do
+    mapM_ (traceWithCallStack tracer callStack) traces
+  pure maxLogLevel
+
+tests :: TestTree
+tests = testGroup "HsBindgen.Util.Tracer"
+  [ testGroup "DefaultLogLevel"
+    [ testCase "none"    $ assertMaxLevel [] Debug
+    , testCase "warning" $ assertMaxLevel [wn] Warning
+    , testCase "error"   $ assertMaxLevel [er] Error
+    , testCase "error1"  $ assertMaxLevel [wn, er] Error
+    , testCase "error2"  $ assertMaxLevel [wn, er, wn] Error
+    , testCase "error3"  $ assertMaxLevel [er, wn] Error
+    ]
+  , testGroup "CustomLogLevel"
+    [ testCase "none"     $ assertMaxLevelWithDegrade [] Debug
+    , testCase "warning"  $ assertMaxLevelWithDegrade [wn] Info
+    , testCase "warning1" $ assertMaxLevelWithDegrade [db, wn] Info
+    , testCase "warning2" $ assertMaxLevelWithDegrade [wn, db] Info
+    , testCase "warning3" $ assertMaxLevelWithDegrade [db, wn, db] Info
+    , testCase "error"    $ assertMaxLevelWithDegrade [er] Info
+    , testCase "error1"   $ assertMaxLevelWithDegrade [wn, er] Info
+    , testCase "error2"   $ assertMaxLevelWithDegrade [wn, er, wn] Info
+    , testCase "error3"   $ assertMaxLevelWithDegrade [er, wn] Info
+    ]
+  ]
+  where db = TestDebug   "Debug message."
+        wn = TestWarning "Be careful!"
+        er = TestError   "Error!"

--- a/hs-bindgen/test/internal/Test/Internal/TH.hs
+++ b/hs-bindgen/test/internal/Test/Internal/TH.hs
@@ -19,13 +19,14 @@ import HsBindgen.Guasi
 import HsBindgen.Lib
 import HsBindgen.Pipeline qualified as Pipeline
 import Test.Internal.Misc
+import Test.Internal.Trace (degradeKnownTraces)
 
 goldenTh :: HasCallStack => FilePath -> TestName -> TestTree
 goldenTh packageRoot name = goldenVsStringDiff_ "th" ("fixtures" </> (name ++ ".th.txt")) $ \report -> do
     -- -<.> does weird stuff for filenames with multiple dots;
     -- I usually simply avoid using it.
     let headerIncludePath = CHeaderQuoteIncludePath $ name ++ ".h"
-        tracer = mkTracer EnableAnsiColor defaultTracerConf report
+        tracer = mkTracer EnableAnsiColor defaultTracerConf degradeKnownTraces report
         opts = Pipeline.defaultOpts {
             Pipeline.optsClangArgs  = clangArgs packageRoot
           , Pipeline.optsTracer = tracer

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -24,6 +24,7 @@ import Test.HsBindgen.Clang.Args qualified
 import Test.Internal.Misc
 import Test.Internal.Rust
 import Test.Internal.TastyGolden (goldenTestSteps)
+import Test.Internal.Trace (degradeKnownTraces)
 import Test.Internal.TreeDiff.Orphans ()
 
 #if __GLASGOW_HASKELL__ >=904
@@ -37,7 +38,7 @@ import Test.Internal.TH
 main :: IO ()
 main = do
     packageRoot <- findPackageDirectory "hs-bindgen"
-    withTracerStdOut defaultTracerConf $ \tracer ->
+    withTracerStdOut defaultTracerConf degradeKnownTraces $ \tracer ->
       defaultMain . withRustBindgen $ tests tracer packageRoot
 
 {-------------------------------------------------------------------------------
@@ -173,8 +174,8 @@ tests tracer packageRoot rustBindgen = testGroup "test-internal" [
 
     mkOpts :: (String -> IO ()) -> Pipeline.Opts
     mkOpts report =
-      let tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning }
-          tracerGolden     = mkTracer EnableAnsiColor tracerConf report
+      let tracerConf   = defaultTracerConf { tVerbosity = Verbosity Warning }
+          tracerGolden = mkTracer EnableAnsiColor tracerConf degradeKnownTraces report
       in  opts {
               Pipeline.optsTracer = tracerGolden
             }

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -21,6 +21,7 @@ import HsBindgen.Pipeline qualified as Pipeline
 
 import Test.HsBindgen.C.Parser qualified
 import Test.HsBindgen.Clang.Args qualified
+import Test.HsBindgen.Util.Tracer qualified
 import Test.Internal.Misc
 import Test.Internal.Rust
 import Test.Internal.TastyGolden (goldenTestSteps)
@@ -38,8 +39,9 @@ import Test.Internal.TH
 main :: IO ()
 main = do
     packageRoot <- findPackageDirectory "hs-bindgen"
-    withTracerStdOut defaultTracerConf degradeKnownTraces $ \tracer ->
+    _ <- withTracerStdOut defaultTracerConf degradeKnownTraces $ \tracer ->
       defaultMain . withRustBindgen $ tests tracer packageRoot
+    pure ()
 
 {-------------------------------------------------------------------------------
   Tests
@@ -49,6 +51,7 @@ tests :: Tracer IO (TraceWithCallStack Trace) -> FilePath -> IO FilePath -> Test
 tests tracer packageRoot rustBindgen = testGroup "test-internal" [
       Test.HsBindgen.C.Parser.tests tracer args
     , Test.HsBindgen.Clang.Args.tests tracer
+    , Test.HsBindgen.Util.Tracer.tests
     , testGroup "examples" [
           golden "simple_structs"
         , golden "recursive_struct"
@@ -121,64 +124,65 @@ tests tracer packageRoot rustBindgen = testGroup "test-internal" [
       let target = "fixtures" </> (name ++ ".tree-diff.txt")
           headerIncludePath = mkHeaderIncludePath name
       ediffGolden1 goldenTestSteps "treediff" target $ \report ->
-        snd <$> Pipeline.parseCHeader (mkOpts report) headerIncludePath
+        withOpts report $ \opts ->
+          snd <$> Pipeline.parseCHeader opts headerIncludePath
 
     goldenHs :: TestName -> TestTree
     goldenHs name = do
       let target = "fixtures" </> (name ++ ".hs")
           headerIncludePath = mkHeaderIncludePath name
       ediffGolden1 goldenTestSteps "hs" target $ \report ->
-        Pipeline.translateCHeader "testmodule" (mkOpts report) headerIncludePath
+        withOpts report $ \opts ->
+          Pipeline.translateCHeader "testmodule" opts headerIncludePath
 
     goldenExtensions :: TestName -> TestTree
     goldenExtensions name = do
       let target = "fixtures" </> (name ++ ".exts.txt")
           headerIncludePath = mkHeaderIncludePath name
-      goldenVsStringDiff_ "exts" target $ \report -> do
-        decls <- Pipeline.translateCHeader "testmodule" (mkOpts report) headerIncludePath
-        return $ unlines $ map show $ List.sort $ toList $
-              Pipeline.genExtensions
-            $ Pipeline.genSHsDecls decls
+      goldenVsStringDiff_ "exts" target $ \report ->
+        withOpts report $ \opts -> do
+          decls <- Pipeline.translateCHeader "testmodule" opts headerIncludePath
+          return $ unlines $ map show $ List.sort $ toList $
+                Pipeline.genExtensions
+              $ Pipeline.genSHsDecls decls
 
     goldenPP :: TestName -> TestTree
     goldenPP name = do
       let target = "fixtures" </> (name ++ ".pp.hs")
           headerIncludePath = mkHeaderIncludePath name
-      goldenVsStringDiff_ "pp" target $ \report -> do
-        decls <- Pipeline.translateCHeader "testmodule" (mkOpts report) headerIncludePath
+      goldenVsStringDiff_ "pp" target $ \report ->
+        withOpts report $ \opts -> do
+          decls <- Pipeline.translateCHeader "testmodule" opts headerIncludePath
 
-        -- TODO: PP.render should add trailing '\n' itself.
-        return $ Pipeline.preprocessPure ppOpts decls ++ "\n"
+          -- TODO: PP.render should add trailing '\n' itself.
+          return $ Pipeline.preprocessPure ppOpts decls ++ "\n"
 
     goldenExtBindings :: TestName -> TestTree
     goldenExtBindings name = do
       let target = "fixtures" </> (name ++ ".extbindings.yaml")
           headerIncludePath = mkHeaderIncludePath name
-      goldenVsStringDiff_ "extbindings" target $ \report -> do
-        decls <- Pipeline.translateCHeader "testmodule" (mkOpts report) headerIncludePath
-        return . UTF8.toString . ExtBindings.encodeUnresolvedExtBindingsYaml $
-          ExtBindings.genExtBindings
-            headerIncludePath
-            (ExtBindings.HsModuleName "Example")
-            decls
+      goldenVsStringDiff_ "extbindings" target $ \report ->
+        withOpts report $ \opts -> do
+          decls <- Pipeline.translateCHeader "testmodule" opts headerIncludePath
+          return . UTF8.toString . ExtBindings.encodeUnresolvedExtBindingsYaml $
+            ExtBindings.genExtBindings
+              headerIncludePath
+              (ExtBindings.HsModuleName "Example")
+              decls
 
     -- -<.> does weird stuff for filenames with multiple dots;
     -- I usually simply avoid using it.
     mkHeaderIncludePath :: String -> CHeaderIncludePath
     mkHeaderIncludePath = CHeaderQuoteIncludePath . (++ ".h")
 
-    opts :: Pipeline.Opts
-    opts = Pipeline.defaultOpts {
-        Pipeline.optsClangArgs  = clangArgs packageRoot
-      }
-
-    mkOpts :: (String -> IO ()) -> Pipeline.Opts
-    mkOpts report =
-      let tracerConf   = defaultTracerConf { tVerbosity = Verbosity Warning }
-          tracerGolden = mkTracer EnableAnsiColor tracerConf degradeKnownTraces report
-      in  opts {
-              Pipeline.optsTracer = tracerGolden
-            }
+    withOpts :: (String -> IO ()) -> (Pipeline.Opts -> IO a) -> IO a
+    withOpts report action = fst <$>
+      let tracerConf = defaultTracerConf { tVerbosity = Verbosity Warning } in
+      withTracerCustom EnableAnsiColor tracerConf degradeKnownTraces report $
+        \tracer' -> action $ Pipeline.defaultOpts {
+            Pipeline.optsClangArgs = clangArgs packageRoot
+          , Pipeline.optsTracer = tracer'
+          }
 
     ppOpts :: Pipeline.PPOpts
     ppOpts = Pipeline.defaultPPOpts {
@@ -189,18 +193,19 @@ tests tracer packageRoot rustBindgen = testGroup "test-internal" [
     failing name = do
       let target = "fixtures" </> (name ++ ".failure.txt")
           headerIncludePath = mkHeaderIncludePath name
-      goldenVsStringDiff_ name target $ \report -> do
-        result <- try $ do
-          decls <- Pipeline.translateCHeader "testmodule" (mkOpts report) headerIncludePath
+      goldenVsStringDiff_ name target $ \report ->
+        withOpts report $ \opts -> do
+          result <- try $ do
+            decls <- Pipeline.translateCHeader "testmodule" opts headerIncludePath
 
-          -- TODO: PP.render should add trailing '\n' itself.
-          evaluate $ force $ Pipeline.preprocessPure ppOpts decls ++ "\n"
+            -- TODO: PP.render should add trailing '\n' itself.
+            evaluate $ force $ Pipeline.preprocessPure ppOpts decls ++ "\n"
 
-        case result of
-          Right result' -> fail $
-            "Expected failure; unexpected success\n" ++ result'
-          Left exc -> return $ normalise $
-            displayException (exc :: HsBindgenException)
+          case result of
+            Right result' -> fail $
+              "Expected failure; unexpected success\n" ++ result'
+            Left exc -> return $ normalise $
+              displayException (exc :: HsBindgenException)
 
 -- | Normalise the test fixture output so it doesn't change that often, nor across various systems.
 normalise :: String -> String

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -19,7 +19,7 @@ $(do
     let args = defaultClangArgs {
             clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
-    extBindings <- snd <$> (withTracerQ defaultTracerConf degradeKnownTraces $
+    extBindings <- snd . fst <$> (withTracerStdOut defaultTracerConf degradeKnownTraces $
       \tracer -> loadExtBindings tracer args [
         joinPath [dir, "bindings", "base.yaml"]
       , joinPath [dir, "bindings", "hs-bindgen-runtime.yaml"]

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -8,6 +8,8 @@ module Test02 where
 
 import HsBindgen.TH
 
+import Test.Internal.Trace (degradeKnownTraces)
+
 -- Used by generated code
 import Data.Word qualified
 import HsBindgen.Runtime.LibC qualified
@@ -17,7 +19,7 @@ $(do
     let args = defaultClangArgs {
             clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
-    extBindings <- snd <$> (withTracerQ defaultTracerConf $
+    extBindings <- snd <$> (withTracerQ defaultTracerConf degradeKnownTraces $
       \tracer -> loadExtBindings tracer args [
         joinPath [dir, "bindings", "base.yaml"]
       , joinPath [dir, "bindings", "hs-bindgen-runtime.yaml"]


### PR DESCRIPTION
Closes #662.

### Support tracers with custom log levels
- Use the machinery to suppress some known traces in tests.
- The tests are now trace-free (but we do still show quite some other putStrLn log messages).

### Track and return maximum log level of traces
- `withTracer...` functions now track and return maximum log level.
- Remove `mkTracer` function to encourage common usage pattern.
- Remove `withTracerQ` because it is handled by polymorphic `withTracerStdOut`.
- We must not "squelch" traces anymore, because we possibly have to ammend the max log level.

### Tasks
- [x] Test tracking of max log level.
- [x] Test custom log levels (we can do that now by degrading an error, and checking the max log level after the run).
- [x] Remove `Quiet`.
- [x] Reintroduce `squelch` (speed).
- [x] Use non-emitting report function in tests.
- [x] `-v0` flag in clients?