### PR TITLE
Rename `Graph.*` to `Analysis.*`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -95,15 +95,15 @@ library internal
       HsBindgen.Eff
       HsBindgen.Errors
       HsBindgen.Frontend
+      HsBindgen.Frontend.Analysis.DeclUseGraph
+      HsBindgen.Frontend.Analysis.IncludeGraph
+      HsBindgen.Frontend.Analysis.UseDeclGraph
       HsBindgen.Frontend.AST.Coerce
       HsBindgen.Frontend.AST.Deps
       HsBindgen.Frontend.AST.External
       HsBindgen.Frontend.AST.Finalize
       HsBindgen.Frontend.AST.Internal
       HsBindgen.Frontend.AST.PrettyPrinter
-      HsBindgen.Frontend.Graph.DeclUse
-      HsBindgen.Frontend.Graph.Includes
-      HsBindgen.Frontend.Graph.UseDecl
       HsBindgen.Frontend.Macros.AST.C
       HsBindgen.Frontend.Macros.AST.Syntax
       HsBindgen.Frontend.NonSelectedDecls

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
@@ -1,9 +1,9 @@
 -- | Construct the final (external) form of the AST
 module HsBindgen.Frontend.AST.Finalize (finalize) where
 
+import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.AST.External qualified as Ext
 import HsBindgen.Frontend.AST.Internal qualified as Int
-import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.Rename.IsPass qualified as Int

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -39,7 +39,7 @@ import Clang.HighLevel.Types
 import Clang.Paths
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Tc.Macro.Type qualified as Macro
-import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.Macros.AST.Syntax qualified as Macro
 import HsBindgen.Frontend.Pass
 import HsBindgen.Imports

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
@@ -2,9 +2,9 @@
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Frontend.Graph.DeclUse (DeclUseGraph)
--- > import HsBindgen.Frontend.Graph.DeclUse qualified as DeclUseGraph
-module HsBindgen.Frontend.Graph.DeclUse (
+-- > import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph)
+-- > import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
+module HsBindgen.Frontend.Analysis.DeclUseGraph (
     -- * Definition
     DeclUseGraph(..)
     -- * Construction
@@ -20,9 +20,9 @@ import Control.Monad.State
 
 import Data.DynGraph.Labelled qualified as DynGraph
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis.UseDeclGraph (Usage (..), UseDeclGraph (..))
+import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.UseDecl (Usage (..), UseDeclGraph (..))
-import HsBindgen.Frontend.Graph.UseDecl qualified as UseDeclGraph
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.Language.C

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
@@ -2,9 +2,9 @@
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
--- > import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
-module HsBindgen.Frontend.Graph.Includes (
+-- > import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
+-- > import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
+module HsBindgen.Frontend.Analysis.IncludeGraph (
     IncludeGraph(..)
     -- * Construction
   , empty

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
@@ -2,9 +2,9 @@
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph, Usage)
--- > import HsBindgen.Frontend.Graph.UseDecl qualified as UseDeclGraph
-module HsBindgen.Frontend.Graph.UseDecl (
+-- > import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph, Usage)
+-- > import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
+module HsBindgen.Frontend.Analysis.UseDeclGraph (
     -- * Definition
     UseDeclGraph(..)
   , Usage(..)
@@ -30,10 +30,10 @@ import Clang.Paths
 import Data.DynGraph.Labelled (DynGraph)
 import Data.DynGraph.Labelled qualified as DynGraph
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
+import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.AST.Deps
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
-import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -2,8 +2,8 @@ module HsBindgen.Frontend.Pass.HandleMacros.IsPass (
     HandleMacros
   ) where
 
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
 import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.IsPass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -9,8 +9,8 @@ module HsBindgen.Frontend.Pass.MangleNames.IsPass (
   ) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Rename.IsPass
 import HsBindgen.Imports

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
@@ -7,8 +7,8 @@ import Clang.HighLevel qualified as HighLevel
 import Clang.LowLevel.Core
 
 import HsBindgen.C.Predicate (IsMainFile, Predicate)
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
 import HsBindgen.Frontend.Pass.Parse.Decl
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.Parse.Monad

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename.hs
@@ -1,13 +1,13 @@
 module HsBindgen.Frontend.Pass.Rename (rename) where
 
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph (..), UseOfDecl (..))
+import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
+import HsBindgen.Frontend.Analysis.UseDeclGraph (Usage (..), ValOrRef (..))
+import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDecl
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Internal
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.DeclUse (DeclUseGraph (..), UseOfDecl (..))
-import HsBindgen.Frontend.Graph.DeclUse qualified as DeclUseGraph
-import HsBindgen.Frontend.Graph.UseDecl (Usage (..), ValOrRef (..))
-import HsBindgen.Frontend.Graph.UseDecl qualified as UseDecl
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename/IsPass.hs
@@ -3,9 +3,9 @@ module HsBindgen.Frontend.Pass.Rename.IsPass (
   , RenamedTypedefRef(..)
   ) where
 
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (ValidPass)
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
 import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Imports

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
@@ -15,9 +15,9 @@ import Clang.HighLevel.Types
 import HsBindgen.BindingSpec (ResolvedBindingSpec)
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
+import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
-import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
 import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.NonSelectedDecls qualified as NonSelectedDecls
 import HsBindgen.Frontend.Pass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
@@ -3,8 +3,8 @@ module HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass (
   ) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Rename.IsPass
 import HsBindgen.Language.C

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort.hs
@@ -1,9 +1,9 @@
 module HsBindgen.Frontend.Pass.Sort (sortDecls) where
 
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
+import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
-import HsBindgen.Frontend.Graph.UseDecl qualified as UseDeclGraph
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.Sort.IsPass
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort/IsPass.hs
@@ -1,7 +1,7 @@
 module HsBindgen.Frontend.Pass.Sort.IsPass (Sort) where
 
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (ValidPass)
-import HsBindgen.Frontend.Graph.UseDecl (UseDeclGraph)
 import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.IsPass (Parse)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/ProcessIncludes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/ProcessIncludes.hs
@@ -12,8 +12,8 @@ import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 import Clang.Paths
 import HsBindgen.C.Predicate (IsMainFile)
-import HsBindgen.Frontend.Graph.Includes (IncludeGraph)
-import HsBindgen.Frontend.Graph.Includes qualified as IncludeGraph
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
+import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.RootHeader (RootHeader)
 import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Frontend.Util.Fold


### PR DESCRIPTION
This is a preparatory step for pulling out the `DeclIndex` from the `UseDeclGraph`.