### PR TITLE
Pull `DeclIndex` out from `UseDeclGraph`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -95,6 +95,7 @@ library internal
       HsBindgen.Eff
       HsBindgen.Errors
       HsBindgen.Frontend
+      HsBindgen.Frontend.Analysis.DeclIndex
       HsBindgen.Frontend.Analysis.DeclUseGraph
       HsBindgen.Frontend.Analysis.IncludeGraph
       HsBindgen.Frontend.Analysis.UseDeclGraph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -1,0 +1,69 @@
+-- | Declaration index
+--
+-- Intended for qualified import.
+--
+-- > import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
+-- > import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
+module HsBindgen.Frontend.Analysis.DeclIndex (
+    DeclIndex -- opaque
+    -- * Construction
+  , fromDecls
+    -- * Query
+  , lookup
+  , (!)
+  ) where
+
+import Prelude hiding (lookup)
+
+import Data.Map.Strict qualified as Map
+
+import HsBindgen.Errors
+import HsBindgen.Frontend.AST.Internal qualified as C
+import HsBindgen.Frontend.Pass.Parse.IsPass
+import HsBindgen.Imports
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Index of all declarations we have parsed
+--
+-- This excludes declarations that were not excluded by the selection predicate.
+newtype DeclIndex = Wrap {
+      unwrap :: Map (C.QualId Parse) (C.Decl Parse)
+    }
+  deriving stock (Show, Eq)
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+fromDecls :: HasCallStack => [C.Decl Parse] -> DeclIndex
+fromDecls decls = Wrap $
+    Map.fromListWith aux $ map (\d -> (C.declQualId d, d)) decls
+  where
+    -- Some declarations can be repeated, but if so, they must be essentially
+    -- the same. For example, this is valid C, which declares the same struct
+    -- "foo" twice:
+    --
+    -- > struct foo;
+    -- > struct foo;
+    aux :: C.Decl Parse -> C.Decl Parse -> C.Decl Parse
+    aux new old
+      | C.declKind old == C.declKind new
+      = old
+
+      | otherwise
+      = panicPure $ "duplicate declaration for " ++ show (C.declQualId new)
+
+{-------------------------------------------------------------------------------
+  Query
+-------------------------------------------------------------------------------}
+
+lookup :: C.QualId Parse -> DeclIndex -> Maybe (C.Decl Parse)
+lookup uid = Map.lookup uid . unwrap
+
+(!) :: HasCallStack => DeclIndex -> C.QualId Parse -> C.Decl Parse
+(!) ud uid =
+    fromMaybe (panicPure $ "Unknown key: " ++ show uid) $
+       lookup uid ud

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -2,11 +2,10 @@ module HsBindgen.Frontend.Pass.HandleMacros.IsPass (
     HandleMacros
   ) where
 
-import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
-import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.IsPass
+import HsBindgen.Frontend.Pass.Sort.IsPass (DeclMeta)
 import HsBindgen.Imports
 import HsBindgen.Language.C
 
@@ -19,7 +18,7 @@ data HandleMacros a deriving anyclass ValidPass
 
 -- We do not need the @ReparseInfo@ anymore, so we drop it from the annotations.
 type family AnnHandleMacros (ix :: Symbol) :: Star where
-  AnnHandleMacros "TranslationUnit" = (UseDeclGraph, NonSelectedDecls)
+  AnnHandleMacros "TranslationUnit" = DeclMeta
   AnnHandleMacros _                 = NoAnn
 
 instance IsPass HandleMacros where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -9,10 +9,10 @@ module HsBindgen.Frontend.Pass.MangleNames.IsPass (
   ) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Rename.IsPass
+import HsBindgen.Frontend.Pass.Sort.IsPass
 import HsBindgen.Imports
 import HsBindgen.Language.C
 import HsBindgen.Language.Haskell
@@ -30,7 +30,7 @@ data NameMangler a deriving anyclass (ValidPass)
 
 type family AnnNameMangler ix where
   AnnNameMangler "Decl"             = DeclSpec
-  AnnNameMangler "TranslationUnit"  = UseDeclGraph
+  AnnNameMangler "TranslationUnit"  = DeclMeta
   AnnNameMangler "Struct"           = RecordNames
   AnnNameMangler "Union"            = NewtypeNames
   AnnNameMangler "Enum"             = NewtypeNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename/IsPass.hs
@@ -3,11 +3,10 @@ module HsBindgen.Frontend.Pass.Rename.IsPass (
   , RenamedTypedefRef(..)
   ) where
 
-import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (ValidPass)
 import HsBindgen.Frontend.AST.Internal qualified as C
-import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
+import HsBindgen.Frontend.Pass.Sort.IsPass (DeclMeta)
 import HsBindgen.Imports
 import HsBindgen.Language.C
 
@@ -19,7 +18,7 @@ type RenameAnon :: Pass
 data RenameAnon a deriving anyclass ValidPass
 
 type family AnnRenameAnon ix where
-  AnnRenameAnon "TranslationUnit" = (UseDeclGraph, NonSelectedDecls)
+  AnnRenameAnon "TranslationUnit" = DeclMeta
   AnnRenameAnon _                 = NoAnn
 
 instance IsPass RenameAnon where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
@@ -23,6 +23,7 @@ import HsBindgen.Frontend.NonSelectedDecls qualified as NonSelectedDecls
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Rename.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass
+import HsBindgen.Frontend.Pass.Sort.IsPass
 import HsBindgen.Imports
 import HsBindgen.Language.C (CName(..))
 import HsBindgen.Language.C qualified as C
@@ -42,7 +43,7 @@ resolveBindingSpec
   extSpec
   C.TranslationUnit{unitDecls, unitIncludeGraph, unitAnn} =
     let (decls, MState{..}) =
-          runM confSpec extSpec unitIncludeGraph (snd unitAnn) $
+          runM confSpec extSpec unitIncludeGraph (declNonSelected unitAnn) $
             resolveDecls unitDecls
         notUsedErrs = BindingSpecTypeNotUsed <$> Set.toAscList stateNoConfTypes
     in  (reassemble decls, reverse stateErrors ++ notUsedErrs)
@@ -52,8 +53,7 @@ resolveBindingSpec
       -> C.TranslationUnit ResolveBindingSpec
     reassemble decls' = C.TranslationUnit{
         unitDecls = decls'
-      , unitIncludeGraph
-      , unitAnn = fst unitAnn
+      , ..
       }
 
 data BindingSpecError =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
@@ -3,10 +3,10 @@ module HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass (
   ) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Rename.IsPass
+import HsBindgen.Frontend.Pass.Sort.IsPass (DeclMeta)
 import HsBindgen.Language.C
 
 {-------------------------------------------------------------------------------
@@ -24,11 +24,9 @@ import HsBindgen.Language.C
 type ResolveBindingSpec :: Pass
 data ResolveBindingSpec a deriving anyclass (ValidPass)
 
--- We do not need the @SourceMap@ anymore, so we drop it from the annotation on
--- @TranslationUnit@.
 type family AnnResolveBindingSpec ix where
   AnnResolveBindingSpec "Decl"            = BindingSpec.TypeSpec
-  AnnResolveBindingSpec "TranslationUnit" = UseDeclGraph
+  AnnResolveBindingSpec "TranslationUnit" = DeclMeta
   AnnResolveBindingSpec _                 = NoAnn
 
 instance IsPass ResolveBindingSpec where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Sort/IsPass.hs
@@ -1,4 +1,7 @@
-module HsBindgen.Frontend.Pass.Sort.IsPass (Sort) where
+module HsBindgen.Frontend.Pass.Sort.IsPass (
+    Sort
+  , DeclMeta(..)
+  ) where
 
 import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Internal (ValidPass)
@@ -6,6 +9,7 @@ import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.IsPass (Parse)
 import HsBindgen.Imports
+import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 
 {-------------------------------------------------------------------------------
   Definition
@@ -18,7 +22,7 @@ type Sort :: Pass
 data Sort a deriving anyclass ValidPass
 
 type family AnalyzeAnn (ix :: Symbol) :: Star where
-  AnalyzeAnn "TranslationUnit" = (UseDeclGraph, NonSelectedDecls)
+  AnalyzeAnn "TranslationUnit" = DeclMeta
   AnalyzeAnn ix                = Ann ix Parse
 
 instance IsPass Sort where
@@ -27,3 +31,14 @@ instance IsPass Sort where
   type TypedefRef Sort = TypedefRef Parse
   type MacroBody  Sort = MacroBody  Parse
   type Ann ix     Sort = AnalyzeAnn ix
+
+{-------------------------------------------------------------------------------
+  Information about the declarations
+-------------------------------------------------------------------------------}
+
+data DeclMeta = DeclMeta {
+      declIndex       :: DeclIndex
+    , declUsage       :: UseDeclGraph
+    , declNonSelected :: NonSelectedDecls
+    }
+  deriving stock (Show, Eq)


### PR DESCRIPTION
This gets us a step closer to changing `DeclUseGraph`.

@TravisCardwell We now introduce a `DeclMeta` in the `Sort` pass:

```hs
data DeclMeta = DeclMeta {
      declIndex       :: DeclIndex
    , declUsage       :: UseDeclGraph
    , declNonSelected :: NonSelectedDecls
    }
```

and we just keep this `DeclMeta` around. Previously we were dropping the `NonSelectedDecls` after resolving external binding specs, but now we keep them until we generate `Hs` declarations. I don't think this is a huge deal, but if you think otherwise, we can reconsider. One benefit is that we can now refer to `declNonSelected` instead of `snd` etc., more descriptive.