### PR TITLE
Resolve and track main headers

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
@@ -164,7 +164,7 @@ parseCHeaders tracer args predicate _extSpec headerIncludePaths =
         SourcePath <$> (clang_getFileName <=< clang_getIncludedFile) cursor
       includePath <- maybe (panicIO "root header unknown include") return $
         headerIncludePaths !? (singleLocLine sloc - 1)
-      return $ Break (Just (sourcePath, includePath))
+      return $ Continue (Just (sourcePath, includePath))
 
 {-------------------------------------------------------------------------------
   Debugging/development


### PR DESCRIPTION
It is surprising how much pain the lack of a `libclang` header resolution API causes.

In the old implementation, the current main header is stored in the state as as `Maybe (CHeaderIncludePath, SourcePath)`.  The `CHeaderIncludePath` is needed for including functions, and the `SourcePath` is needed for the `SelectFromMainFiles` predicate.  I thought we would process one main header at a time, but Edsko pointed out an edge case yesterday: when a user specifies `a.h` and `b.h`, where `a.h` includes `b.h`.  This is indeed problematic because `b.h` is processed before it is included from the root header, breaking `SelectFromMainFiles`.  We need to resolve headers before parsing; we cannot do it as we go like in the old implementation.

Resolving headers is unfortunately expensive, because we get `libclang` to parse them in order to get resolved paths from the include directives.  I had an idea, though: we can use the same translation unit to resolve the main headers and then parse, which should not result in much overhead.  It works!  We still see inclusion directives when folding the second time.

The refactored code did not include enough information to check the `SelectFromMainFiles` predicate.  It attempted to transform a `CHeaderIncludePath` to a `SourcePath`, which does not work since headers must be resolved by Clang.  This explains the path comparison trouble as well as why we got no output.  I resolved this by storing the resolved paths in the parse environment: `envMainHeaders :: Map SourcePath CHeaderIncludePath`.

Another major issue was that the refactored code checked the predicate before inclusion directives were processed.  This does not work, as it results in an incorrect include graph.  We must process all inclusion directives regardless of predicate match.  I implemented a minimal fix, but please feel free to refactor to make it pretty.

By the way, when main file `a.h` includes main file `b.h`, the functions are now associated with the header in which they are declared, not the one that was included by the root header.  That minor issue is resolved. :tada:

One more note is that the `UseDef` function `annSortKey` has an error message that is misleading.  Perhaps we should `show` information about the declaration, not its source location.