### PR TITLE
Improve usability of `hs-bindgen-lib`

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cli.hs
@@ -58,7 +58,10 @@ data Mode =
       , genTestsOutput     :: FilePath
       , genTestsInputs     :: [CHeaderIncludePath]
       }
-  | ModeLiterate FilePath FilePath
+  | ModeLiterate {
+        literateInput  :: FilePath
+      , literateOutput :: FilePath
+      }
   | ModeBindingSpec {
         modeBindingSpec :: BindingSpecMode
       }
@@ -132,7 +135,7 @@ parseModeLiterate :: Parser Mode
 parseModeLiterate = do
     _ <- strOption @String $ mconcat [ short 'h', metavar "IGNORED" ]
 
-    input <- strArgument $ mconcat [ metavar "IN" ]
+    input  <- strArgument $ mconcat [ metavar "IN" ]
     output <- strArgument $ mconcat [ metavar "OUT" ]
     return (ModeLiterate input output)
 

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -6,7 +6,6 @@ module HsBindgen.App.Common (
     -- * Input option
   , parseInput
     -- * Auxiliary hs-bindgen functions
-  , loadExtBindings'
   , environmentVariablesFooter
     -- * Auxiliary optparse-applicative functions
   , cmd
@@ -14,13 +13,11 @@ module HsBindgen.App.Common (
   ) where
 
 import Control.Exception (Exception (displayException))
-import Control.Tracer (Tracer)
 import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Char qualified as Char
 import Data.List qualified as List
 import Data.Text (Text)
 import Data.Text qualified as Text
-import GHC.Stack (HasCallStack)
 import Options.Applicative
 import Options.Applicative.Extra (helperWith)
 import Options.Applicative.Help (Doc, align, extractChunk, pretty, tabulate,
@@ -265,22 +262,6 @@ parseInput =
 {-------------------------------------------------------------------------------
   Auxiliary hs-bindgen functions
 -------------------------------------------------------------------------------}
-
--- | Load exernal bindings, tracing any errors
-loadExtBindings' :: HasCallStack =>
-     Tracer IO (TraceWithCallStack Trace)
-  -> GlobalOpts
-  -> IO ResolvedBindingSpec
-loadExtBindings' tracer GlobalOpts{..} = do
-    (resolveErrs, extBindings) <-
-      loadExtBindings
-        (useTrace TraceExtraClangArgs tracer)
-        globalOptsClangArgs
-        globalOptsStdlibSpecs
-        globalOptsExtBindings
-    mapM_ submitTrace resolveErrs
-    return extBindings
-  where submitTrace = traceWithCallStack (useTrace TraceResolveHeader tracer)
 
 environmentVariablesFooter :: ParserPrefs -> Doc
 environmentVariablesFooter p =

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -26,7 +26,10 @@ execMode Dev{..} = \case
     genBindings inputPaths =
       withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $
         \tracer -> do
-          extBindings <- loadExtBindings' tracer devGlobalOpts
+          extBindings <- loadExtBindings tracer
+                           (globalOptsClangArgs devGlobalOpts)
+                           (globalOptsStdlibSpecs devGlobalOpts)
+                           (globalOptsExtBindings devGlobalOpts)
           let opts :: Opts
               opts = def {
                   optsClangArgs   = globalOptsClangArgs devGlobalOpts

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -220,8 +220,6 @@ library
   build-depends:
       -- Inherited dependencies
     , bytestring
-    , containers
-    , contra-tracer
     , filepath
     , template-haskell
 
@@ -248,7 +246,6 @@ executable hs-bindgen-cli
   build-depends:
       -- Inherited dependencies
     , bytestring
-    , contra-tracer
     , data-default
   build-depends:
       -- External dependencies
@@ -275,9 +272,6 @@ executable hs-bindgen-dev
       -- Internal dependencies
     , hs-bindgen
     , hs-bindgen:internal
-  build-depends:
-      -- Inherited dependencies
-    , contra-tracer
   build-depends:
       -- External dependencies
     , optparse-applicative >= 0.18      && < 0.19
@@ -332,7 +326,6 @@ test-suite test-internal
     , deepseq
   build-depends:
       -- Inherited dependencies
-    , contra-tracer
     , bytestring
     , containers
     , debruijn
@@ -379,7 +372,6 @@ test-suite test-th
       -- Inherited dependencies
     , base <5
     , containers
-    , contra-tracer
     , mtl
   build-depends:
       -- External dependencies
@@ -420,7 +412,6 @@ test-suite test-pp
       -- Inherited dependencies
     , base <5
     , containers
-    , contra-tracer
     , mtl
   build-depends:
       -- External dependencies

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -40,10 +40,10 @@ module HsBindgen.BindingSpec (
   ) where
 
 import Control.Applicative (asum)
-import Control.Exception (Exception(..))
+import Control.Exception (Exception (..))
 import Control.Monad ((<=<))
 import Control.Tracer (Tracer)
-import Data.Aeson ((.=), (.:), (.:?), (.!=))
+import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types qualified as Aeson
@@ -53,7 +53,7 @@ import Data.Either (partitionEithers)
 import Data.Function (on)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
-import Data.Proxy (Proxy(Proxy))
+import Data.Proxy (Proxy (Proxy))
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Typeable (Typeable, typeRep)

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -71,7 +71,7 @@ import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell
 import HsBindgen.Orphans ()
 import HsBindgen.Resolve
-import HsBindgen.Util.Tracer (TraceWithCallStack)
+import HsBindgen.Util.Tracer (TraceWithCallStack, traceWithCallStack)
 
 {-------------------------------------------------------------------------------
   Types
@@ -304,18 +304,18 @@ empty = BindingSpec {
 -- This function throws a @'MultiException' 'BindingSpecException'@ on error.
 load ::
      Tracer IO (TraceWithCallStack ExtraClangArgsLog)
+  -> Tracer IO (TraceWithCallStack ResolveHeaderException)
   -> ClangArgs
   -> UnresolvedBindingSpec
   -> [FilePath]
-  -> IO (Set ResolveHeaderException, ResolvedBindingSpec)
-load tracer args stdSpec paths = do
+  -> IO ResolvedBindingSpec
+load tracerClangArgs tracerResolve args stdSpec paths = do
     (readErrss, uspecs) <- partitionEithers <$> mapM readFile paths
     let readErrs = ReadBindingSpecException <$> mconcat readErrss
-    (resolveErrs, specs) <-
-      first Set.unions . unzip <$> mapM (resolve tracer args) (stdSpec : uspecs)
+    specs <- mapM (resolve tracerClangArgs tracerResolve args) (stdSpec : uspecs)
     case first (fmap MergeBindingSpecException) (merge specs) of
       Right spec
-        | null readErrss -> return (resolveErrs, spec)
+        | null readErrss -> return spec
         | otherwise      -> throwIO readErrs
       Left mergeErrs -> throwIO $ readErrs <> mergeErrs
 
@@ -407,16 +407,18 @@ writeFileYaml path = BSS.writeFile path . encodeYaml' . toABindingSpec
 -- | Resolve headers in a binding specification
 resolve ::
      Tracer IO (TraceWithCallStack ExtraClangArgsLog)
+  -> Tracer IO (TraceWithCallStack ResolveHeaderException)
   -> ClangArgs
   -> UnresolvedBindingSpec
-  -> IO (Set ResolveHeaderException, ResolvedBindingSpec)
-resolve tracer args uSpec = do
+  -> IO ResolvedBindingSpec
+resolve tracerClangArgs tracerResolve args uSpec = do
     let types = bindingSpecTypes uSpec
         cPaths = Set.toAscList . mconcat $ fst <$> concat (Map.elems types)
     (errs, headerMap) <- bimap Set.fromList Map.fromList . partitionEithers
       <$> mapM
-            (\cPath -> fmap (cPath,) <$> resolveHeader' tracer args cPath)
+            (\cPath -> fmap (cPath,) <$> resolveHeader' tracerClangArgs args cPath)
             cPaths
+    mapM_ (traceWithCallStack tracerResolve) errs
     let lookup' :: CHeaderIncludePath -> Maybe (CHeaderIncludePath, SourcePath)
         lookup' header = (header,) <$> Map.lookup header headerMap
         resolveSet ::
@@ -441,7 +443,7 @@ resolve tracer args uSpec = do
         rSpec = BindingSpec {
             bindingSpecTypes = Map.mapMaybe resolve' types
           }
-    return (errs, rSpec)
+    return rSpec
 
 {-------------------------------------------------------------------------------
   API: Merging

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
@@ -1,8 +1,6 @@
 -- | Parse the clang AST
 module HsBindgen.Frontend.Pass.Parse (parseDecls) where
 
-import Control.Tracer (Tracer)
-
 import Clang.HighLevel qualified as HighLevel
 import Clang.LowLevel.Core
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
@@ -27,7 +27,6 @@ module HsBindgen.Frontend.Pass.Parse.Decl.Monad (
   , dispatchFold
   ) where
 
-import Control.Tracer (Tracer)
 import Data.IORef
 import Data.Set qualified as Set
 import Data.Text qualified as Text

--- a/hs-bindgen/src-internal/HsBindgen/ModuleUnique.hs
+++ b/hs-bindgen/src-internal/HsBindgen/ModuleUnique.hs
@@ -6,8 +6,8 @@ module HsBindgen.ModuleUnique (
 import HsBindgen.Imports
 import Language.Haskell.TH.Syntax (Lift)
 
--- | An identifier string used to generate morally module-private but externally visible symbols
--- Such identifiers are e.g. C symbols.
+-- | An identifier string used to generate morally module-private but externally
+-- visible symbols. Such identifiers are, e.g., C symbols.
 newtype ModuleUnique = ModuleUnique { unModuleUnique :: String }
   deriving newtype (Show)
   deriving stock Lift

--- a/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
@@ -28,6 +28,8 @@ module HsBindgen.Util.Tracer (
   , withTracerFile
   , withTracerCustom
   , withTracerCustom'
+  -- | Reexports
+  , module Control.Tracer
   ) where
 
 import Control.Applicative (ZipList (ZipList, getZipList))
@@ -35,7 +37,7 @@ import Control.Exception (Exception (..), throwIO)
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Tracer (Contravariant (contramap), Tracer (Tracer), emit,
-                       squelchUnless, traceWith)
+                       natTracer, nullTracer, squelchUnless, traceWith)
 import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
 import Data.Time (UTCTime, defaultTimeLocale, formatTime, getCurrentTime)
 import Data.Time.Format (FormatTime)

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -65,7 +65,6 @@ module HsBindgen.Lib (
   , FilePath.joinPath
   ) where
 
-import Control.Tracer (Tracer)
 import Data.ByteString (ByteString)
 import System.FilePath qualified as FilePath
 

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -32,6 +32,7 @@ module HsBindgen.Lib (
 
     -- ** External bindings
   , ResolvedBindingSpec
+  , StdlibBindingSpecs(..)
   , Pipeline.loadExtBindings
   , Resolve.ResolveHeaderException(..)
   , emptyExtBindings
@@ -82,6 +83,7 @@ import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports
 import HsBindgen.Imports as Default (Default (..))
 import HsBindgen.ModuleUnique
+import HsBindgen.Pipeline (StdlibBindingSpecs (NoStdlibBindingSpecs))
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.Util.Trace qualified as Trace

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -22,6 +22,7 @@ module HsBindgen.TH (
 
     -- ** External bindings
   , ResolvedBindingSpec -- opaque
+  , StdlibBindingSpecs(..)
   , loadExtBindings
   , emptyExtBindings
   , Resolve.ResolveHeaderException(..)
@@ -60,6 +61,7 @@ import HsBindgen.Clang.Args (ExtraClangArgsLog)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports as Default (Default (..))
+import HsBindgen.Pipeline (StdlibBindingSpecs)
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.Util.Trace qualified as Trace
@@ -85,11 +87,11 @@ import Language.Haskell.TH.Syntax qualified as THSyntax
 loadExtBindings ::
      Tracer TH.Q (TraceWithCallStack Trace.Trace)
   -> Args.ClangArgs
-  -> Bool -- ^ Automatically include @stdlib@?
+  -> StdlibBindingSpecs
   -> [FilePath]
   -> TH.Q (Set Resolve.ResolveHeaderException, ResolvedBindingSpec)
-loadExtBindings tracer args isAutoStdlib =
-    TH.runIO . Pipeline.loadExtBindings tracer' args isAutoStdlib
+loadExtBindings tracer args stdlibSpecs =
+    TH.runIO . Pipeline.loadExtBindings tracer' args stdlibSpecs
   where
     tracer' :: Tracer IO (TraceWithCallStack ExtraClangArgsLog)
     tracer' = useTrace Trace.TraceExtraClangArgs $ natTracer TH.runQ tracer

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -47,8 +47,6 @@ module HsBindgen.TH (
   , THSyntax.getPackageRoot
   ) where
 
-import Control.Tracer (Tracer, natTracer)
-import Data.Set (Set)
 import Language.Haskell.TH qualified as TH
 import System.FilePath qualified as FilePath
 
@@ -57,7 +55,6 @@ import Clang.Paths qualified as Paths
 import HsBindgen.BindingSpec (ResolvedBindingSpec)
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Predicate qualified as Predicate
-import HsBindgen.Clang.Args (ExtraClangArgsLog)
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
 import HsBindgen.Imports as Default (Default (..))
@@ -89,12 +86,12 @@ loadExtBindings ::
   -> Args.ClangArgs
   -> StdlibBindingSpecs
   -> [FilePath]
-  -> TH.Q (Set Resolve.ResolveHeaderException, ResolvedBindingSpec)
+  -> TH.Q ResolvedBindingSpec
 loadExtBindings tracer args stdlibSpecs =
     TH.runIO . Pipeline.loadExtBindings tracer' args stdlibSpecs
   where
-    tracer' :: Tracer IO (TraceWithCallStack ExtraClangArgsLog)
-    tracer' = useTrace Trace.TraceExtraClangArgs $ natTracer TH.runQ tracer
+    tracer' :: Tracer IO (TraceWithCallStack Trace.Trace)
+    tracer' = natTracer TH.runQ tracer
 
 emptyExtBindings :: ResolvedBindingSpec
 emptyExtBindings = BindingSpec.empty

--- a/hs-bindgen/test/common/Test/Internal/Tracer.hs
+++ b/hs-bindgen/test/common/Test/Internal/Tracer.hs
@@ -21,7 +21,6 @@ module Test.Internal.Tracer
 import Control.Exception (Exception, throwIO)
 import Control.Monad.Except (MonadError (throwError), runExceptT)
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Tracer (Tracer (..), emit)
 import Data.Dynamic (Typeable)
 import Data.Foldable qualified as Foldable
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
@@ -30,7 +29,8 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 
 import HsBindgen.Lib (HasDefaultLogLevel (getDefaultLogLevel), Level (..),
-                      PrettyTrace (prettyTrace), TraceWithCallStack (tTrace))
+                      PrettyTrace (prettyTrace), TraceWithCallStack (tTrace),
+                      Tracer (Tracer), emit)
 
 data TraceExpectation = Expected String | Tolerated | Unexpected
   deriving stock (Show, Eq, Ord)

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -303,4 +303,4 @@ initExtBindings packageRoot =
     getExtBindings :: IO ResolvedBindingSpec
     getExtBindings = withTracePredicate defaultTracePredicate $ \tracer ->
       let args = getClangArgs packageRoot []
-      in  snd <$> Pipeline.loadExtBindings tracer args True []
+      in  snd <$> Pipeline.loadExtBindings tracer args UseStdlibBindingSpecs []

--- a/hs-bindgen/test/internal/test-internal.hs
+++ b/hs-bindgen/test/internal/test-internal.hs
@@ -303,4 +303,4 @@ initExtBindings packageRoot =
     getExtBindings :: IO ResolvedBindingSpec
     getExtBindings = withTracePredicate defaultTracePredicate $ \tracer ->
       let args = getClangArgs packageRoot []
-      in  snd <$> Pipeline.loadExtBindings tracer args UseStdlibBindingSpecs []
+      in  Pipeline.loadExtBindings tracer args UseStdlibBindingSpecs []

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -20,7 +20,7 @@ $(do
           }
     extBindings <-
       withTracePredicate defaultTracePredicate $ \tracer ->
-        snd <$> loadExtBindings tracer args True []
+        snd <$> loadExtBindings tracer args UseStdlibBindingSpecs []
     let opts :: Opts
         opts = def {
             optsClangArgs   = args

--- a/hs-bindgen/test/th/Test02.hs
+++ b/hs-bindgen/test/th/Test02.hs
@@ -3,14 +3,19 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Test02 where
 
 import HsBindgen.TH
-import Test.Internal.Tracer (defaultTracePredicate, withTracePredicate)
+import Test.Internal.Tracer (TraceExpectation (..), TracePredicate,
+                             customTracePredicate, defaultTracePredicate,
+                             singleTracePredicate, withTracePredicate)
 
 -- Used by generated code
+import Clang.Paths (getCHeaderIncludePath)
 import HsBindgen.Runtime.Prelude qualified
+
 
 $(do
     dir <- getPackageRoot
@@ -18,9 +23,16 @@ $(do
         args = def {
             clangQuoteIncludePathDirs = [CIncludePathDir (dir </> "examples")]
           }
+        -- `uchar.h` is not available on MacOS.
+        uCharHeaderNotFound :: TracePredicate Trace
+        uCharHeaderNotFound = customTracePredicate [] $ \case
+          TraceResolveHeader (ResolveHeaderNotFound h)
+            | getCHeaderIncludePath h == "uchar.h"
+              -> Just Tolerated
+          _otherTrace -> Nothing
     extBindings <-
-      withTracePredicate defaultTracePredicate $ \tracer ->
-        snd <$> loadExtBindings tracer args UseStdlibBindingSpecs []
+      withTracePredicate uCharHeaderNotFound $ \tracer ->
+        loadExtBindings tracer args UseStdlibBindingSpecs []
     let opts :: Opts
         opts = def {
             optsClangArgs   = args


### PR DESCRIPTION
This is mainly about #716 

- Use StdlibBindingSpecs instead of Bool
- Reexport Control.Tracer
- Improve tracer handling with binding specifications