### PR TITLE
Warn about long double in parser

### DIFF
--- a/hs-bindgen/fixtures/long_double.failure.txt
+++ b/hs-bindgen/fixtures/long_double.failure.txt
@@ -1,4 +1,0 @@
-hs-bindgen known issue: https://github.com/well-typed/hs-bindgen/issues/349
-long double not supported
-CallStack (from HasCallStack):
-  throwPure_TODO, called at src-internal/HsBindgen/Hs/Translation.hs:0:0 in hs-bindgen-0-inplace-internal:HsBindgen.Hs.Translation

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -352,7 +352,6 @@ test-suite test-internal
     , temporary
     , tree-diff     ^>=0.3.4
     , utf8-string   ^>=1.0.2
-    , regex-applicative ^>=0.3.4
 
 test-suite test-th
   type:           exitcode-stdio-1.0

--- a/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Reparse/Type.hs
@@ -73,10 +73,10 @@ reparsePrimType = do
       [             "long" , "long" , "int"] -> primType $ PrimIntegral PrimLongLong Signed
       ["signed"   , "long" , "long" , "int"] -> primType $ PrimIntegral PrimLongLong Signed
       ["unsigned" , "long" , "long" , "int"] -> primType $ PrimIntegral PrimLongLong Unsigned
-      -- float, double, long double
-      [         "float" ] -> primType $ PrimFloating PrimFloat
-      [         "double"] -> primType $ PrimFloating PrimDouble
-      ["long" , "double"] -> primType $ PrimFloating PrimLongDouble
+      -- float, double
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/349>: long double
+      ["float" ] -> primType $ PrimFloating PrimFloat
+      ["double"] -> primType $ PrimFloating PrimDouble
       -- bool
       ["_Bool"] -> primType $ PrimBool
       ["bool"]  -> primType $ PrimBool

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
@@ -41,7 +41,7 @@ cxtype ty =
       CXType_ULongLong  -> prim $ PrimIntegral PrimLongLong Unsigned
       CXType_Float      -> prim $ PrimFloating PrimFloat
       CXType_Double     -> prim $ PrimFloating PrimDouble
-      CXType_LongDouble -> prim $ PrimFloating PrimLongDouble
+      CXType_LongDouble -> failure UnsupportedLongDouble
       CXType_Bool       -> prim $ PrimBool
 
       CXType_Attributed      -> attributed
@@ -56,7 +56,10 @@ cxtype ty =
       CXType_Typedef         -> fromDecl
       CXType_Void            -> const (pure C.TypeVoid)
 
-      kind -> \_ -> throwError $ UnexpectedTypeKind (Right kind)
+      kind -> failure $ UnexpectedTypeKind (Right kind)
+  where
+    failure :: ParseTypeException -> CXType -> ParseType (C.Type Parse)
+    failure err _ty = throwError err
 
 {-------------------------------------------------------------------------------
   Functions for each kind of type

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
@@ -84,6 +84,9 @@ data ParseTypeException =
 
     -- | We do not support variadic (varargs) functions
   | UnsupportedVariadicFunction
+
+    -- | We do not support @long double@
+  | UnsupportedLongDouble
   deriving stock (Show, Eq)
 
 instance PrettyTrace ParseTypeException where
@@ -115,6 +118,9 @@ instance PrettyTrace ParseTypeException where
     UnsupportedVariadicFunction -> concat [
         "Unsupported variadic (varargs) function."
       ]
+    UnsupportedLongDouble -> concat [
+        "Unsupported long double."
+      ]
 
 -- | We use 'Error' for bugs, and 'Warning' for known-to-be-unsupported
 --
@@ -125,6 +131,7 @@ instance HasDefaultLogLevel ParseTypeException where
     UnexpectedTypeKind{}        -> Error
     UnexpectedTypeDecl{}        -> Error
     UnsupportedVariadicFunction -> Warning
+    UnsupportedLongDouble       -> Warning
 
 instance Exception ParseTypeException where
   displayException = prettyTrace

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -887,9 +887,8 @@ integralType C.PrimLongLong C.Unsigned = HsPrimCULLong
 
 floatingType :: C.PrimFloatType -> HsPrimType
 floatingType = \case
-  C.PrimFloat      -> HsPrimCFloat
-  C.PrimDouble     -> HsPrimCDouble
-  C.PrimLongDouble -> throwPure_TODO 349 "long double not supported"
+  C.PrimFloat  -> HsPrimCFloat
+  C.PrimDouble -> HsPrimCDouble
 
 {-------------------------------------------------------------------------------
   Function

--- a/hs-bindgen/src-internal/HsBindgen/Language/C/Prim.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/C/Prim.hs
@@ -51,15 +51,16 @@ data PrimIntType
   | PrimLongLong
   deriving stock (Show, Eq, Enum, Generic)
 
+-- | Primitive floating point types
+--
+-- TODO <https://github.com/well-typed/hs-bindgen/issues/349>
+-- We don't currently support @long double@.
 data PrimFloatType
     -- | @float@
   = PrimFloat
 
     -- | @double@
   | PrimDouble
-
-    -- | @long double@
-  | PrimLongDouble
   deriving stock (Show, Eq, Ord, Generic)
 
 -- | Sign of a primitive type
@@ -114,7 +115,6 @@ showsPrimIntType PrimLongLong = showString "long long"
 showsPrimFloatType :: PrimFloatType -> ShowS
 showsPrimFloatType PrimFloat = showString "float"
 showsPrimFloatType PrimDouble = showString "double"
-showsPrimFloatType PrimLongDouble = showString "long double"
 
 showsPrimSign :: PrimSign -> ShowS
 showsPrimSign Signed = showString "signed"


### PR DESCRIPTION
Unsupported features should be detected in the frontend; panics in the backend should be limited to bugs in hs-bindgen.