### PR TITLE
Use C origin and alias information when generating binding specification

### DIFF
--- a/hs-bindgen/fixtures/anonymous.extbindings.yaml
+++ b/hs-bindgen/fixtures/anonymous.extbindings.yaml
@@ -1,16 +1,40 @@
 types:
 - headers: anonymous.h
-  cname: struct S1
+  cname: S1_c
   module: Example
-  identifier: S1
+  identifier: S1_c
   instances:
   - Eq
   - Show
   - Storable
 - headers: anonymous.h
-  cname: struct S1_c
+  cname: S2_inner
   module: Example
-  identifier: S1_c
+  identifier: S2_inner
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: S2_inner_deep
+  module: Example
+  identifier: S2_inner_deep
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: S3_c
+  module: Example
+  identifier: S3_c
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: struct S1
+  module: Example
+  identifier: S1
   instances:
   - Eq
   - Show
@@ -24,33 +48,9 @@ types:
   - Show
   - Storable
 - headers: anonymous.h
-  cname: struct S2_inner
-  module: Example
-  identifier: S2_inner
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
-  cname: struct S2_inner_deep
-  module: Example
-  identifier: S2_inner_deep
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
   cname: struct S3
   module: Example
   identifier: S3
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
-  cname: struct S3_c
-  module: Example
-  identifier: S3_c
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
+++ b/hs-bindgen/fixtures/distilled_lib_1.extbindings.yaml
@@ -18,9 +18,37 @@ types:
   - Real
   - Storable
 - headers: distilled_lib_1.h
+  cname: a_typedef_enum_e
+  module: Example
+  identifier: A_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: distilled_lib_1.h
   cname: a_typedef_struct_t
   module: Example
   identifier: A_typedef_struct_t
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: distilled_lib_1.h
+  cname: another_typedef_enum_e
+  module: Example
+  identifier: Another_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: distilled_lib_1.h
+  cname: another_typedef_struct_t
+  module: Example
+  identifier: Another_typedef_struct_t
   instances:
   - Eq
   - Show
@@ -32,26 +60,6 @@ types:
   instances:
   - Eq
   - Ord
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
-  cname: enum a_typedef_enum_e
-  module: Example
-  identifier: A_typedef_enum_e
-  instances:
-  - Eq
-  - Ord
-  - Read
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
-  cname: enum another_typedef_enum_e
-  module: Example
-  identifier: Another_typedef_enum_e
-  instances:
-  - Eq
-  - Ord
-  - Read
   - Show
   - Storable
 - headers: distilled_lib_1.h
@@ -76,14 +84,6 @@ types:
   cname: struct a_typedef_struct
   module: Example
   identifier: A_typedef_struct
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
-  cname: struct another_typedef_struct_t
-  module: Example
-  identifier: Another_typedef_struct_t
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/enums.extbindings.yaml
@@ -1,15 +1,5 @@
 types:
 - headers: enums.h
-  cname: enum enumA
-  module: Example
-  identifier: EnumA
-  instances:
-  - Eq
-  - Ord
-  - Read
-  - Show
-  - Storable
-- headers: enums.h
   cname: enum enumB
   module: Example
   identifier: EnumB
@@ -83,6 +73,16 @@ types:
   cname: enum second
   module: Example
   identifier: Second
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: enums.h
+  cname: enumA
+  module: Example
+  identifier: EnumA
   instances:
   - Eq
   - Ord

--- a/hs-bindgen/fixtures/flam.extbindings.yaml
+++ b/hs-bindgen/fixtures/flam.extbindings.yaml
@@ -1,5 +1,13 @@
 types:
 - headers: flam.h
+  cname: foo_bar
+  module: Example
+  identifier: Foo_bar
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: flam.h
   cname: struct diff
   module: Example
   identifier: Diff
@@ -11,14 +19,6 @@ types:
   cname: struct foo
   module: Example
   identifier: Foo
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: flam.h
-  cname: struct foo_bar
-  module: Example
-  identifier: Foo_bar
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.extbindings.yaml
@@ -44,14 +44,6 @@ types:
   - Show
   - Storable
 - headers: macro_in_fundecl_vs_typedef.h
-  cname: struct struct2
-  module: Example
-  identifier: Struct2
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct3
   module: Example
   identifier: Struct3
@@ -63,6 +55,14 @@ types:
   cname: struct struct4
   module: Example
   identifier: Struct4
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: struct2
+  module: Example
+  identifier: Struct2
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/macro_typedef_struct.extbindings.yaml
+++ b/hs-bindgen/fixtures/macro_typedef_struct.extbindings.yaml
@@ -18,7 +18,7 @@ types:
   - Real
   - Storable
 - headers: macro_typedef_struct.h
-  cname: struct bar
+  cname: bar
   module: Example
   identifier: Bar
   instances:

--- a/hs-bindgen/fixtures/manual_examples.extbindings.yaml
+++ b/hs-bindgen/fixtures/manual_examples.extbindings.yaml
@@ -98,6 +98,14 @@ types:
   - Show
   - Storable
 - headers: manual_examples.h
+  cname: config_Deref
+  module: Example
+  identifier: Config_Deref
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: manual_examples.h
   cname: data
   module: Example
   identifier: Data
@@ -186,9 +194,17 @@ types:
   - Show
   - Storable
 - headers: manual_examples.h
-  cname: struct config_Deref
+  cname: rect_lower_left
   module: Example
-  identifier: Config_Deref
+  identifier: Rect_lower_left
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: manual_examples.h
+  cname: rect_upper_right
+  module: Example
+  identifier: Rect_upper_right
   instances:
   - Eq
   - Show
@@ -217,22 +233,6 @@ types:
   cname: struct rect
   module: Example
   identifier: Rect
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: manual_examples.h
-  cname: struct rect_lower_left
-  module: Example
-  identifier: Rect_lower_left
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: manual_examples.h
-  cname: struct rect_upper_right
-  module: Example
-  identifier: Rect_upper_right
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/nested_enums.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_enums.extbindings.yaml
@@ -10,7 +10,7 @@ types:
   - Show
   - Storable
 - headers: nested_enums.h
-  cname: enum exB_fieldB1
+  cname: exB_fieldB1
   module: Example
   identifier: ExB_fieldB1
   instances:

--- a/hs-bindgen/fixtures/nested_types.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_types.extbindings.yaml
@@ -1,5 +1,13 @@
 types:
 - headers: nested_types.h
+  cname: ex3_ex3_struct
+  module: Example
+  identifier: Ex3_ex3_struct
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: nested_types.h
   cname: struct bar
   module: Example
   identifier: Bar
@@ -11,14 +19,6 @@ types:
   cname: struct ex3
   module: Example
   identifier: Ex3
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: nested_types.h
-  cname: struct ex3_ex3_struct
-  module: Example
-  identifier: Ex3_ex3_struct
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/nested_unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/nested_unions.extbindings.yaml
@@ -1,5 +1,11 @@
 types:
 - headers: nested_unions.h
+  cname: exB_fieldB1
+  module: Example
+  identifier: ExB_fieldB1
+  instances:
+  - Storable
+- headers: nested_unions.h
   cname: struct exA
   module: Example
   identifier: ExA
@@ -9,12 +15,6 @@ types:
   cname: struct exB
   module: Example
   identifier: ExB
-  instances:
-  - Storable
-- headers: nested_unions.h
-  cname: union exB_fieldB1
-  module: Example
-  identifier: ExB_fieldB1
   instances:
   - Storable
 - headers: nested_unions.h

--- a/hs-bindgen/fixtures/simple_structs.extbindings.yaml
+++ b/hs-bindgen/fixtures/simple_structs.extbindings.yaml
@@ -8,6 +8,14 @@ types:
   - Show
   - Storable
 - headers: simple_structs.h
+  cname: S3_t
+  module: Example
+  identifier: S3_t
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: simple_structs.h
   cname: S7a
   module: Example
   identifier: S7a
@@ -17,12 +25,28 @@ types:
   - Show
   - Storable
 - headers: simple_structs.h
+  cname: S7a_Deref
+  module: Example
+  identifier: S7a_Deref
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: simple_structs.h
   cname: S7b
   module: Example
   identifier: S7b
   instances:
   - Eq
   - Ord
+  - Show
+  - Storable
+- headers: simple_structs.h
+  cname: S7b_Deref
+  module: Example
+  identifier: S7b_Deref
+  instances:
+  - Eq
   - Show
   - Storable
 - headers: simple_structs.h
@@ -37,14 +61,6 @@ types:
   cname: struct S2
   module: Example
   identifier: S2
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: simple_structs.h
-  cname: struct S3_t
-  module: Example
-  identifier: S3_t
   instances:
   - Eq
   - Show
@@ -69,22 +85,6 @@ types:
   cname: struct S6
   module: Example
   identifier: S6
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: simple_structs.h
-  cname: struct S7a_Deref
-  module: Example
-  identifier: S7a_Deref
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: simple_structs.h
-  cname: struct S7b_Deref
-  module: Example
-  identifier: S7b_Deref
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/type_attributes.extbindings.yaml
+++ b/hs-bindgen/fixtures/type_attributes.extbindings.yaml
@@ -90,7 +90,7 @@ types:
   module: Example
   identifier: Wait
 - headers: type_attributes.h
-  cname: union wait_status_ptr_t
+  cname: wait_status_ptr_t
   module: Example
   identifier: Wait_status_ptr_t
   instances:

--- a/hs-bindgen/fixtures/unions.extbindings.yaml
+++ b/hs-bindgen/fixtures/unions.extbindings.yaml
@@ -1,6 +1,6 @@
 types:
 - headers: unions.h
-  cname: struct AnonA_polar
+  cname: AnonA_polar
   module: Example
   identifier: AnonA_polar
   instances:
@@ -8,7 +8,7 @@ types:
   - Show
   - Storable
 - headers: unions.h
-  cname: struct AnonA_xy
+  cname: AnonA_xy
   module: Example
   identifier: AnonA_xy
   instances:

--- a/hs-bindgen/fixtures/vector.extbindings.yaml
+++ b/hs-bindgen/fixtures/vector.extbindings.yaml
@@ -1,6 +1,6 @@
 types:
 - headers: vector.h
-  cname: struct vector
+  cname: vector
   module: Example
   identifier: Vector
   instances:

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -9,6 +9,8 @@ module HsBindgen.BindingSpec (
   , UnresolvedBindingSpec
   , ResolvedBindingSpec
   , CSpelling(..)
+  , spell
+  , ordinaryCSpelling
   , Omittable(..)
   , TypeSpec(..)
   , defaultTypeSpec
@@ -69,6 +71,7 @@ import Clang.Paths
 import HsBindgen.Clang.Args (ExtraClangArgsLog)
 import HsBindgen.Errors
 import HsBindgen.Imports
+import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell
 import HsBindgen.Orphans ()
 import HsBindgen.Resolve
@@ -115,6 +118,19 @@ newtype CSpelling = CSpelling { getCSpelling :: Text }
 deriving newtype instance Aeson.FromJSON CSpelling
 
 deriving newtype instance Aeson.ToJSON CSpelling
+
+spell :: C.NameKind -> C.CName -> CSpelling
+spell nameKind name = CSpelling $ prefixFor nameKind <> C.getCName name
+  where
+    prefixFor :: C.NameKind -> Text
+    prefixFor = \case
+      C.NameKindOrdinary -> ""
+      C.NameKindStruct   -> "struct "
+      C.NameKindUnion    -> "union "
+      C.NameKindEnum     -> "enum "
+
+ordinaryCSpelling :: C.CName -> CSpelling
+ordinaryCSpelling = CSpelling . C.getCName
 
 --------------------------------------------------------------------------------
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
@@ -24,7 +24,6 @@ import HsBindgen.Frontend.Pass.NameAnon.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass
 import HsBindgen.Frontend.Pass.Sort.IsPass
 import HsBindgen.Imports
-import HsBindgen.Language.C (CName (..))
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell
 
@@ -411,13 +410,7 @@ instance Resolve C.Type where
 -------------------------------------------------------------------------------}
 
 qualIdCSpelling :: C.QualId NameAnon -> BindingSpec.CSpelling
-qualIdCSpelling (C.QualId cname nameKind) =
-    let prefix = case nameKind of
-          C.NameKindOrdinary -> ""
-          C.NameKindStruct   -> "struct "
-          C.NameKindUnion    -> "union "
-          C.NameKindEnum     -> "enum "
-    in  BindingSpec.CSpelling $ prefix <> getCName cname
+qualIdCSpelling (C.QualId cname nameKind) = BindingSpec.spell nameKind cname
 
 getExtHsRef ::
      BindingSpec.CSpelling


### PR DESCRIPTION
* Spellings `struct foo`, `union foo`, and `enum foo` are only used when they are valid spellings in C.
* Spelling `foo` is used for ordinary name kinds (`typedef` and `macro` names), as well as for generated names.