### PR TITLE
Avoid `Aeson.KeyValue` and adjust constraints

### DIFF
--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -77,7 +77,7 @@ test-suite test-runtime
     , hs-bindgen-runtime
   build-depends:
       -- External dependencies
-    , QuickCheck        ^>=2.15.0.1
+    , QuickCheck        >= 2.14.3 && < 2.16
     , tasty             ^>=1.5
     , tasty-expected-failure ^>= 0.12.3
     , tasty-hunit       ^>=0.10.2

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -169,10 +169,9 @@ library internal
     , hs-bindgen-runtime
   build-depends:
       -- External dependencies
-    , aeson              >= 2         && < 2.3
+    , aeson              >= 2.2.1.0   && < 2.3
     , ansi-terminal      >= 1.0.0     && < 1.2
     , array              >= 0.5.4.0   && < 0.6
-    , base-compat        >= 0.13.1    && < 0.15
     , bytestring         >= 0.11.4.0  && < 0.13
     , containers         >= 0.6.5.1   && < 0.8
     , contra-tracer      >= 0.2       && < 0.3
@@ -184,7 +183,7 @@ library internal
     , fin                >= 0.3.2     && < 0.4
     , mtl                >= 2.2       && < 2.4
     , parsec             >= 3.1       && < 3.2
-    , pretty             >= 1.1       && < 1.2
+    , pretty             >= 1.1.3.6   && < 1.2
     , regex-pcre-builtin >= 0.95      && < 0.96
     , scientific         >= 0.3.7     && < 0.4
     , some
@@ -193,7 +192,7 @@ library internal
     , time               >= 1.11      && < 1.15
     , unliftio-core      ^>=0.2.1.0
     , vec                >= 0.5       && < 0.6
-    , witherable         ^>=0.5
+    , witherable         >= 0.4.2     && < 0.6
     , yaml               >= 0.11.11.1 && < 0.12
 
   if impl(ghc < 9.4)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
@@ -15,9 +15,8 @@ module HsBindgen.Frontend.RootHeader (
   , lookup
   ) where
 
+import Data.Maybe (listToMaybe)
 import Prelude hiding (lookup)
-
-import Data.List.Compat ((!?))
 
 import Clang.HighLevel.Types
 import Clang.Paths
@@ -72,3 +71,17 @@ lookup :: RootHeader -> SingleLoc -> Maybe CHeaderIncludePath
 lookup rootHeader loc = do
     guard $ singleLocPath loc == name
     return $ rootHeader `at` loc
+
+{-------------------------------------------------------------------------------
+  Auxiliary functions
+-------------------------------------------------------------------------------}
+
+-- | List index (subscript) operator, starting from 0
+--
+-- Returns 'Nothing' if the index is out of bounds
+(!?) :: [a] -> Int -> Maybe a
+xs !? n
+    | n < 0     = Nothing
+    | otherwise = listToMaybe $ drop n xs
+infixl 9 !?
+{-# INLINABLE (!?) #-}


### PR DESCRIPTION
I refactored the code to avoid `Aeson.KeyValue`.

I made the following constraints changes:

* Tightened `aeson` constraints from `>= 2 && < 2.3` to `>= 2.2.1.0 && < 2.3`.  We currently cannot support older versions because we require `primitive >= 0.9.0.0`.
* Removed `base-compat` dependency.
* Tightened `pretty` constraints from `>= 1.1 && < 1.2` to `>= 1.1.3.6 && < 1.2`.
* Relaxed `QuickCheck` constraints from `^>=2.15.0.1` to `>= 2.14.3 && < 2.16`.  Note that `2.15` is deprecated.  If we would like to reflect this in the constraints, we can change them to `(>= 2.14.3 && < 2.15) || (>= 2.15.0.1 && < 2.16)`, but that is not necessary thanks to the deprecation flag, right?  Note that version `2.16` is already available; perhaps the upper bound can be extended, but I did not test this yet.
* Relaxed `witherable` constraints from `^>=0.5` to `>= 0.4.2 && < 0.6`.

----

**Log**

Our oldest supported GHC is `9.2.8`.

`pretty >= 1.1.3.6` is required to support `base-4.16.4.0` (boot library).

`aeson >=2.0.2.0` is required to support `ghc-prim-0.8.0` (boot library).

`aeson >=2.0.3.0` is required to support `bytestring-0.11.4.0` (boot library).

`aeson >=2.2.2.0` is required to support `witherable-0.5`, which is one of our constraints.  We only use `ordNub`, and it looks like we can relax those constraints to `>=0.4.2 && <0.6`.

`aeson >=2.1.2.1` is required to support `base-compat-0.13.1` (via `base-compat-batteries`), which is one of our constraints.  We just use this library for `(!?)` (from `base-4.19.0.0`), and our lower bound is the version that introduced that operator.  I wrote our own version of the operator so that we can drop this dependency.

`aeson >=2.2.1.0` is required to support `primitive-0.9.0.0`, which is a constraint of `hs-bindgen-runtime`.  I confirmed that we use functionality added to that version.

`aeson >=2.2.2.0` is required to support `QuickCheck-2.15.0.1`, which is a constraint of `hs-bindgen-runtime`.  The constraint was added for [this test](https://github.com/well-typed/hs-bindgen/commit/b5d665db758dd729e858cec4d0ef0aa86bd2cd15#diff-cc49b2c23bbb50c26f106afabee022f73a644a3f3c0282b75ea9abd06a970869), and it looks like we can relax those constraints to `>=2.14.3 && <2.16`.