### PR TITLE
Fix `preprocess` termination scope

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -297,24 +297,22 @@ genBindingsFromCHeader opts unit = do
 
 -- | Generate binding specification
 genBindingSpec ::
-     Opts
+     Tracer IO TraceMsg
   -> PPOpts
   -> [CHeaderIncludePath]
   -> FilePath
   -> [Hs.Decl]
   -> IO ()
-genBindingSpec Opts{..} PPOpts{..} headerIncludePaths path =
-      BindingSpec.writeFile tracer path
+genBindingSpec tracer PPOpts{..} headerIncludePaths path =
+      BindingSpec.writeFile tracer' path
     . BindingSpec.genBindingSpec headerIncludePaths moduleName
   where
     moduleName :: HsModuleName
     moduleName = HsModuleName $ Text.pack (hsModuleOptsName ppOptsModule)
 
-    tracer :: Tracer IO BindingSpec.WriteBindingSpecMsg
-    tracer =
-      contramap
-        (TraceBindingSpec . BindingSpec.WriteBindingSpecMsg)
-        optsTracer
+    tracer' :: Tracer IO BindingSpec.WriteBindingSpecMsg
+    tracer' =
+      contramap (TraceBindingSpec . BindingSpec.WriteBindingSpecMsg) tracer
 
 -- | Configure if the @stdlib@ binding specification should be used
 data StdlibBindingSpecConf =

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -151,14 +151,14 @@ preprocessIO ppOpts fp = Pipeline.preprocessIO ppOpts fp . unwrapHsDecls
 -------------------------------------------------------------------------------}
 
 genBindingSpec ::
-     Pipeline.Opts
+     Tracer IO Common.TraceMsg
   -> Pipeline.PPOpts
   -> [Paths.CHeaderIncludePath]
   -> FilePath
   -> HsDecls
   -> IO ()
-genBindingSpec opts ppOpts headerIncludePaths fp =
-    Pipeline.genBindingSpec opts ppOpts headerIncludePaths fp . unwrapHsDecls
+genBindingSpec tracer ppOpts headerIncludePaths fp =
+    Pipeline.genBindingSpec tracer ppOpts headerIncludePaths fp . unwrapHsDecls
 
 {-------------------------------------------------------------------------------
   Binding specifications


### PR DESCRIPTION
`withTracer` terminates if there were any errors.  The `preprocess` command therefore needs two separate calls with `withTracer`.  The first wraps `translateCHeaders`.  Execution should terminate if there were any errors, before the second wraps the code generation (and binding spec generation).

The `genBindingSpec` functions is changed to take a `Tracer`, as passing `Opts` is now problematic.  We will likely remove the `PPOpts` type, so this change is actually appropriate.