### PR TITLE
Refactor `BindingSpec` and `Resolve` traces/errors

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,3 @@ package hs-bindgen
 package hs-bindgen-runtime
 
 package hs-bindgen-test-runtime
-
--- Temporary fix: splitmix-0.1.3 fails to link on macOS
-constraints:
-    splitmix < 0.1.3

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -19,7 +19,3 @@ package hs-bindgen
 
 package hs-bindgen-runtime
   ghc-options: -Werror
-
--- Temporary fix: splitmix-0.1.3 fails to link on macOS
-constraints:
-    splitmix < 0.1.3

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -24,7 +24,7 @@ import Clang.Paths
 import HsBindgen.Clang
 import HsBindgen.Resolve (resolveHeader)
 import HsBindgen.TraceMsg
-import HsBindgen.Util.Tracer qualified as Tracer
+import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
   Options
@@ -64,9 +64,9 @@ clangAstDump opts@Options{..} = do
     putStrLn $ "## `" ++ renderCHeaderIncludePath optFile ++ "`"
     putStrLn ""
 
-    Tracer.withTracerStdOut tracerConf Tracer.DefaultLogLevel $ \tracer -> do
-      let tracerResolve   = Tracer.contramap TraceResolveHeader  tracer
-          tracerClang     = Tracer.contramap TraceClang          tracer
+    withTracerStdOut tracerConf DefaultLogLevel $ \tracer -> do
+      let tracerResolve = contramap TraceResolveHeader tracer
+          tracerClang   = contramap TraceClang         tracer
       src <- maybe (throwIO HeaderNotFound) return
           =<< resolveHeader tracerResolve cArgs optFile
       let setup :: ClangSetup
@@ -86,9 +86,9 @@ clangAstDump opts@Options{..} = do
               | otherwise                             -> runFold (foldDecls opts) cursor
   where
 
-    tracerConf :: Tracer.TracerConf
-    tracerConf = Tracer.defaultTracerConf {
-        Tracer.tVerbosity = Tracer.Verbosity Tracer.Warning
+    tracerConf :: TracerConf
+    tracerConf = defaultTracerConf {
+        tVerbosity = Verbosity Warning
       }
 
     cArgs :: ClangArgs

--- a/hs-bindgen/src-internal/HsBindgen/Errors.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Errors.hs
@@ -2,7 +2,6 @@ module HsBindgen.Errors (
     HsBindgenException (..),
     hsBindgenExceptionToException,
     hsBindgenExceptionFromException,
-    MultiException (..),
     TODOException (..),
     throwPure_TODO,
     throwIO_TODO,
@@ -39,19 +38,6 @@ hsBindgenExceptionFromException x = do
 
 instance Exception HsBindgenException where
     displayException (HsBindgenException e) = displayException e
-
--------------------------------------------------------------------------------
--- MultiException
--------------------------------------------------------------------------------
-
-newtype MultiException a = MultiException { getMultiExceptions :: [a] }
-    deriving newtype (Functor, Monoid, Semigroup)
-
-instance Exception a => Exception (MultiException a) where
-    displayException = unlines . map displayException . getMultiExceptions
-
-instance Show a => Show (MultiException a) where
-    show = ("MultiException " ++) . show . getMultiExceptions
 
 -------------------------------------------------------------------------------
 -- TODOs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
@@ -27,6 +27,7 @@ import HsBindgen.Frontend.Pass.Sort.IsPass
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell
+import HsBindgen.Util.Monad (mapMaybeM)
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -421,11 +422,3 @@ getExtHsRef cQualName typeSpec = do
       maybe (Left (BindingSpecExtHsRefNoIdentifier cQualName)) Right $
         BindingSpec.typeSpecIdentifier typeSpec
     return ExtHsRef{extHsRefModule, extHsRefIdentifier}
-
-mapMaybeM :: forall a b m. Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
-mapMaybeM f = foldr aux (pure [])
-  where
-    aux :: a -> m [b] -> m [b]
-    aux x doRest = f x >>= \case
-      Just y  -> (y :) <$> doRest
-      Nothing -> doRest

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -5,11 +5,11 @@ module HsBindgen.TraceMsg (
     TraceMsg(..)
   ) where
 
+import HsBindgen.BindingSpec (BindingSpecMsg)
 import HsBindgen.Clang (ClangMsg(..))
 import HsBindgen.Frontend (FrontendMsg(..))
 import HsBindgen.Resolve (ResolveHeaderMsg(..))
 import HsBindgen.Util.Tracer
-import HsBindgen.BindingSpec (ResolveBindingSpecMsg)
 
 {-------------------------------------------------------------------------------
   HsBindgen traces
@@ -19,29 +19,29 @@ import HsBindgen.BindingSpec (ResolveBindingSpecMsg)
 --
 -- Lazy on purpose to avoid evaluation when traces are not reported.
 data TraceMsg =
-    TraceClang ClangMsg
-  | TraceResolveBindingSpec ResolveBindingSpecMsg
+    TraceBindingSpec BindingSpecMsg
+  | TraceClang ClangMsg
   | TraceFrontend FrontendMsg
   | TraceResolveHeader ResolveHeaderMsg
   deriving stock (Show, Eq)
 
 instance PrettyForTrace TraceMsg where
   prettyTrace = \case
+    TraceBindingSpec        x -> prettyTrace x
     TraceClang              x -> prettyTrace x
-    TraceResolveBindingSpec x -> prettyTrace x
     TraceFrontend           x -> prettyTrace x
     TraceResolveHeader      x -> prettyTrace x
 
 instance HasDefaultLogLevel TraceMsg where
   getDefaultLogLevel = \case
+    TraceBindingSpec        x -> getDefaultLogLevel x
     TraceClang              x -> getDefaultLogLevel x
-    TraceResolveBindingSpec x -> getDefaultLogLevel x
     TraceFrontend           x -> getDefaultLogLevel x
     TraceResolveHeader      x -> getDefaultLogLevel x
 
 instance HasSource TraceMsg where
   getSource = \case
+    TraceBindingSpec        x -> getSource x
     TraceClang              x -> getSource x
-    TraceResolveBindingSpec x -> getSource x
     TraceFrontend           x -> getSource x
     TraceResolveHeader      x -> getSource x

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -6,9 +6,9 @@ module HsBindgen.TraceMsg (
   ) where
 
 import HsBindgen.BindingSpec (BindingSpecMsg)
-import HsBindgen.Clang (ClangMsg(..))
-import HsBindgen.Frontend (FrontendMsg(..))
-import HsBindgen.Resolve (ResolveHeaderMsg(..))
+import HsBindgen.Clang (ClangMsg)
+import HsBindgen.Frontend (FrontendMsg)
+import HsBindgen.Resolve (ResolveHeaderMsg)
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -27,21 +27,21 @@ data TraceMsg =
 
 instance PrettyForTrace TraceMsg where
   prettyTrace = \case
-    TraceBindingSpec        x -> prettyTrace x
-    TraceClang              x -> prettyTrace x
-    TraceFrontend           x -> prettyTrace x
-    TraceResolveHeader      x -> prettyTrace x
+    TraceBindingSpec   x -> prettyTrace x
+    TraceClang         x -> prettyTrace x
+    TraceFrontend      x -> prettyTrace x
+    TraceResolveHeader x -> prettyTrace x
 
 instance HasDefaultLogLevel TraceMsg where
   getDefaultLogLevel = \case
-    TraceBindingSpec        x -> getDefaultLogLevel x
-    TraceClang              x -> getDefaultLogLevel x
-    TraceFrontend           x -> getDefaultLogLevel x
-    TraceResolveHeader      x -> getDefaultLogLevel x
+    TraceBindingSpec   x -> getDefaultLogLevel x
+    TraceClang         x -> getDefaultLogLevel x
+    TraceFrontend      x -> getDefaultLogLevel x
+    TraceResolveHeader x -> getDefaultLogLevel x
 
 instance HasSource TraceMsg where
   getSource = \case
-    TraceBindingSpec        x -> getSource x
-    TraceClang              x -> getSource x
-    TraceFrontend           x -> getSource x
-    TraceResolveHeader      x -> getSource x
+    TraceBindingSpec   x -> getSource x
+    TraceClang         x -> getSource x
+    TraceFrontend      x -> getSource x
+    TraceResolveHeader x -> getSource x

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -133,13 +133,14 @@ preprocessIO ppOpts fp = Pipeline.preprocessIO ppOpts fp . unwrapHsDecls
 -------------------------------------------------------------------------------}
 
 genExtBindings ::
-     Pipeline.PPOpts
+     Pipeline.Opts
+  -> Pipeline.PPOpts
   -> [Paths.CHeaderIncludePath]
   -> FilePath
   -> HsDecls
   -> IO ()
-genExtBindings ppOpts headerIncludePaths fp =
-    Pipeline.genExtBindings ppOpts headerIncludePaths fp . unwrapHsDecls
+genExtBindings opts ppOpts headerIncludePaths fp =
+    Pipeline.genExtBindings opts ppOpts headerIncludePaths fp . unwrapHsDecls
 
 {-------------------------------------------------------------------------------
   External bindings

--- a/hs-bindgen/test/th/Test01.hs
+++ b/hs-bindgen/test/th/Test01.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -ddump-splices #-}
+-- {-# OPTIONS_GHC -ddump-splices #-}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}


### PR DESCRIPTION
(From the commit messages)

**`BindingSpec`**

A new `TraceBindingSpec` is used.

The `Exception` types are renamed to indicate that they are traces.  (Example: `ReadBindingSpecTrace`)  They are currently all errors, but we may add other types of traces in the future.

The (upstream) YAML error types do not have `Eq` instances, but we now need `Eq` instances for the `Trace` type.  I resolved this by rendering those errors and just storing `String`s.

The functions are now even more lenient than before.  For example, an empty binding specification is returned when unable to load a file at all.

Type `MultiException` is removed, as we are now managing errors via traces.

This change means that we need tracers in more places.  Notable, the tracer is in `Opts` but not `PPOpts`.  We have discussed making `Opts` opaque and instead using new `Config` types for configuration.  Perhaps `Opts` and `PPOpts` will be combined, resolving this issue.  For now, I simply pass both where `PPOpts` was previously sufficient.

**`Resolve`**

This change is motivated by two things:

* We would like to trace header resolution, both successes and failures.
* Failure to resolve is an error in some cases and a warning in others.  (See #777)

Type `ResolveHeaderException` is removed, and the API now returns a `Maybe`, where `Nothing` indicates failure.  The caller can decide how to handle failure.

Type `ResolveHeaderTrace` is added.  Successful resolution is traced with level `info` and failure is traced with level `warning`.

----

With the way that we configure traces, we do indeed need to expose the trace types in the public API, so `Lib` and `TH` need to be updated/organized.