### PR TITLE
Refer to `DynGraph` directly from `DeclUseGraph`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
@@ -6,7 +6,8 @@
 -- > import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 module HsBindgen.Frontend.Analysis.UseDeclGraph (
     -- * Definition
-    UseDeclGraph(..) -- TODO: should be opaque
+    UseDeclGraph -- opaque
+  , toDynGraph
   , Usage(..)
   , ValOrRef(..)
     -- * Construction
@@ -48,6 +49,9 @@ newtype UseDeclGraph = Wrap {
       unwrap :: DynGraph Usage (C.QualId Parse)
     }
   deriving stock (Show, Eq)
+
+toDynGraph :: UseDeclGraph -> DynGraph Usage (C.QualId Parse)
+toDynGraph = unwrap
 
 {-------------------------------------------------------------------------------
   Construction

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Rename.hs
@@ -5,7 +5,7 @@ import Prelude hiding (lookup)
 import HsBindgen.Errors
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
-import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph (..), UseOfDecl (..))
+import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph, UseOfDecl (..))
 import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph (Usage (..), ValOrRef (..))
 import HsBindgen.Frontend.AST.Coerce


### PR DESCRIPTION
We previously were wrapping a `UseDeclGraph`, but with the edges reversed -- which isn't a `UseDeclGraph` at all! To avoid confusion, we now use the underlying `DynGraph` directly. This should also make @dschrempf happier :)