### PR TITLE
Resolve #279. Cleanup DVar treatment.

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -15,7 +15,7 @@ requiredExtensions = \case
     DComment {} ->
         Set.empty
     DVar _name ty _expr ->
-        foldMap typeExtensions ty
+        typeExtensions ty
     DInst x -> Set.fromList $ catMaybes [
           if length (instanceArgs x) >= 2
             then Just TH.MultiParamTypeClasses

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Render.hs
@@ -11,7 +11,6 @@ module HsBindgen.Backend.PP.Render (
 
 import Data.Char qualified
 import Data.List qualified as List
-import Data.Maybe (maybeToList)
 import Data.Text qualified as Text
 import Data.Word
 import GHC.Exts (Int (..), sizeofByteArray#)
@@ -103,10 +102,8 @@ instance Pretty ImportListItem where
 instance Pretty SDecl where
   pretty = \case
     DComment s -> "--" <+> string s
-    DVar name mbTy expr ->
-      fsep
-        [ pretty name <+> string "::" <+> pretty ty
-        | ty <- maybeToList mbTy ]
+    DVar name ty expr ->
+      (pretty name <+> string "::" <+> pretty ty)
       $$
       fsep
         [ pretty name <+> char '='

--- a/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/PP/Translation.hs
@@ -138,8 +138,8 @@ instance Monoid ImportAcc where
 resolveDeclImports :: SDecl -> ImportAcc
 resolveDeclImports = \case
     DComment {} -> mempty
-    DVar _name mbTy e ->
-      maybe mempty resolveTypeImports mbTy <> resolveExprImports e
+    DVar _name ty e ->
+      resolveTypeImports ty <> resolveExprImports e
     DInst Instance{..} -> mconcat $
         resolveGlobalImports instanceClass
       : map (resolveGlobalImports . fst) instanceDecs

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -487,10 +487,9 @@ mkPrimType = TH.conT . mkGlobalP
 mkDecl :: forall q. Guasi q => SDecl -> q [TH.Dec]
 mkDecl = \case
       DComment {} -> return []
-      DVar x Nothing   f -> singleton <$> simpleDecl (hsNameToTH x) f
-      DVar x (Just ty) f -> sequence
+      DVar x ty tm -> sequence
           [ TH.sigD (hsNameToTH x) (mkType EmptyEnv ty)
-          , simpleDecl (hsNameToTH x) f
+          , simpleDecl (hsNameToTH x) tm
           ]
 
       DInst i  -> singleton <$> TH.instanceD

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -959,13 +959,13 @@ hsWrapperDecl hiName loName res args = case res of
   HeapType {} ->
     SHs.DVar
       hiName
-      (Just (SHs.translateType hsty))
+      (SHs.translateType hsty)
       (goA EmptyEnv args)
 
   WrapType {} ->
     SHs.DVar
       hiName
-      (Just (SHs.translateType hsty))
+      (SHs.translateType hsty)
       (goB EmptyEnv args)
 
   CAType {} ->

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -235,7 +235,7 @@ deriving stock instance Show (SAlt ctx)
 
 -- | Simple declarations
 data SDecl =
-    DVar (HsName NsVar) (Maybe ClosedType) ClosedExpr
+    DVar (HsName NsVar) ClosedType ClosedExpr
   | DInst Instance
   | DRecord Record
   | DNewtype Newtype

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -152,7 +152,7 @@ translateTypeClass Hs.WriteRaw   = TGlobal WriteRaw_class
 translateVarDecl :: Hs.VarDecl -> SDecl
 translateVarDecl Hs.VarDecl {..} = DVar
     varDeclName
-    (Just (translateSigma varDeclType))
+    (translateSigma varDeclType)
     (translateBody varDeclBody)
 
 translateForeignImportDecl :: Hs.ForeignImportDecl -> [SDecl]
@@ -385,12 +385,12 @@ toNameHint (HsName t) = NameHint (T.unpack t)
 
 translateUnionGetter :: HsName NsTypeConstr -> HsType -> HsName NsVar -> SDecl
 translateUnionGetter u f n = DVar n
-    (Just $ TFun (TCon u) (translateType f))
+    (TFun (TCon u) (translateType f))
     (EGlobal ByteArray_getUnionPayload)
 
 translateUnionSetter :: HsName NsTypeConstr -> HsType -> HsName NsVar -> SDecl
 translateUnionSetter u f n = DVar n
-    (Just $ TFun (translateType f) (TCon u))
+    (TFun (translateType f) (TCon u))
     (EGlobal ByteArray_setUnionPayload)
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Treat DVar as "a binding (with type)".
I opened #279 because I didn't like that it was the only statement, which required two TH declarations when translated. It's not true anymore, as pattern synonyms also require two TH declarations (similarly, type and "term").

I think it's fine to have it this way, and by *always* requring the type we avoid conditional treatment.
If we would ever need top-level bindings ("vars") without type annotations (which I think we shouldn't need), then DVar could be split into type-signature and declaration.