### PR TITLE
Fold with selections

### DIFF
--- a/clang/src/Clang/Paths.hs
+++ b/clang/src/Clang/Paths.hs
@@ -1,6 +1,7 @@
 module Clang.Paths (
     -- * Source paths
     SourcePath(..)
+  , equalSourcePath
   , getSourcePath
   , nullSourcePath
 
@@ -15,11 +16,12 @@ module Clang.Paths (
   , CIncludePathDir(..)
   ) where
 
-import Control.Exception (Exception(displayException))
+import Control.Exception (Exception (displayException))
+import Data.List qualified as List
 import Data.String
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.List qualified as List
+import System.FilePath (equalFilePath)
 import System.FilePath qualified as FilePath
 
 {-------------------------------------------------------------------------------
@@ -36,6 +38,11 @@ import System.FilePath qualified as FilePath
 newtype SourcePath = SourcePath Text
   -- 'Show' instance valid due to 'IsString' instance
   deriving newtype (Eq, IsString, Ord, Show)
+
+-- TODO (#678): Improve comparison of file paths.
+equalSourcePath :: SourcePath -> SourcePath -> Bool
+equalSourcePath (SourcePath l) (SourcePath r) =
+  equalFilePath (Text.unpack l) (Text.unpack r)
 
 -- | Get the 'FilePath' representation of a 'SourcePath'
 getSourcePath :: SourcePath -> FilePath

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -103,14 +103,14 @@ parsePredicate = fmap aux . many . asum $ [
           long "select-by-element-name"
         , help "Match element name against PCRE"
         ]
-    , flag' SelectFromMainFile $ mconcat [
-          long "select-from-main-file"
-        , help "Only process elements from the main file (this is the default)"
+    , flag' SelectFromMainFiles $ mconcat [
+          long "select-from-main-files"
+        , help "Only process elements from the main files (this is the default)"
         ]
     ]
   where
     aux :: [Predicate] -> Predicate
-    aux [] = SelectFromMainFile
+    aux [] = SelectFromMainFiles
     aux ps = mconcat ps
 
 parseClangArgs :: Parser ClangArgs

--- a/hs-bindgen/examples/selection.h
+++ b/hs-bindgen/examples/selection.h
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+typedef int a;

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -3,19 +3,14 @@
 -- Intended for unqualified import.
 module HsBindgen.Frontend (processTranslationUnit) where
 
-import Control.Tracer (Tracer)
-
-import Clang.LowLevel.Core
-
-import HsBindgen.Frontend.AST (TranslationUnit(..))
+import HsBindgen.Frontend.AST (TranslationUnit (..))
 import HsBindgen.Frontend.Graph.UseDef qualified as UseDef
 import HsBindgen.Frontend.Pass.HandleMacros
 import HsBindgen.Frontend.Pass.NameMangler
 import HsBindgen.Frontend.Pass.Parse
-import HsBindgen.Frontend.Pass.Parse.Monad (ParseEnv (ParseEnv), ParseLog)
+import HsBindgen.Frontend.Pass.Parse.Monad (ParseEnv)
 import HsBindgen.Frontend.Pass.RenameAnon
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs
-import HsBindgen.Util.Tracer (TraceWithCallStack)
 
 {-------------------------------------------------------------------------------
   Construction
@@ -27,9 +22,9 @@ import HsBindgen.Util.Tracer (TraceWithCallStack)
 -- pass in the C processing pipeline.
 type Final = RenameAnon
 
-processTranslationUnit :: CXTranslationUnit -> Tracer IO (TraceWithCallStack ParseLog) -> IO (TranslationUnit Final)
-processTranslationUnit unit tracer = do
-    afterParse <- parseTranslationUnit $ ParseEnv unit tracer
+processTranslationUnit :: ParseEnv -> IO (TranslationUnit Final)
+processTranslationUnit parseEnvironment = do
+    afterParse <- parseTranslationUnit parseEnvironment
 
     let (afterHandleMacros, macroErrors) = handleMacros afterParse
         afterRenameAnon                  = renameAnon afterHandleMacros

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -87,7 +87,7 @@ defaultOpts = Opts {
     , optsExtBindings = emptyExtBindings
     , optsTranslation = Hs.defaultTranslationOpts
     , optsNameMangler = nameMangler
-    , optsPredicate   = SelectFromMainFile
+    , optsPredicate   = SelectFromMainFiles
     , optsTracer      = nullTracer
     }
   where


### PR DESCRIPTION
Remarks

- Provide predicate for main files (plural).

- We use `Text` for storing `SourcePath`, but have to compare using
  `equalFilePath` which converts to `FilePath`. -> See https://github.com/well-typed/hs-bindgen/issues/678.

- Add `Predicate` and `SourcePath`s of the "main files" to the parse environment.