### PR TITLE
Implement `ResolveBindingSpecs`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -140,6 +140,7 @@ library internal
       HsBindgen.Hs.NameMangler.DSL.ReservedNames
       HsBindgen.Hs.Translation
       HsBindgen.Imports
+      HsBindgen.Language.Hs
       HsBindgen.ModuleUnique
       HsBindgen.NameHint
       HsBindgen.Orphans

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -75,6 +75,7 @@ library internal
       HsBindgen.Backend.PP.Render
       HsBindgen.Backend.PP.Translation
       HsBindgen.Backend.TH.Translation
+      HsBindgen.BindingSpecs
       HsBindgen.C.AST
       HsBindgen.C.Fold
       HsBindgen.C.Fold.Common

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -28,6 +28,7 @@ import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type (HsPrimType(..))
 import HsBindgen.Imports
+import HsBindgen.Language.Hs
 import HsBindgen.NameHint
 import HsBindgen.SHs.AST
 import Text.SimplePrettyPrint

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
@@ -22,6 +22,7 @@ import HsBindgen.ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Type qualified as Hs
 import HsBindgen.Imports
+import HsBindgen.Language.Hs
 import HsBindgen.SHs.AST
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -36,6 +36,7 @@ import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Imports
+import HsBindgen.Language.Hs
 import HsBindgen.NameHint
 import HsBindgen.Runtime.Bitfield qualified
 import HsBindgen.Runtime.ByteArray qualified

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpecs.hs
@@ -22,6 +22,7 @@ module HsBindgen.BindingSpecs (
   , BindingSpecsExceptions(..)
   , GetExtHsRefException(..)
   , OmittedTypeUseException(..)
+  , TypeNotUsedException(..)
     -- * API
   , empty
   , load
@@ -324,6 +325,18 @@ instance Exception OmittedTypeUseException where
   fromException = hsBindgenExceptionFromException
   displayException (OmittedTypeUse cname) =
     "omitted type use: " ++ Text.unpack (getCNameSpelling cname)
+
+--------------------------------------------------------------------------------
+
+-- | Configured type is not used
+newtype TypeNotUsedException = TypeNotUsed CNameSpelling
+  deriving stock (Show)
+
+instance Exception TypeNotUsedException where
+  toException = hsBindgenExceptionToException
+  fromException = hsBindgenExceptionFromException
+  displayException (TypeNotUsed cname) =
+    "configured type not used: " ++ Text.unpack (getCNameSpelling cname)
 
 {-------------------------------------------------------------------------------
   API

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpecs.hs
@@ -1,0 +1,852 @@
+-- | Binding specifications
+--
+-- Intended for qualified import.
+--
+-- > import HsBindgen.BindingSpecs qualified as BindingSpecs
+module HsBindgen.BindingSpecs (
+    -- * Types
+    BindingSpecs(..)
+  , UnresolvedBindingSpecs
+  , ResolvedBindingSpecs
+  , Omittable(..)
+  , Type(..)
+    -- ** Instances
+  , Instance(..)
+  , Strategy(..)
+  , Constraint(..)
+    -- ** Exceptions
+  , ReadBindingSpecsException(..)
+  , WriteBindingSpecsException(..)
+  , MergeBindingSpecsException(..)
+  , BindingSpecsException(..)
+  , BindingSpecsExceptions(..)
+  , GetExtHsRefException(..)
+  , OmittedTypeUseException(..)
+    -- * API
+  , empty
+  , load
+  , lookupCType
+  , lookupType
+  , getExtHsRef
+    -- ** YAML/JSON
+  , readFile
+  , readFileJson
+  , readFileYaml
+  , encodeJson
+  , encodeYaml
+  , writeFile
+  , writeFileJson
+  , writeFileYaml
+    -- ** Header resolution
+  , resolve
+    -- ** Merging
+  , merge
+  ) where
+
+import Control.Applicative (asum)
+import Control.Exception (Exception(..))
+import Control.Tracer (Tracer)
+import Data.Aeson ((.=), (.:), (.:?), (.!=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.Aeson.Types qualified as Aeson
+import Data.ByteString qualified as BSS
+import Data.ByteString.Lazy qualified as BSL
+import Data.Either (partitionEithers)
+import Data.Function (on)
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+import Data.Proxy (Proxy(Proxy))
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Data.Typeable (Typeable, typeRep)
+import Data.Yaml qualified as Yaml
+import Data.Yaml.Internal qualified
+import Data.Yaml.Pretty qualified
+import Prelude hiding (readFile, writeFile)
+
+import Clang.Args
+import Clang.CNameSpelling
+import Clang.Paths
+import HsBindgen.Clang.Args (ExtraClangArgsLog)
+import HsBindgen.Errors
+import HsBindgen.Imports
+import HsBindgen.Language.Hs
+import HsBindgen.Orphans ()
+import HsBindgen.Resolve
+import HsBindgen.Util.Tracer (TraceWithCallStack)
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+-- | Binding specifications
+--
+-- The @header@ type parameter determines the representation of header paths.
+-- See 'UnresolvedBindingSpecs' and 'ResolvedBindingSpecs'.
+newtype BindingSpecs header = BindingSpecs {
+      -- | Type specifications
+      --
+      -- C types are identified using a 'CNameSpelling' and a set of headers
+      -- where the type may be (transitively) declared.  For a given
+      -- 'CNameSpelling', the corresponding sets of headers are disjoint.  The
+      -- type is therefore equivalent to
+      -- @'Map' 'CNameSpelling' ('Map' header 'Omittable Type')@, but this type
+      -- is used as an optimization.  In most cases, each 'CNameSpelling' is
+      -- mapped to a singleton list with a singleton set of headers.
+      bindingSpecsTypes :: Map CNameSpelling [(Set header, Omittable Type)]
+    }
+  deriving stock (Eq, Generic, Show)
+
+-- | Binding specifications with unresolved headers
+type UnresolvedBindingSpecs = BindingSpecs CHeaderIncludePath
+
+-- | Binding specifications with resolved headers
+type ResolvedBindingSpecs = BindingSpecs SourcePath
+
+--------------------------------------------------------------------------------
+
+-- | Wrapper for types that may be omitted
+--
+-- This type is isomorphic with 'Maybe'.
+--
+-- In general, the following conventions are followed:
+--
+-- * If something is specified, it is required.  It is an error if @hs-bindgen@
+--   is unable to satisfy the requirement.
+-- * If something is omitted, then @hs-bindgen@ does /not/ generate the
+--   corresponding code.  Use of something that is omitted is an error.
+-- * If nothing is specified, @hs-bindgen@ generates code using defaults.  This
+--   case is /not/ represented by 'Omittable'.
+data Omittable a =
+    Require a
+  | Omit
+  deriving stock (Eq, Generic, Show)
+
+--------------------------------------------------------------------------------
+
+-- | Binding specifications for a C type
+data Type = Type {
+      -- | Haskell module
+      typeModule :: Maybe HsModuleName
+
+    , -- | Haskell identifier
+      typeIdentifier :: Maybe HsIdentifier
+
+    , -- | Instance specifications
+      typeInstances :: Map HsTypeClass (Omittable Instance)
+    }
+  deriving stock (Eq, Generic, Show)
+
+{-------------------------------------------------------------------------------
+  Types: Instances
+-------------------------------------------------------------------------------}
+
+-- | Instance specifications
+data Instance = Instance {
+      -- | Strategy used to generate/derive the instance
+      --
+      -- A 'Nothing' value indicates that @hs-bindgen@ defaults should be used.
+      instanceStrategy :: Maybe Strategy
+
+    , -- | Instance constraints
+      --
+      -- If specified, /all/ constraints must be listed.
+      instanceConstraints :: [Constraint]
+    }
+  deriving stock (Eq, Generic, Show)
+
+--------------------------------------------------------------------------------
+
+-- | Strategy used to generate/derive an instance
+data Strategy =
+    -- | Generate an instance
+    StrategyHsBindgen
+  | -- | Derive an instance using the @newtype@ strategy
+    StrategyNewtype
+  | -- | Derive an instance using the @stock@ strategy
+    StrategyStock
+  deriving stock (Bounded, Enum, Eq, Generic, Ord, Show)
+
+instance Aeson.FromJSON Strategy where
+  parseJSON = Aeson.withText "Strategy" $ \t ->
+    case Map.lookup t strategyFromText of
+      Just strategy -> return strategy
+      Nothing       -> Aeson.parseFail $ "unknown strategy: " ++ (Text.unpack t)
+
+instance Aeson.ToJSON Strategy where
+  toJSON = Aeson.String . strategyText
+
+strategyText :: Strategy -> Text
+strategyText = \case
+    StrategyHsBindgen -> "hs-bindgen"
+    StrategyNewtype   -> "newtype"
+    StrategyStock     -> "stock"
+
+strategyFromText :: Map Text Strategy
+strategyFromText = Map.fromList [
+      (strategyText strat, strat)
+    | strat <- [minBound..]
+    ]
+
+--------------------------------------------------------------------------------
+
+-- | Constraint of an instance
+data Constraint = Constraint {
+      constraintClass :: HsTypeClass
+    , constraintRef   :: ExtHsRef
+    }
+  deriving stock (Eq, Generic, Show)
+
+{-------------------------------------------------------------------------------
+  Types: Exceptions
+-------------------------------------------------------------------------------}
+
+-- | Failed to load binding specifications file
+data ReadBindingSpecsException =
+    -- | Unknown file extension
+    ReadBindingSpecsUnknownExtension FilePath
+  | -- | Aeson parsing error
+    ReadBindingSpecsAesonError FilePath String
+  | -- | YAML parsing error
+    ReadBindingSpecsYamlError FilePath Yaml.ParseException
+  | -- | YAML parsing warnings (which should be treated like errors)
+    ReadBindingSpecsYamlWarning FilePath [Data.Yaml.Internal.Warning]
+    -- | Multiple specifications for the same C name and header in the same file
+  | ReadBindingSpecsConflict
+      FilePath
+      (Set (CNameSpelling, CHeaderIncludePath))
+  deriving stock (Show)
+
+instance Exception ReadBindingSpecsException where
+  displayException = \case
+    ReadBindingSpecsUnknownExtension path -> "unknown extension: " ++ path
+    ReadBindingSpecsAesonError path err ->
+      "error parsing JSON: " ++ path ++ ": " ++ err
+    ReadBindingSpecsYamlError path err -> unlines [
+        "error parsing YAML: " ++ path
+      , Yaml.prettyPrintParseException err
+      ]
+    ReadBindingSpecsYamlWarning path warnings ->
+      unlines $
+          ("duplicate keys in YAML file: " ++ path)
+        : [ "  " ++ Aeson.formatPath jsonPath
+          | Data.Yaml.Internal.DuplicateKey jsonPath <- warnings
+          ]
+    ReadBindingSpecsConflict path conflicts ->
+      unlines $
+          ( "multiple specifications for same C name and header: "
+              ++ path
+          )
+        : [ "  " ++ Text.unpack (getCNameSpelling cname)
+              ++ ' ' : getCHeaderIncludePath header
+          | (cname, header) <- Set.toAscList conflicts
+          ]
+
+--------------------------------------------------------------------------------
+
+-- | Failed to write binding specifications file
+newtype WriteBindingSpecsException =
+    -- | Unknown file extension
+    WriteBindingSpecsUnknownExtension FilePath
+  deriving stock (Show)
+
+instance Exception WriteBindingSpecsException where
+  displayException = \case
+    WriteBindingSpecsUnknownExtension path -> "unknown extension: " ++ path
+
+--------------------------------------------------------------------------------
+
+-- | Failed to merge binding specifications
+newtype MergeBindingSpecsException =
+    -- | Multiple binding specifications for the same C name and header
+    MergeBindingSpecsConflict (Set CNameSpelling)
+  deriving stock (Show)
+
+instance Exception MergeBindingSpecsException where
+  displayException = \case
+    MergeBindingSpecsConflict cnames ->
+      unlines $
+          "conflicting binding specifications for same C name and header:"
+        : [ "  " ++ Text.unpack (getCNameSpelling cname)
+          | cname <- Set.toAscList cnames
+          ]
+
+--------------------------------------------------------------------------------
+
+-- | Failed loading, resolving, or merging binding specifications
+data BindingSpecsException =
+    ReadBindingSpecsException  ReadBindingSpecsException
+  | MergeBindingSpecsException MergeBindingSpecsException
+  deriving stock (Show)
+
+instance Exception BindingSpecsException where
+  displayException = \case
+    ReadBindingSpecsException  e -> displayException e
+    MergeBindingSpecsException e -> displayException e
+
+--------------------------------------------------------------------------------
+
+-- | Failed loading, resolving, or merging binding specifications
+newtype BindingSpecsExceptions = BindingSpecsExceptions [BindingSpecsException]
+  deriving stock (Show)
+
+instance Exception BindingSpecsExceptions where
+  displayException (BindingSpecsExceptions es) =
+    unlines $ map displayException es
+
+--------------------------------------------------------------------------------
+
+-- | External reference error
+data GetExtHsRefException =
+    -- | No Haskell module specified
+    GetExtHsRefNoModule CNameSpelling
+  | -- | No Haskell identifier specified
+    GetExtHsRefNoIdentifier CNameSpelling
+  deriving stock (Show)
+
+instance Exception GetExtHsRefException where
+  displayException = \case
+    GetExtHsRefNoModule cname ->
+      "no Haskell module specified: " ++ Text.unpack (getCNameSpelling cname)
+    GetExtHsRefNoIdentifier cname ->
+      "no Haskell identifier specified: "
+        ++ Text.unpack (getCNameSpelling cname)
+
+--------------------------------------------------------------------------------
+
+-- | Omitted type is used
+newtype OmittedTypeUseException = OmittedTypeUse CNameSpelling
+  deriving stock (Show)
+
+instance Exception OmittedTypeUseException where
+  toException = hsBindgenExceptionToException
+  fromException = hsBindgenExceptionFromException
+  displayException (OmittedTypeUse cname) =
+    "omitted type use: " ++ Text.unpack (getCNameSpelling cname)
+
+{-------------------------------------------------------------------------------
+  API
+-------------------------------------------------------------------------------}
+
+-- | Empty binding specifications
+empty :: BindingSpecs header
+empty = BindingSpecs {
+      bindingSpecsTypes = Map.empty
+    }
+
+-- | Load, resolve, and merge binding specifications
+--
+-- The format is determined by filename extension.
+load ::
+     Tracer IO (TraceWithCallStack ExtraClangArgsLog)
+  -> ClangArgs
+  -> [FilePath]
+  -> IO
+       ( Either
+           BindingSpecsExceptions
+           (Set ResolveHeaderException, ResolvedBindingSpecs)
+       )
+load tracer args paths = do
+    (errs, uspecs) <-
+      first (map ReadBindingSpecsException) . partitionEithers
+        <$> mapM readFile paths
+    (resolveErrs, specss) <-
+      first Set.unions . unzip <$> mapM (resolve tracer args) uspecs
+    return $ case first MergeBindingSpecsException (merge specss) of
+      Right specs
+        | null errs -> Right (resolveErrs, specs)
+        | otherwise -> Left $ BindingSpecsExceptions errs
+      Left mergeErr -> Left $ BindingSpecsExceptions (errs ++ [mergeErr])
+
+-- | Lookup a type C name spelling in binding specifications
+lookupCType ::
+     CNameSpelling
+  -> ResolvedBindingSpecs
+  -> Maybe [(Set SourcePath, Omittable Type)]
+lookupCType cname = Map.lookup cname . bindingSpecsTypes
+
+-- | Lookup a 'Type' associated with a set of header paths with at least one in
+-- common with the specified set of header paths
+--
+-- This is purposefully separate from 'lookupCType' because we do not need to
+-- compute the set of header paths unless there is a match for the C name
+-- spelling.
+lookupType ::
+     Set SourcePath
+  -> [(Set SourcePath, Omittable Type)]
+  -> Maybe (Omittable Type)
+lookupType headers = fmap snd . List.find (not . Set.disjoint headers . fst)
+
+-- | Get an 'ExtHsRef' for the given 'Type'
+getExtHsRef :: CNameSpelling -> Type -> Either GetExtHsRefException ExtHsRef
+getExtHsRef cname Type{..} = do
+    extHsRefModule <- maybe (Left (GetExtHsRefNoModule cname)) Right typeModule
+    extHsRefIdentifier <-
+      maybe (Left (GetExtHsRefNoIdentifier cname)) Right typeIdentifier
+    return ExtHsRef{..}
+
+{-------------------------------------------------------------------------------
+  API: YAML/JSON
+-------------------------------------------------------------------------------}
+
+-- | Read binding specifications from a file
+-- The format is determined by the filename extension.
+readFile ::
+     FilePath
+  -> IO (Either ReadBindingSpecsException UnresolvedBindingSpecs)
+readFile path
+    | ".yaml" `List.isSuffixOf` path = readFileYaml path
+    | ".json" `List.isSuffixOf` path = readFileJson path
+    | otherwise = return $ Left (ReadBindingSpecsUnknownExtension path)
+
+-- | Read binding specifications from a JSON file
+readFileJson ::
+     FilePath
+  -> IO (Either ReadBindingSpecsException UnresolvedBindingSpecs)
+readFileJson path = do
+    ees <- Aeson.eitherDecodeFileStrict' path
+    return $ case ees of
+      Right specs -> fromABindingSpecs path specs
+      Left err    -> Left (ReadBindingSpecsAesonError path err)
+
+-- | Read binding specifications from a YAML file
+readFileYaml ::
+     FilePath
+  -> IO (Either ReadBindingSpecsException UnresolvedBindingSpecs)
+readFileYaml path = do
+    eews <- Yaml.decodeFileWithWarnings path
+    return $ case eews of
+      Right ([], specs) -> fromABindingSpecs path specs
+      Right (warnings, _) -> Left (ReadBindingSpecsYamlWarning path warnings)
+      Left err -> Left (ReadBindingSpecsYamlError path err)
+
+-- | Encode binding specifications as JSON
+encodeJson :: UnresolvedBindingSpecs -> BSL.ByteString
+encodeJson = encodeJson' . toABindingSpecs
+
+-- | Encode binding specifications as YAML
+encodeYaml :: UnresolvedBindingSpecs -> BSS.ByteString
+encodeYaml = encodeYaml' . toABindingSpecs
+
+-- | Write binding specifications to a file
+--
+-- The format is determined by the filename extension.
+writeFile ::
+     FilePath
+  -> UnresolvedBindingSpecs
+  -> IO (Either WriteBindingSpecsException ())
+writeFile path specs
+    | ".yaml" `List.isSuffixOf` path = Right <$> writeFileYaml path specs
+    | ".json" `List.isSuffixOf` path = Right <$> writeFileJson path specs
+    | otherwise = return $ Left (WriteBindingSpecsUnknownExtension path)
+
+-- | Write binding specifications to a JSON file
+writeFileJson :: FilePath -> UnresolvedBindingSpecs -> IO ()
+writeFileJson path = BSL.writeFile path . encodeJson' . toABindingSpecs
+
+-- | Write binding specifications to a YAML file
+writeFileYaml :: FilePath -> UnresolvedBindingSpecs -> IO ()
+writeFileYaml path = BSS.writeFile path . encodeYaml' . toABindingSpecs
+
+{-------------------------------------------------------------------------------
+  API: Header resolution
+-------------------------------------------------------------------------------}
+
+-- | Resolve headers in binding specifications
+resolve ::
+     Tracer IO (TraceWithCallStack ExtraClangArgsLog)
+  -> ClangArgs
+  -> UnresolvedBindingSpecs
+  -> IO (Set ResolveHeaderException, ResolvedBindingSpecs)
+resolve tracer args uSpecs = do
+    let types = bindingSpecsTypes uSpecs
+        cPaths = Set.toAscList . mconcat $ fst <$> mconcat (Map.elems types)
+    (errs, headerMap) <- bimap Set.fromList Map.fromList . partitionEithers
+      <$> mapM
+            (\cPath -> fmap (cPath,) <$> resolveHeader' tracer args cPath)
+            cPaths
+    let resolveSet :: Set CHeaderIncludePath -> Set SourcePath
+        resolveSet =
+            Set.fromList
+          . mapMaybe (`Map.lookup` headerMap)
+          . Set.toList
+        resolve1 :: (Set CHeaderIncludePath, a) -> Maybe (Set SourcePath, a)
+        resolve1 (sU, x) = case resolveSet sU of
+          sR
+            | Set.null sR -> Nothing
+            | otherwise   -> Just (sR, x)
+        resolve' :: [(Set CHeaderIncludePath, a)] -> Maybe [(Set SourcePath, a)]
+        resolve' lU = case mapMaybe resolve1 lU of
+          lR
+            | null lR   -> Nothing
+            | otherwise -> Just lR
+        rSpecs = BindingSpecs {
+            bindingSpecsTypes = Map.mapMaybe resolve' types
+          }
+    return (errs, rSpecs)
+
+{-------------------------------------------------------------------------------
+  API: Merging
+-------------------------------------------------------------------------------}
+
+-- | Merge binding specifications
+merge ::
+     [ResolvedBindingSpecs]
+  -> Either MergeBindingSpecsException ResolvedBindingSpecs
+merge = \case
+    []   -> Right empty
+    x:xs -> do
+      bindingSpecsTypes <- mergeTypes Set.empty (bindingSpecsTypes x) $
+        concatMap (Map.toList . bindingSpecsTypes) xs
+      return BindingSpecs{..}
+  where
+    mergeTypes ::
+         Set CNameSpelling
+      -> Map CNameSpelling [(Set SourcePath, a)]
+      -> [(CNameSpelling, [(Set SourcePath, a)])]
+      -> Either
+           MergeBindingSpecsException
+           (Map CNameSpelling [(Set SourcePath, a)])
+    mergeTypes dupSet acc = \case
+      []
+        | Set.null dupSet -> Right acc
+        | otherwise       -> Left $ MergeBindingSpecsConflict dupSet
+      (cname, rs):ps ->
+        case Map.insertLookupWithKey (const (++)) cname rs acc of
+          (Nothing, acc') -> mergeTypes dupSet acc' ps
+          (Just ls, acc') ->
+            let lHeaders = Set.unions $ fst <$> ls
+                rHeaders = Set.unions $ fst <$> rs
+                iHeaders = Set.intersection lHeaders rHeaders
+            in  if Set.null iHeaders
+                  then mergeTypes dupSet acc' ps
+                  else mergeTypes (Set.insert cname dupSet) acc' ps
+
+{-------------------------------------------------------------------------------
+  Auxiliary: Specifications files
+-------------------------------------------------------------------------------}
+
+data AOmittable a = ARequire a | AOmit a
+  deriving stock Show
+
+instance Aeson.FromJSON a => Aeson.FromJSON (AOmittable a) where
+  parseJSON = \case
+    Aeson.Object o | KM.size o == 1 && KM.member "omit" o ->
+      AOmit <$> o .: "omit"
+    v -> ARequire <$> Aeson.parseJSON v
+
+instance Aeson.ToJSON a => Aeson.ToJSON (AOmittable a) where
+  toJSON = \case
+    ARequire x -> Aeson.toJSON x
+    AOmit    x -> Aeson.object ["omit" .= x]
+
+--------------------------------------------------------------------------------
+
+newtype ABindingSpecs = ABindingSpecs {
+      aBindingSpecsTypes :: [AOmittable ATypeMapping]
+    }
+  deriving stock Show
+
+instance Aeson.FromJSON ABindingSpecs where
+  parseJSON = Aeson.withObject "ABindingSpecs" $ \o -> do
+    aBindingSpecsTypes <- o .: "types"
+    return ABindingSpecs{..}
+
+instance Aeson.ToJSON ABindingSpecs where
+  toJSON ABindingSpecs{..} = Aeson.object [
+    "types" .= aBindingSpecsTypes
+    ]
+
+--------------------------------------------------------------------------------
+
+data ATypeMapping = ATypeMapping {
+      aTypeMappingHeaders    :: [CHeaderIncludePath]
+    , aTypeMappingCName      :: CNameSpelling
+    , aTypeMappingModule     :: Maybe HsModuleName
+    , aTypeMappingIdentifier :: Maybe HsIdentifier
+    , aTypeMappingInstances  :: [AOmittable AInstanceMapping]
+    }
+  deriving stock Show
+
+instance Aeson.FromJSON ATypeMapping where
+  parseJSON = Aeson.withObject "ATypeMapping" $ \o -> do
+    aTypeMappingHeaders    <- o .:  "headers" >>= listFromJSON
+    aTypeMappingCName      <- o .:  "cname"
+    aTypeMappingModule     <- o .:? "module"
+    aTypeMappingIdentifier <- o .:? "identifier"
+    aTypeMappingInstances  <- o .:? "instances" .!= []
+    return ATypeMapping{..}
+
+instance Aeson.ToJSON ATypeMapping where
+  toJSON ATypeMapping{..} = objectWithOptionalFields [
+      "headers"    .=! listToJSON aTypeMappingHeaders
+    , "cname"      .=! aTypeMappingCName
+    , "module"     .=? aTypeMappingModule
+    , "identifier" .=? aTypeMappingIdentifier
+    , "instances"  .=? omitWhenNull aTypeMappingInstances
+    ]
+
+--------------------------------------------------------------------------------
+
+data AInstanceMapping = AInstanceMapping {
+      aInstanceMappingClass       :: HsTypeClass
+    , aInstanceMappingStrategy    :: Maybe Strategy
+    , aInstanceMappingConstraints :: [AConstraint]
+    }
+  deriving stock Show
+
+instance Aeson.FromJSON AInstanceMapping where
+  parseJSON = \case
+    s@Aeson.String{} -> do
+      aInstanceMappingClass <- Aeson.parseJSON s
+      let aInstanceMappingStrategy    = Nothing
+          aInstanceMappingConstraints = []
+      return AInstanceMapping{..}
+    Aeson.Object o -> do
+      aInstanceMappingClass       <- o .:  "class"
+      aInstanceMappingStrategy    <- o .:? "strategy"
+      aInstanceMappingConstraints <- o .:? "constraints" .!= []
+      return AInstanceMapping{..}
+    v -> Aeson.parseFail $
+      "expected AInstanceMapping String or Object, but encountered " ++ typeOf v
+
+instance Aeson.ToJSON AInstanceMapping where
+  toJSON AInstanceMapping{..}
+    | isNothing aInstanceMappingStrategy && null aInstanceMappingConstraints =
+        Aeson.toJSON aInstanceMappingClass
+    | otherwise = objectWithOptionalFields [
+          "class"       .=! aInstanceMappingClass
+        , "strategy"    .=? aInstanceMappingStrategy
+        , "constraints" .=? omitWhenNull aInstanceMappingConstraints
+        ]
+
+--------------------------------------------------------------------------------
+
+newtype AConstraint = AConstraint Constraint
+  deriving stock Show
+
+instance Aeson.FromJSON AConstraint where
+  parseJSON = Aeson.withObject "AConstraint" $ \o -> do
+    constraintClass    <- o .: "class"
+    extHsRefModule     <- o .: "module"
+    extHsRefIdentifier <- o .: "identifier"
+    let constraintRef = ExtHsRef{..}
+    return $ AConstraint Constraint{..}
+
+instance Aeson.ToJSON AConstraint where
+  toJSON (AConstraint Constraint{..}) =
+    let ExtHsRef{..} = constraintRef
+    in  Aeson.object [
+            "class"      .= constraintClass
+          , "module"     .= extHsRefModule
+          , "identifier" .= extHsRefIdentifier
+          ]
+
+--------------------------------------------------------------------------------
+
+fromABindingSpecs ::
+     FilePath
+  -> ABindingSpecs
+  -> Either ReadBindingSpecsException UnresolvedBindingSpecs
+fromABindingSpecs path ABindingSpecs{..} = do
+    bindingSpecsTypes <- mkTypeMap aBindingSpecsTypes
+    return BindingSpecs{..}
+  where
+    mkTypeMap ::
+         [AOmittable ATypeMapping]
+      -> Either
+           ReadBindingSpecsException
+           (Map CNameSpelling [(Set CHeaderIncludePath, Omittable Type)])
+    mkTypeMap = mkTypeMapErr . foldr mkTypeMapInsert (Map.empty, Map.empty)
+
+    mkTypeMapErr ::
+         (Map CNameSpelling (Set CHeaderIncludePath), a)
+      -> Either ReadBindingSpecsException a
+    mkTypeMapErr (dupMap, x)
+      | Map.null dupMap = Right x
+      | otherwise = Left . ReadBindingSpecsConflict path $ Set.fromList [
+            (cname, header)
+          | (cname, headers) <- Map.toList dupMap
+          , header <- Set.toList headers
+          ]
+
+    mkTypeMapInsert ::
+         AOmittable ATypeMapping
+      -> ( Map CNameSpelling (Set CHeaderIncludePath)
+         , Map CNameSpelling [(Set CHeaderIncludePath, Omittable Type)]
+         )
+      -> ( Map CNameSpelling (Set CHeaderIncludePath)
+         , Map CNameSpelling [(Set CHeaderIncludePath, Omittable Type)]
+         )
+    mkTypeMapInsert aoTypeMapping (dupMap, accMap) =
+      let (cname, headers, oTypeSpec) = case aoTypeMapping of
+            ARequire ATypeMapping{..} ->
+              let typ = Type {
+                      typeModule     = aTypeMappingModule
+                    , typeIdentifier = aTypeMappingIdentifier
+                    , typeInstances  = mkInstanceMap aTypeMappingInstances
+                    }
+              in  (aTypeMappingCName, aTypeMappingHeaders, Require typ)
+            AOmit ATypeMapping{..} ->
+              (aTypeMappingCName, aTypeMappingHeaders, Omit)
+          newV = [(Set.fromList headers, oTypeSpec)]
+          x = Map.insertLookupWithKey (const (++)) cname newV accMap
+      in  case x of
+            (Nothing,   accMap') -> (dupMap, accMap')
+            (Just oldV, accMap') ->
+              (mkTypeMapDup cname newV oldV dupMap, accMap')
+
+    mkTypeMapDup ::
+         CNameSpelling
+      -> [(Set CHeaderIncludePath, a)]
+      -> [(Set CHeaderIncludePath, a)]
+      -> Map CNameSpelling (Set CHeaderIncludePath)
+      -> Map CNameSpelling (Set CHeaderIncludePath)
+    mkTypeMapDup cname newV oldV dupMap =
+      let commonHeaders =
+            Set.intersection (mconcat (fst <$> newV)) (mconcat (fst <$> oldV))
+      in  if Set.null commonHeaders
+            then dupMap
+            else Map.insertWith Set.union cname commonHeaders dupMap
+
+    -- duplicates ignored, last value retained
+    mkInstanceMap ::
+         [AOmittable AInstanceMapping]
+      -> Map HsTypeClass (Omittable Instance)
+    mkInstanceMap xs = Map.fromList . flip map xs $ \case
+      ARequire AInstanceMapping{..} ->
+        let inst = Instance {
+                instanceStrategy    = aInstanceMappingStrategy
+              , instanceConstraints = [
+                    constr
+                  | AConstraint constr <- aInstanceMappingConstraints
+                  ]
+              }
+        in  (aInstanceMappingClass, Require inst)
+      AOmit AInstanceMapping{..} -> (aInstanceMappingClass, Omit)
+
+toABindingSpecs :: UnresolvedBindingSpecs -> ABindingSpecs
+toABindingSpecs BindingSpecs{..} = ABindingSpecs{..}
+  where
+    aBindingSpecsTypes :: [AOmittable ATypeMapping]
+    aBindingSpecsTypes = [
+        case oType of
+          Require Type{..} -> ARequire ATypeMapping {
+              aTypeMappingHeaders    = Set.toAscList headers
+            , aTypeMappingCName      = cname
+            , aTypeMappingModule     = typeModule
+            , aTypeMappingIdentifier = typeIdentifier
+            , aTypeMappingInstances  = [
+                  case oInst of
+                    Require Instance{..} -> ARequire AInstanceMapping {
+                        aInstanceMappingClass       = clss
+                      , aInstanceMappingStrategy    = instanceStrategy
+                      , aInstanceMappingConstraints =
+                          map AConstraint instanceConstraints
+                      }
+                    Omit -> AOmit AInstanceMapping {
+                        aInstanceMappingClass       = clss
+                      , aInstanceMappingStrategy    = Nothing
+                      , aInstanceMappingConstraints = []
+                      }
+                | (clss, oInst) <- Map.toAscList typeInstances
+                ]
+            }
+          Omit -> AOmit ATypeMapping {
+              aTypeMappingHeaders    = Set.toAscList headers
+            , aTypeMappingCName      = cname
+            , aTypeMappingModule     = Nothing
+            , aTypeMappingIdentifier = Nothing
+            , aTypeMappingInstances  = []
+            }
+      | (cname, xs) <- Map.toAscList bindingSpecsTypes
+      , (headers, oType) <- xs
+      ]
+
+encodeJson' :: ABindingSpecs -> BSL.ByteString
+encodeJson' = Aeson.encode
+
+encodeYaml' :: ABindingSpecs -> BSS.ByteString
+encodeYaml' = Data.Yaml.Pretty.encodePretty yamlConfig
+  where
+    yamlConfig :: Data.Yaml.Pretty.Config
+    yamlConfig =
+          Data.Yaml.Pretty.setConfCompare (compare `on` keyPosition)
+        $ Data.Yaml.Pretty.defConfig
+
+    keyPosition :: Text -> Int
+    keyPosition = \case
+      "omit"        -> 0  -- Omittable:1
+      "types"       -> 1  -- ABindingSpecs:1
+      "class"       -> 2  -- AInstanceMapping:1, AConstraint:1
+      "headers"     -> 3  -- ATypeMapping:1
+      "cname"       -> 4  -- ATypeMapping:2
+      "module"      -> 5  -- ATypeMapping:3, AConstraint:2
+      "identifier"  -> 6  -- ATypeMapping:4, AConstraint:3
+      "instances"   -> 7  -- ATypeMapping:5
+      "strategy"    -> 8  -- AInstanceMapping:2
+      "constraints" -> 9  -- AInstanceMapping:3
+      key -> panicPure $ "Unknown key: " ++ show key
+
+{-------------------------------------------------------------------------------
+  Auxiliary: Aeson helpers
+-------------------------------------------------------------------------------}
+
+-- | Create an object 'Aeson.Value', supporting optional fields
+objectWithOptionalFields :: [Maybe Aeson.Pair] -> Aeson.Value
+objectWithOptionalFields = Aeson.Object . KM.fromList . catMaybes
+
+-- | Construct a required field, for use with 'objectWithOptionalFields'
+(.=!) :: (Aeson.KeyValue e kv, Aeson.ToJSON v) => Aeson.Key -> v -> Maybe kv
+key .=! x = Just (key .= x)
+
+-- | Construct an optional field, for use with 'objectWithOptionalFields'
+(.=?) ::
+     (Aeson.KeyValue e kv, Aeson.ToJSON v)
+  => Aeson.Key
+  -> Maybe v
+  -> Maybe kv
+key .=? mX = (key .=) <$> mX
+
+-- | Omit empty lists, for use with 'objectWithOptionalFields' and '(.=?)'
+omitWhenNull :: [a] -> Maybe [a]
+omitWhenNull xs
+    | null xs   = Nothing
+    | otherwise = Just xs
+
+-- | Convert list to JSON, with special case for the singleton list
+--
+-- This results in format that is somewhat more friendly for human consumption.
+-- It can however not be used for lists-of-lists.
+--
+-- See also 'listFromJSON'.
+listToJSON :: Aeson.ToJSON a => [a] -> Aeson.Value
+listToJSON [x] = Aeson.toJSON x
+listToJSON xs  = Aeson.toJSON xs
+
+-- | Inverse to 'listToJSON'
+listFromJSON :: forall a.
+     (Aeson.FromJSON a, Typeable a)
+  => Aeson.Value
+  -> Aeson.Parser [a]
+listFromJSON value = asum [
+      Aeson.withArray (show (typeRep (Proxy @[a]))) parseList value
+    , parseSingleton
+    ]
+  where
+    parseList :: Aeson.Array -> Aeson.Parser [a]
+    parseList = mapM Aeson.parseJSON . toList
+
+    parseSingleton :: Aeson.Parser [a]
+    parseSingleton = List.singleton <$> Aeson.parseJSON value
+
+-- | 'Aeson.Value' constructor name, for use in error messages
+typeOf :: Aeson.Value -> String
+typeOf = \case
+    Aeson.Object{} -> "Object"
+    Aeson.Array{}  -> "Array"
+    Aeson.String{} -> "String"
+    Aeson.Number{} -> "Number"
+    Aeson.Bool{}   -> "Bool"
+    Aeson.Null     -> "Null"

--- a/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ExtBindings/Gen.hs
@@ -15,6 +15,7 @@ import HsBindgen.ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Imports
+import HsBindgen.Language.Hs
 
 {-------------------------------------------------------------------------------
   API

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST.hs
@@ -31,9 +31,11 @@ module HsBindgen.Frontend.AST (
   ) where
 
 import Clang.HighLevel.Types
+import HsBindgen.BindingSpecs qualified as BindingSpecs
 import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Imports
+import HsBindgen.Language.Hs (ExtHsRef)
 
 {-------------------------------------------------------------------------------
   Declarations
@@ -151,6 +153,7 @@ data Type p =
   | TypePointer (Type p)
   | TypeFunction [Type p] (Type p)
   | TypeVoid
+  | TypeExtBinding ExtHsRef BindingSpecs.Type
 
 data PrimType =
     PrimChar PrimSignChar

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -80,3 +80,4 @@ depsOfType (TypeTypedef uid _ann) = [(ByValue, QualId uid NamespaceTypedef)]
 depsOfType (TypePointer ty)       = first (const ByRef) <$> depsOfType ty
 depsOfType (TypeFunction tys ty)  = concatMap depsOfType tys <> depsOfType ty
 depsOfType TypeVoid               = []
+depsOfType (TypeExtBinding _ _)   = []

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Graph/Includes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Graph/Includes.hs
@@ -10,10 +10,12 @@ module HsBindgen.Frontend.Graph.Includes (
   , empty
   , register
     -- * Query
+  , reaches
   , toSortedList
   ) where
 
 import Data.List qualified as List
+import Data.Set (Set)
 
 import Clang.Paths
 import Data.DynGraph (DynGraph)
@@ -49,6 +51,9 @@ register header incHeader (IncludeGraph graph) =
 {-------------------------------------------------------------------------------
   Query
 -------------------------------------------------------------------------------}
+
+reaches :: IncludeGraph -> SourcePath -> Set SourcePath
+reaches (IncludeGraph graph) = DynGraph.reaches graph
 
 toSortedList :: IncludeGraph -> [SourcePath]
 toSortedList (IncludeGraph graph) =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -266,14 +266,15 @@ processFunction info Function {..} =
 
 processType :: Type Parse -> Type HandleMacros
 processType = \case
-    TypePrim    prim    -> TypePrim prim
-    TypeStruct  uid     -> TypeStruct uid
-    TypeUnion   uid     -> TypeUnion uid
-    TypeEnum    uid     -> TypeEnum uid
-    TypeTypedef uid ann -> TypeTypedef uid ann
-    TypePointer ty      -> TypePointer (processType ty)
-    TypeFunction tys ty -> TypeFunction (map processType tys) (processType ty)
-    TypeVoid            -> TypeVoid
+    TypePrim    prim     -> TypePrim prim
+    TypeStruct  uid      -> TypeStruct uid
+    TypeUnion   uid      -> TypeUnion uid
+    TypeEnum    uid      -> TypeEnum uid
+    TypeTypedef uid ann  -> TypeTypedef uid ann
+    TypePointer ty       -> TypePointer (processType ty)
+    TypeFunction tys ty  -> TypeFunction (map processType tys) (processType ty)
+    TypeVoid             -> TypeVoid
+    TypeExtBinding ref t -> TypeExtBinding ref t
 
 {-------------------------------------------------------------------------------
   Internal: monad used for parsing macros

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/RenameAnon.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/RenameAnon.hs
@@ -73,14 +73,15 @@ squash Decl{declInfo = DeclInfo{declId}, declKind} =
       _otherwise          -> False
   where
     aroundAnon :: Type p -> Bool
-    aroundAnon (TypePrim   _)     = False
-    aroundAnon (TypeStruct uid)   = anonOrSameName uid
-    aroundAnon (TypeUnion uid)    = anonOrSameName uid
-    aroundAnon (TypeEnum uid)     = anonOrSameName uid
-    aroundAnon (TypeTypedef _ _)  = False
-    aroundAnon (TypePointer _)    = False
-    aroundAnon (TypeFunction _ _) = False
-    aroundAnon TypeVoid = False
+    aroundAnon (TypePrim   _)       = False
+    aroundAnon (TypeStruct uid)     = anonOrSameName uid
+    aroundAnon (TypeUnion uid)      = anonOrSameName uid
+    aroundAnon (TypeEnum uid)       = anonOrSameName uid
+    aroundAnon (TypeTypedef _ _)    = False
+    aroundAnon (TypePointer _)      = False
+    aroundAnon (TypeFunction _ _)   = False
+    aroundAnon TypeVoid             = False
+    aroundAnon (TypeExtBinding _ _) = False
 
     anonOrSameName :: DeclId -> Bool
     anonOrSameName (DeclNamed name) =
@@ -168,6 +169,8 @@ instance RenameUseSites Type where
         TypeFunction (map (renameUses du) tys) (renameUses du ty)
       TypeVoid ->
         TypeVoid
+      TypeExtBinding extHsRef typeSpec ->
+        TypeExtBinding extHsRef typeSpec
 
 -- | Rename specific use site
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -1,14 +1,288 @@
 module HsBindgen.Frontend.Pass.ResolveBindingSpecs (
     module HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
   , resolveBindingSpecs
+  , BindingSpecsError(..)
   ) where
 
+import Control.Monad.State
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+
+import Clang.CNameSpelling
+import Clang.HighLevel.Types
+import Clang.Paths
+import HsBindgen.BindingSpecs (ResolvedBindingSpecs)
+import HsBindgen.BindingSpecs qualified as BindingSpecs
 import HsBindgen.Frontend.AST
+import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
+import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
+import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.RenameAnon
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
+import HsBindgen.Imports
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
 
 resolveBindingSpecs ::
-     TranslationUnit RenameAnon
-  -> TranslationUnit ResolveBindingSpecs
-resolveBindingSpecs = undefined
+     ResolvedBindingSpecs -- ^ Configuration binding specifications
+  -> ResolvedBindingSpecs -- ^ External binding specifications
+  -> TranslationUnit RenameAnon
+  -> (TranslationUnit ResolveBindingSpecs, [BindingSpecsError])
+resolveBindingSpecs
+  confSpecs
+  extSpecs
+  TranslationUnit{unitDecls, unitIncludeGraph, unitAnn} =
+    first reassemble . runM $
+      resolveDecls confSpecs extSpecs unitIncludeGraph unitDecls
+  where
+    reassemble ::
+         [Decl ResolveBindingSpecs]
+      -> TranslationUnit ResolveBindingSpecs
+    reassemble decls' = TranslationUnit{
+        unitDecls = decls'
+      , unitIncludeGraph
+      , unitAnn
+      }
 
+data BindingSpecsError =
+    BindingSpecsOmittedTypeUse BindingSpecs.OmittedTypeUseException
+  | BindingSpecsInvalidExtRef  BindingSpecs.GetExtHsRefException
+  deriving stock (Show)
+
+{-------------------------------------------------------------------------------
+  Internal: monad
+-------------------------------------------------------------------------------}
+
+newtype M a = WrapM {
+      unwrapM :: State Ctx a
+    }
+  deriving newtype (Applicative, Functor, Monad, MonadState Ctx)
+
+runM :: M a -> (a, [BindingSpecsError])
+runM = fmap (reverse . ctxErrors) . flip runState initCtx . unwrapM
+
+{-------------------------------------------------------------------------------
+  Internal: state context
+-------------------------------------------------------------------------------}
+
+data Ctx = Ctx {
+      ctxErrors       :: [BindingSpecsError] -- ^ Stored in reverse order
+    , ctxExtTypes     :: Map (QualId RenameAnon) (Type ResolveBindingSpecs)
+    , ctxOmittedTypes :: Set (QualId RenameAnon)
+    }
+
+initCtx :: Ctx
+initCtx = Ctx {
+      ctxErrors       = []
+    , ctxExtTypes     = Map.empty
+    , ctxOmittedTypes = Set.empty
+    }
+
+insertError :: BindingSpecsError -> Ctx -> Ctx
+insertError e ctx = ctx {
+      ctxErrors = e : ctxErrors ctx
+    }
+
+insertExtType :: QualId RenameAnon -> Type ResolveBindingSpecs -> Ctx -> Ctx
+insertExtType qualId typ ctx = ctx {
+      ctxExtTypes = Map.insert qualId typ (ctxExtTypes ctx)
+    }
+
+insertOmittedType :: QualId RenameAnon -> Ctx -> Ctx
+insertOmittedType qualId ctx = ctx {
+      ctxOmittedTypes = Set.insert qualId (ctxOmittedTypes ctx)
+    }
+
+{-------------------------------------------------------------------------------
+  Internal: implementation
+-------------------------------------------------------------------------------}
+
+resolveDecls ::
+     ResolvedBindingSpecs -- ^ Configuration binding specifications
+  -> ResolvedBindingSpecs -- ^ External binding specifications
+  -> IncludeGraph
+  -> [Decl RenameAnon]
+  -> M [Decl ResolveBindingSpecs]
+resolveDecls confSpecs extSpecs includeGraph = mapMaybeM aux
+  where
+    aux :: Decl RenameAnon -> M (Maybe (Decl ResolveBindingSpecs))
+    aux decl = auxExt
+      where
+        qualId :: QualId RenameAnon
+        qualId = declQualId decl
+
+        cname :: CNameSpelling
+        cname = qualIdCNameSpelling qualId
+
+        declPaths :: Set SourcePath
+        declPaths = IncludeGraph.reaches includeGraph $
+          singleLocPath (declLoc (declInfo decl))
+
+        auxExt :: M (Maybe (Decl ResolveBindingSpecs))
+        auxExt = case BindingSpecs.lookupType cname declPaths extSpecs of
+          Just (BindingSpecs.Require typeSpec) ->
+            case BindingSpecs.getExtHsRef cname typeSpec of
+              Right extHsRef -> do
+                let t = TypeExtBinding extHsRef typeSpec
+                modify' $ insertExtType qualId t
+                return Nothing
+              Left e -> do
+                modify' $ insertError (BindingSpecsInvalidExtRef e)
+                auxConf
+          Just BindingSpecs.Omit -> do
+            let e = BindingSpecs.OmittedTypeUse cname
+            modify' $ insertError (BindingSpecsOmittedTypeUse e)
+            auxConf
+          Nothing -> auxConf
+
+        auxConf :: M (Maybe (Decl ResolveBindingSpecs))
+        auxConf = case BindingSpecs.lookupType cname declPaths confSpecs of
+          Just (BindingSpecs.Require typeSpec) ->
+            Just <$> mkDecl decl (Just typeSpec)
+          Just BindingSpecs.Omit -> do
+            modify' $ insertOmittedType qualId
+            return Nothing
+          Nothing -> Just <$> mkDecl decl Nothing
+
+qualIdCNameSpelling :: QualId RenameAnon -> CNameSpelling
+qualIdCNameSpelling (QualId (CName cname) namespace) =
+    let prefix = case namespace of
+          NamespaceTypedef  -> ""
+          NamespaceStruct   -> "struct "
+          NamespaceUnion    -> "union "
+          NamespaceEnum     -> "enum "
+          NamespaceMacro    -> ""
+          NamespaceFunction -> ""
+    in  CNameSpelling $ prefix <> cname
+
+mkDecl ::
+     Decl RenameAnon
+  -> Maybe BindingSpecs.Type
+  -> M (Decl ResolveBindingSpecs)
+mkDecl decl mTypeSpec = reassemble <$> mkDeclKind (declKind decl)
+  where
+    reassemble :: DeclKind ResolveBindingSpecs -> Decl ResolveBindingSpecs
+    reassemble declKind = Decl {
+        declInfo = mkDeclInfo (declInfo decl)
+      , declKind
+      , declAnn = mTypeSpec
+      }
+
+mkDeclInfo :: DeclInfo RenameAnon -> DeclInfo ResolveBindingSpecs
+mkDeclInfo DeclInfo{declLoc, declId} = DeclInfo{declLoc, declId}
+
+mkDeclKind :: DeclKind RenameAnon -> M (DeclKind ResolveBindingSpecs)
+mkDeclKind = \case
+    DeclStruct struct   -> DeclStruct <$> mkStruct struct
+    DeclStructOpaque    -> return DeclStructOpaque
+    DeclUnion union     -> DeclUnion <$> mkUnion union
+    DeclUnionOpaque     -> return DeclUnionOpaque
+    DeclTypedef typedef -> DeclTypedef <$> mkTypedef typedef
+    DeclEnum enumConsts -> return (DeclEnum enumConsts)
+    DeclEnumOpaque      -> return DeclEnumOpaque
+    DeclMacro macro     -> return (DeclMacro macro)
+    DeclFunction fun    -> DeclFunction <$> mkFunction fun
+
+mkStruct :: Struct RenameAnon -> M (Struct ResolveBindingSpecs)
+mkStruct struct = reassemble <$> mapM mkStructField (structFields struct)
+  where
+    reassemble ::
+         [StructField ResolveBindingSpecs]
+      -> Struct ResolveBindingSpecs
+    reassemble structFields = Struct {
+        structSizeof = structSizeof struct
+      , structAlignment = structAlignment struct
+      , structFields
+      }
+
+mkStructField :: StructField RenameAnon -> M (StructField ResolveBindingSpecs)
+mkStructField field = reassemble <$> mkType (structFieldType field)
+  where
+    reassemble :: Type ResolveBindingSpecs -> StructField ResolveBindingSpecs
+    reassemble structFieldType = StructField {
+        structFieldName = structFieldName field
+      , structFieldType
+      , structFieldOffset = structFieldOffset field
+      , structFieldAnn = structFieldAnn field
+      }
+
+mkUnion :: Union RenameAnon -> M (Union ResolveBindingSpecs)
+mkUnion union = reassemble <$> mapM mkUnionField (unionFields union)
+  where
+    reassemble :: [UnionField ResolveBindingSpecs] -> Union ResolveBindingSpecs
+    reassemble unionFields = Union {
+        unionSizeof = unionSizeof union
+      , unionAlignment = unionAlignment union
+      , unionFields
+      }
+
+mkUnionField :: UnionField RenameAnon -> M (UnionField ResolveBindingSpecs)
+mkUnionField field = reassemble <$> mkType (unionFieldType field)
+  where
+    reassemble :: Type ResolveBindingSpecs -> UnionField ResolveBindingSpecs
+    reassemble unionFieldType = UnionField {
+        unionFieldName = unionFieldName field
+      , unionFieldType
+      , unionFieldAnn = unionFieldAnn field
+      }
+
+mkTypedef :: Typedef RenameAnon -> M (Typedef ResolveBindingSpecs)
+mkTypedef typedef = reassemble <$> mkType (typedefType typedef)
+  where
+    reassemble :: Type ResolveBindingSpecs -> Typedef ResolveBindingSpecs
+    reassemble typedefType = Typedef {
+        typedefType
+      , typedefAnn = typedefAnn typedef
+      }
+
+mkFunction :: Function RenameAnon -> M (Function ResolveBindingSpecs)
+mkFunction fun = do
+    functionArgs <- mapM mkType (functionArgs fun)
+    functionRes <- mkType (functionRes fun)
+    return Function {
+        functionName = functionName fun
+      , functionArgs
+      , functionRes
+      , functionAnn = functionAnn fun
+      }
+
+mkType :: Type RenameAnon -> M (Type ResolveBindingSpecs)
+mkType = \case
+    TypePrim t -> return (TypePrim t)
+    TypeStruct uid -> aux TypeStruct uid NamespaceStruct
+    TypeUnion uid -> aux TypeUnion uid NamespaceUnion
+    TypeEnum uid -> aux TypeEnum uid NamespaceEnum
+    TypeTypedef uid ann -> aux (`TypeTypedef` ann) uid NamespaceTypedef
+    TypePointer t -> TypePointer <$> mkType t
+    TypeFunction args res -> TypeFunction <$> mapM mkType args <*> mkType res
+    TypeVoid -> return TypeVoid
+    TypeExtBinding extHsRef typeSpec ->
+      return (TypeExtBinding extHsRef typeSpec)
+  where
+    aux ::
+         (Id ResolveBindingSpecs -> Type ResolveBindingSpecs)
+      -> Id RenameAnon
+      -> Namespace
+      -> M (Type ResolveBindingSpecs)
+    aux mk uid namespace = do
+      let qualId = QualId uid namespace
+          cname  = qualIdCNameSpelling qualId
+      isOmitted <- gets $ Set.member qualId . ctxOmittedTypes
+      when isOmitted $
+        let e = BindingSpecs.OmittedTypeUse cname
+        in  modify' $ insertError (BindingSpecsOmittedTypeUse e)
+      gets $ fromMaybe (mk uid) . Map.lookup qualId . ctxExtTypes
+
+{-------------------------------------------------------------------------------
+  Internal: auxiliary functions
+-------------------------------------------------------------------------------}
+
+mapMaybeM :: forall a b m. Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM f = foldr aux (pure [])
+  where
+    aux :: a -> m [b] -> m [b]
+    aux x doRest = f x >>= \case
+      Just y  -> (y :) <$> doRest
+      Nothing -> doRest

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -2,9 +2,12 @@ module HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass (
     ResolveBindingSpecs
   ) where
 
-import HsBindgen.Frontend.AST
+import HsBindgen.BindingSpecs qualified as BindingSpecs
 import HsBindgen.Frontend.Pass
+import HsBindgen.Frontend.Pass.HandleMacros.IsPass
+import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.RenameAnon
+import HsBindgen.Frontend.Graph.UseDef (UseDefGraph)
 
 {-------------------------------------------------------------------------------
   Definition
@@ -21,8 +24,13 @@ import HsBindgen.Frontend.Pass.RenameAnon
 type ResolveBindingSpecs :: Pass
 data ResolveBindingSpecs a
 
+type family AnnResolveBindingSpecs ix where
+  AnnResolveBindingSpecs "Decl"            = Maybe BindingSpecs.Type
+  AnnResolveBindingSpecs "TranslationUnit" = UseDefGraph Parse
+  AnnResolveBindingSpecs "TypeTypedef"     = SquashedTypedef
+  AnnResolveBindingSpecs _                 = NoAnn
+
 instance IsPass ResolveBindingSpecs where
-
--- instance ShowPass ResolveBindingSpecs
-
-
+  type Id     ResolveBindingSpecs = CName
+  type Macro  ResolveBindingSpecs = CheckedMacro
+  type Ann ix ResolveBindingSpecs = AnnResolveBindingSpecs ix

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST.hs
@@ -64,8 +64,8 @@ import Data.Type.Nat qualified as Nat
 import HsBindgen.C.AST qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro
 
-import HsBindgen.ExtBindings (HsTypeClass(..))
 import HsBindgen.Imports
+import HsBindgen.Language.Hs (HsTypeClass(..))
 import HsBindgen.NameHint
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -37,13 +37,13 @@ import HsBindgen.C.AST qualified as C
 import HsBindgen.C.AST.Type qualified as C
 import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Errors
-import HsBindgen.ExtBindings (HsTypeClass)
 import HsBindgen.ExtBindings qualified as ExtBindings
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Hs.NameMangler
 import HsBindgen.Imports
+import HsBindgen.Language.Hs (HsTypeClass)
 import HsBindgen.ModuleUnique
 import HsBindgen.NameHint
 

--- a/hs-bindgen/src-internal/HsBindgen/Language/Hs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/Hs.hs
@@ -1,7 +1,9 @@
 -- | General Haskell language types
 module HsBindgen.Language.Hs (
     -- * References
-    HsModuleName(..)
+    HsRef(..)
+  , ExtHsRef(..)
+  , HsModuleName(..)
   , HsIdentifier(..)
     -- * Instances
   , HsTypeClass(..)
@@ -17,6 +19,22 @@ import HsBindgen.Imports
 {-------------------------------------------------------------------------------
   References
 -------------------------------------------------------------------------------}
+
+-- | Haskell reference
+data HsRef =
+    -- | Reference to an identifier in the local scope
+    HsRefLocal HsIdentifier
+
+  | -- | Reference to an identifier in a different module
+    HsRefExt ExtHsRef
+  deriving stock (Eq, Show)
+
+-- | External Haskell reference
+data ExtHsRef = ExtHsRef {
+      extHsRefModule     :: HsModuleName
+    , extHsRefIdentifier :: HsIdentifier
+    }
+  deriving stock (Eq, Show)
 
 -- | Haskell module name
 --

--- a/hs-bindgen/src-internal/HsBindgen/Language/Hs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/Hs.hs
@@ -1,0 +1,82 @@
+-- | General Haskell language types
+module HsBindgen.Language.Hs (
+    -- * References
+    HsModuleName(..)
+  , HsIdentifier(..)
+    -- * Instances
+  , HsTypeClass(..)
+  ) where
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
+import Data.Text qualified as Text
+import Text.Read (readMaybe)
+
+import HsBindgen.Imports
+
+{-------------------------------------------------------------------------------
+  References
+-------------------------------------------------------------------------------}
+
+-- | Haskell module name
+--
+-- Example: @HsBindgen.Runtime.LibC@
+newtype HsModuleName = HsModuleName { getHsModuleName :: Text }
+  deriving stock (Generic)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, IsString, Ord, Show)
+
+-- | Haskell identifier
+--
+-- Example: @CTm@
+--
+-- This type is different from 'HsBindgen.Hs.AST.HsName' in that it does not
+-- specify a 'HsBindgen.Hs.AST.Namespace'.
+newtype HsIdentifier = HsIdentifier { getHsIdentifier :: Text }
+  deriving stock (Generic)
+  -- 'Show' instance valid due to 'IsString' instance
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, Eq, IsString, Ord, Show)
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+-- | Type class
+data HsTypeClass =
+    -- Haskell98 derivable classes
+    -- <https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/deriving.html>
+    Eq
+  | Ord
+  | Enum
+  | Ix
+  | Bounded
+  | Read
+  | Show
+
+    -- Classes we can only derive through newtype deriving
+  | Bits
+  | FiniteBits
+  | Floating
+  | Fractional
+  | Integral
+  | Num
+  | Real
+  | RealFloat
+  | RealFrac
+
+    -- Classes we can generate when all components have instances
+  | StaticSize
+  | ReadRaw
+  | WriteRaw
+  | Storable
+  deriving stock (Eq, Generic, Ord, Read, Show)
+
+instance Aeson.FromJSON HsTypeClass where
+  parseJSON = Aeson.withText "HsTypeClass" $ \t ->
+    let s = Text.unpack t
+    in  case readMaybe s of
+          Just clss -> return clss
+          Nothing   -> Aeson.parseFail $ "unknown type class: " ++ s
+
+instance Aeson.ToJSON HsTypeClass where
+  toJSON = Aeson.String . Text.pack . show

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -60,6 +60,7 @@ import HsBindgen.Hs.NameMangler qualified as NameMangler
 import HsBindgen.Hs.NameMangler.DSL qualified as NameMangler.DSL
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports
+import HsBindgen.Language.Hs
 import HsBindgen.ModuleUnique
 import HsBindgen.SHs.AST qualified as SHs
 import HsBindgen.SHs.Translation qualified as SHs

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -12,11 +12,11 @@ import Data.Vec.Lazy qualified as Vec
 
 import HsBindgen.C.AST qualified as C (MFun(..))
 import HsBindgen.C.Tc.Macro qualified as Macro hiding ( IntegralType )
-import HsBindgen.ExtBindings (HsTypeClass)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.AST.Name
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Imports
+import HsBindgen.Language.Hs (HsTypeClass)
 import HsBindgen.NameHint
 import HsBindgen.SHs.AST
 import HsBindgen.Errors


### PR DESCRIPTION
Configuration ("input") binding specifications are processed, and matching type specifications are put in `Decl` annotations.

External binding specifications are processed.  Matching types are replaced with external references.

This is a WIP, however, as it has had little testing.  I know that it does not handle aliases correctly yet.  As discussed, we will fix this by changing the AST as well as adding "origin" information to `CName`.  There are likely other issues that we will discover and resolve once we get the `Frontend` integrated with the rest of the system.

@edsko Please feel free to refactor as needed without worrying about stepping on my toes.