### PR TITLE
Make `Next` opaque

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -37,6 +37,7 @@
 - ignore: {name: "Use map once"}
 - ignore: {name: "Use section"}
 - ignore: {name: "Redundant lambda"}
+- ignore: {name: "Use const"}
 
 # Specify additional command line arguments
 #

--- a/clang/src/Clang/HighLevel/Types.hs
+++ b/clang/src/Clang/HighLevel/Types.hs
@@ -24,12 +24,22 @@ module Clang.HighLevel.Types (
   , diagnosticIsError
     -- * Folds
   , Fold
-  , Next(..)
+  , Next
     -- ** Construction
   , simpleFold
   , runFold
-  , continueWith
-  , recursePure
+    -- ** Fold-specific functionality
+  , foldBreak
+  , foldBreakWith
+  , foldBreakOpt
+  , foldContinue
+  , foldContinueWith
+  , foldContinueOpt
+  , foldRecurse
+  , foldRecurseWith
+  , foldRecurseOpt
+  , foldRecursePure
+  , foldRecursePureOpt
     -- * User-provided names
   , UserProvided
   , getUserProvided

--- a/clang/test/TestClangBindings/Traversal.hs
+++ b/clang/test/TestClangBindings/Traversal.hs
@@ -42,7 +42,7 @@ testGetAST test expected =
     astShape :: Fold IO (Tree (SimpleEnum CXCursorKind))
     astShape = simpleFold $ \curr -> do
         kind <- clang_getCursorKind curr
-        return $ Recurse astShape (return . Just . Node kind)
+        foldRecursePure astShape (Node kind)
 
 ast_singleFunction :: Assertion
 ast_singleFunction =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/ProcessIncludes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/ProcessIncludes.hs
@@ -110,10 +110,11 @@ processIncludes rootHeader unit = do
     includes <- HighLevel.clang_visitChildren root $ simpleFold $ \curr -> do
                   mKind <- fromSimpleEnum <$> clang_getCursorKind curr
                   case mKind of
-                    Right CXCursor_InclusionDirective ->
-                      Continue . Just <$> processInclude rootHeader curr
+                    Right CXCursor_InclusionDirective -> do
+                      include <- processInclude rootHeader curr
+                      foldContinueWith include
                     _otherwise ->
-                      return $ Continue Nothing
+                      foldContinue
 
     let includeGraph :: IncludeGraph
         includeGraph = IncludeGraph.fromList $

--- a/hs-bindgen/src-internal/HsBindgen/Resolve.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Resolve.hs
@@ -96,8 +96,8 @@ resolveHeader' tracer args target =
     visit = simpleFold $ \curr -> do
         mResolved <- tryResolve generatedName target curr
         case mResolved of
-          Nothing   -> return $ Continue Nothing
-          Just path -> return $ Break (Just path)
+          Nothing   -> foldContinue
+          Just path -> foldBreakWith path
 
     generatedName :: FilePath
     generatedName = "hs-bindgen-resolve.h"


### PR DESCRIPTION
This makes more of the `Fold` infrastructure opaque, so that we have more freedom to make internal representation changes. I think the new API also cleans up the client code a bit.