### PR TITLE
Enu sizeof and alignment

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
@@ -221,9 +221,7 @@ class ( IsPass p
 
         -- Annotations
       , Show (Ann "Decl"            p)
-      , Show (Ann "Struct"          p)
       , Show (Ann "StructField"     p)
-      , Show (Ann "Union"           p)
       , Show (Ann "UnionField"      p)
       , Show (Ann "TranslationUnit" p)
       , Show (Ann "Typedef"         p)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
@@ -119,7 +119,9 @@ data Typedef p = Typedef {
     }
 
 data Enu = Enu {
-      enumConstants :: [EnumConstant]
+      enumSizeof    :: Int
+    , enumAlignment :: Int
+    , enumConstants :: [EnumConstant]
     }
   deriving stock (Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
@@ -10,6 +10,7 @@ module HsBindgen.Frontend.AST (
   , Union(..)
   , UnionField(..)
   , Typedef(..)
+  , Enu(..)
   , EnumConstant(..)
   , Function(..)
     -- * Types (at use sites)
@@ -82,7 +83,7 @@ data DeclKind p =
   | DeclUnion (Union p)
   | DeclUnionOpaque
   | DeclTypedef (Typedef p)
-  | DeclEnum [EnumConstant]
+  | DeclEnum Enu
   | DeclEnumOpaque
   | DeclMacro (Macro p)
   | DeclFunction (Function p)
@@ -116,6 +117,11 @@ data Typedef p = Typedef {
       typedefType :: Type p
     , typedefAnn  :: Ann "Typedef" p
     }
+
+data Enu = Enu {
+      enumConstants :: [EnumConstant]
+    }
+  deriving stock (Show)
 
 data EnumConstant = EnumConstant {
       enumConstantName  :: Text

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -61,15 +61,15 @@ handleMacros TranslationUnit{unitDecls, unitIncludeGraph, unitAnn} =
 processDecl :: Decl Parse -> M (Maybe (Decl HandleMacros))
 processDecl Decl{declInfo = DeclInfo{declId, declLoc}, declKind} =
     case declKind of
-      DeclMacro   macro       -> processMacro info' macro
-      DeclTypedef typedef     -> processTypedef info' typedef
-      DeclStruct  struct      -> Just <$> processStruct info' struct
-      DeclStructOpaque        -> Just <$> processOpaqueWith DeclStructOpaque info'
-      DeclUnion   union       -> Just <$> processUnion info' union
-      DeclUnionOpaque         -> Just <$> processOpaqueWith DeclUnionOpaque info'
-      DeclEnum    enumerators -> Just <$> processEnum info' enumerators
-      DeclEnumOpaque          -> Just <$> processOpaqueWith DeclEnumOpaque info'
-      DeclFunction fun        -> processFunction info' fun
+      DeclMacro   macro   -> processMacro info' macro
+      DeclTypedef typedef -> processTypedef info' typedef
+      DeclStruct  struct  -> Just <$> processStruct info' struct
+      DeclStructOpaque    -> Just <$> processOpaqueWith DeclStructOpaque info'
+      DeclUnion   union   -> Just <$> processUnion info' union
+      DeclUnionOpaque     -> Just <$> processOpaqueWith DeclUnionOpaque info'
+      DeclEnum    enum    -> Just <$> processEnum info' enum
+      DeclEnumOpaque      -> Just <$> processOpaqueWith DeclEnumOpaque info'
+      DeclFunction fun    -> processFunction info' fun
   where
     info' :: DeclInfo HandleMacros
     info' = DeclInfo{declId, declLoc}
@@ -153,13 +153,16 @@ processOpaqueWith kind info =
       , declAnn  = NoAnn
       }
 
-processEnum :: DeclInfo HandleMacros -> [EnumConstant] -> M (Decl HandleMacros)
-processEnum info = fmap (mkDecl . catMaybes) . mapM processEnumConstant
+processEnum :: DeclInfo HandleMacros -> Enu -> M (Decl HandleMacros)
+processEnum info =
+    fmap (mkDecl . catMaybes) . mapM processEnumConstant . enumConstants
   where
     mkDecl :: [EnumConstant] -> Decl HandleMacros
     mkDecl enumerators = Decl{
           declInfo = info
-        , declKind = DeclEnum enumerators
+        , declKind = DeclEnum Enu{
+              enumConstants = enumerators
+            }
         , declAnn  = NoAnn
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -154,14 +154,15 @@ processOpaqueWith kind info =
       }
 
 processEnum :: DeclInfo HandleMacros -> Enu -> M (Decl HandleMacros)
-processEnum info =
-    fmap (mkDecl . catMaybes) . mapM processEnumConstant . enumConstants
+processEnum info Enu{..} =
+    mkDecl . catMaybes <$> mapM processEnumConstant enumConstants
   where
     mkDecl :: [EnumConstant] -> Decl HandleMacros
     mkDecl enumerators = Decl{
           declInfo = info
         , declKind = DeclEnum Enu{
               enumConstants = enumerators
+            , ..
             }
         , declAnn  = NoAnn
         }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -291,13 +291,22 @@ enumDecl curr = do
         pure $ Continue $ Nothing
     where
       aux :: DeclInfo Parse -> [EnumConstant] -> M (Maybe [Decl Parse])
-      aux info es = let decl = Decl { declInfo = info
-                                    , declKind = DeclEnum Enu{
-                                          enumConstants = es
-                                        }
-                                    , declAnn  = NoAnn
-                                    }
-                     in pure $ Just [decl]
+      aux info es = do
+        ty        <- clang_getCursorType curr
+        sizeof    <- clang_Type_getSizeOf  ty
+        alignment <- clang_Type_getAlignOf ty
+
+        let decl :: Decl Parse
+            decl = Decl{
+                declInfo = info
+              , declKind = DeclEnum Enu{
+                    enumSizeof    = fromIntegral sizeof
+                  , enumAlignment = fromIntegral alignment
+                  , enumConstants = es
+                  }
+              , declAnn  = NoAnn
+              }
+        return $ Just [decl]
 
 enumeratorDecl :: Fold M EnumConstant
 enumeratorDecl curr = do

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -292,7 +292,9 @@ enumDecl curr = do
     where
       aux :: DeclInfo Parse -> [EnumConstant] -> M (Maybe [Decl Parse])
       aux info es = let decl = Decl { declInfo = info
-                                    , declKind = DeclEnum es
+                                    , declKind = DeclEnum Enu{
+                                          enumConstants = es
+                                        }
                                     , declAnn  = NoAnn
                                     }
                      in pure $ Just [decl]


### PR DESCRIPTION
Similar to #685, this small PR adds the `Enu` type to the AST.  `sizeof` and `alignment` are implemented for it.

This continues to use the type name `Enu` that was used in the `C` AST.