### PR TITLE
Remove foreignImportCRes and foreignImportCRes args

### DIFF
--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -242,8 +242,6 @@
         "c\978",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_\978",
       foreignImportHeader = "adios.h",
@@ -266,8 +264,6 @@
         "\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_\25308\25308",
       foreignImportHeader = "adios.h",
@@ -291,8 +287,6 @@
         "say\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_Say\25308\25308",
       foreignImportHeader = "adios.h",

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -3971,16 +3971,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "Int32_t"))))),
-      foreignImportCRes = TypeTypedef
-        (CName "int32_t"),
-      foreignImportCArgs = [
-        TypePointer
-          (TypeTypedef
-            (CName "a_type_t")),
-        TypeTypedef (CName "uint32_t"),
-        TypeIncompleteArray
-          (TypeTypedef
-            (CName "uint8_t"))],
       foreignImportOrigName =
       "testmodule_some_fun",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -538,14 +538,6 @@
           (HsPrimType HsPrimCChar)
           (HsIO
             (HsPrimType HsPrimCChar))),
-      foreignImportCRes = TypePrim
-        (PrimChar
-          (PrimSignImplicit Nothing)),
-      foreignImportCArgs = [
-        TypeTypedef (CName "F"),
-        TypePrim
-          (PrimChar
-            (PrimSignImplicit Nothing))],
       foreignImportOrigName =
       "testmodule_quux",
       foreignImportHeader =
@@ -587,13 +579,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "C"))))),
-      foreignImportCRes = TypePointer
-        (TypeTypedef (CName "C")),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimFloat),
-        TypePointer
-          (TypeTypedef (CName "C"))],
       foreignImportOrigName =
       "testmodule_wam",
       foreignImportHeader =
@@ -632,23 +617,6 @@
           (HsIO
             (HsPtr
               (HsPrimType HsPrimCChar)))),
-      foreignImportCRes = TypePointer
-        (TypePrim
-          (PrimChar
-            (PrimSignImplicit
-              (Just Signed)))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimFloat),
-        TypePointer
-          (TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimInt Signed)]
-            (TypePrim
-              (PrimIntegral
-                PrimInt
-                Signed)))],
       foreignImportOrigName =
       "testmodule_foo1",
       foreignImportHeader =
@@ -698,21 +666,6 @@
           (HsIO
             (HsPtr
               (HsPrimType HsPrimCChar)))),
-      foreignImportCRes = TypePointer
-        (TypePrim
-          (PrimChar
-            (PrimSignImplicit Nothing))),
-      foreignImportCArgs = [
-        TypeTypedef (CName "F"),
-        TypePointer
-          (TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimInt Signed)]
-            (TypePrim
-              (PrimIntegral
-                PrimInt
-                Signed)))],
       foreignImportOrigName =
       "testmodule_foo2",
       foreignImportHeader =
@@ -762,20 +715,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "C"))))),
-      foreignImportCRes = TypePointer
-        (TypeTypedef (CName "C")),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimFloat),
-        TypePointer
-          (TypeFun
-            [
-              TypePrim
-                (PrimIntegral PrimInt Signed)]
-            (TypePrim
-              (PrimIntegral
-                PrimInt
-                Signed)))],
       foreignImportOrigName =
       "testmodule_foo3",
       foreignImportHeader =
@@ -819,16 +758,6 @@
               (HsPrimType HsPrimCShort)
               (HsIO
                 (HsPrimType HsPrimCInt))))),
-      foreignImportCRes = TypePointer
-        (TypeFun
-          [
-            TypePrim
-              (PrimIntegral PrimShort Signed)]
-          (TypePrim
-            (PrimIntegral PrimInt Signed))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName =
       "testmodule_bar1",
       foreignImportHeader =
@@ -869,15 +798,6 @@
               (HsPrimType HsPrimCShort)
               (HsIO
                 (HsPrimType HsPrimCInt))))),
-      foreignImportCRes = TypePointer
-        (TypeFun
-          [
-            TypePrim
-              (PrimIntegral PrimShort Signed)]
-          (TypePrim
-            (PrimIntegral PrimInt Signed))),
-      foreignImportCArgs = [
-        TypeTypedef (CName "L")],
       foreignImportOrigName =
       "testmodule_bar2",
       foreignImportHeader =
@@ -917,14 +837,6 @@
                 (HsName "@NsTypeConstr" "S"))
               (HsIO
                 (HsPrimType HsPrimCInt))))),
-      foreignImportCRes = TypePointer
-        (TypeFun
-          [TypeTypedef (CName "S")]
-          (TypePrim
-            (PrimIntegral PrimInt Signed))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName =
       "testmodule_bar3",
       foreignImportHeader =
@@ -965,15 +877,6 @@
                   (HsName
                     "@NsTypeConstr"
                     "I")))))),
-      foreignImportCRes = TypePointer
-        (TypeFun
-          [
-            TypePrim
-              (PrimIntegral PrimShort Signed)]
-          (TypeTypedef (CName "I"))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimLong Signed)],
       foreignImportOrigName =
       "testmodule_bar4",
       foreignImportHeader =
@@ -1013,32 +916,6 @@
               (HsConstArray
                 3
                 (HsPrimType HsPrimCInt))))),
-      foreignImportCRes = TypePointer
-        (TypeConstArray
-          Size {
-            size = 2,
-            sizeExpression = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "2",
-                  integerLiteralType = Size,
-                  integerLiteralValue = 2})}
-          (TypeConstArray
-            Size {
-              size = 3,
-              sizeExpression = MTerm
-                (MInt
-                  IntegerLiteral {
-                    integerLiteralText = "3",
-                    integerLiteralType = Size,
-                    integerLiteralValue = 3})}
-            (TypePrim
-              (PrimIntegral
-                PrimInt
-                Signed)))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimInt Signed)],
       foreignImportOrigName =
       "testmodule_baz1",
       foreignImportHeader =
@@ -1096,31 +973,6 @@
               (HsConstArray
                 3
                 (HsPrimType HsPrimCInt))))),
-      foreignImportCRes = TypePointer
-        (TypeConstArray
-          Size {
-            size = 2,
-            sizeExpression = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "2",
-                  integerLiteralType = Int Signed,
-                  integerLiteralValue = 2})}
-          (TypeConstArray
-            Size {
-              size = 3,
-              sizeExpression = MTerm
-                (MInt
-                  IntegerLiteral {
-                    integerLiteralText = "3",
-                    integerLiteralType = Int Signed,
-                    integerLiteralValue = 3})}
-            (TypePrim
-              (PrimIntegral
-                PrimInt
-                Signed)))),
-      foreignImportCArgs = [
-        TypeTypedef (CName "I")],
       foreignImportOrigName =
       "testmodule_baz2",
       foreignImportHeader =
@@ -1179,29 +1031,6 @@
                   (HsName
                     "@NsTypeConstr"
                     "I")))))),
-      foreignImportCRes = TypePointer
-        (TypeConstArray
-          Size {
-            size = 2,
-            sizeExpression = MTerm
-              (MInt
-                IntegerLiteral {
-                  integerLiteralText = "2",
-                  integerLiteralType = Int Signed,
-                  integerLiteralValue = 2})}
-          (TypeConstArray
-            Size {
-              size = 3,
-              sizeExpression = MTerm
-                (MInt
-                  IntegerLiteral {
-                    integerLiteralText = "3",
-                    integerLiteralType = Int Signed,
-                    integerLiteralValue = 3})}
-            (TypeTypedef (CName "I")))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimInt Signed)],
       foreignImportOrigName =
       "testmodule_baz3",
       foreignImportHeader =
@@ -1249,9 +1078,6 @@
       foreignImportType = HsIO
         (HsTypRef
           (HsName "@NsTypeConstr" "I")),
-      foreignImportCRes = TypeTypedef
-        (CName "I"),
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_no_args_no_void",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -214,12 +214,6 @@
             (HsName "@NsTypeConstr" "TC"))
           (HsIO
             (HsPrimType HsPrimCChar))),
-      foreignImportCRes = TypePrim
-        (PrimChar
-          (PrimSignImplicit Nothing)),
-      foreignImportCArgs = [
-        TypeTypedef (CName "MC"),
-        TypeTypedef (CName "TC")],
       foreignImportOrigName =
       "testmodule_quux1",
       foreignImportHeader =
@@ -257,13 +251,6 @@
               (HsName
                 "@NsTypeConstr"
                 "TC")))),
-      foreignImportCRes = TypeTypedef
-        (CName "TC"),
-      foreignImportCArgs = [
-        TypeTypedef (CName "MC"),
-        TypePrim
-          (PrimChar
-            (PrimSignImplicit Nothing))],
       foreignImportOrigName =
       "testmodule_quux2",
       foreignImportHeader =
@@ -304,13 +291,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "MC"))))),
-      foreignImportCRes = TypePointer
-        (TypeTypedef (CName "MC")),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimFloat),
-        TypePointer
-          (TypeTypedef (CName "TC"))],
       foreignImportOrigName =
       "testmodule_wam1",
       foreignImportHeader =
@@ -351,13 +331,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "TC"))))),
-      foreignImportCRes = TypePointer
-        (TypeTypedef (CName "TC")),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimFloat),
-        TypePointer
-          (TypeTypedef (CName "MC"))],
       foreignImportOrigName =
       "testmodule_wam2",
       foreignImportHeader =
@@ -1330,14 +1303,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathAnon
-              (DeclPathCtxtTypedef
-                (CName "struct2")))),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_typedef1",
       foreignImportHeader =
@@ -1378,12 +1343,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeTypedef
-            (CName "struct3_t")),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_typedef2",
       foreignImportHeader =
@@ -1422,11 +1381,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeTypedef (CName "struct4")),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_typedef3",
       foreignImportHeader =
@@ -1464,13 +1418,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "struct1"))),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_name1",
       foreignImportHeader =
@@ -1510,13 +1457,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "struct3"))),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_name2",
       foreignImportHeader =
@@ -1556,13 +1496,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "MC"))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "struct4"))),
-        TypeTypedef (CName "MC")],
       foreignImportOrigName =
       "testmodule_struct_name3",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -443,18 +443,6 @@
                     "Triple")))
               (HsIO
                 (HsPrimType HsPrimUnit))))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimInt Signed),
-        TypePrim
-          (PrimIntegral PrimInt Signed),
-        TypePrim
-          (PrimIntegral PrimInt Signed),
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "triple")))],
       foreignImportOrigName =
       "testmodule_mk_triple",
       foreignImportHeader =
@@ -983,15 +971,6 @@
               "@NsTypeConstr"
               "Index"))
           (HsIO (HsPrimType HsPrimCInt))),
-      foreignImportCRes = TypePrim
-        (PrimIntegral PrimInt Signed),
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "triple"))),
-        TypeEnum
-          (DeclPathName (CName "index"))],
       foreignImportOrigName =
       "testmodule_index_triple",
       foreignImportHeader =
@@ -1233,13 +1212,6 @@
             (HsName
               "@NsTypeConstr"
               "Sum"))),
-      foreignImportCRes = TypeTypedef
-        (CName "sum"),
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "triple")))],
       foreignImportOrigName =
       "testmodule_sum_triple",
       foreignImportHeader =
@@ -1280,13 +1252,6 @@
             (HsName
               "@NsTypeConstr"
               "Average"))),
-      foreignImportCRes = TypeTypedef
-        (CName "average"),
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName
-              (CName "triple")))],
       foreignImportOrigName =
       "testmodule_average_triple",
       foreignImportHeader =
@@ -2195,11 +2160,6 @@
             (HsName
               "@NsTypeConstr"
               "YEAR"))),
-      foreignImportCRes = TypeTypedef
-        (CName "YEAR"),
-      foreignImportCArgs = [
-        TypePointer
-          (TypeTypedef (CName "date"))],
       foreignImportOrigName =
       "testmodule_getYear",
       foreignImportHeader =
@@ -3153,14 +3113,6 @@
                 "@NsTypeConstr"
                 "Occupation")))
           (HsIO (HsPrimType HsPrimUnit))),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePrim
-          (PrimIntegral PrimInt Signed),
-        TypePointer
-          (TypeUnion
-            (DeclPathName
-              (CName "occupation")))],
       foreignImportOrigName =
       "testmodule_print_occupation",
       foreignImportHeader =
@@ -4749,8 +4701,6 @@
         "\25308\25308",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_\25308\25308",
       foreignImportHeader =
@@ -4894,8 +4844,6 @@
         "c\978",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_\978",
       foreignImportHeader =
@@ -5011,8 +4959,6 @@
         "import'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_import",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/names.hs
+++ b/hs-bindgen/fixtures/names.hs
@@ -9,8 +9,6 @@
         "by'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_by",
       foreignImportHeader = "names.h",
@@ -33,8 +31,6 @@
         "forall'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_forall",
       foreignImportHeader = "names.h",
@@ -57,8 +53,6 @@
         "mdo'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_mdo",
       foreignImportHeader = "names.h",
@@ -81,8 +75,6 @@
         "pattern'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_pattern",
       foreignImportHeader = "names.h",
@@ -105,8 +97,6 @@
         "proc'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_proc",
       foreignImportHeader = "names.h",
@@ -129,8 +119,6 @@
         "rec'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_rec",
       foreignImportHeader = "names.h",
@@ -153,8 +141,6 @@
         "using'",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_using",
       foreignImportHeader = "names.h",
@@ -177,8 +163,6 @@
         "anyclass",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_anyclass",
       foreignImportHeader = "names.h",
@@ -201,8 +185,6 @@
         "capi",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_capi",
       foreignImportHeader = "names.h",
@@ -225,8 +207,6 @@
         "cases",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_cases",
       foreignImportHeader = "names.h",
@@ -249,8 +229,6 @@
         "ccall",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_ccall",
       foreignImportHeader = "names.h",
@@ -273,8 +251,6 @@
         "dynamic",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_dynamic",
       foreignImportHeader = "names.h",
@@ -297,8 +273,6 @@
         "export",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_export",
       foreignImportHeader = "names.h",
@@ -321,8 +295,6 @@
         "family",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_family",
       foreignImportHeader = "names.h",
@@ -345,8 +317,6 @@
         "group",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_group",
       foreignImportHeader = "names.h",
@@ -369,8 +339,6 @@
         "interruptible",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_interruptible",
       foreignImportHeader = "names.h",
@@ -394,8 +362,6 @@
         "javascript",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_javascript",
       foreignImportHeader = "names.h",
@@ -419,8 +385,6 @@
         "label",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_label",
       foreignImportHeader = "names.h",
@@ -443,8 +407,6 @@
         "prim",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_prim",
       foreignImportHeader = "names.h",
@@ -467,8 +429,6 @@
         "role",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_role",
       foreignImportHeader = "names.h",
@@ -491,8 +451,6 @@
         "safe",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_safe",
       foreignImportHeader = "names.h",
@@ -515,8 +473,6 @@
         "stdcall",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_stdcall",
       foreignImportHeader = "names.h",
@@ -539,8 +495,6 @@
         "stock",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_stock",
       foreignImportHeader = "names.h",
@@ -563,8 +517,6 @@
         "unsafe",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_unsafe",
       foreignImportHeader = "names.h",
@@ -587,8 +539,6 @@
         "via",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_via",
       foreignImportHeader = "names.h",

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -12,11 +12,6 @@
         (HsPrimType HsPrimCDouble)
         (HsIO
           (HsPrimType HsPrimCDouble)),
-      foreignImportCRes = TypePrim
-        (PrimFloating PrimDouble),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimDouble)],
       foreignImportOrigName =
       "testmodule_erf",
       foreignImportHeader =
@@ -51,15 +46,6 @@
             (HsPrimType HsPrimCDouble)
             (HsIO
               (HsPrimType HsPrimCDouble)))),
-      foreignImportCRes = TypePrim
-        (PrimFloating PrimDouble),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimDouble),
-        TypePrim
-          (PrimFloating PrimDouble),
-        TypePrim
-          (PrimFloating PrimDouble)],
       foreignImportOrigName =
       "testmodule_bad_fma",
       foreignImportHeader =
@@ -92,8 +78,6 @@
         "no_args",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_no_args",
       foreignImportHeader =
@@ -119,8 +103,6 @@
         "no_args_no_void",
       foreignImportType = HsIO
         (HsPrimType HsPrimUnit),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [],
       foreignImportOrigName =
       "testmodule_no_args_no_void",
       foreignImportHeader =
@@ -150,15 +132,6 @@
         (HsFun
           (HsPrimType HsPrimCDouble)
           (HsIO (HsPrimType HsPrimCInt))),
-      foreignImportCRes = TypePrim
-        (PrimIntegral PrimInt Signed),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimChar
-            (PrimSignImplicit
-              (Just Signed))),
-        TypePrim
-          (PrimFloating PrimDouble)],
       foreignImportOrigName =
       "testmodule_fun",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/vector.hs
+++ b/hs-bindgen/fixtures/vector.hs
@@ -340,16 +340,6 @@
                 (HsName
                   "@NsTypeConstr"
                   "Vector"))))),
-      foreignImportCRes = TypePointer
-        (TypeStruct
-          (DeclPathAnon
-            (DeclPathCtxtTypedef
-              (CName "vector")))),
-      foreignImportCArgs = [
-        TypePrim
-          (PrimFloating PrimDouble),
-        TypePrim
-          (PrimFloating PrimDouble)],
       foreignImportOrigName =
       "testmodule_new_vector",
       foreignImportHeader =

--- a/hs-bindgen/fixtures/weird01.hs
+++ b/hs-bindgen/fixtures/weird01.hs
@@ -444,11 +444,6 @@
           (HsTypRef
             (HsName "@NsTypeConstr" "Bar")))
         (HsIO (HsPrimType HsPrimUnit)),
-      foreignImportCRes = TypeVoid,
-      foreignImportCArgs = [
-        TypePointer
-          (TypeStruct
-            (DeclPathName (CName "bar")))],
       foreignImportOrigName =
       "testmodule_func",
       foreignImportHeader =

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -136,8 +136,6 @@ data NewtypeOrigin =
 data ForeignImportDecl = ForeignImportDecl
     { foreignImportName       :: HsName NsVar
     , foreignImportType       :: HsType
-    , foreignImportCRes       :: C.Type
-    , foreignImportCArgs      :: [C.Type]
     , foreignImportOrigName   :: Text
     , foreignImportHeader     :: FilePath -- TODO: https://github.com/well-typed/hs-bindgen/issues/333
     , foreignImportDeclOrigin :: ForeignImportDeclOrigin

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -896,8 +896,6 @@ functionDecs nm mu typedefs f
     , Hs.DeclForeignImport $ Hs.ForeignImportDecl
         { foreignImportName       = mangle nm $ NameVar $ C.functionName f
         , foreignImportType       = ty
-        , foreignImportCRes       = C.functionRes f
-        , foreignImportCArgs      = C.functionArgs f
         , foreignImportOrigName   = T.pack wrapperName
         , foreignImportHeader     = getCHeaderIncludePath $ C.functionHeader f
         , foreignImportDeclOrigin = Hs.ForeignImportDeclOriginFunction f


### PR DESCRIPTION
I thought I'd need them for userland-capi, but it looks like I don't, as everything is generated in C->Hs translation already.