### PR TITLE
Detect ANSI color support in golden tests

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -297,6 +297,7 @@ test-suite test-internal
     , deepseq
   build-depends:
       -- Inherited dependencies
+    , ansi-terminal
     , contra-tracer
     , bytestring
     , debruijn

--- a/hs-bindgen/test/common/Test/Internal/Trace.hs
+++ b/hs-bindgen/test/common/Test/Internal/Trace.hs
@@ -1,19 +1,20 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Test.Internal.Trace
   ( degradeKnownTraces
   ) where
 
-import Clang.HighLevel.Types (Diagnostic (diagnosticCategory))
+import Clang.HighLevel.Types (Diagnostic (diagnosticCategoryText))
 import HsBindgen.Lib
 
 -- | Degrade log levels of known traces in tests.
 degradeKnownTraces :: CustomLogLevel Trace
 degradeKnownTraces = CustomLogLevel $ \case
-  -- "Sematic Issue": "declaration does not declare anything".
-  TraceDiagnostic x | diagnosticCategory x == 2 -> Debug
-  -- "Nullability Issue": "pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)".
-  TraceDiagnostic x | diagnosticCategory x == 26 -> Debug
+  -- "Declaration does not declare anything".
+  TraceDiagnostic x | diagnosticCategoryText x == "Semantic Issue" -> Debug
+  -- "Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)".
+  TraceDiagnostic x | diagnosticCategoryText x == "Nullability Issue" -> Debug
   TraceExtraClangArgs _ -> Debug
   TraceSkipped _        -> Debug
   x                     -> getDefaultLogLevel x


### PR DESCRIPTION
Fixes #675.

This was actually tricky because we need to have access to Tasty options (`UseColor`), and also to `stdout` (to query ANSI color features).