### PR TITLE
Better error when we encounter unknown kind

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/C/Predicate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Predicate.hs
@@ -70,6 +70,9 @@ data SkipReason =
       , skippedLoc    :: SingleLoc
       , skippedReason :: Text
       }
+  | SkipUnexposed {
+        skippedLoc :: SingleLoc
+      }
   deriving stock (Show, Eq)
 
 instance PrettyTrace SkipReason where
@@ -86,11 +89,16 @@ instance PrettyTrace SkipReason where
         , ": "
         , skippedReason
         ]
+      SkipUnexposed{skippedLoc} -> concat [
+          "Skipped unexposed declaration at "
+        , show skippedLoc
+        ]
 
 instance HasDefaultLogLevel SkipReason where
   getDefaultLogLevel = \case
       SkipBuiltin{}   -> Debug
       SkipPredicate{} -> Info
+      SkipUnexposed{} -> Warning
 
 {-------------------------------------------------------------------------------
   Matching

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
@@ -17,8 +17,6 @@ import HsBindgen.Language.C
 
 {-------------------------------------------------------------------------------
   Top-level
-
-  TODO: This needs entries for const and incomplete arrays.
 -------------------------------------------------------------------------------}
 
 fromCXType :: HasCallStack => CXType -> M (C.Type Parse)
@@ -44,18 +42,16 @@ fromCXType ty =
       CXType_Attributed      -> attributed
       CXType_ConstantArray   -> constantArray
       CXType_Elaborated      -> elaborated
+      CXType_Enum            -> fromDecl
       CXType_FunctionNoProto -> function
       CXType_FunctionProto   -> function
       CXType_IncompleteArray -> incompleteArray
       CXType_Pointer         -> pointer
+      CXType_Record          -> fromDecl
+      CXType_Typedef         -> fromDecl
+      CXType_Void            -> const (pure C.TypeVoid)
 
-      CXType_Enum          -> fromDecl
-      CXType_Record        -> fromDecl
-      CXType_Typedef       -> fromDecl
-
-      CXType_Void          -> const (pure C.TypeVoid)
-
-      kind -> \_ -> panicIO $ "fromCXType: " ++ show kind
+      kind -> unknownTypeKind kind
 
 {-------------------------------------------------------------------------------
   Functions for each kind of type
@@ -79,7 +75,7 @@ fromDecl ty = do
       CXCursor_StructDecl  -> return $ C.TypeStruct  declId
       CXCursor_UnionDecl   -> return $ C.TypeUnion   declId
       CXCursor_TypedefDecl -> return $ C.TypeTypedef (typedefName declId)
-      kind -> panicIO $ "fromDecl: " ++ show kind
+      kind                 -> unknownCursorKind kind decl
   where
     typedefName :: DeclId -> CName
     typedefName (DeclNamed name) = name

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Util/Fold.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Util/Fold.hs
@@ -2,6 +2,9 @@ module HsBindgen.Frontend.Util.Fold (
     -- * Writing folds
     Dispatch(..)
   , dispatchWithArg
+    -- * Errors
+  , unknownCursorKind
+  , unknownTypeKind
     -- * Debugging
   , showNode
   ) where
@@ -14,6 +17,8 @@ import Clang.HighLevel qualified as HighLevel
 import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 import HsBindgen.Errors
+import HsBindgen.Imports
+import Data.Text qualified as Text
 
 {-------------------------------------------------------------------------------
   Writing folds
@@ -30,20 +35,59 @@ dispatchWithArg x f = dispatch x $ \kind -> f kind x
 instance Dispatch CXCursor where
   type Kind CXCursor = CXCursorKind
 
-  dispatch x f = do
-      mKind <- fromSimpleEnum <$> clang_getCursorKind x
+  dispatch curr k = do
+      mKind <- fromSimpleEnum <$> clang_getCursorKind curr
       case mKind of
-        Right kind   -> f kind
-        Left unknown -> panicIO $ "Unrecognized CXCursorKind " ++ show unknown
+        Right kind -> k kind
+        Left  i    -> panicIO $ "Unrecognized CXCursorKind " ++ show i
 
 instance Dispatch CXType where
   type Kind CXType = CXTypeKind
 
-  dispatch x f = do
-      let mKind = fromSimpleEnum $ cxtKind x
+  dispatch curr k = do
+      let mKind = fromSimpleEnum $ cxtKind curr
       case mKind of
-        Right kind   -> f kind
-        Left unknown -> panicIO $ "Unrecognized CXTypeKind " ++ show unknown
+        Right kind -> k kind
+        Left  i    -> panicIO $ "Unrecognized CXTypeKind " ++ show i
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+unknownCursorKind ::
+     (MonadIO m, HasCallStack)
+  => CXCursorKind -> CXCursor -> m x
+unknownCursorKind kind curr = do
+    loc      <- HighLevel.clang_getCursorLocation' curr
+    spelling <- clang_getCursorKindSpelling (simpleEnum kind)
+    panicIO $ concat [
+        "Unknown cursor of kind "
+      , show kind
+      , " ("
+      , Text.unpack spelling
+      , ") at "
+      , show loc
+      ]
+
+-- | Unknown type
+--
+-- TODO: It would be better if we could report a source location here, but clang
+-- does not make it easy to associate a 'CXType' with a location. Perhaps it
+-- would be possible to add a 'SingleLoc' argument to 'fromCXType', but it might
+-- be hard to get right in all cases, and a /wrong/ source location might be
+-- worse than none at all.
+unknownTypeKind ::
+     (MonadIO m, HasCallStack)
+  => CXTypeKind -> CXType -> m x
+unknownTypeKind kind _ = do
+    spelling <- clang_getTypeKindSpelling (simpleEnum kind)
+    panicIO $ concat [
+        "Unknown cursor of kind "
+      , show kind
+      , " ("
+      , Text.unpack spelling
+      , ")"
+      ]
 
 {-------------------------------------------------------------------------------
   Debugging


### PR DESCRIPTION
This should help users submit better bug reports; prior to this commit, we'd get something like

```
foldDecl: CXCursor_AlignedAttr
CallStack (from HasCallStack): <callstack>
```

but no information about what part of the input led to this exception.