### PR TITLE
Common module for exports shared between Lib and TH

### DIFF
--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -87,7 +87,7 @@ clangAstDump opts@Options{..} = do
   where
 
     tracerConf :: TracerConf
-    tracerConf = defaultTracerConf {
+    tracerConf = def {
         tVerbosity = Verbosity Warning
       }
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -211,6 +211,8 @@ library
   exposed-modules:
       HsBindgen.Lib
       HsBindgen.TH
+  other-modules:
+      HsBindgen.Common
   reexported-modules:
     , HsBindgen.Config.FixCandidate
     , HsBindgen.Config.FixCandidate.ReservedNames

--- a/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
@@ -24,7 +24,6 @@ module HsBindgen.Util.Tracer (
   , ShowTimeStamp (..)
   , ShowCallStack (..)
   , TracerConf (..)
-  , defaultTracerConf
   , CustomLogLevel (..)
     -- * Tracers
   , withTracerStdOut
@@ -37,7 +36,7 @@ import Control.Applicative (ZipList (ZipList, getZipList))
 import Control.Exception (Exception (..), throwIO)
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Tracer (Contravariant(..))
+import Control.Tracer (Contravariant (..))
 import Control.Tracer qualified as ContraTracer
 import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
 import Data.Time (UTCTime, defaultTimeLocale, formatTime, getCurrentTime)
@@ -50,6 +49,7 @@ import System.Console.ANSI (Color (..), ColorIntensity (Vivid),
                             hSupportsANSIColor, setSGRCode)
 import System.IO (Handle, IOMode (AppendMode), hPutStrLn, stdout, withFile)
 
+import Data.Default (Default (..))
 import HsBindgen.Errors (hsBindgenExceptionFromException,
                          hsBindgenExceptionToException)
 
@@ -190,12 +190,12 @@ data TracerConf = TracerConf {
   }
   deriving stock (Show, Eq)
 
-defaultTracerConf :: TracerConf
-defaultTracerConf = TracerConf
-  { tVerbosity      = (Verbosity Info)
-  , tShowTimeStamp  = DisableTimeStamp
-  , tShowCallStack  = DisableCallStack
-  }
+instance Default TracerConf where
+  def = TracerConf
+    { tVerbosity      = (Verbosity Info)
+    , tShowTimeStamp  = DisableTimeStamp
+    , tShowCallStack  = DisableCallStack
+    }
 
 -- | Sometimes, we want to change log levels. For example, we want to suppress
 -- specific traces in tests.

--- a/hs-bindgen/src/HsBindgen/Common.hs
+++ b/hs-bindgen/src/HsBindgen/Common.hs
@@ -1,0 +1,92 @@
+module HsBindgen.Common (
+
+    -- * Options
+    Pipeline.Opts(..)
+
+    -- * Binding specifications
+  , BindingSpec -- opaque
+  , Pipeline.StdlibBindingSpecConf(..)
+  , emptyBindingSpec
+
+    -- ** Clang arguments
+  , Args.ClangArgs(..)
+  , Args.Target(..)
+  , Args.TargetEnv(..)
+  , Args.targetTriple
+  , Args.CStandard(..)
+
+    -- ** Translation options
+  , Hs.TranslationOpts(..)
+  , Hs.Strategy(..)
+  , Hs.HsTypeClass(..)
+
+    -- ** Selection predicates
+  , Predicate.Predicate(..)
+  , Predicate.Regex -- opaque
+
+    -- ** Program slicing
+  , Slice.ProgramSlicing(..)
+
+
+    -- * Paths
+  , Paths.CIncludePathDir(..)
+  , (FilePath.</>)
+  , FilePath.joinPath
+
+    -- * Logging
+  , TraceMsg.TraceMsg(..)
+  , Resolve.ResolveHeaderMsg(..)
+    -- ** Tracer definition and main API
+  , Tracer.Tracer -- opaque
+  , Tracer.Contravariant(..)
+  , Tracer.traceWith
+  , Tracer.simpleTracer
+    -- ** Data types and typeclasses useful for tracing
+  , Tracer.Level(..)
+  , Tracer.PrettyForTrace(..)
+  , Tracer.HasDefaultLogLevel(..)
+  , Tracer.Source(..)
+  , Tracer.HasSource(..)
+  , Tracer.Verbosity(..)
+  , Tracer.ErrorTraceException(..)
+    -- ** Tracer configuration
+  , Tracer.AnsiColor(..)
+  , Tracer.ShowTimeStamp(..)
+  , Tracer.ShowCallStack(..)
+  , Tracer.TracerConf(..)
+  , Tracer.CustomLogLevel(..)
+    -- ** Tracers
+  , Tracer.withTracerStdOut
+  , Tracer.withTracerCustom
+  , Tracer.withTracerCustom'
+
+    -- * Re-exports
+  , Default(..)
+  ) where
+
+import System.FilePath qualified as FilePath
+
+import Clang.Args qualified as Args
+import Clang.Paths qualified as Paths
+
+import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.C.Predicate qualified as Predicate
+import HsBindgen.Frontend.Pass.Slice qualified as Slice
+import HsBindgen.Hs.AST qualified as Hs
+import HsBindgen.Hs.Translation qualified as Hs
+import HsBindgen.Pipeline qualified as Pipeline
+import HsBindgen.Resolve qualified as Resolve
+import HsBindgen.TraceMsg qualified as TraceMsg
+import HsBindgen.Util.Tracer qualified as Tracer
+
+import HsBindgen.Imports (Default (..))
+
+{-------------------------------------------------------------------------------
+  Binding specifications
+-------------------------------------------------------------------------------}
+
+ -- TODO use opaque wrapper
+type BindingSpec = BindingSpec.ResolvedBindingSpec
+
+emptyBindingSpec :: BindingSpec.ResolvedBindingSpec
+emptyBindingSpec = BindingSpec.empty

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -1,75 +1,92 @@
 {-# LANGUAGE CPP #-}
 
--- | Main entry point for using @hs-bindgen@ in TH mode
+-- | Main entry point for using @hs-bindgen@ in TH mode.
+--
+-- Intended for unqualified import.
+
+-- NOTE: Client code should /NOT/ have to import from @clang@.
 module HsBindgen.TH (
     -- * Template Haskell API
     Pipeline.hashInclude'
   , Pipeline.hashInclude
   , Pipeline.hashIncludeWith
 
-    -- * Debugging
-    -- ** Header resolution
-  , Resolve.ResolveHeaderMsg(..)
-
     -- * Options
-  , module Default
-  , Pipeline.Opts(..)
-  , Pipeline.QuoteIncludeDir(..)
+  , Common.Opts(..)
+  , Pipeline.QuoteIncludePathDir(..)
   , Pipeline.HashIncludeOpts(..)
 
     -- ** Clang arguments
-  , Args.ClangArgs(..)
-  , Args.Target(..)
-  , Args.TargetEnv(..)
-  , Args.targetTriple
-  , Args.CStandard(..)
+  , Common.ClangArgs(..)
+  , Common.Target(..)
+  , Common.TargetEnv(..)
+  , Common.targetTriple
+  , Common.CStandard(..)
 
     -- ** Binding specifications
-  , BindingSpec -- opaque
+  , Common.BindingSpec -- opaque
   , loadExtBindingSpecs
-  , emptyBindingSpec
-  , StdlibBindingSpecConf(..)
+  , Common.emptyBindingSpec
+  , Common.StdlibBindingSpecConf(..)
 
     -- ** Translation options
-  , Hs.TranslationOpts(..)
-  , Hs.Strategy(..)
-  , Hs.HsTypeClass(..)
+  , Common.TranslationOpts(..)
+  , Common.Strategy(..)
+  , Common.HsTypeClass(..)
 
     -- ** Selection predicates
-  , Predicate.Predicate(..)
-  , Predicate.Regex -- opaque
+  , Common.Predicate(..)
+  , Common.Regex -- opaque
 
     -- ** Program slicing
-  , Slice.ProgramSlicing(..)
-
-    -- ** Logging
-  , TraceMsg(..)
-  , module HsBindgen.Util.Tracer
+  , Common.ProgramSlicing(..)
 
     -- * Paths
-  , Paths.CIncludePathDir(..)
-  , (FilePath.</>)
-  , FilePath.joinPath
+  , Common.CIncludePathDir(..)
+  , (Common.</>)
+  , Common.joinPath
   , THSyntax.getPackageRoot
+
+    -- * Logging
+  , Common.TraceMsg(..)
+  , Common.ResolveHeaderMsg(..)
+    -- ** Tracer definition and main API
+  , Common.Tracer -- opaque
+  , Common.Contravariant(..)
+  , Common.traceWith
+  , Common.simpleTracer
+    -- ** Data types and typeclasses useful for tracing
+  , Common.Level(..)
+  , Common.PrettyForTrace(..)
+  , Common.HasDefaultLogLevel(..)
+  , Common.Source(..)
+  , Common.HasSource(..)
+  , Common.Verbosity(..)
+  , Common.ErrorTraceException(..)
+    -- ** Tracer configuration
+  , Common.AnsiColor(..)
+  , Common.ShowTimeStamp(..)
+  , Common.ShowCallStack(..)
+  , Common.TracerConf(..)
+  , Common.CustomLogLevel(..)
+    -- ** Tracers
+  , Common.withTracerStdOut
+  , Common.withTracerCustom
+  , Common.withTracerCustom'
+
+   -- * Re-exports
+  , Common.Default(..)
   ) where
 
 import Language.Haskell.TH qualified as TH
-import System.FilePath qualified as FilePath
+
+import HsBindgen.Common qualified as Common
 
 import Clang.Args qualified as Args
-import Clang.Paths qualified as Paths
-import HsBindgen.BindingSpec (ResolvedBindingSpec)
-import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.C.Predicate qualified as Predicate
-import HsBindgen.Frontend.Pass.Slice qualified as Slice
-import HsBindgen.Hs.AST qualified as Hs
-import HsBindgen.Hs.Translation qualified as Hs
-import HsBindgen.Imports as Default (Default (..))
-import HsBindgen.Pipeline (StdlibBindingSpecConf (..))
 import HsBindgen.Pipeline qualified as Pipeline
-import HsBindgen.Resolve qualified as Resolve
+
 import HsBindgen.TraceMsg
-import HsBindgen.Util.Tracer hiding (withTracerFile)
+import HsBindgen.Util.Tracer
 
 #ifdef MIN_VERSION_th_compat
 import Language.Haskell.TH.Syntax.Compat qualified as THSyntax
@@ -81,9 +98,6 @@ import Language.Haskell.TH.Syntax qualified as THSyntax
   Binding specifications
 -------------------------------------------------------------------------------}
 
--- TODO use opaque wrapper
-type BindingSpec = ResolvedBindingSpec
-
 -- | Load external binding specifications
 --
 -- The format is determined by filename extension.  The following formats are
@@ -94,14 +108,11 @@ type BindingSpec = ResolvedBindingSpec
 loadExtBindingSpecs ::
      Tracer TH.Q TraceMsg
   -> Args.ClangArgs
-  -> StdlibBindingSpecConf
+  -> Pipeline.StdlibBindingSpecConf
   -> [FilePath]
-  -> TH.Q BindingSpec
+  -> TH.Q Common.BindingSpec
 loadExtBindingSpecs tracer args stdlibConf =
     TH.runIO . Pipeline.loadExtBindingSpecs tracer' args stdlibConf
   where
     tracer' :: Tracer IO TraceMsg
     tracer' = natTracer TH.runQ tracer
-
-emptyBindingSpec :: BindingSpec
-emptyBindingSpec = BindingSpec.empty

--- a/hs-bindgen/test/internal/Test/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/test/internal/Test/HsBindgen/Util/Tracer.hs
@@ -48,7 +48,7 @@ assertMaxLevelWithCustomLogLevel customLogLevel traces expectedLevel = do
 testTracerIO :: CustomLogLevel TestTrace -> [TestTrace] -> IO Level
 testTracerIO customLogLevel traces = do
   let noOutput _ = pure ()
-      tracerConf = defaultTracerConf { tVerbosity = Verbosity Debug }
+      tracerConf = def { tVerbosity = Verbosity Debug }
       -- NB: Use and test the tracer functionality provided by @hs-bindgen:lib@,
       -- and not by the tests (e.g., 'withTracePredicate').
       withTracer = withTracerCustom' DisableAnsiColor tracerConf customLogLevel noOutput
@@ -81,7 +81,7 @@ tests = testGroup "HsBindgen.Util.Tracer"
     [ testCase "exception" $
         assertException "Expected ErrorTraceException" (Proxy :: Proxy ErrorTraceException) $ do
           let noOutput _ = pure ()
-              tracerConf = defaultTracerConf { tVerbosity = Verbosity Debug }
+              tracerConf = def { tVerbosity = Verbosity Debug }
               withTracer = withTracerCustom DisableAnsiColor tracerConf DefaultLogLevel noOutput
           withTracer $ \tracer -> do
             traceWith tracer er


### PR DESCRIPTION
This is an attempt to shed some light on the exports from `Lib` and `TH` by introducing a (hidden) `Common` module that contains all declarations exported by both, `Lib`, and `TH`.

Direct reexport of `Common` is, sadly, not possible because we loose the headings in the Haddock.

However, like this we can see in the export lists of `Lib`, and `TH`, which exports are specific to the module, and which exports are common to both modules.

It's not perfect, and may be a controversial change. Let me know what you think.