### PR TITLE
Refactor the `.Resolve`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -190,6 +190,7 @@ library internal
     , template-haskell   >= 2.18      && < 2.24
     , text               >= 1.2       && < 2.2
     , time               >= 1.11      && < 1.15
+    , transformers       >= 0.5       && < 0.7
     , unliftio-core      ^>=0.2.1.0
     , vec                >= 0.5       && < 0.6
     , witherable         >= 0.4.2     && < 0.6


### PR DESCRIPTION
This teases apart the control flow in the `Fold` from the decision making process, making subsequent changes to the `Fold` infrastructure easier.

While I was here also tidied up a code a bit in a way that I find a bit more readable. Hope that's okay.

@TravisCardwell The only "real" difference is that this code now _always_ uses `Continue` rather than `Break` whenever a particular cursor doesn't allow us to resolve the target, but I think that's actually correct. Bu  perhaps you were intentionally making a subtle distinction when we should `Break` early, but if so, I don't understand it :)