### PR TITLE
Simplification pass for `SHs`

### DIFF
--- a/hs-bindgen/fixtures/adios.exts.txt
+++ b/hs-bindgen/fixtures/adios.exts.txt
@@ -1,5 +1,4 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/adios.pp.hs
+++ b/hs-bindgen/fixtures/adios.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -20,62 +19,14 @@ $(CAPI.addCSource "#include \"adios.h\"\nvoid testmodule_\978 (void) { \978(); }
 newtype Adio'0301s = Adio'0301s
   { un_Adio'0301s :: FC.CInt
   }
-
-deriving newtype instance F.Storable Adio'0301s
-
-deriving stock instance Eq Adio'0301s
-
-deriving stock instance Ord Adio'0301s
-
-deriving stock instance Read Adio'0301s
-
-deriving stock instance Show Adio'0301s
-
-deriving newtype instance Enum Adio'0301s
-
-deriving newtype instance Ix.Ix Adio'0301s
-
-deriving newtype instance Bounded Adio'0301s
-
-deriving newtype instance Bits.Bits Adio'0301s
-
-deriving newtype instance FiniteBits Adio'0301s
-
-deriving newtype instance Integral Adio'0301s
-
-deriving newtype instance Num Adio'0301s
-
-deriving newtype instance Real Adio'0301s
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype C数字 = C数字
   { un_C数字 :: FC.CInt
   }
-
-deriving newtype instance F.Storable C数字
-
-deriving stock instance Eq C数字
-
-deriving stock instance Ord C数字
-
-deriving stock instance Read C数字
-
-deriving stock instance Show C数字
-
-deriving newtype instance Enum C数字
-
-deriving newtype instance Ix.Ix C数字
-
-deriving newtype instance Bounded C数字
-
-deriving newtype instance Bits.Bits C数字
-
-deriving newtype instance FiniteBits C数字
-
-deriving newtype instance Integral C数字
-
-deriving newtype instance Num C数字
-
-deriving newtype instance Real C数字
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_ϒ" cϒ :: IO ()
 

--- a/hs-bindgen/fixtures/adios.th.txt
+++ b/hs-bindgen/fixtures/adios.th.txt
@@ -3,34 +3,30 @@
 -- void test_internal_ϒ (void) { ϒ(); }
 -- void test_internal_拜拜 (void) { 拜拜(); }
 -- void test_internal_Say拜拜 (void) { Say拜拜(); }
-newtype Adio'0301s = Adio'0301s {un_Adio'0301s :: CInt}
-deriving newtype instance Storable Adio'0301s
-deriving stock instance Eq Adio'0301s
-deriving stock instance Ord Adio'0301s
-deriving stock instance Read Adio'0301s
-deriving stock instance Show Adio'0301s
-deriving newtype instance Enum Adio'0301s
-deriving newtype instance Ix Adio'0301s
-deriving newtype instance Bounded Adio'0301s
-deriving newtype instance Bits Adio'0301s
-deriving newtype instance FiniteBits Adio'0301s
-deriving newtype instance Integral Adio'0301s
-deriving newtype instance Num Adio'0301s
-deriving newtype instance Real Adio'0301s
-newtype C数字 = C数字 {un_C数字 :: CInt}
-deriving newtype instance Storable C数字
-deriving stock instance Eq C数字
-deriving stock instance Ord C数字
-deriving stock instance Read C数字
-deriving stock instance Show C数字
-deriving newtype instance Enum C数字
-deriving newtype instance Ix C数字
-deriving newtype instance Bounded C数字
-deriving newtype instance Bits C数字
-deriving newtype instance FiniteBits C数字
-deriving newtype instance Integral C数字
-deriving newtype instance Num C数字
-deriving newtype instance Real C数字
+newtype Adio'0301s
+    = Adio'0301s {un_Adio'0301s :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype C数字
+    = C数字 {un_C数字 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_\978" cϒ :: IO Unit
 foreign import ccall safe "test_internal_\25308\25308" 拜拜 :: IO Unit
 foreign import ccall safe "test_internal_Say\25308\25308" say拜拜 :: IO Unit

--- a/hs-bindgen/fixtures/anonymous.exts.txt
+++ b/hs-bindgen/fixtures/anonymous.exts.txt
@@ -1,2 +1,1 @@
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/anonymous.pp.hs
+++ b/hs-bindgen/fixtures/anonymous.pp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -12,6 +11,7 @@ data S1_c = S1_c
   { s1_c_a :: FC.CInt
   , s1_c_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S1_c where
 
@@ -33,14 +33,11 @@ instance F.Storable S1_c where
                F.pokeByteOff ptr0 (0 :: Int) s1_c_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s1_c_b3
 
-deriving stock instance Show S1_c
-
-deriving stock instance Eq S1_c
-
 data S1 = S1
   { s1_c :: S1_c
   , s1_d :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S1 where
 
@@ -62,13 +59,10 @@ instance F.Storable S1 where
                F.pokeByteOff ptr0 (0 :: Int) s1_c2
             >> F.pokeByteOff ptr0 (8 :: Int) s1_d3
 
-deriving stock instance Show S1
-
-deriving stock instance Eq S1
-
 data S2_inner_deep = S2_inner_deep
   { s2_inner_deep_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2_inner_deep where
 
@@ -87,14 +81,11 @@ instance F.Storable S2_inner_deep where
         case s1 of
           S2_inner_deep s2_inner_deep_b2 -> F.pokeByteOff ptr0 (0 :: Int) s2_inner_deep_b2
 
-deriving stock instance Show S2_inner_deep
-
-deriving stock instance Eq S2_inner_deep
-
 data S2_inner = S2_inner
   { s2_inner_a :: FC.CInt
   , s2_inner_deep :: S2_inner_deep
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2_inner where
 
@@ -116,14 +107,11 @@ instance F.Storable S2_inner where
                F.pokeByteOff ptr0 (0 :: Int) s2_inner_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s2_inner_deep3
 
-deriving stock instance Show S2_inner
-
-deriving stock instance Eq S2_inner
-
 data S2 = S2
   { s2_inner :: S2_inner
   , s2_d :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2 where
 
@@ -145,14 +133,11 @@ instance F.Storable S2 where
                F.pokeByteOff ptr0 (0 :: Int) s2_inner2
             >> F.pokeByteOff ptr0 (8 :: Int) s2_d3
 
-deriving stock instance Show S2
-
-deriving stock instance Eq S2
-
 data S3_c = S3_c
   { s3_c_a :: FC.CInt
   , s3_c_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S3_c where
 
@@ -174,14 +159,11 @@ instance F.Storable S3_c where
                F.pokeByteOff ptr0 (0 :: Int) s3_c_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s3_c_b3
 
-deriving stock instance Show S3_c
-
-deriving stock instance Eq S3_c
-
 data S3 = S3
   { s3_c :: F.Ptr (F.Ptr S3_c)
   , s3_d :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S3 where
 
@@ -202,7 +184,3 @@ instance F.Storable S3 where
           S3 s3_c2 s3_d3 ->
                F.pokeByteOff ptr0 (0 :: Int) s3_c2
             >> F.pokeByteOff ptr0 (8 :: Int) s3_d3
-
-deriving stock instance Show S3
-
-deriving stock instance Eq S3

--- a/hs-bindgen/fixtures/anonymous.th.txt
+++ b/hs-bindgen/fixtures/anonymous.th.txt
@@ -1,5 +1,7 @@
 -- addDependentFile examples/golden/anonymous.h
-data S1_c = S1_c {s1_c_a :: CInt, s1_c_b :: CInt}
+data S1_c
+    = S1_c {s1_c_a :: CInt, s1_c_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S1_c
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -7,9 +9,7 @@ instance Storable S1_c
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S1_c s1_c_a_3
                                           s1_c_b_4 -> pokeByteOff ptr_1 (0 :: Int) s1_c_a_3 >> pokeByteOff ptr_1 (4 :: Int) s1_c_b_4}}
-deriving stock instance Show S1_c
-deriving stock instance Eq S1_c
-data S1 = S1 {s1_c :: S1_c, s1_d :: CInt}
+data S1 = S1 {s1_c :: S1_c, s1_d :: CInt} deriving stock (Eq, Show)
 instance Storable S1
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -17,19 +17,18 @@ instance Storable S1
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S1 s1_c_3
                                         s1_d_4 -> pokeByteOff ptr_1 (0 :: Int) s1_c_3 >> pokeByteOff ptr_1 (8 :: Int) s1_d_4}}
-deriving stock instance Show S1
-deriving stock instance Eq S1
-data S2_inner_deep = S2_inner_deep {s2_inner_deep_b :: CInt}
+data S2_inner_deep
+    = S2_inner_deep {s2_inner_deep_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S2_inner_deep
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure S2_inner_deep <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S2_inner_deep s2_inner_deep_b_3 -> pokeByteOff ptr_1 (0 :: Int) s2_inner_deep_b_3}}
-deriving stock instance Show S2_inner_deep
-deriving stock instance Eq S2_inner_deep
 data S2_inner
     = S2_inner {s2_inner_a :: CInt, s2_inner_deep :: S2_inner_deep}
+    deriving stock (Eq, Show)
 instance Storable S2_inner
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -37,9 +36,9 @@ instance Storable S2_inner
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S2_inner s2_inner_a_3
                                               s2_inner_deep_4 -> pokeByteOff ptr_1 (0 :: Int) s2_inner_a_3 >> pokeByteOff ptr_1 (4 :: Int) s2_inner_deep_4}}
-deriving stock instance Show S2_inner
-deriving stock instance Eq S2_inner
-data S2 = S2 {s2_inner :: S2_inner, s2_d :: CInt}
+data S2
+    = S2 {s2_inner :: S2_inner, s2_d :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S2
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -47,9 +46,9 @@ instance Storable S2
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S2 s2_inner_3
                                         s2_d_4 -> pokeByteOff ptr_1 (0 :: Int) s2_inner_3 >> pokeByteOff ptr_1 (8 :: Int) s2_d_4}}
-deriving stock instance Show S2
-deriving stock instance Eq S2
-data S3_c = S3_c {s3_c_a :: CInt, s3_c_b :: CInt}
+data S3_c
+    = S3_c {s3_c_a :: CInt, s3_c_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S3_c
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -57,9 +56,9 @@ instance Storable S3_c
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S3_c s3_c_a_3
                                           s3_c_b_4 -> pokeByteOff ptr_1 (0 :: Int) s3_c_a_3 >> pokeByteOff ptr_1 (4 :: Int) s3_c_b_4}}
-deriving stock instance Show S3_c
-deriving stock instance Eq S3_c
-data S3 = S3 {s3_c :: (Ptr (Ptr S3_c)), s3_d :: CInt}
+data S3
+    = S3 {s3_c :: (Ptr (Ptr S3_c)), s3_d :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S3
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -67,5 +66,3 @@ instance Storable S3
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S3 s3_c_3
                                         s3_d_4 -> pokeByteOff ptr_1 (0 :: Int) s3_c_3 >> pokeByteOff ptr_1 (8 :: Int) s3_d_4}}
-deriving stock instance Show S3
-deriving stock instance Eq S3

--- a/hs-bindgen/fixtures/attributes.exts.txt
+++ b/hs-bindgen/fixtures/attributes.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/attributes.pp.hs
+++ b/hs-bindgen/fixtures/attributes.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -14,6 +13,7 @@ data Foo = Foo
   { foo_c :: FC.CChar
   , foo_i :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -35,14 +35,11 @@ instance F.Storable Foo where
                F.pokeByteOff ptr0 (0 :: Int) foo_c2
             >> F.pokeByteOff ptr0 (1 :: Int) foo_i3
 
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo
-
 data Bar = Bar
   { bar_c :: FC.CChar
   , bar_i :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bar where
 
@@ -64,14 +61,11 @@ instance F.Storable Bar where
                F.pokeByteOff ptr0 (0 :: Int) bar_c2
             >> F.pokeByteOff ptr0 (1 :: Int) bar_i3
 
-deriving stock instance Show Bar
-
-deriving stock instance Eq Bar
-
 data Baz = Baz
   { baz_c :: FC.CChar
   , baz_i :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Baz where
 
@@ -93,14 +87,11 @@ instance F.Storable Baz where
                F.pokeByteOff ptr0 (0 :: Int) baz_c2
             >> F.pokeByteOff ptr0 (1 :: Int) baz_i3
 
-deriving stock instance Show Baz
-
-deriving stock instance Eq Baz
-
 data Qux = Qux
   { qux_c :: FC.CChar
   , qux_i :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Qux where
 
@@ -122,15 +113,12 @@ instance F.Storable Qux where
                F.pokeByteOff ptr0 (0 :: Int) qux_c2
             >> F.pokeByteOff ptr0 (1 :: Int) qux_i3
 
-deriving stock instance Show Qux
-
-deriving stock instance Eq Qux
-
 data C__SFILE = C__SFILE
   { __sFILE__r :: FC.CInt
   , __sFILE__w :: FC.CInt
   , __sFILE__close :: F.FunPtr ((F.Ptr Void) -> IO FC.CInt)
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable C__SFILE where
 
@@ -154,16 +142,8 @@ instance F.Storable C__SFILE where
             >> F.pokeByteOff ptr0 (4 :: Int) __sFILE__w3
             >> F.pokeByteOff ptr0 (8 :: Int) __sFILE__close4
 
-deriving stock instance Show C__SFILE
-
-deriving stock instance Eq C__SFILE
-
 newtype FILE = FILE
   { un_FILE :: C__SFILE
   }
-
-deriving newtype instance F.Storable FILE
-
-deriving stock instance Eq FILE
-
-deriving stock instance Show FILE
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/attributes.th.txt
+++ b/hs-bindgen/fixtures/attributes.th.txt
@@ -1,5 +1,7 @@
 -- addDependentFile examples/golden/attributes.h
-data Foo = Foo {foo_c :: CChar, foo_i :: CInt}
+data Foo
+    = Foo {foo_c :: CChar, foo_i :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 5 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -7,9 +9,9 @@ instance Storable Foo
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_c_3
                                          foo_i_4 -> pokeByteOff ptr_1 (0 :: Int) foo_c_3 >> pokeByteOff ptr_1 (1 :: Int) foo_i_4}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo
-data Bar = Bar {bar_c :: CChar, bar_i :: CInt}
+data Bar
+    = Bar {bar_c :: CChar, bar_i :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Bar
     where {sizeOf = \_ -> 5 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -17,9 +19,9 @@ instance Storable Bar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bar bar_c_3
                                          bar_i_4 -> pokeByteOff ptr_1 (0 :: Int) bar_c_3 >> pokeByteOff ptr_1 (1 :: Int) bar_i_4}}
-deriving stock instance Show Bar
-deriving stock instance Eq Bar
-data Baz = Baz {baz_c :: CChar, baz_i :: CInt}
+data Baz
+    = Baz {baz_c :: CChar, baz_i :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Baz
     where {sizeOf = \_ -> 5 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -27,9 +29,9 @@ instance Storable Baz
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Baz baz_c_3
                                          baz_i_4 -> pokeByteOff ptr_1 (0 :: Int) baz_c_3 >> pokeByteOff ptr_1 (1 :: Int) baz_i_4}}
-deriving stock instance Show Baz
-deriving stock instance Eq Baz
-data Qux = Qux {qux_c :: CChar, qux_i :: CInt}
+data Qux
+    = Qux {qux_c :: CChar, qux_i :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Qux
     where {sizeOf = \_ -> 5 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -37,12 +39,11 @@ instance Storable Qux
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Qux qux_c_3
                                          qux_i_4 -> pokeByteOff ptr_1 (0 :: Int) qux_c_3 >> pokeByteOff ptr_1 (1 :: Int) qux_i_4}}
-deriving stock instance Show Qux
-deriving stock instance Eq Qux
 data C__SFILE
     = C__SFILE {__sFILE__r :: CInt,
                 __sFILE__w :: CInt,
                 __sFILE__close :: (FunPtr (Ptr Void -> IO CInt))}
+    deriving stock (Eq, Show)
 instance Storable C__SFILE
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -51,9 +52,7 @@ instance Storable C__SFILE
                                     {C__SFILE __sFILE__r_3
                                               __sFILE__w_4
                                               __sFILE__close_5 -> pokeByteOff ptr_1 (0 :: Int) __sFILE__r_3 >> (pokeByteOff ptr_1 (4 :: Int) __sFILE__w_4 >> pokeByteOff ptr_1 (8 :: Int) __sFILE__close_5)}}
-deriving stock instance Show C__SFILE
-deriving stock instance Eq C__SFILE
-newtype FILE = FILE {un_FILE :: C__SFILE}
-deriving newtype instance Storable FILE
-deriving stock instance Eq FILE
-deriving stock instance Show FILE
+newtype FILE
+    = FILE {un_FILE :: C__SFILE}
+    deriving stock (Eq, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/bitfields.exts.txt
+++ b/hs-bindgen/fixtures/bitfields.exts.txt
@@ -1,2 +1,1 @@
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/bitfields.pp.hs
+++ b/hs-bindgen/fixtures/bitfields.pp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -17,6 +16,7 @@ data Flags = Flags
   , flags_fieldY :: FC.CChar
   , flags_bits :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Flags where
 
@@ -46,15 +46,12 @@ instance F.Storable Flags where
             >> F.pokeByteOff ptr0 (2 :: Int) flags_fieldY6
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (24 :: Int) (2 :: Int) flags_bits7
 
-deriving stock instance Show Flags
-
-deriving stock instance Eq Flags
-
 data Overflow32 = Overflow32
   { overflow32_x :: FC.CInt
   , overflow32_y :: FC.CInt
   , overflow32_z :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Overflow32 where
 
@@ -78,15 +75,12 @@ instance F.Storable Overflow32 where
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (32 :: Int) (17 :: Int) overflow32_y3
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (64 :: Int) (17 :: Int) overflow32_z4
 
-deriving stock instance Show Overflow32
-
-deriving stock instance Eq Overflow32
-
 data Overflow32b = Overflow32b
   { overflow32b_x :: FC.CLong
   , overflow32b_y :: FC.CLong
   , overflow32b_z :: FC.CLong
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Overflow32b where
 
@@ -110,15 +104,12 @@ instance F.Storable Overflow32b where
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (17 :: Int) (17 :: Int) overflow32b_y3
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (34 :: Int) (17 :: Int) overflow32b_z4
 
-deriving stock instance Show Overflow32b
-
-deriving stock instance Eq Overflow32b
-
 data Overflow32c = Overflow32c
   { overflow32c_x :: FC.CLong
   , overflow32c_y :: FC.CInt
   , overflow32c_z :: FC.CLong
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Overflow32c where
 
@@ -142,14 +133,11 @@ instance F.Storable Overflow32c where
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (32 :: Int) (17 :: Int) overflow32c_y3
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (64 :: Int) (17 :: Int) overflow32c_z4
 
-deriving stock instance Show Overflow32c
-
-deriving stock instance Eq Overflow32c
-
 data Overflow64 = Overflow64
   { overflow64_x :: FC.CLong
   , overflow64_y :: FC.CLong
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Overflow64 where
 
@@ -171,14 +159,11 @@ instance F.Storable Overflow64 where
                HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (0 :: Int) (33 :: Int) overflow64_x2
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (64 :: Int) (33 :: Int) overflow64_y3
 
-deriving stock instance Show Overflow64
-
-deriving stock instance Eq Overflow64
-
 data AlignA = AlignA
   { alignA_x :: FC.CUChar
   , alignA_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable AlignA where
 
@@ -200,14 +185,11 @@ instance F.Storable AlignA where
                HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (0 :: Int) (1 :: Int) alignA_x2
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (1 :: Int) (10 :: Int) alignA_y3
 
-deriving stock instance Show AlignA
-
-deriving stock instance Eq AlignA
-
 data AlignB = AlignB
   { alignB_x :: FC.CUChar
   , alignB_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable AlignB where
 
@@ -228,7 +210,3 @@ instance F.Storable AlignB where
           AlignB alignB_x2 alignB_y3 ->
                HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (0 :: Int) (7 :: Int) alignB_x2
             >> HsBindgen.Runtime.Bitfield.pokeBitOffWidth ptr0 (32 :: Int) (31 :: Int) alignB_y3
-
-deriving stock instance Show AlignB
-
-deriving stock instance Eq AlignB

--- a/hs-bindgen/fixtures/bitfields.th.txt
+++ b/hs-bindgen/fixtures/bitfields.th.txt
@@ -6,6 +6,7 @@ data Flags
              flags_flagC :: CInt,
              flags_fieldY :: CChar,
              flags_bits :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Flags
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -17,12 +18,11 @@ instance Storable Flags
                                            flags_flagC_6
                                            flags_fieldY_7
                                            flags_bits_8 -> pokeByteOff ptr_1 (0 :: Int) flags_fieldX_3 >> (pokeBitOffWidth ptr_1 (8 :: Int) (1 :: Int) flags_flagA_4 >> (pokeBitOffWidth ptr_1 (9 :: Int) (1 :: Int) flags_flagB_5 >> (pokeBitOffWidth ptr_1 (10 :: Int) (1 :: Int) flags_flagC_6 >> (pokeByteOff ptr_1 (2 :: Int) flags_fieldY_7 >> pokeBitOffWidth ptr_1 (24 :: Int) (2 :: Int) flags_bits_8))))}}
-deriving stock instance Show Flags
-deriving stock instance Eq Flags
 data Overflow32
     = Overflow32 {overflow32_x :: CInt,
                   overflow32_y :: CInt,
                   overflow32_z :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Overflow32
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -31,12 +31,11 @@ instance Storable Overflow32
                                     {Overflow32 overflow32_x_3
                                                 overflow32_y_4
                                                 overflow32_z_5 -> pokeBitOffWidth ptr_1 (0 :: Int) (17 :: Int) overflow32_x_3 >> (pokeBitOffWidth ptr_1 (32 :: Int) (17 :: Int) overflow32_y_4 >> pokeBitOffWidth ptr_1 (64 :: Int) (17 :: Int) overflow32_z_5)}}
-deriving stock instance Show Overflow32
-deriving stock instance Eq Overflow32
 data Overflow32b
     = Overflow32b {overflow32b_x :: CLong,
                    overflow32b_y :: CLong,
                    overflow32b_z :: CLong}
+    deriving stock (Eq, Show)
 instance Storable Overflow32b
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -45,12 +44,11 @@ instance Storable Overflow32b
                                     {Overflow32b overflow32b_x_3
                                                  overflow32b_y_4
                                                  overflow32b_z_5 -> pokeBitOffWidth ptr_1 (0 :: Int) (17 :: Int) overflow32b_x_3 >> (pokeBitOffWidth ptr_1 (17 :: Int) (17 :: Int) overflow32b_y_4 >> pokeBitOffWidth ptr_1 (34 :: Int) (17 :: Int) overflow32b_z_5)}}
-deriving stock instance Show Overflow32b
-deriving stock instance Eq Overflow32b
 data Overflow32c
     = Overflow32c {overflow32c_x :: CLong,
                    overflow32c_y :: CInt,
                    overflow32c_z :: CLong}
+    deriving stock (Eq, Show)
 instance Storable Overflow32c
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -59,10 +57,9 @@ instance Storable Overflow32c
                                     {Overflow32c overflow32c_x_3
                                                  overflow32c_y_4
                                                  overflow32c_z_5 -> pokeBitOffWidth ptr_1 (0 :: Int) (17 :: Int) overflow32c_x_3 >> (pokeBitOffWidth ptr_1 (32 :: Int) (17 :: Int) overflow32c_y_4 >> pokeBitOffWidth ptr_1 (64 :: Int) (17 :: Int) overflow32c_z_5)}}
-deriving stock instance Show Overflow32c
-deriving stock instance Eq Overflow32c
 data Overflow64
     = Overflow64 {overflow64_x :: CLong, overflow64_y :: CLong}
+    deriving stock (Eq, Show)
 instance Storable Overflow64
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -70,9 +67,9 @@ instance Storable Overflow64
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Overflow64 overflow64_x_3
                                                 overflow64_y_4 -> pokeBitOffWidth ptr_1 (0 :: Int) (33 :: Int) overflow64_x_3 >> pokeBitOffWidth ptr_1 (64 :: Int) (33 :: Int) overflow64_y_4}}
-deriving stock instance Show Overflow64
-deriving stock instance Eq Overflow64
-data AlignA = AlignA {alignA_x :: CUChar, alignA_y :: CInt}
+data AlignA
+    = AlignA {alignA_x :: CUChar, alignA_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable AlignA
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -80,9 +77,9 @@ instance Storable AlignA
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {AlignA alignA_x_3
                                             alignA_y_4 -> pokeBitOffWidth ptr_1 (0 :: Int) (1 :: Int) alignA_x_3 >> pokeBitOffWidth ptr_1 (1 :: Int) (10 :: Int) alignA_y_4}}
-deriving stock instance Show AlignA
-deriving stock instance Eq AlignA
-data AlignB = AlignB {alignB_x :: CUChar, alignB_y :: CInt}
+data AlignB
+    = AlignB {alignB_x :: CUChar, alignB_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable AlignB
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -90,5 +87,3 @@ instance Storable AlignB
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {AlignB alignB_x_3
                                             alignB_y_4 -> pokeBitOffWidth ptr_1 (0 :: Int) (7 :: Int) alignB_x_3 >> pokeBitOffWidth ptr_1 (32 :: Int) (31 :: Int) alignB_y_4}}
-deriving stock instance Show AlignB
-deriving stock instance Eq AlignB

--- a/hs-bindgen/fixtures/bool.exts.txt
+++ b/hs-bindgen/fixtures/bool.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/bool.pp.hs
+++ b/hs-bindgen/fixtures/bool.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -16,6 +15,7 @@ data Bools1 = Bools1
   { bools1_x :: FC.CBool
   , bools1_y :: FC.CBool
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bools1 where
 
@@ -37,14 +37,11 @@ instance F.Storable Bools1 where
                F.pokeByteOff ptr0 (0 :: Int) bools1_x2
             >> F.pokeByteOff ptr0 (1 :: Int) bools1_y3
 
-deriving stock instance Show Bools1
-
-deriving stock instance Eq Bools1
-
 data Bools2 = Bools2
   { bools2_x :: FC.CBool
   , bools2_y :: FC.CBool
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bools2 where
 
@@ -66,44 +63,17 @@ instance F.Storable Bools2 where
                F.pokeByteOff ptr0 (0 :: Int) bools2_x2
             >> F.pokeByteOff ptr0 (1 :: Int) bools2_y3
 
-deriving stock instance Show Bools2
-
-deriving stock instance Eq Bools2
-
 newtype BOOL = BOOL
   { un_BOOL :: FC.CBool
   }
-
-deriving newtype instance F.Storable BOOL
-
-deriving stock instance Eq BOOL
-
-deriving stock instance Ord BOOL
-
-deriving stock instance Read BOOL
-
-deriving stock instance Show BOOL
-
-deriving newtype instance Enum BOOL
-
-deriving newtype instance Ix.Ix BOOL
-
-deriving newtype instance Bounded BOOL
-
-deriving newtype instance Bits.Bits BOOL
-
-deriving newtype instance FiniteBits BOOL
-
-deriving newtype instance Integral BOOL
-
-deriving newtype instance Num BOOL
-
-deriving newtype instance Real BOOL
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data Bools3 = Bools3
   { bools3_x :: BOOL
   , bools3_y :: BOOL
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bools3 where
 
@@ -124,7 +94,3 @@ instance F.Storable Bools3 where
           Bools3 bools3_x2 bools3_y3 ->
                F.pokeByteOff ptr0 (0 :: Int) bools3_x2
             >> F.pokeByteOff ptr0 (1 :: Int) bools3_y3
-
-deriving stock instance Show Bools3
-
-deriving stock instance Eq Bools3

--- a/hs-bindgen/fixtures/bool.th.txt
+++ b/hs-bindgen/fixtures/bool.th.txt
@@ -1,6 +1,8 @@
 -- addDependentFile musl-include/x86_64/stdbool.h
 -- addDependentFile examples/golden/bool.h
-data Bools1 = Bools1 {bools1_x :: CBool, bools1_y :: CBool}
+data Bools1
+    = Bools1 {bools1_x :: CBool, bools1_y :: CBool}
+    deriving stock (Eq, Show)
 instance Storable Bools1
     where {sizeOf = \_ -> 2 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -8,9 +10,9 @@ instance Storable Bools1
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bools1 bools1_x_3
                                             bools1_y_4 -> pokeByteOff ptr_1 (0 :: Int) bools1_x_3 >> pokeByteOff ptr_1 (1 :: Int) bools1_y_4}}
-deriving stock instance Show Bools1
-deriving stock instance Eq Bools1
-data Bools2 = Bools2 {bools2_x :: CBool, bools2_y :: CBool}
+data Bools2
+    = Bools2 {bools2_x :: CBool, bools2_y :: CBool}
+    deriving stock (Eq, Show)
 instance Storable Bools2
     where {sizeOf = \_ -> 2 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -18,23 +20,21 @@ instance Storable Bools2
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bools2 bools2_x_3
                                             bools2_y_4 -> pokeByteOff ptr_1 (0 :: Int) bools2_x_3 >> pokeByteOff ptr_1 (1 :: Int) bools2_y_4}}
-deriving stock instance Show Bools2
-deriving stock instance Eq Bools2
-newtype BOOL = BOOL {un_BOOL :: CBool}
-deriving newtype instance Storable BOOL
-deriving stock instance Eq BOOL
-deriving stock instance Ord BOOL
-deriving stock instance Read BOOL
-deriving stock instance Show BOOL
-deriving newtype instance Enum BOOL
-deriving newtype instance Ix BOOL
-deriving newtype instance Bounded BOOL
-deriving newtype instance Bits BOOL
-deriving newtype instance FiniteBits BOOL
-deriving newtype instance Integral BOOL
-deriving newtype instance Num BOOL
-deriving newtype instance Real BOOL
-data Bools3 = Bools3 {bools3_x :: BOOL, bools3_y :: BOOL}
+newtype BOOL
+    = BOOL {un_BOOL :: CBool}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+data Bools3
+    = Bools3 {bools3_x :: BOOL, bools3_y :: BOOL}
+    deriving stock (Eq, Show)
 instance Storable Bools3
     where {sizeOf = \_ -> 2 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -42,5 +42,3 @@ instance Storable Bools3
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bools3 bools3_x_3
                                             bools3_y_4 -> pokeByteOff ptr_1 (0 :: Int) bools3_x_3 >> pokeByteOff ptr_1 (1 :: Int) bools3_y_4}}
-deriving stock instance Show Bools3
-deriving stock instance Eq Bools3

--- a/hs-bindgen/fixtures/distilled_lib_1.exts.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.exts.txt
@@ -2,7 +2,6 @@ CApiFFI
 TemplateHaskell
 TypeFamilies
 DataKinds
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving
 ExplicitForAll

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -31,6 +30,7 @@ data Another_typedef_struct_t = Another_typedef_struct_t
   { another_typedef_struct_t_foo :: FC.CInt
   , another_typedef_struct_t_bar :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Another_typedef_struct_t where
 
@@ -52,13 +52,10 @@ instance F.Storable Another_typedef_struct_t where
                F.pokeByteOff ptr0 (0 :: Int) another_typedef_struct_t_foo2
             >> F.pokeByteOff ptr0 (4 :: Int) another_typedef_struct_t_bar3
 
-deriving stock instance Show Another_typedef_struct_t
-
-deriving stock instance Eq Another_typedef_struct_t
-
 newtype Another_typedef_enum_e = Another_typedef_enum_e
   { un_Another_typedef_enum_e :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Another_typedef_enum_e where
 
@@ -77,10 +74,6 @@ instance F.Storable Another_typedef_enum_e where
         case s1 of
           Another_typedef_enum_e un_Another_typedef_enum_e2 ->
             F.pokeByteOff ptr0 (0 :: Int) un_Another_typedef_enum_e2
-
-deriving stock instance Eq Another_typedef_enum_e
-
-deriving stock instance Ord Another_typedef_enum_e
 
 instance HsBindgen.Runtime.CEnum.CEnum Another_typedef_enum_e where
 
@@ -140,62 +133,14 @@ sOME_DEFINED_CONSTANT = (4 :: FC.CInt)
 newtype A_type_t = A_type_t
   { un_A_type_t :: FC.CInt
   }
-
-deriving newtype instance F.Storable A_type_t
-
-deriving stock instance Eq A_type_t
-
-deriving stock instance Ord A_type_t
-
-deriving stock instance Read A_type_t
-
-deriving stock instance Show A_type_t
-
-deriving newtype instance Enum A_type_t
-
-deriving newtype instance Ix.Ix A_type_t
-
-deriving newtype instance Bounded A_type_t
-
-deriving newtype instance Bits.Bits A_type_t
-
-deriving newtype instance FiniteBits A_type_t
-
-deriving newtype instance Integral A_type_t
-
-deriving newtype instance Num A_type_t
-
-deriving newtype instance Real A_type_t
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype Var_t = Var_t
   { un_Var_t :: FC.CInt
   }
-
-deriving newtype instance F.Storable Var_t
-
-deriving stock instance Eq Var_t
-
-deriving stock instance Ord Var_t
-
-deriving stock instance Read Var_t
-
-deriving stock instance Show Var_t
-
-deriving newtype instance Enum Var_t
-
-deriving newtype instance Ix.Ix Var_t
-
-deriving newtype instance Bounded Var_t
-
-deriving newtype instance Bits.Bits Var_t
-
-deriving newtype instance FiniteBits Var_t
-
-deriving newtype instance Integral Var_t
-
-deriving newtype instance Num Var_t
-
-deriving newtype instance Real Var_t
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data A_typedef_struct = A_typedef_struct
   { a_typedef_struct_field_0 :: FC.CBool
@@ -210,6 +155,7 @@ data A_typedef_struct = A_typedef_struct
   , a_typedef_struct_field_9 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) Another_typedef_enum_e
   , a_typedef_struct_field_10 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 5) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Another_typedef_enum_e)
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable A_typedef_struct where
 
@@ -260,19 +206,11 @@ instance F.Storable A_typedef_struct where
               >> F.pokeByteOff ptr0 (64 :: Int) a_typedef_struct_field_911
               >> F.pokeByteOff ptr0 (80 :: Int) a_typedef_struct_field_1012
 
-deriving stock instance Show A_typedef_struct
-
-deriving stock instance Eq A_typedef_struct
-
 newtype A_typedef_struct_t = A_typedef_struct_t
   { un_A_typedef_struct_t :: A_typedef_struct
   }
-
-deriving newtype instance F.Storable A_typedef_struct_t
-
-deriving stock instance Eq A_typedef_struct_t
-
-deriving stock instance Show A_typedef_struct_t
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 a_DEFINE_0 :: FC.CInt
 a_DEFINE_0 = (0 :: FC.CInt)
@@ -289,6 +227,7 @@ tWO_ARGS = (,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 newtype A_typedef_enum_e = A_typedef_enum_e
   { un_A_typedef_enum_e :: FC.CUChar
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable A_typedef_enum_e where
 
@@ -307,10 +246,6 @@ instance F.Storable A_typedef_enum_e where
         case s1 of
           A_typedef_enum_e un_A_typedef_enum_e2 ->
             F.pokeByteOff ptr0 (0 :: Int) un_A_typedef_enum_e2
-
-deriving stock instance Eq A_typedef_enum_e
-
-deriving stock instance Ord A_typedef_enum_e
 
 instance HsBindgen.Runtime.CEnum.CEnum A_typedef_enum_e where
 
@@ -373,11 +308,5 @@ foreign import ccall safe "testmodule_some_fun" some_fun :: (F.Ptr A_type_t) -> 
 newtype Callback_t = Callback_t
   { un_Callback_t :: F.FunPtr ((F.Ptr Void) -> HsBindgen.Runtime.Prelude.Word32 -> IO HsBindgen.Runtime.Prelude.Word32)
   }
-
-deriving newtype instance F.Storable Callback_t
-
-deriving stock instance Eq Callback_t
-
-deriving stock instance Ord Callback_t
-
-deriving stock instance Show Callback_t
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -8,6 +8,7 @@
 data Another_typedef_struct_t
     = Another_typedef_struct_t {another_typedef_struct_t_foo :: CInt,
                                 another_typedef_struct_t_bar :: CChar}
+    deriving stock (Eq, Show)
 instance Storable Another_typedef_struct_t
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -15,18 +16,15 @@ instance Storable Another_typedef_struct_t
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Another_typedef_struct_t another_typedef_struct_t_foo_3
                                                               another_typedef_struct_t_bar_4 -> pokeByteOff ptr_1 (0 :: Int) another_typedef_struct_t_foo_3 >> pokeByteOff ptr_1 (4 :: Int) another_typedef_struct_t_bar_4}}
-deriving stock instance Show Another_typedef_struct_t
-deriving stock instance Eq Another_typedef_struct_t
 newtype Another_typedef_enum_e
     = Another_typedef_enum_e {un_Another_typedef_enum_e :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable Another_typedef_enum_e
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Another_typedef_enum_e <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Another_typedef_enum_e un_Another_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_Another_typedef_enum_e_3}}
-deriving stock instance Eq Another_typedef_enum_e
-deriving stock instance Ord Another_typedef_enum_e
 instance CEnum Another_typedef_enum_e
     where {type CEnumZ Another_typedef_enum_e = CUInt;
            toCEnum = Another_typedef_enum_e;
@@ -56,34 +54,30 @@ b :: CInt
 b = 3 :: CInt
 sOME_DEFINED_CONSTANT :: CInt
 sOME_DEFINED_CONSTANT = 4 :: CInt
-newtype A_type_t = A_type_t {un_A_type_t :: CInt}
-deriving newtype instance Storable A_type_t
-deriving stock instance Eq A_type_t
-deriving stock instance Ord A_type_t
-deriving stock instance Read A_type_t
-deriving stock instance Show A_type_t
-deriving newtype instance Enum A_type_t
-deriving newtype instance Ix A_type_t
-deriving newtype instance Bounded A_type_t
-deriving newtype instance Bits A_type_t
-deriving newtype instance FiniteBits A_type_t
-deriving newtype instance Integral A_type_t
-deriving newtype instance Num A_type_t
-deriving newtype instance Real A_type_t
-newtype Var_t = Var_t {un_Var_t :: CInt}
-deriving newtype instance Storable Var_t
-deriving stock instance Eq Var_t
-deriving stock instance Ord Var_t
-deriving stock instance Read Var_t
-deriving stock instance Show Var_t
-deriving newtype instance Enum Var_t
-deriving newtype instance Ix Var_t
-deriving newtype instance Bounded Var_t
-deriving newtype instance Bits Var_t
-deriving newtype instance FiniteBits Var_t
-deriving newtype instance Integral Var_t
-deriving newtype instance Num Var_t
-deriving newtype instance Real Var_t
+newtype A_type_t
+    = A_type_t {un_A_type_t :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype Var_t
+    = Var_t {un_Var_t :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 data A_typedef_struct
     = A_typedef_struct {a_typedef_struct_field_0 :: CBool,
                         a_typedef_struct_field_1 :: HsBindgen.Runtime.Prelude.Word8,
@@ -100,6 +94,7 @@ data A_typedef_struct
                         a_typedef_struct_field_10 :: (ConstantArray 5
                                                                     (ConstantArray 3
                                                                                    Another_typedef_enum_e))}
+    deriving stock (Eq, Show)
 instance Storable A_typedef_struct
     where {sizeOf = \_ -> 140 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -116,13 +111,10 @@ instance Storable A_typedef_struct
                                                       a_typedef_struct_field_8_11
                                                       a_typedef_struct_field_9_12
                                                       a_typedef_struct_field_10_13 -> pokeByteOff ptr_1 (0 :: Int) a_typedef_struct_field_0_3 >> (pokeByteOff ptr_1 (1 :: Int) a_typedef_struct_field_1_4 >> (pokeByteOff ptr_1 (2 :: Int) a_typedef_struct_field_2_5 >> (pokeByteOff ptr_1 (4 :: Int) a_typedef_struct_field_3_6 >> (pokeByteOff ptr_1 (8 :: Int) a_typedef_struct_field_4_7 >> (pokeByteOff ptr_1 (16 :: Int) a_typedef_struct_field_5_8 >> (pokeByteOff ptr_1 (24 :: Int) a_typedef_struct_field_6_9 >> (pokeByteOff ptr_1 (32 :: Int) a_typedef_struct_field_7_10 >> (pokeByteOff ptr_1 (60 :: Int) a_typedef_struct_field_8_11 >> (pokeByteOff ptr_1 (64 :: Int) a_typedef_struct_field_9_12 >> pokeByteOff ptr_1 (80 :: Int) a_typedef_struct_field_10_13)))))))))}}
-deriving stock instance Show A_typedef_struct
-deriving stock instance Eq A_typedef_struct
 newtype A_typedef_struct_t
     = A_typedef_struct_t {un_A_typedef_struct_t :: A_typedef_struct}
-deriving newtype instance Storable A_typedef_struct_t
-deriving stock instance Eq A_typedef_struct_t
-deriving stock instance Show A_typedef_struct_t
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 a_DEFINE_0 :: CInt
 a_DEFINE_0 = 0 :: CInt
 a_DEFINE_1 :: CUInt
@@ -133,14 +125,13 @@ tWO_ARGS :: (,) CInt CInt
 tWO_ARGS = (,) (13398 :: CInt) (30874 :: CInt)
 newtype A_typedef_enum_e
     = A_typedef_enum_e {un_A_typedef_enum_e :: CUChar}
+    deriving stock (Eq, Ord)
 instance Storable A_typedef_enum_e
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure A_typedef_enum_e <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {A_typedef_enum_e un_A_typedef_enum_e_3 -> pokeByteOff ptr_1 (0 :: Int) un_A_typedef_enum_e_3}}
-deriving stock instance Eq A_typedef_enum_e
-deriving stock instance Ord A_typedef_enum_e
 instance CEnum A_typedef_enum_e
     where {type CEnumZ A_typedef_enum_e = CUChar;
            toCEnum = A_typedef_enum_e;
@@ -179,7 +170,5 @@ newtype Callback_t
     = Callback_t {un_Callback_t :: (FunPtr (Ptr Void ->
                                             HsBindgen.Runtime.Prelude.Word32 ->
                                             IO HsBindgen.Runtime.Prelude.Word32))}
-deriving newtype instance Storable Callback_t
-deriving stock instance Eq Callback_t
-deriving stock instance Ord Callback_t
-deriving stock instance Show Callback_t
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/enums.exts.txt
+++ b/hs-bindgen/fixtures/enums.exts.txt
@@ -1,5 +1,4 @@
 TypeFamilies
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving
 PatternSynonyms

--- a/hs-bindgen/fixtures/enums.pp.hs
+++ b/hs-bindgen/fixtures/enums.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Example where
@@ -17,6 +16,7 @@ import qualified Text.Read
 newtype First = First
   { un_First :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable First where
 
@@ -34,10 +34,6 @@ instance F.Storable First where
       \s1 ->
         case s1 of
           First un_First2 -> F.pokeByteOff ptr0 (0 :: Int) un_First2
-
-deriving stock instance Eq First
-
-deriving stock instance Ord First
 
 instance HsBindgen.Runtime.CEnum.CEnum First where
 
@@ -86,6 +82,7 @@ pattern FIRST2 = First 1
 newtype Second = Second
   { un_Second :: FC.CInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Second where
 
@@ -103,10 +100,6 @@ instance F.Storable Second where
       \s1 ->
         case s1 of
           Second un_Second2 -> F.pokeByteOff ptr0 (0 :: Int) un_Second2
-
-deriving stock instance Eq Second
-
-deriving stock instance Ord Second
 
 instance HsBindgen.Runtime.CEnum.CEnum Second where
 
@@ -161,6 +154,7 @@ pattern SECOND_C = Second 1
 newtype Same = Same
   { un_Same :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Same where
 
@@ -178,10 +172,6 @@ instance F.Storable Same where
       \s1 ->
         case s1 of
           Same un_Same2 -> F.pokeByteOff ptr0 (0 :: Int) un_Same2
-
-deriving stock instance Eq Same
-
-deriving stock instance Ord Same
 
 instance HsBindgen.Runtime.CEnum.CEnum Same where
 
@@ -230,6 +220,7 @@ pattern SAME_B = Same 1
 newtype Nonseq = Nonseq
   { un_Nonseq :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Nonseq where
 
@@ -247,10 +238,6 @@ instance F.Storable Nonseq where
       \s1 ->
         case s1 of
           Nonseq un_Nonseq2 -> F.pokeByteOff ptr0 (0 :: Int) un_Nonseq2
-
-deriving stock instance Eq Nonseq
-
-deriving stock instance Ord Nonseq
 
 instance HsBindgen.Runtime.CEnum.CEnum Nonseq where
 
@@ -295,6 +282,7 @@ pattern NONSEQ_C = Nonseq 404
 newtype Packed = Packed
   { un_Packed :: FC.CUChar
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Packed where
 
@@ -312,10 +300,6 @@ instance F.Storable Packed where
       \s1 ->
         case s1 of
           Packed un_Packed2 -> F.pokeByteOff ptr0 (0 :: Int) un_Packed2
-
-deriving stock instance Eq Packed
-
-deriving stock instance Ord Packed
 
 instance HsBindgen.Runtime.CEnum.CEnum Packed where
 
@@ -370,6 +354,7 @@ pattern PACKED_C = Packed 2
 newtype EnumA = EnumA
   { un_EnumA :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable EnumA where
 
@@ -387,10 +372,6 @@ instance F.Storable EnumA where
       \s1 ->
         case s1 of
           EnumA un_EnumA2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumA2
-
-deriving stock instance Eq EnumA
-
-deriving stock instance Ord EnumA
 
 instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
@@ -439,6 +420,7 @@ pattern A_BAR = EnumA 1
 newtype EnumB = EnumB
   { un_EnumB :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable EnumB where
 
@@ -456,10 +438,6 @@ instance F.Storable EnumB where
       \s1 ->
         case s1 of
           EnumB un_EnumB2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumB2
-
-deriving stock instance Eq EnumB
-
-deriving stock instance Ord EnumB
 
 instance HsBindgen.Runtime.CEnum.CEnum EnumB where
 
@@ -508,6 +486,7 @@ pattern B_BAR = EnumB 1
 newtype EnumC = EnumC
   { un_EnumC :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable EnumC where
 
@@ -525,10 +504,6 @@ instance F.Storable EnumC where
       \s1 ->
         case s1 of
           EnumC un_EnumC2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumC2
-
-deriving stock instance Eq EnumC
-
-deriving stock instance Ord EnumC
 
 instance HsBindgen.Runtime.CEnum.CEnum EnumC where
 
@@ -577,6 +552,7 @@ pattern C_BAR = EnumC 1
 newtype EnumD = EnumD
   { un_EnumD :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable EnumD where
 
@@ -594,10 +570,6 @@ instance F.Storable EnumD where
       \s1 ->
         case s1 of
           EnumD un_EnumD2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumD2
-
-deriving stock instance Eq EnumD
-
-deriving stock instance Ord EnumD
 
 instance HsBindgen.Runtime.CEnum.CEnum EnumD where
 
@@ -646,13 +618,5 @@ pattern D_BAR = EnumD 1
 newtype EnumD_t = EnumD_t
   { un_EnumD_t :: EnumD
   }
-
-deriving newtype instance F.Storable EnumD_t
-
-deriving stock instance Eq EnumD_t
-
-deriving stock instance Ord EnumD_t
-
-deriving stock instance Read EnumD_t
-
-deriving stock instance Show EnumD_t
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/enums.th.txt
+++ b/hs-bindgen/fixtures/enums.th.txt
@@ -1,13 +1,11 @@
 -- addDependentFile examples/golden/enums.h
-newtype First = First {un_First :: CUInt}
+newtype First = First {un_First :: CUInt} deriving stock (Eq, Ord)
 instance Storable First
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure First <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {First un_First_3 -> pokeByteOff ptr_1 (0 :: Int) un_First_3}}
-deriving stock instance Eq First
-deriving stock instance Ord First
 instance CEnum First
     where {type CEnumZ First = CUInt;
            toCEnum = First;
@@ -31,15 +29,15 @@ pattern FIRST1 :: First
 pattern FIRST1 = First 0
 pattern FIRST2 :: First
 pattern FIRST2 = First 1
-newtype Second = Second {un_Second :: CInt}
+newtype Second
+    = Second {un_Second :: CInt}
+    deriving stock (Eq, Ord)
 instance Storable Second
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Second <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Second un_Second_3 -> pokeByteOff ptr_1 (0 :: Int) un_Second_3}}
-deriving stock instance Eq Second
-deriving stock instance Ord Second
 instance CEnum Second
     where {type CEnumZ Second = CInt;
            toCEnum = Second;
@@ -66,15 +64,13 @@ pattern SECOND_B :: Second
 pattern SECOND_B = Second 0
 pattern SECOND_C :: Second
 pattern SECOND_C = Second 1
-newtype Same = Same {un_Same :: CUInt}
+newtype Same = Same {un_Same :: CUInt} deriving stock (Eq, Ord)
 instance Storable Same
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Same <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Same un_Same_3 -> pokeByteOff ptr_1 (0 :: Int) un_Same_3}}
-deriving stock instance Eq Same
-deriving stock instance Ord Same
 instance CEnum Same
     where {type CEnumZ Same = CUInt;
            toCEnum = Same;
@@ -97,15 +93,15 @@ pattern SAME_A :: Same
 pattern SAME_A = Same 1
 pattern SAME_B :: Same
 pattern SAME_B = Same 1
-newtype Nonseq = Nonseq {un_Nonseq :: CUInt}
+newtype Nonseq
+    = Nonseq {un_Nonseq :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable Nonseq
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Nonseq <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Nonseq un_Nonseq_3 -> pokeByteOff ptr_1 (0 :: Int) un_Nonseq_3}}
-deriving stock instance Eq Nonseq
-deriving stock instance Ord Nonseq
 instance CEnum Nonseq
     where {type CEnumZ Nonseq = CUInt;
            toCEnum = Nonseq;
@@ -128,15 +124,15 @@ pattern NONSEQ_B :: Nonseq
 pattern NONSEQ_B = Nonseq 301
 pattern NONSEQ_C :: Nonseq
 pattern NONSEQ_C = Nonseq 404
-newtype Packed = Packed {un_Packed :: CUChar}
+newtype Packed
+    = Packed {un_Packed :: CUChar}
+    deriving stock (Eq, Ord)
 instance Storable Packed
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure Packed <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Packed un_Packed_3 -> pokeByteOff ptr_1 (0 :: Int) un_Packed_3}}
-deriving stock instance Eq Packed
-deriving stock instance Ord Packed
 instance CEnum Packed
     where {type CEnumZ Packed = CUChar;
            toCEnum = Packed;
@@ -163,15 +159,13 @@ pattern PACKED_B :: Packed
 pattern PACKED_B = Packed 1
 pattern PACKED_C :: Packed
 pattern PACKED_C = Packed 2
-newtype EnumA = EnumA {un_EnumA :: CUInt}
+newtype EnumA = EnumA {un_EnumA :: CUInt} deriving stock (Eq, Ord)
 instance Storable EnumA
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumA <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {EnumA un_EnumA_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumA_3}}
-deriving stock instance Eq EnumA
-deriving stock instance Ord EnumA
 instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            toCEnum = EnumA;
@@ -195,15 +189,13 @@ pattern A_FOO :: EnumA
 pattern A_FOO = EnumA 0
 pattern A_BAR :: EnumA
 pattern A_BAR = EnumA 1
-newtype EnumB = EnumB {un_EnumB :: CUInt}
+newtype EnumB = EnumB {un_EnumB :: CUInt} deriving stock (Eq, Ord)
 instance Storable EnumB
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumB <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {EnumB un_EnumB_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumB_3}}
-deriving stock instance Eq EnumB
-deriving stock instance Ord EnumB
 instance CEnum EnumB
     where {type CEnumZ EnumB = CUInt;
            toCEnum = EnumB;
@@ -227,15 +219,13 @@ pattern B_FOO :: EnumB
 pattern B_FOO = EnumB 0
 pattern B_BAR :: EnumB
 pattern B_BAR = EnumB 1
-newtype EnumC = EnumC {un_EnumC :: CUInt}
+newtype EnumC = EnumC {un_EnumC :: CUInt} deriving stock (Eq, Ord)
 instance Storable EnumC
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumC <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {EnumC un_EnumC_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumC_3}}
-deriving stock instance Eq EnumC
-deriving stock instance Ord EnumC
 instance CEnum EnumC
     where {type CEnumZ EnumC = CUInt;
            toCEnum = EnumC;
@@ -259,15 +249,13 @@ pattern C_FOO :: EnumC
 pattern C_FOO = EnumC 0
 pattern C_BAR :: EnumC
 pattern C_BAR = EnumC 1
-newtype EnumD = EnumD {un_EnumD :: CUInt}
+newtype EnumD = EnumD {un_EnumD :: CUInt} deriving stock (Eq, Ord)
 instance Storable EnumD
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumD <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {EnumD un_EnumD_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumD_3}}
-deriving stock instance Eq EnumD
-deriving stock instance Ord EnumD
 instance CEnum EnumD
     where {type CEnumZ EnumD = CUInt;
            toCEnum = EnumD;
@@ -291,9 +279,7 @@ pattern D_FOO :: EnumD
 pattern D_FOO = EnumD 0
 pattern D_BAR :: EnumD
 pattern D_BAR = EnumD 1
-newtype EnumD_t = EnumD_t {un_EnumD_t :: EnumD}
-deriving newtype instance Storable EnumD_t
-deriving stock instance Eq EnumD_t
-deriving stock instance Ord EnumD_t
-deriving stock instance Read EnumD_t
-deriving stock instance Show EnumD_t
+newtype EnumD_t
+    = EnumD_t {un_EnumD_t :: EnumD}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/fixedarray.exts.txt
+++ b/hs-bindgen/fixtures/fixedarray.exts.txt
@@ -1,4 +1,3 @@
 DataKinds
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/fixedarray.pp.hs
+++ b/hs-bindgen/fixtures/fixedarray.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -14,17 +13,14 @@ import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 newtype Triple = Triple
   { un_Triple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-
-deriving newtype instance F.Storable Triple
-
-deriving stock instance Eq Triple
-
-deriving stock instance Show Triple
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 data Example = Example
   { example_triple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   , example_sudoku :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Example where
 
@@ -45,7 +41,3 @@ instance F.Storable Example where
           Example example_triple2 example_sudoku3 ->
                F.pokeByteOff ptr0 (0 :: Int) example_triple2
             >> F.pokeByteOff ptr0 (12 :: Int) example_sudoku3
-
-deriving stock instance Show Example
-
-deriving stock instance Eq Example

--- a/hs-bindgen/fixtures/fixedarray.th.txt
+++ b/hs-bindgen/fixtures/fixedarray.th.txt
@@ -1,11 +1,12 @@
 -- addDependentFile examples/golden/fixedarray.h
-newtype Triple = Triple {un_Triple :: (ConstantArray 3 CInt)}
-deriving newtype instance Storable Triple
-deriving stock instance Eq Triple
-deriving stock instance Show Triple
+newtype Triple
+    = Triple {un_Triple :: (ConstantArray 3 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 data Example
     = Example {example_triple :: (ConstantArray 3 CInt),
                example_sudoku :: (ConstantArray 3 (ConstantArray 3 CInt))}
+    deriving stock (Eq, Show)
 instance Storable Example
     where {sizeOf = \_ -> 48 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -13,5 +14,3 @@ instance Storable Example
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Example example_triple_3
                                              example_sudoku_4 -> pokeByteOff ptr_1 (0 :: Int) example_triple_3 >> pokeByteOff ptr_1 (12 :: Int) example_sudoku_4}}
-deriving stock instance Show Example
-deriving stock instance Eq Example

--- a/hs-bindgen/fixtures/fixedarray_arg.exts.txt
+++ b/hs-bindgen/fixtures/fixedarray_arg.exts.txt
@@ -1,6 +1,5 @@
 CApiFFI
 TemplateHaskell
 DataKinds
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/fixedarray_arg.pp.hs
+++ b/hs-bindgen/fixtures/fixedarray_arg.pp.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -27,12 +26,8 @@ fun_1 =
 newtype Triple = Triple
   { un_Triple :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-
-deriving newtype instance F.Storable Triple
-
-deriving stock instance Eq Triple
-
-deriving stock instance Show Triple
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 foreign import ccall safe "testmodule_fun_2" fun_2_wrapper :: (F.Ptr FC.CInt) -> IO FC.CInt
 

--- a/hs-bindgen/fixtures/fixedarray_arg.th.txt
+++ b/hs-bindgen/fixtures/fixedarray_arg.th.txt
@@ -6,10 +6,10 @@ foreign import ccall safe "test_internal_fun_1" fun_1_wrapper :: CInt ->
                                                                  Ptr CInt -> IO CInt
 fun_1 :: CInt -> ConstantArray 3 CInt -> IO CInt
 fun_1 = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_1_wrapper x_0 ptr_2)
-newtype Triple = Triple {un_Triple :: (ConstantArray 3 CInt)}
-deriving newtype instance Storable Triple
-deriving stock instance Eq Triple
-deriving stock instance Show Triple
+newtype Triple
+    = Triple {un_Triple :: (ConstantArray 3 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 foreign import ccall safe "test_internal_fun_2" fun_2_wrapper :: Ptr CInt ->
                                                                  IO CInt
 fun_2 :: Triple -> IO CInt

--- a/hs-bindgen/fixtures/fixedwidth.exts.txt
+++ b/hs-bindgen/fixtures/fixedwidth.exts.txt
@@ -1,2 +1,1 @@
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/fixedwidth.pp.hs
+++ b/hs-bindgen/fixtures/fixedwidth.pp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -12,6 +11,7 @@ data Foo = Foo
   { foo_sixty_four :: HsBindgen.Runtime.Prelude.Word64
   , foo_thirty_two :: HsBindgen.Runtime.Prelude.Word32
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -32,7 +32,3 @@ instance F.Storable Foo where
           Foo foo_sixty_four2 foo_thirty_two3 ->
                F.pokeByteOff ptr0 (0 :: Int) foo_sixty_four2
             >> F.pokeByteOff ptr0 (8 :: Int) foo_thirty_two3
-
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/fixedwidth.th.txt
+++ b/hs-bindgen/fixtures/fixedwidth.th.txt
@@ -5,6 +5,7 @@
 data Foo
     = Foo {foo_sixty_four :: HsBindgen.Runtime.Prelude.Word64,
            foo_thirty_two :: HsBindgen.Runtime.Prelude.Word32}
+    deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -12,5 +13,3 @@ instance Storable Foo
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_sixty_four_3
                                          foo_thirty_two_4 -> pokeByteOff ptr_1 (0 :: Int) foo_sixty_four_3 >> pokeByteOff ptr_1 (8 :: Int) foo_thirty_two_4}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/flam.exts.txt
+++ b/hs-bindgen/fixtures/flam.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 MultiParamTypeClasses

--- a/hs-bindgen/fixtures/flam.pp.hs
+++ b/hs-bindgen/fixtures/flam.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -13,6 +12,7 @@ import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 data Pascal = Pascal
   { pascal_len :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Pascal where
 
@@ -31,10 +31,6 @@ instance F.Storable Pascal where
         case s1 of
           Pascal pascal_len2 -> F.pokeByteOff ptr0 (0 :: Int) pascal_len2
 
-deriving stock instance Show Pascal
-
-deriving stock instance Eq Pascal
-
 instance HsBindgen.Runtime.FlexibleArrayMember.HasFlexibleArrayMember FC.CChar Pascal where
 
   flexibleArrayMemberOffset = \_ty0 -> 4
@@ -43,6 +39,7 @@ data Foo_bar = Foo_bar
   { foo_bar_x :: FC.CInt
   , foo_bar_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo_bar where
 
@@ -64,13 +61,10 @@ instance F.Storable Foo_bar where
                F.pokeByteOff ptr0 (0 :: Int) foo_bar_x2
             >> F.pokeByteOff ptr0 (4 :: Int) foo_bar_y3
 
-deriving stock instance Show Foo_bar
-
-deriving stock instance Eq Foo_bar
-
 data Foo = Foo
   { foo_len :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -89,10 +83,6 @@ instance F.Storable Foo where
         case s1 of
           Foo foo_len2 -> F.pokeByteOff ptr0 (0 :: Int) foo_len2
 
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo
-
 instance HsBindgen.Runtime.FlexibleArrayMember.HasFlexibleArrayMember Foo_bar Foo where
 
   flexibleArrayMemberOffset = \_ty0 -> 4
@@ -101,6 +91,7 @@ data Diff = Diff
   { diff_first :: FC.CLong
   , diff_second :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Diff where
 
@@ -121,10 +112,6 @@ instance F.Storable Diff where
           Diff diff_first2 diff_second3 ->
                F.pokeByteOff ptr0 (0 :: Int) diff_first2
             >> F.pokeByteOff ptr0 (8 :: Int) diff_second3
-
-deriving stock instance Show Diff
-
-deriving stock instance Eq Diff
 
 instance HsBindgen.Runtime.FlexibleArrayMember.HasFlexibleArrayMember FC.CChar Diff where
 

--- a/hs-bindgen/fixtures/flam.th.txt
+++ b/hs-bindgen/fixtures/flam.th.txt
@@ -1,16 +1,16 @@
 -- addDependentFile examples/golden/flam.h
-data Pascal = Pascal {pascal_len :: CInt}
+data Pascal = Pascal {pascal_len :: CInt} deriving stock (Eq, Show)
 instance Storable Pascal
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Pascal <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Pascal pascal_len_3 -> pokeByteOff ptr_1 (0 :: Int) pascal_len_3}}
-deriving stock instance Show Pascal
-deriving stock instance Eq Pascal
 instance HasFlexibleArrayMember CChar Pascal
     where {flexibleArrayMemberOffset = \_ty_0 -> 4}
-data Foo_bar = Foo_bar {foo_bar_x :: CInt, foo_bar_y :: CInt}
+data Foo_bar
+    = Foo_bar {foo_bar_x :: CInt, foo_bar_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Foo_bar
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -18,20 +18,18 @@ instance Storable Foo_bar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo_bar foo_bar_x_3
                                              foo_bar_y_4 -> pokeByteOff ptr_1 (0 :: Int) foo_bar_x_3 >> pokeByteOff ptr_1 (4 :: Int) foo_bar_y_4}}
-deriving stock instance Show Foo_bar
-deriving stock instance Eq Foo_bar
-data Foo = Foo {foo_len :: CInt}
+data Foo = Foo {foo_len :: CInt} deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_len_3 -> pokeByteOff ptr_1 (0 :: Int) foo_len_3}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo
 instance HasFlexibleArrayMember Foo_bar Foo
     where {flexibleArrayMemberOffset = \_ty_0 -> 4}
-data Diff = Diff {diff_first :: CLong, diff_second :: CChar}
+data Diff
+    = Diff {diff_first :: CLong, diff_second :: CChar}
+    deriving stock (Eq, Show)
 instance Storable Diff
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -39,7 +37,5 @@ instance Storable Diff
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Diff diff_first_3
                                           diff_second_4 -> pokeByteOff ptr_1 (0 :: Int) diff_first_3 >> pokeByteOff ptr_1 (8 :: Int) diff_second_4}}
-deriving stock instance Show Diff
-deriving stock instance Eq Diff
 instance HasFlexibleArrayMember CChar Diff
     where {flexibleArrayMemberOffset = \_ty_0 -> 9}

--- a/hs-bindgen/fixtures/forward_declaration.exts.txt
+++ b/hs-bindgen/fixtures/forward_declaration.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/forward_declaration.pp.hs
+++ b/hs-bindgen/fixtures/forward_declaration.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -12,6 +11,7 @@ import Prelude ((<*>), Eq, Int, Show, pure)
 data S1 = S1
   { s1_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S1 where
 
@@ -30,23 +30,16 @@ instance F.Storable S1 where
         case s1 of
           S1 s1_a2 -> F.pokeByteOff ptr0 (0 :: Int) s1_a2
 
-deriving stock instance Show S1
-
-deriving stock instance Eq S1
-
 newtype S1_t = S1_t
   { un_S1_t :: S1
   }
-
-deriving newtype instance F.Storable S1_t
-
-deriving stock instance Eq S1_t
-
-deriving stock instance Show S1_t
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 data S2 = S2
   { s2_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2 where
 
@@ -64,7 +57,3 @@ instance F.Storable S2 where
       \s1 ->
         case s1 of
           S2 s2_a2 -> F.pokeByteOff ptr0 (0 :: Int) s2_a2
-
-deriving stock instance Show S2
-
-deriving stock instance Eq S2

--- a/hs-bindgen/fixtures/forward_declaration.th.txt
+++ b/hs-bindgen/fixtures/forward_declaration.th.txt
@@ -1,23 +1,19 @@
 -- addDependentFile examples/golden/forward_declaration.h
-data S1 = S1 {s1_a :: CInt}
+data S1 = S1 {s1_a :: CInt} deriving stock (Eq, Show)
 instance Storable S1
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure S1 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S1 s1_a_3 -> pokeByteOff ptr_1 (0 :: Int) s1_a_3}}
-deriving stock instance Show S1
-deriving stock instance Eq S1
-newtype S1_t = S1_t {un_S1_t :: S1}
-deriving newtype instance Storable S1_t
-deriving stock instance Eq S1_t
-deriving stock instance Show S1_t
-data S2 = S2 {s2_a :: CInt}
+newtype S1_t
+    = S1_t {un_S1_t :: S1}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+data S2 = S2 {s2_a :: CInt} deriving stock (Eq, Show)
 instance Storable S2
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure S2 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S2 s2_a_3 -> pokeByteOff ptr_1 (0 :: Int) s2_a_3}}
-deriving stock instance Show S2
-deriving stock instance Eq S2

--- a/hs-bindgen/fixtures/macro_in_fundecl.exts.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.exts.txt
@@ -1,5 +1,4 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -21,150 +20,32 @@ $(CAPI.addCSource "#include \"macro_in_fundecl.h\"\nchar testmodule_quux (F arg1
 newtype I = I
   { un_I :: FC.CInt
   }
-
-deriving newtype instance F.Storable I
-
-deriving stock instance Eq I
-
-deriving stock instance Ord I
-
-deriving stock instance Read I
-
-deriving stock instance Show I
-
-deriving newtype instance Enum I
-
-deriving newtype instance Ix.Ix I
-
-deriving newtype instance Bounded I
-
-deriving newtype instance Bits.Bits I
-
-deriving newtype instance FiniteBits I
-
-deriving newtype instance Integral I
-
-deriving newtype instance Num I
-
-deriving newtype instance Real I
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype C = C
   { un_C :: FC.CChar
   }
-
-deriving newtype instance F.Storable C
-
-deriving stock instance Eq C
-
-deriving stock instance Ord C
-
-deriving stock instance Read C
-
-deriving stock instance Show C
-
-deriving newtype instance Enum C
-
-deriving newtype instance Ix.Ix C
-
-deriving newtype instance Bounded C
-
-deriving newtype instance Bits.Bits C
-
-deriving newtype instance FiniteBits C
-
-deriving newtype instance Integral C
-
-deriving newtype instance Num C
-
-deriving newtype instance Real C
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype F = F
   { un_F :: FC.CFloat
   }
-
-deriving newtype instance F.Storable F
-
-deriving stock instance Eq F
-
-deriving stock instance Ord F
-
-deriving stock instance Read F
-
-deriving stock instance Show F
-
-deriving newtype instance Enum F
-
-deriving newtype instance Floating F
-
-deriving newtype instance Fractional F
-
-deriving newtype instance Num F
-
-deriving newtype instance Real F
-
-deriving newtype instance RealFloat F
-
-deriving newtype instance RealFrac F
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)
 
 newtype L = L
   { un_L :: FC.CLong
   }
-
-deriving newtype instance F.Storable L
-
-deriving stock instance Eq L
-
-deriving stock instance Ord L
-
-deriving stock instance Read L
-
-deriving stock instance Show L
-
-deriving newtype instance Enum L
-
-deriving newtype instance Ix.Ix L
-
-deriving newtype instance Bounded L
-
-deriving newtype instance Bits.Bits L
-
-deriving newtype instance FiniteBits L
-
-deriving newtype instance Integral L
-
-deriving newtype instance Num L
-
-deriving newtype instance Real L
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype S = S
   { un_S :: FC.CShort
   }
-
-deriving newtype instance F.Storable S
-
-deriving stock instance Eq S
-
-deriving stock instance Ord S
-
-deriving stock instance Read S
-
-deriving stock instance Show S
-
-deriving newtype instance Enum S
-
-deriving newtype instance Ix.Ix S
-
-deriving newtype instance Bounded S
-
-deriving newtype instance Bits.Bits S
-
-deriving newtype instance FiniteBits S
-
-deriving newtype instance Integral S
-
-deriving newtype instance Num S
-
-deriving newtype instance Real S
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_quux" quux :: F -> FC.CChar -> IO FC.CChar
 

--- a/hs-bindgen/fixtures/macro_in_fundecl.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.th.txt
@@ -13,75 +13,65 @@
 -- signed int *test_internal_baz2[2][3] (I arg1) { return baz2(arg1); }
 -- I *test_internal_baz3[2][3] (signed int arg1) { return baz3(arg1); }
 -- I test_internal_no_args_no_void (void) { return no_args_no_void(); }
-newtype I = I {un_I :: CInt}
-deriving newtype instance Storable I
-deriving stock instance Eq I
-deriving stock instance Ord I
-deriving stock instance Read I
-deriving stock instance Show I
-deriving newtype instance Enum I
-deriving newtype instance Ix I
-deriving newtype instance Bounded I
-deriving newtype instance Bits I
-deriving newtype instance FiniteBits I
-deriving newtype instance Integral I
-deriving newtype instance Num I
-deriving newtype instance Real I
-newtype C = C {un_C :: CChar}
-deriving newtype instance Storable C
-deriving stock instance Eq C
-deriving stock instance Ord C
-deriving stock instance Read C
-deriving stock instance Show C
-deriving newtype instance Enum C
-deriving newtype instance Ix C
-deriving newtype instance Bounded C
-deriving newtype instance Bits C
-deriving newtype instance FiniteBits C
-deriving newtype instance Integral C
-deriving newtype instance Num C
-deriving newtype instance Real C
-newtype F = F {un_F :: CFloat}
-deriving newtype instance Storable F
-deriving stock instance Eq F
-deriving stock instance Ord F
-deriving stock instance Read F
-deriving stock instance Show F
-deriving newtype instance Enum F
-deriving newtype instance Floating F
-deriving newtype instance Fractional F
-deriving newtype instance Num F
-deriving newtype instance Real F
-deriving newtype instance RealFloat F
-deriving newtype instance RealFrac F
-newtype L = L {un_L :: CLong}
-deriving newtype instance Storable L
-deriving stock instance Eq L
-deriving stock instance Ord L
-deriving stock instance Read L
-deriving stock instance Show L
-deriving newtype instance Enum L
-deriving newtype instance Ix L
-deriving newtype instance Bounded L
-deriving newtype instance Bits L
-deriving newtype instance FiniteBits L
-deriving newtype instance Integral L
-deriving newtype instance Num L
-deriving newtype instance Real L
-newtype S = S {un_S :: CShort}
-deriving newtype instance Storable S
-deriving stock instance Eq S
-deriving stock instance Ord S
-deriving stock instance Read S
-deriving stock instance Show S
-deriving newtype instance Enum S
-deriving newtype instance Ix S
-deriving newtype instance Bounded S
-deriving newtype instance Bits S
-deriving newtype instance FiniteBits S
-deriving newtype instance Integral S
-deriving newtype instance Num S
-deriving newtype instance Real S
+newtype I
+    = I {un_I :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype C
+    = C {un_C :: CChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype F
+    = F {un_F :: CFloat}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)
+newtype L
+    = L {un_L :: CLong}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype S
+    = S {un_S :: CShort}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_quux" quux :: F ->
                                                        CChar -> IO CChar
 foreign import ccall safe "test_internal_wam" wam :: CFloat ->

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.exts.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.exts.txt
@@ -1,5 +1,4 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -20,62 +19,14 @@ $(CAPI.addCSource "#include \"macro_in_fundecl_vs_typedef.h\"\nchar testmodule_q
 newtype MC = MC
   { un_MC :: FC.CChar
   }
-
-deriving newtype instance F.Storable MC
-
-deriving stock instance Eq MC
-
-deriving stock instance Ord MC
-
-deriving stock instance Read MC
-
-deriving stock instance Show MC
-
-deriving newtype instance Enum MC
-
-deriving newtype instance Ix.Ix MC
-
-deriving newtype instance Bounded MC
-
-deriving newtype instance Bits.Bits MC
-
-deriving newtype instance FiniteBits MC
-
-deriving newtype instance Integral MC
-
-deriving newtype instance Num MC
-
-deriving newtype instance Real MC
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype TC = TC
   { un_TC :: FC.CChar
   }
-
-deriving newtype instance F.Storable TC
-
-deriving stock instance Eq TC
-
-deriving stock instance Ord TC
-
-deriving stock instance Read TC
-
-deriving stock instance Show TC
-
-deriving newtype instance Enum TC
-
-deriving newtype instance Ix.Ix TC
-
-deriving newtype instance Bounded TC
-
-deriving newtype instance Bits.Bits TC
-
-deriving newtype instance FiniteBits TC
-
-deriving newtype instance Integral TC
-
-deriving newtype instance Num TC
-
-deriving newtype instance Real TC
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_quux1" quux1 :: MC -> TC -> IO FC.CChar
 
@@ -88,6 +39,7 @@ foreign import ccall safe "testmodule_wam2" wam2 :: FC.CFloat -> (F.Ptr MC) -> I
 data Struct1 = Struct1
   { struct1_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Struct1 where
 
@@ -106,13 +58,10 @@ instance F.Storable Struct1 where
         case s1 of
           Struct1 struct1_a2 -> F.pokeByteOff ptr0 (0 :: Int) struct1_a2
 
-deriving stock instance Show Struct1
-
-deriving stock instance Eq Struct1
-
 data Struct2 = Struct2
   { struct2_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Struct2 where
 
@@ -131,13 +80,10 @@ instance F.Storable Struct2 where
         case s1 of
           Struct2 struct2_a2 -> F.pokeByteOff ptr0 (0 :: Int) struct2_a2
 
-deriving stock instance Show Struct2
-
-deriving stock instance Eq Struct2
-
 data Struct3 = Struct3
   { struct3_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Struct3 where
 
@@ -156,23 +102,16 @@ instance F.Storable Struct3 where
         case s1 of
           Struct3 struct3_a2 -> F.pokeByteOff ptr0 (0 :: Int) struct3_a2
 
-deriving stock instance Show Struct3
-
-deriving stock instance Eq Struct3
-
 newtype Struct3_t = Struct3_t
   { un_Struct3_t :: Struct3
   }
-
-deriving newtype instance F.Storable Struct3_t
-
-deriving stock instance Eq Struct3_t
-
-deriving stock instance Show Struct3_t
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 data Struct4 = Struct4
   { struct4_a :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Struct4 where
 
@@ -190,10 +129,6 @@ instance F.Storable Struct4 where
       \s1 ->
         case s1 of
           Struct4 struct4_a2 -> F.pokeByteOff ptr0 (0 :: Int) struct4_a2
-
-deriving stock instance Show Struct4
-
-deriving stock instance Eq Struct4
 
 foreign import ccall safe "testmodule_struct_typedef1" struct_typedef1 :: (F.Ptr Struct2) -> MC -> IO ()
 

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.th.txt
@@ -10,34 +10,30 @@
 -- void test_internal_struct_name1 (struct struct1 *arg1, MC arg2) { struct_name1(arg1, arg2); }
 -- void test_internal_struct_name2 (struct struct3 *arg1, MC arg2) { struct_name2(arg1, arg2); }
 -- void test_internal_struct_name3 (struct struct4 *arg1, MC arg2) { struct_name3(arg1, arg2); }
-newtype MC = MC {un_MC :: CChar}
-deriving newtype instance Storable MC
-deriving stock instance Eq MC
-deriving stock instance Ord MC
-deriving stock instance Read MC
-deriving stock instance Show MC
-deriving newtype instance Enum MC
-deriving newtype instance Ix MC
-deriving newtype instance Bounded MC
-deriving newtype instance Bits MC
-deriving newtype instance FiniteBits MC
-deriving newtype instance Integral MC
-deriving newtype instance Num MC
-deriving newtype instance Real MC
-newtype TC = TC {un_TC :: CChar}
-deriving newtype instance Storable TC
-deriving stock instance Eq TC
-deriving stock instance Ord TC
-deriving stock instance Read TC
-deriving stock instance Show TC
-deriving newtype instance Enum TC
-deriving newtype instance Ix TC
-deriving newtype instance Bounded TC
-deriving newtype instance Bits TC
-deriving newtype instance FiniteBits TC
-deriving newtype instance Integral TC
-deriving newtype instance Num TC
-deriving newtype instance Real TC
+newtype MC
+    = MC {un_MC :: CChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype TC
+    = TC {un_TC :: CChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_quux1" quux1 :: MC ->
                                                          TC -> IO CChar
 foreign import ccall safe "test_internal_quux2" quux2 :: MC ->
@@ -46,46 +42,46 @@ foreign import ccall safe "test_internal_wam1" wam1 :: CFloat ->
                                                        Ptr TC -> IO (Ptr MC)
 foreign import ccall safe "test_internal_wam2" wam2 :: CFloat ->
                                                        Ptr MC -> IO (Ptr TC)
-data Struct1 = Struct1 {struct1_a :: CInt}
+data Struct1
+    = Struct1 {struct1_a :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Struct1
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Struct1 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Struct1 struct1_a_3 -> pokeByteOff ptr_1 (0 :: Int) struct1_a_3}}
-deriving stock instance Show Struct1
-deriving stock instance Eq Struct1
-data Struct2 = Struct2 {struct2_a :: CInt}
+data Struct2
+    = Struct2 {struct2_a :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Struct2
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Struct2 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Struct2 struct2_a_3 -> pokeByteOff ptr_1 (0 :: Int) struct2_a_3}}
-deriving stock instance Show Struct2
-deriving stock instance Eq Struct2
-data Struct3 = Struct3 {struct3_a :: CInt}
+data Struct3
+    = Struct3 {struct3_a :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Struct3
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Struct3 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Struct3 struct3_a_3 -> pokeByteOff ptr_1 (0 :: Int) struct3_a_3}}
-deriving stock instance Show Struct3
-deriving stock instance Eq Struct3
-newtype Struct3_t = Struct3_t {un_Struct3_t :: Struct3}
-deriving newtype instance Storable Struct3_t
-deriving stock instance Eq Struct3_t
-deriving stock instance Show Struct3_t
-data Struct4 = Struct4 {struct4_a :: CInt}
+newtype Struct3_t
+    = Struct3_t {un_Struct3_t :: Struct3}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+data Struct4
+    = Struct4 {struct4_a :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Struct4
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Struct4 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Struct4 struct4_a_3 -> pokeByteOff ptr_1 (0 :: Int) struct4_a_3}}
-deriving stock instance Show Struct4
-deriving stock instance Eq Struct4
 foreign import ccall safe "test_internal_struct_typedef1" struct_typedef1 :: Ptr Struct2 ->
                                                                              MC -> IO Unit
 foreign import ccall safe "test_internal_struct_typedef2" struct_typedef2 :: Ptr Struct3_t ->

--- a/hs-bindgen/fixtures/macro_typedef_scope.exts.txt
+++ b/hs-bindgen/fixtures/macro_typedef_scope.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/macro_typedef_scope.pp.hs
+++ b/hs-bindgen/fixtures/macro_typedef_scope.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -15,119 +14,23 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype T1 = T1
   { un_T1 :: FC.CInt
   }
-
-deriving newtype instance F.Storable T1
-
-deriving stock instance Eq T1
-
-deriving stock instance Ord T1
-
-deriving stock instance Read T1
-
-deriving stock instance Show T1
-
-deriving newtype instance Enum T1
-
-deriving newtype instance Ix.Ix T1
-
-deriving newtype instance Bounded T1
-
-deriving newtype instance Bits.Bits T1
-
-deriving newtype instance FiniteBits T1
-
-deriving newtype instance Integral T1
-
-deriving newtype instance Num T1
-
-deriving newtype instance Real T1
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype T2 = T2
   { un_T2 :: T1
   }
-
-deriving newtype instance F.Storable T2
-
-deriving stock instance Eq T2
-
-deriving stock instance Ord T2
-
-deriving stock instance Read T2
-
-deriving stock instance Show T2
-
-deriving newtype instance Enum T2
-
-deriving newtype instance Ix.Ix T2
-
-deriving newtype instance Bounded T2
-
-deriving newtype instance Bits.Bits T2
-
-deriving newtype instance FiniteBits T2
-
-deriving newtype instance Integral T2
-
-deriving newtype instance Num T2
-
-deriving newtype instance Real T2
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype T3 = T3
   { un_T3 :: T2
   }
-
-deriving newtype instance F.Storable T3
-
-deriving stock instance Eq T3
-
-deriving stock instance Ord T3
-
-deriving stock instance Read T3
-
-deriving stock instance Show T3
-
-deriving newtype instance Enum T3
-
-deriving newtype instance Ix.Ix T3
-
-deriving newtype instance Bounded T3
-
-deriving newtype instance Bits.Bits T3
-
-deriving newtype instance FiniteBits T3
-
-deriving newtype instance Integral T3
-
-deriving newtype instance Num T3
-
-deriving newtype instance Real T3
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype T4 = T4
   { un_T4 :: T3
   }
-
-deriving newtype instance F.Storable T4
-
-deriving stock instance Eq T4
-
-deriving stock instance Ord T4
-
-deriving stock instance Read T4
-
-deriving stock instance Show T4
-
-deriving newtype instance Enum T4
-
-deriving newtype instance Ix.Ix T4
-
-deriving newtype instance Bounded T4
-
-deriving newtype instance Bits.Bits T4
-
-deriving newtype instance FiniteBits T4
-
-deriving newtype instance Integral T4
-
-deriving newtype instance Num T4
-
-deriving newtype instance Real T4
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)

--- a/hs-bindgen/fixtures/macro_typedef_scope.th.txt
+++ b/hs-bindgen/fixtures/macro_typedef_scope.th.txt
@@ -1,57 +1,49 @@
 -- addDependentFile examples/golden/macro_typedef_scope.h
-newtype T1 = T1 {un_T1 :: CInt}
-deriving newtype instance Storable T1
-deriving stock instance Eq T1
-deriving stock instance Ord T1
-deriving stock instance Read T1
-deriving stock instance Show T1
-deriving newtype instance Enum T1
-deriving newtype instance Ix T1
-deriving newtype instance Bounded T1
-deriving newtype instance Bits T1
-deriving newtype instance FiniteBits T1
-deriving newtype instance Integral T1
-deriving newtype instance Num T1
-deriving newtype instance Real T1
-newtype T2 = T2 {un_T2 :: T1}
-deriving newtype instance Storable T2
-deriving stock instance Eq T2
-deriving stock instance Ord T2
-deriving stock instance Read T2
-deriving stock instance Show T2
-deriving newtype instance Enum T2
-deriving newtype instance Ix T2
-deriving newtype instance Bounded T2
-deriving newtype instance Bits T2
-deriving newtype instance FiniteBits T2
-deriving newtype instance Integral T2
-deriving newtype instance Num T2
-deriving newtype instance Real T2
-newtype T3 = T3 {un_T3 :: T2}
-deriving newtype instance Storable T3
-deriving stock instance Eq T3
-deriving stock instance Ord T3
-deriving stock instance Read T3
-deriving stock instance Show T3
-deriving newtype instance Enum T3
-deriving newtype instance Ix T3
-deriving newtype instance Bounded T3
-deriving newtype instance Bits T3
-deriving newtype instance FiniteBits T3
-deriving newtype instance Integral T3
-deriving newtype instance Num T3
-deriving newtype instance Real T3
-newtype T4 = T4 {un_T4 :: T3}
-deriving newtype instance Storable T4
-deriving stock instance Eq T4
-deriving stock instance Ord T4
-deriving stock instance Read T4
-deriving stock instance Show T4
-deriving newtype instance Enum T4
-deriving newtype instance Ix T4
-deriving newtype instance Bounded T4
-deriving newtype instance Bits T4
-deriving newtype instance FiniteBits T4
-deriving newtype instance Integral T4
-deriving newtype instance Num T4
-deriving newtype instance Real T4
+newtype T1
+    = T1 {un_T1 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype T2
+    = T2 {un_T2 :: T1}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype T3
+    = T3 {un_T3 :: T2}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype T4
+    = T4 {un_T4 :: T3}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)

--- a/hs-bindgen/fixtures/macro_typedef_struct.exts.txt
+++ b/hs-bindgen/fixtures/macro_typedef_struct.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/macro_typedef_struct.pp.hs
+++ b/hs-bindgen/fixtures/macro_typedef_struct.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -15,37 +14,14 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype MY_TYPE = MY_TYPE
   { un_MY_TYPE :: FC.CInt
   }
-
-deriving newtype instance F.Storable MY_TYPE
-
-deriving stock instance Eq MY_TYPE
-
-deriving stock instance Ord MY_TYPE
-
-deriving stock instance Read MY_TYPE
-
-deriving stock instance Show MY_TYPE
-
-deriving newtype instance Enum MY_TYPE
-
-deriving newtype instance Ix.Ix MY_TYPE
-
-deriving newtype instance Bounded MY_TYPE
-
-deriving newtype instance Bits.Bits MY_TYPE
-
-deriving newtype instance FiniteBits MY_TYPE
-
-deriving newtype instance Integral MY_TYPE
-
-deriving newtype instance Num MY_TYPE
-
-deriving newtype instance Real MY_TYPE
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data Bar = Bar
   { bar_x :: FC.CInt
   , bar_y :: MY_TYPE
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bar where
 
@@ -66,7 +42,3 @@ instance F.Storable Bar where
           Bar bar_x2 bar_y3 ->
                F.pokeByteOff ptr0 (0 :: Int) bar_x2
             >> F.pokeByteOff ptr0 (4 :: Int) bar_y3
-
-deriving stock instance Show Bar
-
-deriving stock instance Eq Bar

--- a/hs-bindgen/fixtures/macro_typedef_struct.th.txt
+++ b/hs-bindgen/fixtures/macro_typedef_struct.th.txt
@@ -1,19 +1,19 @@
 -- addDependentFile examples/golden/macro_typedef_struct.h
-newtype MY_TYPE = MY_TYPE {un_MY_TYPE :: CInt}
-deriving newtype instance Storable MY_TYPE
-deriving stock instance Eq MY_TYPE
-deriving stock instance Ord MY_TYPE
-deriving stock instance Read MY_TYPE
-deriving stock instance Show MY_TYPE
-deriving newtype instance Enum MY_TYPE
-deriving newtype instance Ix MY_TYPE
-deriving newtype instance Bounded MY_TYPE
-deriving newtype instance Bits MY_TYPE
-deriving newtype instance FiniteBits MY_TYPE
-deriving newtype instance Integral MY_TYPE
-deriving newtype instance Num MY_TYPE
-deriving newtype instance Real MY_TYPE
-data Bar = Bar {bar_x :: CInt, bar_y :: MY_TYPE}
+newtype MY_TYPE
+    = MY_TYPE {un_MY_TYPE :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+data Bar
+    = Bar {bar_x :: CInt, bar_y :: MY_TYPE}
+    deriving stock (Eq, Show)
 instance Storable Bar
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -21,5 +21,3 @@ instance Storable Bar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bar bar_x_3
                                          bar_y_4 -> pokeByteOff ptr_1 (0 :: Int) bar_x_3 >> pokeByteOff ptr_1 (4 :: Int) bar_y_4}}
-deriving stock instance Show Bar
-deriving stock instance Eq Bar

--- a/hs-bindgen/fixtures/macro_types.exts.txt
+++ b/hs-bindgen/fixtures/macro_types.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/macro_types.pp.hs
+++ b/hs-bindgen/fixtures/macro_types.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -16,56 +15,32 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord,
 newtype PtrInt = PtrInt
   { un_PtrInt :: F.Ptr FC.CInt
   }
-
-deriving newtype instance F.Storable PtrInt
-
-deriving stock instance Eq PtrInt
-
-deriving stock instance Ord PtrInt
-
-deriving stock instance Show PtrInt
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 newtype PtrPtrChar = PtrPtrChar
   { un_PtrPtrChar :: F.Ptr (F.Ptr FC.CChar)
   }
-
-deriving newtype instance F.Storable PtrPtrChar
-
-deriving stock instance Eq PtrPtrChar
-
-deriving stock instance Ord PtrPtrChar
-
-deriving stock instance Show PtrPtrChar
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr1 = Arr1
   { un_Arr1 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 2) FC.CInt
   }
-
-deriving newtype instance F.Storable Arr1
-
-deriving stock instance Eq Arr1
-
-deriving stock instance Show Arr1
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr2 = Arr2
   { un_Arr2 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) (F.Ptr FC.CFloat)
   }
-
-deriving newtype instance F.Storable Arr2
-
-deriving stock instance Eq Arr2
-
-deriving stock instance Show Arr2
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr3 = Arr3
   { un_Arr3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) (F.FunPtr (FC.CDouble -> IO FC.CFloat))
   }
-
-deriving newtype instance F.Storable Arr3
-
-deriving stock instance Eq Arr3
-
-deriving stock instance Show Arr3
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Fun1 = Fun1
   { un_Fun1 :: FC.CInt -> IO (F.Ptr FC.CFloat)
@@ -74,26 +49,14 @@ newtype Fun1 = Fun1
 newtype Fun2 = Fun2
   { un_Fun2 :: F.FunPtr (FC.CFloat -> (F.Ptr FC.CDouble) -> IO FC.CInt)
   }
-
-deriving newtype instance F.Storable Fun2
-
-deriving stock instance Eq Fun2
-
-deriving stock instance Ord Fun2
-
-deriving stock instance Show Fun2
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 newtype Fun3 = Fun3
   { un_Fun3 :: F.FunPtr ((F.Ptr FC.CFloat) -> IO (F.Ptr FC.CInt))
   }
-
-deriving newtype instance F.Storable Fun3
-
-deriving stock instance Eq Fun3
-
-deriving stock instance Ord Fun3
-
-deriving stock instance Show Fun3
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 newtype Fun4 = Fun4
   { un_Fun4 :: FC.CInt -> (F.Ptr FC.CLong) -> IO (F.FunPtr (FC.CFloat -> (F.Ptr FC.CDouble) -> IO (F.Ptr FC.CLong)))
@@ -106,145 +69,29 @@ newtype Fun5 = Fun5
 newtype MTy = MTy
   { un_MTy :: FC.CFloat
   }
-
-deriving newtype instance F.Storable MTy
-
-deriving stock instance Eq MTy
-
-deriving stock instance Ord MTy
-
-deriving stock instance Read MTy
-
-deriving stock instance Show MTy
-
-deriving newtype instance Enum MTy
-
-deriving newtype instance Floating MTy
-
-deriving newtype instance Fractional MTy
-
-deriving newtype instance Num MTy
-
-deriving newtype instance Real MTy
-
-deriving newtype instance RealFloat MTy
-
-deriving newtype instance RealFrac MTy
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)
 
 newtype Tty = Tty
   { un_Tty :: MTy
   }
-
-deriving newtype instance F.Storable Tty
-
-deriving stock instance Eq Tty
-
-deriving stock instance Ord Tty
-
-deriving stock instance Read Tty
-
-deriving stock instance Show Tty
-
-deriving newtype instance Enum Tty
-
-deriving newtype instance Floating Tty
-
-deriving newtype instance Fractional Tty
-
-deriving newtype instance Num Tty
-
-deriving newtype instance Real Tty
-
-deriving newtype instance RealFloat Tty
-
-deriving newtype instance RealFrac Tty
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)
 
 newtype UINT8_T = UINT8_T
   { un_UINT8_T :: FC.CUChar
   }
-
-deriving newtype instance F.Storable UINT8_T
-
-deriving stock instance Eq UINT8_T
-
-deriving stock instance Ord UINT8_T
-
-deriving stock instance Read UINT8_T
-
-deriving stock instance Show UINT8_T
-
-deriving newtype instance Enum UINT8_T
-
-deriving newtype instance Ix.Ix UINT8_T
-
-deriving newtype instance Bounded UINT8_T
-
-deriving newtype instance Bits.Bits UINT8_T
-
-deriving newtype instance FiniteBits UINT8_T
-
-deriving newtype instance Integral UINT8_T
-
-deriving newtype instance Num UINT8_T
-
-deriving newtype instance Real UINT8_T
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype BOOLEAN_T = BOOLEAN_T
   { un_BOOLEAN_T :: UINT8_T
   }
-
-deriving newtype instance F.Storable BOOLEAN_T
-
-deriving stock instance Eq BOOLEAN_T
-
-deriving stock instance Ord BOOLEAN_T
-
-deriving stock instance Read BOOLEAN_T
-
-deriving stock instance Show BOOLEAN_T
-
-deriving newtype instance Enum BOOLEAN_T
-
-deriving newtype instance Ix.Ix BOOLEAN_T
-
-deriving newtype instance Bounded BOOLEAN_T
-
-deriving newtype instance Bits.Bits BOOLEAN_T
-
-deriving newtype instance FiniteBits BOOLEAN_T
-
-deriving newtype instance Integral BOOLEAN_T
-
-deriving newtype instance Num BOOLEAN_T
-
-deriving newtype instance Real BOOLEAN_T
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype Boolean_T = Boolean_T
   { un_Boolean_T :: BOOLEAN_T
   }
-
-deriving newtype instance F.Storable Boolean_T
-
-deriving stock instance Eq Boolean_T
-
-deriving stock instance Ord Boolean_T
-
-deriving stock instance Read Boolean_T
-
-deriving stock instance Show Boolean_T
-
-deriving newtype instance Enum Boolean_T
-
-deriving newtype instance Ix.Ix Boolean_T
-
-deriving newtype instance Bounded Boolean_T
-
-deriving newtype instance Bits.Bits Boolean_T
-
-deriving newtype instance FiniteBits Boolean_T
-
-deriving newtype instance Integral Boolean_T
-
-deriving newtype instance Num Boolean_T
-
-deriving newtype instance Real Boolean_T
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)

--- a/hs-bindgen/fixtures/macro_types.th.txt
+++ b/hs-bindgen/fixtures/macro_types.th.txt
@@ -1,42 +1,34 @@
 -- addDependentFile examples/golden/macro_types.h
-newtype PtrInt = PtrInt {un_PtrInt :: (Ptr CInt)}
-deriving newtype instance Storable PtrInt
-deriving stock instance Eq PtrInt
-deriving stock instance Ord PtrInt
-deriving stock instance Show PtrInt
+newtype PtrInt
+    = PtrInt {un_PtrInt :: (Ptr CInt)}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
 newtype PtrPtrChar
     = PtrPtrChar {un_PtrPtrChar :: (Ptr (Ptr CChar))}
-deriving newtype instance Storable PtrPtrChar
-deriving stock instance Eq PtrPtrChar
-deriving stock instance Ord PtrPtrChar
-deriving stock instance Show PtrPtrChar
-newtype Arr1 = Arr1 {un_Arr1 :: (ConstantArray 2 CInt)}
-deriving newtype instance Storable Arr1
-deriving stock instance Eq Arr1
-deriving stock instance Show Arr1
-newtype Arr2 = Arr2 {un_Arr2 :: (ConstantArray 3 (Ptr CFloat))}
-deriving newtype instance Storable Arr2
-deriving stock instance Eq Arr2
-deriving stock instance Show Arr2
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
+newtype Arr1
+    = Arr1 {un_Arr1 :: (ConstantArray 2 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+newtype Arr2
+    = Arr2 {un_Arr2 :: (ConstantArray 3 (Ptr CFloat))}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 newtype Arr3
     = Arr3 {un_Arr3 :: (ConstantArray 4
                                       (FunPtr (CDouble -> IO CFloat)))}
-deriving newtype instance Storable Arr3
-deriving stock instance Eq Arr3
-deriving stock instance Show Arr3
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 newtype Fun1 = Fun1 {un_Fun1 :: (CInt -> IO (Ptr CFloat))}
 newtype Fun2
     = Fun2 {un_Fun2 :: (FunPtr (CFloat -> Ptr CDouble -> IO CInt))}
-deriving newtype instance Storable Fun2
-deriving stock instance Eq Fun2
-deriving stock instance Ord Fun2
-deriving stock instance Show Fun2
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
 newtype Fun3
     = Fun3 {un_Fun3 :: (FunPtr (Ptr CFloat -> IO (Ptr CInt)))}
-deriving newtype instance Storable Fun3
-deriving stock instance Eq Fun3
-deriving stock instance Ord Fun3
-deriving stock instance Show Fun3
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
 newtype Fun4
     = Fun4 {un_Fun4 :: (CInt ->
                         Ptr CLong ->
@@ -44,71 +36,61 @@ newtype Fun4
 newtype Fun5
     = Fun5 {un_Fun5 :: (ConstantArray 8 CChar ->
                         IO (Ptr (ConstantArray 2 (Ptr CShort))))}
-newtype MTy = MTy {un_MTy :: CFloat}
-deriving newtype instance Storable MTy
-deriving stock instance Eq MTy
-deriving stock instance Ord MTy
-deriving stock instance Read MTy
-deriving stock instance Show MTy
-deriving newtype instance Enum MTy
-deriving newtype instance Floating MTy
-deriving newtype instance Fractional MTy
-deriving newtype instance Num MTy
-deriving newtype instance Real MTy
-deriving newtype instance RealFloat MTy
-deriving newtype instance RealFrac MTy
-newtype Tty = Tty {un_Tty :: MTy}
-deriving newtype instance Storable Tty
-deriving stock instance Eq Tty
-deriving stock instance Ord Tty
-deriving stock instance Read Tty
-deriving stock instance Show Tty
-deriving newtype instance Enum Tty
-deriving newtype instance Floating Tty
-deriving newtype instance Fractional Tty
-deriving newtype instance Num Tty
-deriving newtype instance Real Tty
-deriving newtype instance RealFloat Tty
-deriving newtype instance RealFrac Tty
-newtype UINT8_T = UINT8_T {un_UINT8_T :: CUChar}
-deriving newtype instance Storable UINT8_T
-deriving stock instance Eq UINT8_T
-deriving stock instance Ord UINT8_T
-deriving stock instance Read UINT8_T
-deriving stock instance Show UINT8_T
-deriving newtype instance Enum UINT8_T
-deriving newtype instance Ix UINT8_T
-deriving newtype instance Bounded UINT8_T
-deriving newtype instance Bits UINT8_T
-deriving newtype instance FiniteBits UINT8_T
-deriving newtype instance Integral UINT8_T
-deriving newtype instance Num UINT8_T
-deriving newtype instance Real UINT8_T
-newtype BOOLEAN_T = BOOLEAN_T {un_BOOLEAN_T :: UINT8_T}
-deriving newtype instance Storable BOOLEAN_T
-deriving stock instance Eq BOOLEAN_T
-deriving stock instance Ord BOOLEAN_T
-deriving stock instance Read BOOLEAN_T
-deriving stock instance Show BOOLEAN_T
-deriving newtype instance Enum BOOLEAN_T
-deriving newtype instance Ix BOOLEAN_T
-deriving newtype instance Bounded BOOLEAN_T
-deriving newtype instance Bits BOOLEAN_T
-deriving newtype instance FiniteBits BOOLEAN_T
-deriving newtype instance Integral BOOLEAN_T
-deriving newtype instance Num BOOLEAN_T
-deriving newtype instance Real BOOLEAN_T
-newtype Boolean_T = Boolean_T {un_Boolean_T :: BOOLEAN_T}
-deriving newtype instance Storable Boolean_T
-deriving stock instance Eq Boolean_T
-deriving stock instance Ord Boolean_T
-deriving stock instance Read Boolean_T
-deriving stock instance Show Boolean_T
-deriving newtype instance Enum Boolean_T
-deriving newtype instance Ix Boolean_T
-deriving newtype instance Bounded Boolean_T
-deriving newtype instance Bits Boolean_T
-deriving newtype instance FiniteBits Boolean_T
-deriving newtype instance Integral Boolean_T
-deriving newtype instance Num Boolean_T
-deriving newtype instance Real Boolean_T
+newtype MTy
+    = MTy {un_MTy :: CFloat}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)
+newtype Tty
+    = Tty {un_Tty :: MTy}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)
+newtype UINT8_T
+    = UINT8_T {un_UINT8_T :: CUChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype BOOLEAN_T
+    = BOOLEAN_T {un_BOOLEAN_T :: UINT8_T}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype Boolean_T
+    = Boolean_T {un_Boolean_T :: BOOLEAN_T}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)

--- a/hs-bindgen/fixtures/manual_examples.pp.hs
+++ b/hs-bindgen/fixtures/manual_examples.pp.hs
@@ -37,6 +37,7 @@ data Triple = Triple
   , triple_b :: FC.CInt
   , triple_c :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Triple where
 
@@ -60,15 +61,12 @@ instance F.Storable Triple where
             >> F.pokeByteOff ptr0 (4 :: Int) triple_b3
             >> F.pokeByteOff ptr0 (8 :: Int) triple_c4
 
-deriving stock instance Show Triple
-
-deriving stock instance Eq Triple
-
 foreign import ccall safe "testmodule_mk_triple" mk_triple :: FC.CInt -> FC.CInt -> FC.CInt -> (F.Ptr Triple) -> IO ()
 
 newtype Index = Index
   { un_Index :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Index where
 
@@ -86,10 +84,6 @@ instance F.Storable Index where
       \s1 ->
         case s1 of
           Index un_Index2 -> F.pokeByteOff ptr0 (0 :: Int) un_Index2
-
-deriving stock instance Eq Index
-
-deriving stock instance Ord Index
 
 instance HsBindgen.Runtime.CEnum.CEnum Index where
 
@@ -143,60 +137,14 @@ foreign import ccall safe "testmodule_index_triple" index_triple :: (F.Ptr Tripl
 newtype Sum = Sum
   { un_Sum :: FC.CInt
   }
-
-deriving newtype instance F.Storable Sum
-
-deriving stock instance Eq Sum
-
-deriving stock instance Ord Sum
-
-deriving stock instance Read Sum
-
-deriving stock instance Show Sum
-
-deriving newtype instance Enum Sum
-
-deriving newtype instance Ix.Ix Sum
-
-deriving newtype instance Bounded Sum
-
-deriving newtype instance Bits.Bits Sum
-
-deriving newtype instance FiniteBits Sum
-
-deriving newtype instance Integral Sum
-
-deriving newtype instance Num Sum
-
-deriving newtype instance Real Sum
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype Average = Average
   { un_Average :: FC.CDouble
   }
-
-deriving newtype instance F.Storable Average
-
-deriving stock instance Eq Average
-
-deriving stock instance Ord Average
-
-deriving stock instance Read Average
-
-deriving stock instance Show Average
-
-deriving newtype instance Enum Average
-
-deriving newtype instance Floating Average
-
-deriving newtype instance Fractional Average
-
-deriving newtype instance Num Average
-
-deriving newtype instance Real Average
-
-deriving newtype instance RealFloat Average
-
-deriving newtype instance RealFrac Average
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)
 
 foreign import ccall safe "testmodule_sum_triple" sum_triple :: (F.Ptr Triple) -> IO Sum
 
@@ -214,98 +162,27 @@ pTR_TO_FIELD = \ptr0 -> (+) ptr0 (4 :: FC.CInt)
 newtype YEAR = YEAR
   { un_YEAR :: FC.CInt
   }
-
-deriving newtype instance F.Storable YEAR
-
-deriving stock instance Eq YEAR
-
-deriving stock instance Ord YEAR
-
-deriving stock instance Read YEAR
-
-deriving stock instance Show YEAR
-
-deriving newtype instance Enum YEAR
-
-deriving newtype instance Ix.Ix YEAR
-
-deriving newtype instance Bounded YEAR
-
-deriving newtype instance Bits.Bits YEAR
-
-deriving newtype instance FiniteBits YEAR
-
-deriving newtype instance Integral YEAR
-
-deriving newtype instance Num YEAR
-
-deriving newtype instance Real YEAR
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype MONTH = MONTH
   { un_MONTH :: FC.CInt
   }
-
-deriving newtype instance F.Storable MONTH
-
-deriving stock instance Eq MONTH
-
-deriving stock instance Ord MONTH
-
-deriving stock instance Read MONTH
-
-deriving stock instance Show MONTH
-
-deriving newtype instance Enum MONTH
-
-deriving newtype instance Ix.Ix MONTH
-
-deriving newtype instance Bounded MONTH
-
-deriving newtype instance Bits.Bits MONTH
-
-deriving newtype instance FiniteBits MONTH
-
-deriving newtype instance Integral MONTH
-
-deriving newtype instance Num MONTH
-
-deriving newtype instance Real MONTH
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype DAY = DAY
   { un_DAY :: FC.CInt
   }
-
-deriving newtype instance F.Storable DAY
-
-deriving stock instance Eq DAY
-
-deriving stock instance Ord DAY
-
-deriving stock instance Read DAY
-
-deriving stock instance Show DAY
-
-deriving newtype instance Enum DAY
-
-deriving newtype instance Ix.Ix DAY
-
-deriving newtype instance Bounded DAY
-
-deriving newtype instance Bits.Bits DAY
-
-deriving newtype instance FiniteBits DAY
-
-deriving newtype instance Integral DAY
-
-deriving newtype instance Num DAY
-
-deriving newtype instance Real DAY
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data Date = Date
   { date_year :: YEAR
   , date_month :: MONTH
   , date_day :: DAY
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Date where
 
@@ -329,16 +206,13 @@ instance F.Storable Date where
             >> F.pokeByteOff ptr0 (4 :: Int) date_month3
             >> F.pokeByteOff ptr0 (8 :: Int) date_day4
 
-deriving stock instance Show Date
-
-deriving stock instance Eq Date
-
 foreign import ccall safe "testmodule_getYear" getYear :: (F.Ptr Date) -> IO YEAR
 
 data Student = Student
   { student_university :: F.Ptr FC.CChar
   , student_year :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Student where
 
@@ -360,10 +234,6 @@ instance F.Storable Student where
                F.pokeByteOff ptr0 (0 :: Int) student_university2
             >> F.pokeByteOff ptr0 (8 :: Int) student_year3
 
-deriving stock instance Show Student
-
-deriving stock instance Eq Student
-
 data Person
 
 data Employee = Employee
@@ -371,6 +241,7 @@ data Employee = Employee
   , employee_supervisor :: F.Ptr Person
   , employee_salary :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Employee where
 
@@ -393,10 +264,6 @@ instance F.Storable Employee where
                F.pokeByteOff ptr0 (0 :: Int) employee_company2
             >> F.pokeByteOff ptr0 (8 :: Int) employee_supervisor3
             >> F.pokeByteOff ptr0 (16 :: Int) employee_salary4
-
-deriving stock instance Show Employee
-
-deriving stock instance Eq Employee
 
 newtype Occupation = Occupation
   { un_Occupation :: Data.Array.Byte.ByteArray
@@ -422,6 +289,7 @@ data Rect_lower_left = Rect_lower_left
   { rect_lower_left_x :: FC.CInt
   , rect_lower_left_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Rect_lower_left where
 
@@ -443,14 +311,11 @@ instance F.Storable Rect_lower_left where
                F.pokeByteOff ptr0 (0 :: Int) rect_lower_left_x2
             >> F.pokeByteOff ptr0 (4 :: Int) rect_lower_left_y3
 
-deriving stock instance Show Rect_lower_left
-
-deriving stock instance Eq Rect_lower_left
-
 data Rect_upper_right = Rect_upper_right
   { rect_upper_right_x :: FC.CInt
   , rect_upper_right_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Rect_upper_right where
 
@@ -472,14 +337,11 @@ instance F.Storable Rect_upper_right where
                F.pokeByteOff ptr0 (0 :: Int) rect_upper_right_x2
             >> F.pokeByteOff ptr0 (4 :: Int) rect_upper_right_y3
 
-deriving stock instance Show Rect_upper_right
-
-deriving stock instance Eq Rect_upper_right
-
 data Rect = Rect
   { rect_lower_left :: Rect_lower_left
   , rect_upper_right :: Rect_upper_right
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Rect where
 
@@ -501,14 +363,11 @@ instance F.Storable Rect where
                F.pokeByteOff ptr0 (0 :: Int) rect_lower_left2
             >> F.pokeByteOff ptr0 (8 :: Int) rect_upper_right3
 
-deriving stock instance Show Rect
-
-deriving stock instance Eq Rect
-
 data Config_Deref = Config_Deref
   { config_Deref_width :: FC.CInt
   , config_Deref_height :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Config_Deref where
 
@@ -530,121 +389,40 @@ instance F.Storable Config_Deref where
                F.pokeByteOff ptr0 (0 :: Int) config_Deref_width2
             >> F.pokeByteOff ptr0 (4 :: Int) config_Deref_height3
 
-deriving stock instance Show Config_Deref
-
-deriving stock instance Eq Config_Deref
-
 newtype Config = Config
   { un_Config :: F.Ptr Config_Deref
   }
-
-deriving newtype instance F.Storable Config
-
-deriving stock instance Eq Config
-
-deriving stock instance Ord Config
-
-deriving stock instance Show Config
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 newtype Adio'0301s = Adio'0301s
   { un_Adio'0301s :: FC.CInt
   }
-
-deriving newtype instance F.Storable Adio'0301s
-
-deriving stock instance Eq Adio'0301s
-
-deriving stock instance Ord Adio'0301s
-
-deriving stock instance Read Adio'0301s
-
-deriving stock instance Show Adio'0301s
-
-deriving newtype instance Enum Adio'0301s
-
-deriving newtype instance Ix.Ix Adio'0301s
-
-deriving newtype instance Bounded Adio'0301s
-
-deriving newtype instance Bits.Bits Adio'0301s
-
-deriving newtype instance FiniteBits Adio'0301s
-
-deriving newtype instance Integral Adio'0301s
-
-deriving newtype instance Num Adio'0301s
-
-deriving newtype instance Real Adio'0301s
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_拜拜" 拜拜 :: IO ()
 
 newtype C数字 = C数字
   { un_C数字 :: FC.CInt
   }
-
-deriving newtype instance F.Storable C数字
-
-deriving stock instance Eq C数字
-
-deriving stock instance Ord C数字
-
-deriving stock instance Read C数字
-
-deriving stock instance Show C数字
-
-deriving newtype instance Enum C数字
-
-deriving newtype instance Ix.Ix C数字
-
-deriving newtype instance Bounded C数字
-
-deriving newtype instance Bits.Bits C数字
-
-deriving newtype instance FiniteBits C数字
-
-deriving newtype instance Integral C数字
-
-deriving newtype instance Num C数字
-
-deriving newtype instance Real C数字
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_ϒ" cϒ :: IO ()
 
 newtype Data = Data
   { un_Data :: FC.CInt
   }
-
-deriving newtype instance F.Storable Data
-
-deriving stock instance Eq Data
-
-deriving stock instance Ord Data
-
-deriving stock instance Read Data
-
-deriving stock instance Show Data
-
-deriving newtype instance Enum Data
-
-deriving newtype instance Ix.Ix Data
-
-deriving newtype instance Bounded Data
-
-deriving newtype instance Bits.Bits Data
-
-deriving newtype instance FiniteBits Data
-
-deriving newtype instance Integral Data
-
-deriving newtype instance Num Data
-
-deriving newtype instance Real Data
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 foreign import ccall safe "testmodule_import" import' :: IO ()
 
 newtype Signal = Signal
   { un_Signal :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Signal where
 
@@ -662,10 +440,6 @@ instance F.Storable Signal where
       \s1 ->
         case s1 of
           Signal un_Signal2 -> F.pokeByteOff ptr0 (0 :: Int) un_Signal2
-
-deriving stock instance Eq Signal
-
-deriving stock instance Ord Signal
 
 instance HsBindgen.Runtime.CEnum.CEnum Signal where
 
@@ -724,6 +498,7 @@ pattern Stop = Signal 4
 newtype HTTP_status = HTTP_status
   { un_HTTP_status :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable HTTP_status where
 
@@ -741,10 +516,6 @@ instance F.Storable HTTP_status where
       \s1 ->
         case s1 of
           HTTP_status un_HTTP_status2 -> F.pokeByteOff ptr0 (0 :: Int) un_HTTP_status2
-
-deriving stock instance Eq HTTP_status
-
-deriving stock instance Ord HTTP_status
 
 instance HsBindgen.Runtime.CEnum.CEnum HTTP_status where
 
@@ -798,6 +569,7 @@ pattern Not_found = HTTP_status 404
 newtype Descending = Descending
   { un_Descending :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Descending where
 
@@ -815,10 +587,6 @@ instance F.Storable Descending where
       \s1 ->
         case s1 of
           Descending un_Descending2 -> F.pokeByteOff ptr0 (0 :: Int) un_Descending2
-
-deriving stock instance Eq Descending
-
-deriving stock instance Ord Descending
 
 instance HsBindgen.Runtime.CEnum.CEnum Descending where
 
@@ -877,6 +645,7 @@ pattern Z = Descending 98
 newtype Result = Result
   { un_Result :: FC.CInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Result where
 
@@ -894,10 +663,6 @@ instance F.Storable Result where
       \s1 ->
         case s1 of
           Result un_Result2 -> F.pokeByteOff ptr0 (0 :: Int) un_Result2
-
-deriving stock instance Eq Result
-
-deriving stock instance Ord Result
 
 instance HsBindgen.Runtime.CEnum.CEnum Result where
 
@@ -956,6 +721,7 @@ pattern Already_done = Result 2
 newtype Vote = Vote
   { un_Vote :: FC.CUChar
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable Vote where
 
@@ -973,10 +739,6 @@ instance F.Storable Vote where
       \s1 ->
         case s1 of
           Vote un_Vote2 -> F.pokeByteOff ptr0 (0 :: Int) un_Vote2
-
-deriving stock instance Eq Vote
-
-deriving stock instance Ord Vote
 
 instance HsBindgen.Runtime.CEnum.CEnum Vote where
 
@@ -1031,6 +793,7 @@ pattern Abstain = Vote 2
 newtype CXCursorKind = CXCursorKind
   { un_CXCursorKind :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable CXCursorKind where
 
@@ -1048,10 +811,6 @@ instance F.Storable CXCursorKind where
       \s1 ->
         case s1 of
           CXCursorKind un_CXCursorKind2 -> F.pokeByteOff ptr0 (0 :: Int) un_CXCursorKind2
-
-deriving stock instance Eq CXCursorKind
-
-deriving stock instance Ord CXCursorKind
 
 instance HsBindgen.Runtime.CEnum.CEnum CXCursorKind where
 

--- a/hs-bindgen/fixtures/manual_examples.th.txt
+++ b/hs-bindgen/fixtures/manual_examples.th.txt
@@ -12,6 +12,7 @@
 -- signed int test_internal_mod_10 (signed int arg1) { return mod_10(arg1); }
 data Triple
     = Triple {triple_a :: CInt, triple_b :: CInt, triple_c :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Triple
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -20,20 +21,16 @@ instance Storable Triple
                                     {Triple triple_a_3
                                             triple_b_4
                                             triple_c_5 -> pokeByteOff ptr_1 (0 :: Int) triple_a_3 >> (pokeByteOff ptr_1 (4 :: Int) triple_b_4 >> pokeByteOff ptr_1 (8 :: Int) triple_c_5)}}
-deriving stock instance Show Triple
-deriving stock instance Eq Triple
 foreign import ccall safe "test_internal_mk_triple" mk_triple :: CInt ->
                                                                  CInt ->
                                                                  CInt -> Ptr Triple -> IO Unit
-newtype Index = Index {un_Index :: CUInt}
+newtype Index = Index {un_Index :: CUInt} deriving stock (Eq, Ord)
 instance Storable Index
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Index <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Index un_Index_3 -> pokeByteOff ptr_1 (0 :: Int) un_Index_3}}
-deriving stock instance Eq Index
-deriving stock instance Ord Index
 instance CEnum Index
     where {type CEnumZ Index = CUInt;
            toCEnum = Index;
@@ -61,33 +58,29 @@ pattern C :: Index
 pattern C = Index 2
 foreign import ccall safe "test_internal_index_triple" index_triple :: Ptr Triple ->
                                                                        Index -> IO CInt
-newtype Sum = Sum {un_Sum :: CInt}
-deriving newtype instance Storable Sum
-deriving stock instance Eq Sum
-deriving stock instance Ord Sum
-deriving stock instance Read Sum
-deriving stock instance Show Sum
-deriving newtype instance Enum Sum
-deriving newtype instance Ix Sum
-deriving newtype instance Bounded Sum
-deriving newtype instance Bits Sum
-deriving newtype instance FiniteBits Sum
-deriving newtype instance Integral Sum
-deriving newtype instance Num Sum
-deriving newtype instance Real Sum
-newtype Average = Average {un_Average :: CDouble}
-deriving newtype instance Storable Average
-deriving stock instance Eq Average
-deriving stock instance Ord Average
-deriving stock instance Read Average
-deriving stock instance Show Average
-deriving newtype instance Enum Average
-deriving newtype instance Floating Average
-deriving newtype instance Fractional Average
-deriving newtype instance Num Average
-deriving newtype instance Real Average
-deriving newtype instance RealFloat Average
-deriving newtype instance RealFrac Average
+newtype Sum
+    = Sum {un_Sum :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype Average
+    = Average {un_Average :: CDouble}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)
 foreign import ccall safe "test_internal_sum_triple" sum_triple :: Ptr Triple ->
                                                                    IO Sum
 foreign import ccall safe "test_internal_average_triple" average_triple :: Ptr Triple ->
@@ -98,50 +91,45 @@ ePSILON :: CDouble
 ePSILON = 0.1000000000000000055511151231257827021181583404541015625 :: CDouble
 pTR_TO_FIELD :: forall a_0 . Add a_0 CInt => a_0 -> AddRes a_0 CInt
 pTR_TO_FIELD = \ptr_0 -> (+) ptr_0 (4 :: CInt)
-newtype YEAR = YEAR {un_YEAR :: CInt}
-deriving newtype instance Storable YEAR
-deriving stock instance Eq YEAR
-deriving stock instance Ord YEAR
-deriving stock instance Read YEAR
-deriving stock instance Show YEAR
-deriving newtype instance Enum YEAR
-deriving newtype instance Ix YEAR
-deriving newtype instance Bounded YEAR
-deriving newtype instance Bits YEAR
-deriving newtype instance FiniteBits YEAR
-deriving newtype instance Integral YEAR
-deriving newtype instance Num YEAR
-deriving newtype instance Real YEAR
-newtype MONTH = MONTH {un_MONTH :: CInt}
-deriving newtype instance Storable MONTH
-deriving stock instance Eq MONTH
-deriving stock instance Ord MONTH
-deriving stock instance Read MONTH
-deriving stock instance Show MONTH
-deriving newtype instance Enum MONTH
-deriving newtype instance Ix MONTH
-deriving newtype instance Bounded MONTH
-deriving newtype instance Bits MONTH
-deriving newtype instance FiniteBits MONTH
-deriving newtype instance Integral MONTH
-deriving newtype instance Num MONTH
-deriving newtype instance Real MONTH
-newtype DAY = DAY {un_DAY :: CInt}
-deriving newtype instance Storable DAY
-deriving stock instance Eq DAY
-deriving stock instance Ord DAY
-deriving stock instance Read DAY
-deriving stock instance Show DAY
-deriving newtype instance Enum DAY
-deriving newtype instance Ix DAY
-deriving newtype instance Bounded DAY
-deriving newtype instance Bits DAY
-deriving newtype instance FiniteBits DAY
-deriving newtype instance Integral DAY
-deriving newtype instance Num DAY
-deriving newtype instance Real DAY
+newtype YEAR
+    = YEAR {un_YEAR :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype MONTH
+    = MONTH {un_MONTH :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype DAY
+    = DAY {un_DAY :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 data Date
     = Date {date_year :: YEAR, date_month :: MONTH, date_day :: DAY}
+    deriving stock (Eq, Show)
 instance Storable Date
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -150,12 +138,11 @@ instance Storable Date
                                     {Date date_year_3
                                           date_month_4
                                           date_day_5 -> pokeByteOff ptr_1 (0 :: Int) date_year_3 >> (pokeByteOff ptr_1 (4 :: Int) date_month_4 >> pokeByteOff ptr_1 (8 :: Int) date_day_5)}}
-deriving stock instance Show Date
-deriving stock instance Eq Date
 foreign import ccall safe "test_internal_getYear" getYear :: Ptr Date ->
                                                              IO YEAR
 data Student
     = Student {student_university :: (Ptr CChar), student_year :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Student
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -163,13 +150,12 @@ instance Storable Student
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Student student_university_3
                                              student_year_4 -> pokeByteOff ptr_1 (0 :: Int) student_university_3 >> pokeByteOff ptr_1 (8 :: Int) student_year_4}}
-deriving stock instance Show Student
-deriving stock instance Eq Student
 data Person
 data Employee
     = Employee {employee_company :: (Ptr CChar),
                 employee_supervisor :: (Ptr Person),
                 employee_salary :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Employee
     where {sizeOf = \_ -> 24 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -178,8 +164,6 @@ instance Storable Employee
                                     {Employee employee_company_3
                                               employee_supervisor_4
                                               employee_salary_5 -> pokeByteOff ptr_1 (0 :: Int) employee_company_3 >> (pokeByteOff ptr_1 (8 :: Int) employee_supervisor_4 >> pokeByteOff ptr_1 (16 :: Int) employee_salary_5)}}
-deriving stock instance Show Employee
-deriving stock instance Eq Employee
 newtype Occupation = Occupation {un_Occupation :: ByteArray}
 deriving via (SizedByteArray 24 8) instance Storable Occupation
 get_occupation_student :: Occupation -> Student
@@ -196,6 +180,7 @@ foreign import ccall safe "test_internal_print_occupation" print_occupation :: C
 data Rect_lower_left
     = Rect_lower_left {rect_lower_left_x :: CInt,
                        rect_lower_left_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Rect_lower_left
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -203,11 +188,10 @@ instance Storable Rect_lower_left
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Rect_lower_left rect_lower_left_x_3
                                                      rect_lower_left_y_4 -> pokeByteOff ptr_1 (0 :: Int) rect_lower_left_x_3 >> pokeByteOff ptr_1 (4 :: Int) rect_lower_left_y_4}}
-deriving stock instance Show Rect_lower_left
-deriving stock instance Eq Rect_lower_left
 data Rect_upper_right
     = Rect_upper_right {rect_upper_right_x :: CInt,
                         rect_upper_right_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Rect_upper_right
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -215,11 +199,10 @@ instance Storable Rect_upper_right
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Rect_upper_right rect_upper_right_x_3
                                                       rect_upper_right_y_4 -> pokeByteOff ptr_1 (0 :: Int) rect_upper_right_x_3 >> pokeByteOff ptr_1 (4 :: Int) rect_upper_right_y_4}}
-deriving stock instance Show Rect_upper_right
-deriving stock instance Eq Rect_upper_right
 data Rect
     = Rect {rect_lower_left :: Rect_lower_left,
             rect_upper_right :: Rect_upper_right}
+    deriving stock (Eq, Show)
 instance Storable Rect
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -227,11 +210,10 @@ instance Storable Rect
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Rect rect_lower_left_3
                                           rect_upper_right_4 -> pokeByteOff ptr_1 (0 :: Int) rect_lower_left_3 >> pokeByteOff ptr_1 (8 :: Int) rect_upper_right_4}}
-deriving stock instance Show Rect
-deriving stock instance Eq Rect
 data Config_Deref
     = Config_Deref {config_Deref_width :: CInt,
                     config_Deref_height :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Config_Deref
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -239,67 +221,58 @@ instance Storable Config_Deref
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Config_Deref config_Deref_width_3
                                                   config_Deref_height_4 -> pokeByteOff ptr_1 (0 :: Int) config_Deref_width_3 >> pokeByteOff ptr_1 (4 :: Int) config_Deref_height_4}}
-deriving stock instance Show Config_Deref
-deriving stock instance Eq Config_Deref
-newtype Config = Config {un_Config :: (Ptr Config_Deref)}
-deriving newtype instance Storable Config
-deriving stock instance Eq Config
-deriving stock instance Ord Config
-deriving stock instance Show Config
-newtype Adio'0301s = Adio'0301s {un_Adio'0301s :: CInt}
-deriving newtype instance Storable Adio'0301s
-deriving stock instance Eq Adio'0301s
-deriving stock instance Ord Adio'0301s
-deriving stock instance Read Adio'0301s
-deriving stock instance Show Adio'0301s
-deriving newtype instance Enum Adio'0301s
-deriving newtype instance Ix Adio'0301s
-deriving newtype instance Bounded Adio'0301s
-deriving newtype instance Bits Adio'0301s
-deriving newtype instance FiniteBits Adio'0301s
-deriving newtype instance Integral Adio'0301s
-deriving newtype instance Num Adio'0301s
-deriving newtype instance Real Adio'0301s
+newtype Config
+    = Config {un_Config :: (Ptr Config_Deref)}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
+newtype Adio'0301s
+    = Adio'0301s {un_Adio'0301s :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_\25308\25308" 拜拜 :: IO Unit
-newtype C数字 = C数字 {un_C数字 :: CInt}
-deriving newtype instance Storable C数字
-deriving stock instance Eq C数字
-deriving stock instance Ord C数字
-deriving stock instance Read C数字
-deriving stock instance Show C数字
-deriving newtype instance Enum C数字
-deriving newtype instance Ix C数字
-deriving newtype instance Bounded C数字
-deriving newtype instance Bits C数字
-deriving newtype instance FiniteBits C数字
-deriving newtype instance Integral C数字
-deriving newtype instance Num C数字
-deriving newtype instance Real C数字
+newtype C数字
+    = C数字 {un_C数字 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_\978" cϒ :: IO Unit
-newtype Data = Data {un_Data :: CInt}
-deriving newtype instance Storable Data
-deriving stock instance Eq Data
-deriving stock instance Ord Data
-deriving stock instance Read Data
-deriving stock instance Show Data
-deriving newtype instance Enum Data
-deriving newtype instance Ix Data
-deriving newtype instance Bounded Data
-deriving newtype instance Bits Data
-deriving newtype instance FiniteBits Data
-deriving newtype instance Integral Data
-deriving newtype instance Num Data
-deriving newtype instance Real Data
+newtype Data
+    = Data {un_Data :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 foreign import ccall safe "test_internal_import" import' :: IO Unit
-newtype Signal = Signal {un_Signal :: CUInt}
+newtype Signal
+    = Signal {un_Signal :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable Signal
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Signal <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Signal un_Signal_3 -> pokeByteOff ptr_1 (0 :: Int) un_Signal_3}}
-deriving stock instance Eq Signal
-deriving stock instance Ord Signal
 instance CEnum Signal
     where {type CEnumZ Signal = CUInt;
            toCEnum = Signal;
@@ -329,15 +302,15 @@ pattern Resume :: Signal
 pattern Resume = Signal 3
 pattern Stop :: Signal
 pattern Stop = Signal 4
-newtype HTTP_status = HTTP_status {un_HTTP_status :: CUInt}
+newtype HTTP_status
+    = HTTP_status {un_HTTP_status :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable HTTP_status
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure HTTP_status <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {HTTP_status un_HTTP_status_3 -> pokeByteOff ptr_1 (0 :: Int) un_HTTP_status_3}}
-deriving stock instance Eq HTTP_status
-deriving stock instance Ord HTTP_status
 instance CEnum HTTP_status
     where {type CEnumZ HTTP_status = CUInt;
            toCEnum = HTTP_status;
@@ -366,15 +339,15 @@ pattern Unauthorized :: HTTP_status
 pattern Unauthorized = HTTP_status 401
 pattern Not_found :: HTTP_status
 pattern Not_found = HTTP_status 404
-newtype Descending = Descending {un_Descending :: CUInt}
+newtype Descending
+    = Descending {un_Descending :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable Descending
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Descending <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Descending un_Descending_3 -> pokeByteOff ptr_1 (0 :: Int) un_Descending_3}}
-deriving stock instance Eq Descending
-deriving stock instance Ord Descending
 instance CEnum Descending
     where {type CEnumZ Descending = CUInt;
            toCEnum = Descending;
@@ -402,15 +375,15 @@ pattern Y_alias :: Descending
 pattern Y_alias = Descending 99
 pattern Z :: Descending
 pattern Z = Descending 98
-newtype Result = Result {un_Result :: CInt}
+newtype Result
+    = Result {un_Result :: CInt}
+    deriving stock (Eq, Ord)
 instance Storable Result
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Result <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Result un_Result_3 -> pokeByteOff ptr_1 (0 :: Int) un_Result_3}}
-deriving stock instance Eq Result
-deriving stock instance Ord Result
 instance CEnum Result
     where {type CEnumZ Result = CInt;
            toCEnum = Result;
@@ -440,15 +413,13 @@ pattern Postponed :: Result
 pattern Postponed = Result 1
 pattern Already_done :: Result
 pattern Already_done = Result 2
-newtype Vote = Vote {un_Vote :: CUChar}
+newtype Vote = Vote {un_Vote :: CUChar} deriving stock (Eq, Ord)
 instance Storable Vote
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure Vote <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Vote un_Vote_3 -> pokeByteOff ptr_1 (0 :: Int) un_Vote_3}}
-deriving stock instance Eq Vote
-deriving stock instance Ord Vote
 instance CEnum Vote
     where {type CEnumZ Vote = CUChar;
            toCEnum = Vote;
@@ -475,15 +446,15 @@ pattern Against :: Vote
 pattern Against = Vote 1
 pattern Abstain :: Vote
 pattern Abstain = Vote 2
-newtype CXCursorKind = CXCursorKind {un_CXCursorKind :: CUInt}
+newtype CXCursorKind
+    = CXCursorKind {un_CXCursorKind :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable CXCursorKind
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure CXCursorKind <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {CXCursorKind un_CXCursorKind_3 -> pokeByteOff ptr_1 (0 :: Int) un_CXCursorKind_3}}
-deriving stock instance Eq CXCursorKind
-deriving stock instance Ord CXCursorKind
 instance CEnum CXCursorKind
     where {type CEnumZ CXCursorKind = CUInt;
            toCEnum = CXCursorKind;

--- a/hs-bindgen/fixtures/nested_enums.exts.txt
+++ b/hs-bindgen/fixtures/nested_enums.exts.txt
@@ -1,4 +1,3 @@
 TypeFamilies
-StandaloneDeriving
 DerivingStrategies
 PatternSynonyms

--- a/hs-bindgen/fixtures/nested_enums.pp.hs
+++ b/hs-bindgen/fixtures/nested_enums.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Example where
@@ -16,6 +15,7 @@ import qualified Text.Read
 newtype EnumA = EnumA
   { un_EnumA :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable EnumA where
 
@@ -33,10 +33,6 @@ instance F.Storable EnumA where
       \s1 ->
         case s1 of
           EnumA un_EnumA2 -> F.pokeByteOff ptr0 (0 :: Int) un_EnumA2
-
-deriving stock instance Eq EnumA
-
-deriving stock instance Ord EnumA
 
 instance HsBindgen.Runtime.CEnum.CEnum EnumA where
 
@@ -85,6 +81,7 @@ pattern VALA_2 = EnumA 1
 data ExA = ExA
   { exA_fieldA1 :: EnumA
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable ExA where
 
@@ -103,13 +100,10 @@ instance F.Storable ExA where
         case s1 of
           ExA exA_fieldA12 -> F.pokeByteOff ptr0 (0 :: Int) exA_fieldA12
 
-deriving stock instance Show ExA
-
-deriving stock instance Eq ExA
-
 newtype ExB_fieldB1 = ExB_fieldB1
   { un_ExB_fieldB1 :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable ExB_fieldB1 where
 
@@ -127,10 +121,6 @@ instance F.Storable ExB_fieldB1 where
       \s1 ->
         case s1 of
           ExB_fieldB1 un_ExB_fieldB12 -> F.pokeByteOff ptr0 (0 :: Int) un_ExB_fieldB12
-
-deriving stock instance Eq ExB_fieldB1
-
-deriving stock instance Ord ExB_fieldB1
 
 instance HsBindgen.Runtime.CEnum.CEnum ExB_fieldB1 where
 
@@ -180,6 +170,7 @@ pattern VALB_2 = ExB_fieldB1 1
 data ExB = ExB
   { exB_fieldB1 :: ExB_fieldB1
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable ExB where
 
@@ -197,7 +188,3 @@ instance F.Storable ExB where
       \s1 ->
         case s1 of
           ExB exB_fieldB12 -> F.pokeByteOff ptr0 (0 :: Int) exB_fieldB12
-
-deriving stock instance Show ExB
-
-deriving stock instance Eq ExB

--- a/hs-bindgen/fixtures/nested_enums.th.txt
+++ b/hs-bindgen/fixtures/nested_enums.th.txt
@@ -1,13 +1,11 @@
 -- addDependentFile examples/golden/nested_enums.h
-newtype EnumA = EnumA {un_EnumA :: CUInt}
+newtype EnumA = EnumA {un_EnumA :: CUInt} deriving stock (Eq, Ord)
 instance Storable EnumA
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure EnumA <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {EnumA un_EnumA_3 -> pokeByteOff ptr_1 (0 :: Int) un_EnumA_3}}
-deriving stock instance Eq EnumA
-deriving stock instance Ord EnumA
 instance CEnum EnumA
     where {type CEnumZ EnumA = CUInt;
            toCEnum = EnumA;
@@ -31,24 +29,22 @@ pattern VALA_1 :: EnumA
 pattern VALA_1 = EnumA 0
 pattern VALA_2 :: EnumA
 pattern VALA_2 = EnumA 1
-data ExA = ExA {exA_fieldA1 :: EnumA}
+data ExA = ExA {exA_fieldA1 :: EnumA} deriving stock (Eq, Show)
 instance Storable ExA
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure ExA <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {ExA exA_fieldA1_3 -> pokeByteOff ptr_1 (0 :: Int) exA_fieldA1_3}}
-deriving stock instance Show ExA
-deriving stock instance Eq ExA
-newtype ExB_fieldB1 = ExB_fieldB1 {un_ExB_fieldB1 :: CUInt}
+newtype ExB_fieldB1
+    = ExB_fieldB1 {un_ExB_fieldB1 :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable ExB_fieldB1
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure ExB_fieldB1 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {ExB_fieldB1 un_ExB_fieldB1_3 -> pokeByteOff ptr_1 (0 :: Int) un_ExB_fieldB1_3}}
-deriving stock instance Eq ExB_fieldB1
-deriving stock instance Ord ExB_fieldB1
 instance CEnum ExB_fieldB1
     where {type CEnumZ ExB_fieldB1 = CUInt;
            toCEnum = ExB_fieldB1;
@@ -72,12 +68,12 @@ pattern VALB_1 :: ExB_fieldB1
 pattern VALB_1 = ExB_fieldB1 0
 pattern VALB_2 :: ExB_fieldB1
 pattern VALB_2 = ExB_fieldB1 1
-data ExB = ExB {exB_fieldB1 :: ExB_fieldB1}
+data ExB
+    = ExB {exB_fieldB1 :: ExB_fieldB1}
+    deriving stock (Eq, Show)
 instance Storable ExB
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure ExB <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {ExB exB_fieldB1_3 -> pokeByteOff ptr_1 (0 :: Int) exB_fieldB1_3}}
-deriving stock instance Show ExB
-deriving stock instance Eq ExB

--- a/hs-bindgen/fixtures/nested_types.exts.txt
+++ b/hs-bindgen/fixtures/nested_types.exts.txt
@@ -1,2 +1,1 @@
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/nested_types.pp.hs
+++ b/hs-bindgen/fixtures/nested_types.pp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -12,6 +11,7 @@ data Foo = Foo
   { foo_i :: FC.CInt
   , foo_c :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -33,14 +33,11 @@ instance F.Storable Foo where
                F.pokeByteOff ptr0 (0 :: Int) foo_i2
             >> F.pokeByteOff ptr0 (4 :: Int) foo_c3
 
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo
-
 data Bar = Bar
   { bar_foo1 :: Foo
   , bar_foo2 :: Foo
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bar where
 
@@ -62,14 +59,11 @@ instance F.Storable Bar where
                F.pokeByteOff ptr0 (0 :: Int) bar_foo12
             >> F.pokeByteOff ptr0 (8 :: Int) bar_foo23
 
-deriving stock instance Show Bar
-
-deriving stock instance Eq Bar
-
 data Ex3_ex3_struct = Ex3_ex3_struct
   { ex3_ex3_struct_ex3_a :: FC.CInt
   , ex3_ex3_struct_ex3_b :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Ex3_ex3_struct where
 
@@ -91,14 +85,11 @@ instance F.Storable Ex3_ex3_struct where
                F.pokeByteOff ptr0 (0 :: Int) ex3_ex3_struct_ex3_a2
             >> F.pokeByteOff ptr0 (4 :: Int) ex3_ex3_struct_ex3_b3
 
-deriving stock instance Show Ex3_ex3_struct
-
-deriving stock instance Eq Ex3_ex3_struct
-
 data Ex3 = Ex3
   { ex3_ex3_struct :: Ex3_ex3_struct
   , ex3_ex3_c :: FC.CFloat
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Ex3 where
 
@@ -120,14 +111,11 @@ instance F.Storable Ex3 where
                F.pokeByteOff ptr0 (0 :: Int) ex3_ex3_struct2
             >> F.pokeByteOff ptr0 (8 :: Int) ex3_ex3_c3
 
-deriving stock instance Show Ex3
-
-deriving stock instance Eq Ex3
-
 data Ex4_even = Ex4_even
   { ex4_even_value :: FC.CDouble
   , ex4_even_next :: F.Ptr Ex4_odd
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Ex4_even where
 
@@ -149,14 +137,11 @@ instance F.Storable Ex4_even where
                F.pokeByteOff ptr0 (0 :: Int) ex4_even_value2
             >> F.pokeByteOff ptr0 (8 :: Int) ex4_even_next3
 
-deriving stock instance Show Ex4_even
-
-deriving stock instance Eq Ex4_even
-
 data Ex4_odd = Ex4_odd
   { ex4_odd_value :: FC.CInt
   , ex4_odd_next :: F.Ptr Ex4_even
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Ex4_odd where
 
@@ -177,7 +162,3 @@ instance F.Storable Ex4_odd where
           Ex4_odd ex4_odd_value2 ex4_odd_next3 ->
                F.pokeByteOff ptr0 (0 :: Int) ex4_odd_value2
             >> F.pokeByteOff ptr0 (8 :: Int) ex4_odd_next3
-
-deriving stock instance Show Ex4_odd
-
-deriving stock instance Eq Ex4_odd

--- a/hs-bindgen/fixtures/nested_types.th.txt
+++ b/hs-bindgen/fixtures/nested_types.th.txt
@@ -1,5 +1,7 @@
 -- addDependentFile examples/golden/nested_types.h
-data Foo = Foo {foo_i :: CInt, foo_c :: CChar}
+data Foo
+    = Foo {foo_i :: CInt, foo_c :: CChar}
+    deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -7,9 +9,9 @@ instance Storable Foo
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_i_3
                                          foo_c_4 -> pokeByteOff ptr_1 (0 :: Int) foo_i_3 >> pokeByteOff ptr_1 (4 :: Int) foo_c_4}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo
-data Bar = Bar {bar_foo1 :: Foo, bar_foo2 :: Foo}
+data Bar
+    = Bar {bar_foo1 :: Foo, bar_foo2 :: Foo}
+    deriving stock (Eq, Show)
 instance Storable Bar
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -17,11 +19,10 @@ instance Storable Bar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bar bar_foo1_3
                                          bar_foo2_4 -> pokeByteOff ptr_1 (0 :: Int) bar_foo1_3 >> pokeByteOff ptr_1 (8 :: Int) bar_foo2_4}}
-deriving stock instance Show Bar
-deriving stock instance Eq Bar
 data Ex3_ex3_struct
     = Ex3_ex3_struct {ex3_ex3_struct_ex3_a :: CInt,
                       ex3_ex3_struct_ex3_b :: CChar}
+    deriving stock (Eq, Show)
 instance Storable Ex3_ex3_struct
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -29,10 +30,9 @@ instance Storable Ex3_ex3_struct
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Ex3_ex3_struct ex3_ex3_struct_ex3_a_3
                                                     ex3_ex3_struct_ex3_b_4 -> pokeByteOff ptr_1 (0 :: Int) ex3_ex3_struct_ex3_a_3 >> pokeByteOff ptr_1 (4 :: Int) ex3_ex3_struct_ex3_b_4}}
-deriving stock instance Show Ex3_ex3_struct
-deriving stock instance Eq Ex3_ex3_struct
 data Ex3
     = Ex3 {ex3_ex3_struct :: Ex3_ex3_struct, ex3_ex3_c :: CFloat}
+    deriving stock (Eq, Show)
 instance Storable Ex3
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -40,11 +40,10 @@ instance Storable Ex3
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Ex3 ex3_ex3_struct_3
                                          ex3_ex3_c_4 -> pokeByteOff ptr_1 (0 :: Int) ex3_ex3_struct_3 >> pokeByteOff ptr_1 (8 :: Int) ex3_ex3_c_4}}
-deriving stock instance Show Ex3
-deriving stock instance Eq Ex3
 data Ex4_even
     = Ex4_even {ex4_even_value :: CDouble,
                 ex4_even_next :: (Ptr Ex4_odd)}
+    deriving stock (Eq, Show)
 instance Storable Ex4_even
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -52,10 +51,9 @@ instance Storable Ex4_even
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Ex4_even ex4_even_value_3
                                               ex4_even_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_even_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_even_next_4}}
-deriving stock instance Show Ex4_even
-deriving stock instance Eq Ex4_even
 data Ex4_odd
     = Ex4_odd {ex4_odd_value :: CInt, ex4_odd_next :: (Ptr Ex4_even)}
+    deriving stock (Eq, Show)
 instance Storable Ex4_odd
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -63,5 +61,3 @@ instance Storable Ex4_odd
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Ex4_odd ex4_odd_value_3
                                              ex4_odd_next_4 -> pokeByteOff ptr_1 (0 :: Int) ex4_odd_value_3 >> pokeByteOff ptr_1 (8 :: Int) ex4_odd_next_4}}
-deriving stock instance Show Ex4_odd
-deriving stock instance Eq Ex4_odd

--- a/hs-bindgen/fixtures/opaque_declaration.exts.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 EmptyDataDecls

--- a/hs-bindgen/fixtures/opaque_declaration.pp.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -14,6 +13,7 @@ data Bar = Bar
   { bar_ptrA :: F.Ptr Foo
   , bar_ptrB :: F.Ptr Bar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Bar where
 
@@ -35,12 +35,9 @@ instance F.Storable Bar where
                F.pokeByteOff ptr0 (0 :: Int) bar_ptrA2
             >> F.pokeByteOff ptr0 (8 :: Int) bar_ptrB3
 
-deriving stock instance Show Bar
-
-deriving stock instance Eq Bar
-
 data Baz = Baz
   {}
+  deriving stock (Eq, Show)
 
 instance F.Storable Baz where
 
@@ -55,10 +52,6 @@ instance F.Storable Baz where
       \s1 ->
         case s1 of
           Baz -> return ()
-
-deriving stock instance Show Baz
-
-deriving stock instance Eq Baz
 
 data Quu
 

--- a/hs-bindgen/fixtures/opaque_declaration.th.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.th.txt
@@ -1,6 +1,8 @@
 -- addDependentFile examples/golden/opaque_declaration.h
 data Foo
-data Bar = Bar {bar_ptrA :: (Ptr Foo), bar_ptrB :: (Ptr Bar)}
+data Bar
+    = Bar {bar_ptrA :: (Ptr Foo), bar_ptrB :: (Ptr Bar)}
+    deriving stock (Eq, Show)
 instance Storable Bar
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -8,16 +10,12 @@ instance Storable Bar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Bar bar_ptrA_3
                                          bar_ptrB_4 -> pokeByteOff ptr_1 (0 :: Int) bar_ptrA_3 >> pokeByteOff ptr_1 (8 :: Int) bar_ptrB_4}}
-deriving stock instance Show Bar
-deriving stock instance Eq Bar
-data Baz = Baz {}
+data Baz = Baz {} deriving stock (Eq, Show)
 instance Storable Baz
     where {sizeOf = \_ -> 0 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure Baz;
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Baz -> return ()}}
-deriving stock instance Show Baz
-deriving stock instance Eq Baz
 data Quu
 data Opaque_union

--- a/hs-bindgen/fixtures/primitive_types.exts.txt
+++ b/hs-bindgen/fixtures/primitive_types.exts.txt
@@ -1,2 +1,1 @@
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/primitive_types.pp.hs
+++ b/hs-bindgen/fixtures/primitive_types.pp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -38,6 +37,7 @@ data Primitive = Primitive
   , primitive_f :: FC.CFloat
   , primitive_d :: FC.CDouble
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Primitive where
 
@@ -138,7 +138,3 @@ instance F.Storable Primitive where
               >> F.pokeByteOff ptr0 (128 :: Int) primitive_ulli27
               >> F.pokeByteOff ptr0 (136 :: Int) primitive_f28
               >> F.pokeByteOff ptr0 (144 :: Int) primitive_d29
-
-deriving stock instance Show Primitive
-
-deriving stock instance Eq Primitive

--- a/hs-bindgen/fixtures/primitive_types.th.txt
+++ b/hs-bindgen/fixtures/primitive_types.th.txt
@@ -28,6 +28,7 @@ data Primitive
                  primitive_ulli :: CULLong,
                  primitive_f :: CFloat,
                  primitive_d :: CDouble}
+    deriving stock (Eq, Show)
 instance Storable Primitive
     where {sizeOf = \_ -> 152 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -61,5 +62,3 @@ instance Storable Primitive
                                                primitive_ulli_28
                                                primitive_f_29
                                                primitive_d_30 -> pokeByteOff ptr_1 (0 :: Int) primitive_c_3 >> (pokeByteOff ptr_1 (1 :: Int) primitive_sc_4 >> (pokeByteOff ptr_1 (2 :: Int) primitive_uc_5 >> (pokeByteOff ptr_1 (4 :: Int) primitive_s_6 >> (pokeByteOff ptr_1 (6 :: Int) primitive_si_7 >> (pokeByteOff ptr_1 (8 :: Int) primitive_ss_8 >> (pokeByteOff ptr_1 (10 :: Int) primitive_ssi_9 >> (pokeByteOff ptr_1 (12 :: Int) primitive_us_10 >> (pokeByteOff ptr_1 (14 :: Int) primitive_usi_11 >> (pokeByteOff ptr_1 (16 :: Int) primitive_i_12 >> (pokeByteOff ptr_1 (20 :: Int) primitive_s2_13 >> (pokeByteOff ptr_1 (24 :: Int) primitive_si2_14 >> (pokeByteOff ptr_1 (28 :: Int) primitive_u_15 >> (pokeByteOff ptr_1 (32 :: Int) primitive_ui_16 >> (pokeByteOff ptr_1 (40 :: Int) primitive_l_17 >> (pokeByteOff ptr_1 (48 :: Int) primitive_li_18 >> (pokeByteOff ptr_1 (56 :: Int) primitive_sl_19 >> (pokeByteOff ptr_1 (64 :: Int) primitive_sli_20 >> (pokeByteOff ptr_1 (72 :: Int) primitive_ul_21 >> (pokeByteOff ptr_1 (80 :: Int) primitive_uli_22 >> (pokeByteOff ptr_1 (88 :: Int) primitive_ll_23 >> (pokeByteOff ptr_1 (96 :: Int) primitive_lli_24 >> (pokeByteOff ptr_1 (104 :: Int) primitive_sll_25 >> (pokeByteOff ptr_1 (112 :: Int) primitive_slli_26 >> (pokeByteOff ptr_1 (120 :: Int) primitive_ull_27 >> (pokeByteOff ptr_1 (128 :: Int) primitive_ulli_28 >> (pokeByteOff ptr_1 (136 :: Int) primitive_f_29 >> pokeByteOff ptr_1 (144 :: Int) primitive_d_30))))))))))))))))))))))))))}}
-deriving stock instance Show Primitive
-deriving stock instance Eq Primitive

--- a/hs-bindgen/fixtures/program_slicing.exts.txt
+++ b/hs-bindgen/fixtures/program_slicing.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/program_slicing.pp.hs
+++ b/hs-bindgen/fixtures/program_slicing.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -16,37 +15,14 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype Uint32_t = Uint32_t
   { un_Uint32_t :: FC.CUInt
   }
-
-deriving newtype instance F.Storable Uint32_t
-
-deriving stock instance Eq Uint32_t
-
-deriving stock instance Ord Uint32_t
-
-deriving stock instance Read Uint32_t
-
-deriving stock instance Show Uint32_t
-
-deriving newtype instance Enum Uint32_t
-
-deriving newtype instance Ix.Ix Uint32_t
-
-deriving newtype instance Bounded Uint32_t
-
-deriving newtype instance Bits.Bits Uint32_t
-
-deriving newtype instance FiniteBits Uint32_t
-
-deriving newtype instance Integral Uint32_t
-
-deriving newtype instance Num Uint32_t
-
-deriving newtype instance Real Uint32_t
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data Foo = Foo
   { foo_sixty_four :: HsBindgen.Runtime.Prelude.Word64
   , foo_thirty_two :: Uint32_t
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -67,7 +43,3 @@ instance F.Storable Foo where
           Foo foo_sixty_four2 foo_thirty_two3 ->
                F.pokeByteOff ptr0 (0 :: Int) foo_sixty_four2
             >> F.pokeByteOff ptr0 (8 :: Int) foo_thirty_two3
-
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/program_slicing.th.txt
+++ b/hs-bindgen/fixtures/program_slicing.th.txt
@@ -2,23 +2,22 @@
 -- addDependentFile musl-include/x86_64/bits/alltypes.h
 -- addDependentFile musl-include/x86_64/stdint.h
 -- addDependentFile examples/golden/program_slicing.h
-newtype Uint32_t = Uint32_t {un_Uint32_t :: CUInt}
-deriving newtype instance Storable Uint32_t
-deriving stock instance Eq Uint32_t
-deriving stock instance Ord Uint32_t
-deriving stock instance Read Uint32_t
-deriving stock instance Show Uint32_t
-deriving newtype instance Enum Uint32_t
-deriving newtype instance Ix Uint32_t
-deriving newtype instance Bounded Uint32_t
-deriving newtype instance Bits Uint32_t
-deriving newtype instance FiniteBits Uint32_t
-deriving newtype instance Integral Uint32_t
-deriving newtype instance Num Uint32_t
-deriving newtype instance Real Uint32_t
+newtype Uint32_t
+    = Uint32_t {un_Uint32_t :: CUInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
 data Foo
     = Foo {foo_sixty_four :: HsBindgen.Runtime.Prelude.Word64,
            foo_thirty_two :: Uint32_t}
+    deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -26,5 +25,3 @@ instance Storable Foo
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_sixty_four_3
                                          foo_thirty_two_4 -> pokeByteOff ptr_1 (0 :: Int) foo_sixty_four_3 >> pokeByteOff ptr_1 (8 :: Int) foo_thirty_two_4}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/recursive_struct.exts.txt
+++ b/hs-bindgen/fixtures/recursive_struct.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/recursive_struct.pp.hs
+++ b/hs-bindgen/fixtures/recursive_struct.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -13,6 +12,7 @@ data Linked_list_A_s = Linked_list_A_s
   { linked_list_A_s_x :: FC.CInt
   , linked_list_A_s_next :: F.Ptr Linked_list_A_s
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Linked_list_A_s where
 
@@ -34,24 +34,17 @@ instance F.Storable Linked_list_A_s where
                F.pokeByteOff ptr0 (0 :: Int) linked_list_A_s_x2
             >> F.pokeByteOff ptr0 (8 :: Int) linked_list_A_s_next3
 
-deriving stock instance Show Linked_list_A_s
-
-deriving stock instance Eq Linked_list_A_s
-
 newtype Linked_list_A_t = Linked_list_A_t
   { un_Linked_list_A_t :: Linked_list_A_s
   }
-
-deriving newtype instance F.Storable Linked_list_A_t
-
-deriving stock instance Eq Linked_list_A_t
-
-deriving stock instance Show Linked_list_A_t
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 data Linked_list_B_t = Linked_list_B_t
   { linked_list_B_t_x :: FC.CInt
   , linked_list_B_t_next :: F.Ptr Linked_list_B_t
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Linked_list_B_t where
 
@@ -72,7 +65,3 @@ instance F.Storable Linked_list_B_t where
           Linked_list_B_t linked_list_B_t_x2 linked_list_B_t_next3 ->
                F.pokeByteOff ptr0 (0 :: Int) linked_list_B_t_x2
             >> F.pokeByteOff ptr0 (8 :: Int) linked_list_B_t_next3
-
-deriving stock instance Show Linked_list_B_t
-
-deriving stock instance Eq Linked_list_B_t

--- a/hs-bindgen/fixtures/recursive_struct.th.txt
+++ b/hs-bindgen/fixtures/recursive_struct.th.txt
@@ -2,6 +2,7 @@
 data Linked_list_A_s
     = Linked_list_A_s {linked_list_A_s_x :: CInt,
                        linked_list_A_s_next :: (Ptr Linked_list_A_s)}
+    deriving stock (Eq, Show)
 instance Storable Linked_list_A_s
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -9,16 +10,14 @@ instance Storable Linked_list_A_s
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Linked_list_A_s linked_list_A_s_x_3
                                                      linked_list_A_s_next_4 -> pokeByteOff ptr_1 (0 :: Int) linked_list_A_s_x_3 >> pokeByteOff ptr_1 (8 :: Int) linked_list_A_s_next_4}}
-deriving stock instance Show Linked_list_A_s
-deriving stock instance Eq Linked_list_A_s
 newtype Linked_list_A_t
     = Linked_list_A_t {un_Linked_list_A_t :: Linked_list_A_s}
-deriving newtype instance Storable Linked_list_A_t
-deriving stock instance Eq Linked_list_A_t
-deriving stock instance Show Linked_list_A_t
+    deriving stock (Eq, Show)
+    deriving newtype Storable
 data Linked_list_B_t
     = Linked_list_B_t {linked_list_B_t_x :: CInt,
                        linked_list_B_t_next :: (Ptr Linked_list_B_t)}
+    deriving stock (Eq, Show)
 instance Storable Linked_list_B_t
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -26,5 +25,3 @@ instance Storable Linked_list_B_t
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Linked_list_B_t linked_list_B_t_x_3
                                                      linked_list_B_t_next_4 -> pokeByteOff ptr_1 (0 :: Int) linked_list_B_t_x_3 >> pokeByteOff ptr_1 (8 :: Int) linked_list_B_t_next_4}}
-deriving stock instance Show Linked_list_B_t
-deriving stock instance Eq Linked_list_B_t

--- a/hs-bindgen/fixtures/simple_structs.exts.txt
+++ b/hs-bindgen/fixtures/simple_structs.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/simple_structs.pp.hs
+++ b/hs-bindgen/fixtures/simple_structs.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -13,6 +12,7 @@ data S1 = S1
   { s1_a :: FC.CInt
   , s1_b :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S1 where
 
@@ -34,15 +34,12 @@ instance F.Storable S1 where
                F.pokeByteOff ptr0 (0 :: Int) s1_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s1_b3
 
-deriving stock instance Show S1
-
-deriving stock instance Eq S1
-
 data S2 = S2
   { s2_a :: FC.CChar
   , s2_b :: FC.CInt
   , s2_c :: FC.CFloat
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2 where
 
@@ -66,23 +63,16 @@ instance F.Storable S2 where
             >> F.pokeByteOff ptr0 (4 :: Int) s2_b3
             >> F.pokeByteOff ptr0 (8 :: Int) s2_c4
 
-deriving stock instance Show S2
-
-deriving stock instance Eq S2
-
 newtype S2_t = S2_t
   { un_S2_t :: S2
   }
-
-deriving newtype instance F.Storable S2_t
-
-deriving stock instance Eq S2_t
-
-deriving stock instance Show S2_t
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 data S3_t = S3_t
   { s3_t_a :: FC.CChar
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S3_t where
 
@@ -101,15 +91,12 @@ instance F.Storable S3_t where
         case s1 of
           S3_t s3_t_a2 -> F.pokeByteOff ptr0 (0 :: Int) s3_t_a2
 
-deriving stock instance Show S3_t
-
-deriving stock instance Eq S3_t
-
 data S4 = S4
   { s4_b :: FC.CChar
   , s4_a :: FC.CInt
   , s4_c :: F.Ptr FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S4 where
 
@@ -133,14 +120,11 @@ instance F.Storable S4 where
             >> F.pokeByteOff ptr0 (4 :: Int) s4_a3
             >> F.pokeByteOff ptr0 (8 :: Int) s4_c4
 
-deriving stock instance Show S4
-
-deriving stock instance Eq S4
-
 data S5 = S5
   { s5_a :: FC.CChar
   , s5_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S5 where
 
@@ -162,14 +146,11 @@ instance F.Storable S5 where
                F.pokeByteOff ptr0 (0 :: Int) s5_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s5_b3
 
-deriving stock instance Show S5
-
-deriving stock instance Eq S5
-
 data S6 = S6
   { s6_a :: FC.CChar
   , s6_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S6 where
 
@@ -191,14 +172,11 @@ instance F.Storable S6 where
                F.pokeByteOff ptr0 (0 :: Int) s6_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s6_b3
 
-deriving stock instance Show S6
-
-deriving stock instance Eq S6
-
 data S7a_Deref = S7a_Deref
   { s7a_Deref_a :: FC.CChar
   , s7a_Deref_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S7a_Deref where
 
@@ -220,26 +198,17 @@ instance F.Storable S7a_Deref where
                F.pokeByteOff ptr0 (0 :: Int) s7a_Deref_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s7a_Deref_b3
 
-deriving stock instance Show S7a_Deref
-
-deriving stock instance Eq S7a_Deref
-
 newtype S7a = S7a
   { un_S7a :: F.Ptr S7a_Deref
   }
-
-deriving newtype instance F.Storable S7a
-
-deriving stock instance Eq S7a
-
-deriving stock instance Ord S7a
-
-deriving stock instance Show S7a
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 data S7b_Deref = S7b_Deref
   { s7b_Deref_a :: FC.CChar
   , s7b_Deref_b :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S7b_Deref where
 
@@ -261,18 +230,8 @@ instance F.Storable S7b_Deref where
                F.pokeByteOff ptr0 (0 :: Int) s7b_Deref_a2
             >> F.pokeByteOff ptr0 (4 :: Int) s7b_Deref_b3
 
-deriving stock instance Show S7b_Deref
-
-deriving stock instance Eq S7b_Deref
-
 newtype S7b = S7b
   { un_S7b :: F.Ptr (F.Ptr (F.Ptr S7b_Deref))
   }
-
-deriving newtype instance F.Storable S7b
-
-deriving stock instance Eq S7b
-
-deriving stock instance Ord S7b
-
-deriving stock instance Show S7b
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/simple_structs.th.txt
+++ b/hs-bindgen/fixtures/simple_structs.th.txt
@@ -1,5 +1,7 @@
 -- addDependentFile examples/golden/simple_structs.h
-data S1 = S1 {s1_a :: CInt, s1_b :: CChar}
+data S1
+    = S1 {s1_a :: CInt, s1_b :: CChar}
+    deriving stock (Eq, Show)
 instance Storable S1
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -7,9 +9,9 @@ instance Storable S1
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S1 s1_a_3
                                         s1_b_4 -> pokeByteOff ptr_1 (0 :: Int) s1_a_3 >> pokeByteOff ptr_1 (4 :: Int) s1_b_4}}
-deriving stock instance Show S1
-deriving stock instance Eq S1
-data S2 = S2 {s2_a :: CChar, s2_b :: CInt, s2_c :: CFloat}
+data S2
+    = S2 {s2_a :: CChar, s2_b :: CInt, s2_c :: CFloat}
+    deriving stock (Eq, Show)
 instance Storable S2
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -18,22 +20,20 @@ instance Storable S2
                                     {S2 s2_a_3
                                         s2_b_4
                                         s2_c_5 -> pokeByteOff ptr_1 (0 :: Int) s2_a_3 >> (pokeByteOff ptr_1 (4 :: Int) s2_b_4 >> pokeByteOff ptr_1 (8 :: Int) s2_c_5)}}
-deriving stock instance Show S2
-deriving stock instance Eq S2
-newtype S2_t = S2_t {un_S2_t :: S2}
-deriving newtype instance Storable S2_t
-deriving stock instance Eq S2_t
-deriving stock instance Show S2_t
-data S3_t = S3_t {s3_t_a :: CChar}
+newtype S2_t
+    = S2_t {un_S2_t :: S2}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+data S3_t = S3_t {s3_t_a :: CChar} deriving stock (Eq, Show)
 instance Storable S3_t
     where {sizeOf = \_ -> 1 :: Int;
            alignment = \_ -> 1 :: Int;
            peek = \ptr_0 -> pure S3_t <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S3_t s3_t_a_3 -> pokeByteOff ptr_1 (0 :: Int) s3_t_a_3}}
-deriving stock instance Show S3_t
-deriving stock instance Eq S3_t
-data S4 = S4 {s4_b :: CChar, s4_a :: CInt, s4_c :: (Ptr CInt)}
+data S4
+    = S4 {s4_b :: CChar, s4_a :: CInt, s4_c :: (Ptr CInt)}
+    deriving stock (Eq, Show)
 instance Storable S4
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -42,9 +42,9 @@ instance Storable S4
                                     {S4 s4_b_3
                                         s4_a_4
                                         s4_c_5 -> pokeByteOff ptr_1 (0 :: Int) s4_b_3 >> (pokeByteOff ptr_1 (4 :: Int) s4_a_4 >> pokeByteOff ptr_1 (8 :: Int) s4_c_5)}}
-deriving stock instance Show S4
-deriving stock instance Eq S4
-data S5 = S5 {s5_a :: CChar, s5_b :: CInt}
+data S5
+    = S5 {s5_a :: CChar, s5_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S5
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -52,9 +52,9 @@ instance Storable S5
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S5 s5_a_3
                                         s5_b_4 -> pokeByteOff ptr_1 (0 :: Int) s5_a_3 >> pokeByteOff ptr_1 (4 :: Int) s5_b_4}}
-deriving stock instance Show S5
-deriving stock instance Eq S5
-data S6 = S6 {s6_a :: CChar, s6_b :: CInt}
+data S6
+    = S6 {s6_a :: CChar, s6_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S6
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -62,10 +62,9 @@ instance Storable S6
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S6 s6_a_3
                                         s6_b_4 -> pokeByteOff ptr_1 (0 :: Int) s6_a_3 >> pokeByteOff ptr_1 (4 :: Int) s6_b_4}}
-deriving stock instance Show S6
-deriving stock instance Eq S6
 data S7a_Deref
     = S7a_Deref {s7a_Deref_a :: CChar, s7a_Deref_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S7a_Deref
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -73,15 +72,13 @@ instance Storable S7a_Deref
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S7a_Deref s7a_Deref_a_3
                                                s7a_Deref_b_4 -> pokeByteOff ptr_1 (0 :: Int) s7a_Deref_a_3 >> pokeByteOff ptr_1 (4 :: Int) s7a_Deref_b_4}}
-deriving stock instance Show S7a_Deref
-deriving stock instance Eq S7a_Deref
-newtype S7a = S7a {un_S7a :: (Ptr S7a_Deref)}
-deriving newtype instance Storable S7a
-deriving stock instance Eq S7a
-deriving stock instance Ord S7a
-deriving stock instance Show S7a
+newtype S7a
+    = S7a {un_S7a :: (Ptr S7a_Deref)}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
 data S7b_Deref
     = S7b_Deref {s7b_Deref_a :: CChar, s7b_Deref_b :: CInt}
+    deriving stock (Eq, Show)
 instance Storable S7b_Deref
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -89,10 +86,7 @@ instance Storable S7b_Deref
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S7b_Deref s7b_Deref_a_3
                                                s7b_Deref_b_4 -> pokeByteOff ptr_1 (0 :: Int) s7b_Deref_a_3 >> pokeByteOff ptr_1 (4 :: Int) s7b_Deref_b_4}}
-deriving stock instance Show S7b_Deref
-deriving stock instance Eq S7b_Deref
-newtype S7b = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Deref)))}
-deriving newtype instance Storable S7b
-deriving stock instance Eq S7b
-deriving stock instance Ord S7b
-deriving stock instance Show S7b
+newtype S7b
+    = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Deref)))}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/skip_over_long_double.exts.txt
+++ b/hs-bindgen/fixtures/skip_over_long_double.exts.txt
@@ -1,4 +1,3 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/skip_over_long_double.pp.hs
+++ b/hs-bindgen/fixtures/skip_over_long_double.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -18,6 +17,7 @@ foreign import ccall safe "testmodule_fun2" fun2 :: FC.CInt -> IO ()
 data Struct2 = Struct2
   { struct2_x :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Struct2 where
 
@@ -35,7 +35,3 @@ instance F.Storable Struct2 where
       \s1 ->
         case s1 of
           Struct2 struct2_x2 -> F.pokeByteOff ptr0 (0 :: Int) struct2_x2
-
-deriving stock instance Show Struct2
-
-deriving stock instance Eq Struct2

--- a/hs-bindgen/fixtures/skip_over_long_double.th.txt
+++ b/hs-bindgen/fixtures/skip_over_long_double.th.txt
@@ -3,12 +3,12 @@
 -- void test_internal_fun2 (signed int arg1) { fun2(arg1); }
 foreign import ccall safe "test_internal_fun2" fun2 :: CInt ->
                                                        IO Unit
-data Struct2 = Struct2 {struct2_x :: CInt}
+data Struct2
+    = Struct2 {struct2_x :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Struct2
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Struct2 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Struct2 struct2_x_3 -> pokeByteOff ptr_1 (0 :: Int) struct2_x_3}}
-deriving stock instance Show Struct2
-deriving stock instance Eq Struct2

--- a/hs-bindgen/fixtures/struct_arg.exts.txt
+++ b/hs-bindgen/fixtures/struct_arg.exts.txt
@@ -1,4 +1,3 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/struct_arg.pp.hs
+++ b/hs-bindgen/fixtures/struct_arg.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -17,6 +16,7 @@ $(CAPI.addCSource "#include \"struct_arg.h\"\nsigned int testmodule_thing_fun_1 
 data Thing = Thing
   { thing_x :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Thing where
 
@@ -34,10 +34,6 @@ instance F.Storable Thing where
       \s1 ->
         case s1 of
           Thing thing_x2 -> F.pokeByteOff ptr0 (0 :: Int) thing_x2
-
-deriving stock instance Show Thing
-
-deriving stock instance Eq Thing
 
 foreign import ccall safe "testmodule_thing_fun_1" thing_fun_1_wrapper :: (F.Ptr Thing) -> IO FC.CInt
 

--- a/hs-bindgen/fixtures/struct_arg.th.txt
+++ b/hs-bindgen/fixtures/struct_arg.th.txt
@@ -4,15 +4,13 @@
 -- void test_internal_thing_fun_2 (signed int arg1, struct thing *arg2) { *arg2 = thing_fun_2(arg1); }
 -- void test_internal_thing_fun_3a (signed int arg1, struct thing *arg2, double arg3, struct thing *arg4) { *arg4 = thing_fun_3a(arg1, *arg2, arg3); }
 -- char test_internal_thing_fun_3b (signed int arg1, struct thing *arg2, double arg3) { return thing_fun_3b(arg1, *arg2, arg3); }
-data Thing = Thing {thing_x :: CInt}
+data Thing = Thing {thing_x :: CInt} deriving stock (Eq, Show)
 instance Storable Thing
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Thing <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Thing thing_x_3 -> pokeByteOff ptr_1 (0 :: Int) thing_x_3}}
-deriving stock instance Show Thing
-deriving stock instance Eq Thing
 foreign import ccall safe "test_internal_thing_fun_1" thing_fun_1_wrapper :: Ptr Thing ->
                                                                              IO CInt
 thing_fun_1 :: Thing -> IO CInt

--- a/hs-bindgen/fixtures/type_attributes.pp.hs
+++ b/hs-bindgen/fixtures/type_attributes.pp.hs
@@ -22,6 +22,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 data S = S
   { s_f :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S where
 
@@ -40,43 +41,16 @@ instance F.Storable S where
         case s1 of
           S s_f2 -> F.pokeByteOff ptr0 (0 :: Int) s_f2
 
-deriving stock instance Show S
-
-deriving stock instance Eq S
-
 newtype More_aligned_int = More_aligned_int
   { un_More_aligned_int :: FC.CInt
   }
-
-deriving newtype instance F.Storable More_aligned_int
-
-deriving stock instance Eq More_aligned_int
-
-deriving stock instance Ord More_aligned_int
-
-deriving stock instance Read More_aligned_int
-
-deriving stock instance Show More_aligned_int
-
-deriving newtype instance Enum More_aligned_int
-
-deriving newtype instance Ix.Ix More_aligned_int
-
-deriving newtype instance Bounded More_aligned_int
-
-deriving newtype instance Bits.Bits More_aligned_int
-
-deriving newtype instance FiniteBits More_aligned_int
-
-deriving newtype instance Integral More_aligned_int
-
-deriving newtype instance Num More_aligned_int
-
-deriving newtype instance Real More_aligned_int
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data S2 = S2
   { s2_f :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable S2 where
 
@@ -95,14 +69,11 @@ instance F.Storable S2 where
         case s1 of
           S2 s2_f2 -> F.pokeByteOff ptr0 (0 :: Int) s2_f2
 
-deriving stock instance Show S2
-
-deriving stock instance Eq S2
-
 data My_unpacked_struct = My_unpacked_struct
   { my_unpacked_struct_c :: FC.CChar
   , my_unpacked_struct_i :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable My_unpacked_struct where
 
@@ -124,15 +95,12 @@ instance F.Storable My_unpacked_struct where
                F.pokeByteOff ptr0 (0 :: Int) my_unpacked_struct_c2
             >> F.pokeByteOff ptr0 (4 :: Int) my_unpacked_struct_i3
 
-deriving stock instance Show My_unpacked_struct
-
-deriving stock instance Eq My_unpacked_struct
-
 data My_packed_struct = My_packed_struct
   { my_packed_struct_c :: FC.CChar
   , my_packed_struct_i :: FC.CInt
   , my_packed_struct_s :: My_unpacked_struct
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable My_packed_struct where
 
@@ -155,10 +123,6 @@ instance F.Storable My_packed_struct where
                F.pokeByteOff ptr0 (0 :: Int) my_packed_struct_c2
             >> F.pokeByteOff ptr0 (1 :: Int) my_packed_struct_i3
             >> F.pokeByteOff ptr0 (5 :: Int) my_packed_struct_s4
-
-deriving stock instance Show My_packed_struct
-
-deriving stock instance Eq My_packed_struct
 
 data Wait
 
@@ -183,59 +147,11 @@ set_wait_status_ptr_t___up = HsBindgen.Runtime.ByteArray.setUnionPayload
 newtype T1 = T1
   { un_T1 :: FC.CInt
   }
-
-deriving newtype instance F.Storable T1
-
-deriving stock instance Eq T1
-
-deriving stock instance Ord T1
-
-deriving stock instance Read T1
-
-deriving stock instance Show T1
-
-deriving newtype instance Enum T1
-
-deriving newtype instance Ix.Ix T1
-
-deriving newtype instance Bounded T1
-
-deriving newtype instance Bits.Bits T1
-
-deriving newtype instance FiniteBits T1
-
-deriving newtype instance Integral T1
-
-deriving newtype instance Num T1
-
-deriving newtype instance Real T1
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype Short_a = Short_a
   { un_Short_a :: FC.CShort
   }
-
-deriving newtype instance F.Storable Short_a
-
-deriving stock instance Eq Short_a
-
-deriving stock instance Ord Short_a
-
-deriving stock instance Read Short_a
-
-deriving stock instance Show Short_a
-
-deriving newtype instance Enum Short_a
-
-deriving newtype instance Ix.Ix Short_a
-
-deriving newtype instance Bounded Short_a
-
-deriving newtype instance Bits.Bits Short_a
-
-deriving newtype instance FiniteBits Short_a
-
-deriving newtype instance Integral Short_a
-
-deriving newtype instance Num Short_a
-
-deriving newtype instance Real Short_a
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)

--- a/hs-bindgen/fixtures/type_attributes.th.txt
+++ b/hs-bindgen/fixtures/type_attributes.th.txt
@@ -1,40 +1,38 @@
 -- addDependentFile examples/golden-norust/type_attributes.h
-data S = S {s_f :: (ConstantArray 3 CShort)}
+data S
+    = S {s_f :: (ConstantArray 3 CShort)}
+    deriving stock (Eq, Show)
 instance Storable S
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 8 :: Int;
            peek = \ptr_0 -> pure S <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S s_f_3 -> pokeByteOff ptr_1 (0 :: Int) s_f_3}}
-deriving stock instance Show S
-deriving stock instance Eq S
 newtype More_aligned_int
     = More_aligned_int {un_More_aligned_int :: CInt}
-deriving newtype instance Storable More_aligned_int
-deriving stock instance Eq More_aligned_int
-deriving stock instance Ord More_aligned_int
-deriving stock instance Read More_aligned_int
-deriving stock instance Show More_aligned_int
-deriving newtype instance Enum More_aligned_int
-deriving newtype instance Ix More_aligned_int
-deriving newtype instance Bounded More_aligned_int
-deriving newtype instance Bits More_aligned_int
-deriving newtype instance FiniteBits More_aligned_int
-deriving newtype instance Integral More_aligned_int
-deriving newtype instance Num More_aligned_int
-deriving newtype instance Real More_aligned_int
-data S2 = S2 {s2_f :: (ConstantArray 3 CShort)}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+data S2
+    = S2 {s2_f :: (ConstantArray 3 CShort)}
+    deriving stock (Eq, Show)
 instance Storable S2
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 16 :: Int;
            peek = \ptr_0 -> pure S2 <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {S2 s2_f_3 -> pokeByteOff ptr_1 (0 :: Int) s2_f_3}}
-deriving stock instance Show S2
-deriving stock instance Eq S2
 data My_unpacked_struct
     = My_unpacked_struct {my_unpacked_struct_c :: CChar,
                           my_unpacked_struct_i :: CInt}
+    deriving stock (Eq, Show)
 instance Storable My_unpacked_struct
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -42,12 +40,11 @@ instance Storable My_unpacked_struct
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {My_unpacked_struct my_unpacked_struct_c_3
                                                         my_unpacked_struct_i_4 -> pokeByteOff ptr_1 (0 :: Int) my_unpacked_struct_c_3 >> pokeByteOff ptr_1 (4 :: Int) my_unpacked_struct_i_4}}
-deriving stock instance Show My_unpacked_struct
-deriving stock instance Eq My_unpacked_struct
 data My_packed_struct
     = My_packed_struct {my_packed_struct_c :: CChar,
                         my_packed_struct_i :: CInt,
                         my_packed_struct_s :: My_unpacked_struct}
+    deriving stock (Eq, Show)
 instance Storable My_packed_struct
     where {sizeOf = \_ -> 13 :: Int;
            alignment = \_ -> 1 :: Int;
@@ -56,8 +53,6 @@ instance Storable My_packed_struct
                                     {My_packed_struct my_packed_struct_c_3
                                                       my_packed_struct_i_4
                                                       my_packed_struct_s_5 -> pokeByteOff ptr_1 (0 :: Int) my_packed_struct_c_3 >> (pokeByteOff ptr_1 (1 :: Int) my_packed_struct_i_4 >> pokeByteOff ptr_1 (5 :: Int) my_packed_struct_s_5)}}
-deriving stock instance Show My_packed_struct
-deriving stock instance Eq My_packed_struct
 data Wait
 newtype Wait_status_ptr_t
     = Wait_status_ptr_t {un_Wait_status_ptr_t :: ByteArray}
@@ -71,31 +66,27 @@ get_wait_status_ptr_t___up :: Wait_status_ptr_t -> Ptr Wait
 get_wait_status_ptr_t___up = getUnionPayload
 set_wait_status_ptr_t___up :: Ptr Wait -> Wait_status_ptr_t
 set_wait_status_ptr_t___up = setUnionPayload
-newtype T1 = T1 {un_T1 :: CInt}
-deriving newtype instance Storable T1
-deriving stock instance Eq T1
-deriving stock instance Ord T1
-deriving stock instance Read T1
-deriving stock instance Show T1
-deriving newtype instance Enum T1
-deriving newtype instance Ix T1
-deriving newtype instance Bounded T1
-deriving newtype instance Bits T1
-deriving newtype instance FiniteBits T1
-deriving newtype instance Integral T1
-deriving newtype instance Num T1
-deriving newtype instance Real T1
-newtype Short_a = Short_a {un_Short_a :: CShort}
-deriving newtype instance Storable Short_a
-deriving stock instance Eq Short_a
-deriving stock instance Ord Short_a
-deriving stock instance Read Short_a
-deriving stock instance Show Short_a
-deriving newtype instance Enum Short_a
-deriving newtype instance Ix Short_a
-deriving newtype instance Bounded Short_a
-deriving newtype instance Bits Short_a
-deriving newtype instance FiniteBits Short_a
-deriving newtype instance Integral Short_a
-deriving newtype instance Num Short_a
-deriving newtype instance Real Short_a
+newtype T1
+    = T1 {un_T1 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype Short_a
+    = Short_a {un_Short_a :: CShort}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)

--- a/hs-bindgen/fixtures/type_naturals.exts.txt
+++ b/hs-bindgen/fixtures/type_naturals.exts.txt
@@ -1,4 +1,3 @@
-StandaloneDeriving
 DerivingStrategies
 FlexibleContexts
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/type_naturals.pp.hs
+++ b/hs-bindgen/fixtures/type_naturals.pp.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -32,39 +31,23 @@ k = g (11.77 :: FC.CDouble) (f (f (2 :: FC.CInt) m) n)
 newtype Arr1 = Arr1
   { un_Arr1 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-
-deriving newtype instance F.Storable Arr1
-
-deriving stock instance Eq Arr1
-
-deriving stock instance Show Arr1
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr2 = Arr2
   { un_Arr2 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 8) FC.CInt
   }
-
-deriving newtype instance F.Storable Arr2
-
-deriving stock instance Eq Arr2
-
-deriving stock instance Show Arr2
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr3 = Arr3
   { un_Arr3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 18) FC.CInt
   }
-
-deriving newtype instance F.Storable Arr3
-
-deriving stock instance Eq Arr3
-
-deriving stock instance Show Arr3
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype Arr4 = Arr4
   { un_Arr4 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 252) FC.CInt
   }
-
-deriving newtype instance F.Storable Arr4
-
-deriving stock instance Eq Arr4
-
-deriving stock instance Show Arr4
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/type_naturals.th.txt
+++ b/hs-bindgen/fixtures/type_naturals.th.txt
@@ -17,19 +17,19 @@ g = \u_0 -> \x_1 -> \y_2 -> (+) ((*) (10 :: CInt) x_1) ((*) (16 :: CInt) y_2)
 k :: forall a_0 . (Add CInt (MultRes CInt a_0), Mult CInt a_0) =>
      a_0 -> AddRes CInt (MultRes CInt a_0)
 k = g (11.769999999999999573674358543939888477325439453125 :: CDouble) (f (f (2 :: CInt) m) n)
-newtype Arr1 = Arr1 {un_Arr1 :: (ConstantArray 3 CInt)}
-deriving newtype instance Storable Arr1
-deriving stock instance Eq Arr1
-deriving stock instance Show Arr1
-newtype Arr2 = Arr2 {un_Arr2 :: (ConstantArray 8 CInt)}
-deriving newtype instance Storable Arr2
-deriving stock instance Eq Arr2
-deriving stock instance Show Arr2
-newtype Arr3 = Arr3 {un_Arr3 :: (ConstantArray 18 CInt)}
-deriving newtype instance Storable Arr3
-deriving stock instance Eq Arr3
-deriving stock instance Show Arr3
-newtype Arr4 = Arr4 {un_Arr4 :: (ConstantArray 252 CInt)}
-deriving newtype instance Storable Arr4
-deriving stock instance Eq Arr4
-deriving stock instance Show Arr4
+newtype Arr1
+    = Arr1 {un_Arr1 :: (ConstantArray 3 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+newtype Arr2
+    = Arr2 {un_Arr2 :: (ConstantArray 8 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+newtype Arr3
+    = Arr3 {un_Arr3 :: (ConstantArray 18 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+newtype Arr4
+    = Arr4 {un_Arr4 :: (ConstantArray 252 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/typedef_vs_macro.exts.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -16,144 +15,38 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype T1 = T1
   { un_T1 :: FC.CInt
   }
-
-deriving newtype instance F.Storable T1
-
-deriving stock instance Eq T1
-
-deriving stock instance Ord T1
-
-deriving stock instance Read T1
-
-deriving stock instance Show T1
-
-deriving newtype instance Enum T1
-
-deriving newtype instance Ix.Ix T1
-
-deriving newtype instance Bounded T1
-
-deriving newtype instance Bits.Bits T1
-
-deriving newtype instance FiniteBits T1
-
-deriving newtype instance Integral T1
-
-deriving newtype instance Num T1
-
-deriving newtype instance Real T1
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype T2 = T2
   { un_T2 :: FC.CChar
   }
-
-deriving newtype instance F.Storable T2
-
-deriving stock instance Eq T2
-
-deriving stock instance Ord T2
-
-deriving stock instance Read T2
-
-deriving stock instance Show T2
-
-deriving newtype instance Enum T2
-
-deriving newtype instance Ix.Ix T2
-
-deriving newtype instance Bounded T2
-
-deriving newtype instance Bits.Bits T2
-
-deriving newtype instance FiniteBits T2
-
-deriving newtype instance Integral T2
-
-deriving newtype instance Num T2
-
-deriving newtype instance Real T2
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype M1 = M1
   { un_M1 :: FC.CInt
   }
-
-deriving newtype instance F.Storable M1
-
-deriving stock instance Eq M1
-
-deriving stock instance Ord M1
-
-deriving stock instance Read M1
-
-deriving stock instance Show M1
-
-deriving newtype instance Enum M1
-
-deriving newtype instance Ix.Ix M1
-
-deriving newtype instance Bounded M1
-
-deriving newtype instance Bits.Bits M1
-
-deriving newtype instance FiniteBits M1
-
-deriving newtype instance Integral M1
-
-deriving newtype instance Num M1
-
-deriving newtype instance Real M1
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype M2 = M2
   { un_M2 :: FC.CChar
   }
-
-deriving newtype instance F.Storable M2
-
-deriving stock instance Eq M2
-
-deriving stock instance Ord M2
-
-deriving stock instance Read M2
-
-deriving stock instance Show M2
-
-deriving newtype instance Enum M2
-
-deriving newtype instance Ix.Ix M2
-
-deriving newtype instance Bounded M2
-
-deriving newtype instance Bits.Bits M2
-
-deriving newtype instance FiniteBits M2
-
-deriving newtype instance Integral M2
-
-deriving newtype instance Num M2
-
-deriving newtype instance Real M2
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype M3 = M3
   { un_M3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-
-deriving newtype instance F.Storable M3
-
-deriving stock instance Eq M3
-
-deriving stock instance Show M3
+  deriving stock (Eq, Show)
+  deriving newtype (F.Storable)
 
 newtype M4 = M4
   { un_M4 :: F.Ptr FC.CInt
   }
-
-deriving newtype instance F.Storable M4
-
-deriving stock instance Eq M4
-
-deriving stock instance Ord M4
-
-deriving stock instance Show M4
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)
 
 data ExampleStruct = ExampleStruct
   { exampleStruct_t1 :: T1
@@ -161,6 +54,7 @@ data ExampleStruct = ExampleStruct
   , exampleStruct_m1 :: M1
   , exampleStruct_m2 :: M2
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable ExampleStruct where
 
@@ -186,43 +80,16 @@ instance F.Storable ExampleStruct where
             >> F.pokeByteOff ptr0 (8 :: Int) exampleStruct_m14
             >> F.pokeByteOff ptr0 (12 :: Int) exampleStruct_m25
 
-deriving stock instance Show ExampleStruct
-
-deriving stock instance Eq ExampleStruct
-
 newtype Uint64_t = Uint64_t
   { un_Uint64_t :: FC.CInt
   }
-
-deriving newtype instance F.Storable Uint64_t
-
-deriving stock instance Eq Uint64_t
-
-deriving stock instance Ord Uint64_t
-
-deriving stock instance Read Uint64_t
-
-deriving stock instance Show Uint64_t
-
-deriving newtype instance Enum Uint64_t
-
-deriving newtype instance Ix.Ix Uint64_t
-
-deriving newtype instance Bounded Uint64_t
-
-deriving newtype instance Bits.Bits Uint64_t
-
-deriving newtype instance FiniteBits Uint64_t
-
-deriving newtype instance Integral Uint64_t
-
-deriving newtype instance Num Uint64_t
-
-deriving newtype instance Real Uint64_t
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 data Foo = Foo
   { foo_a :: F.Ptr Uint64_t
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Foo where
 
@@ -240,7 +107,3 @@ instance F.Storable Foo where
       \s1 ->
         case s1 of
           Foo foo_a2 -> F.pokeByteOff ptr0 (0 :: Int) foo_a2
-
-deriving stock instance Show Foo
-
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/typedef_vs_macro.th.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.th.txt
@@ -1,74 +1,66 @@
 -- addDependentFile examples/golden/typedef_vs_macro.h
-newtype T1 = T1 {un_T1 :: CInt}
-deriving newtype instance Storable T1
-deriving stock instance Eq T1
-deriving stock instance Ord T1
-deriving stock instance Read T1
-deriving stock instance Show T1
-deriving newtype instance Enum T1
-deriving newtype instance Ix T1
-deriving newtype instance Bounded T1
-deriving newtype instance Bits T1
-deriving newtype instance FiniteBits T1
-deriving newtype instance Integral T1
-deriving newtype instance Num T1
-deriving newtype instance Real T1
-newtype T2 = T2 {un_T2 :: CChar}
-deriving newtype instance Storable T2
-deriving stock instance Eq T2
-deriving stock instance Ord T2
-deriving stock instance Read T2
-deriving stock instance Show T2
-deriving newtype instance Enum T2
-deriving newtype instance Ix T2
-deriving newtype instance Bounded T2
-deriving newtype instance Bits T2
-deriving newtype instance FiniteBits T2
-deriving newtype instance Integral T2
-deriving newtype instance Num T2
-deriving newtype instance Real T2
-newtype M1 = M1 {un_M1 :: CInt}
-deriving newtype instance Storable M1
-deriving stock instance Eq M1
-deriving stock instance Ord M1
-deriving stock instance Read M1
-deriving stock instance Show M1
-deriving newtype instance Enum M1
-deriving newtype instance Ix M1
-deriving newtype instance Bounded M1
-deriving newtype instance Bits M1
-deriving newtype instance FiniteBits M1
-deriving newtype instance Integral M1
-deriving newtype instance Num M1
-deriving newtype instance Real M1
-newtype M2 = M2 {un_M2 :: CChar}
-deriving newtype instance Storable M2
-deriving stock instance Eq M2
-deriving stock instance Ord M2
-deriving stock instance Read M2
-deriving stock instance Show M2
-deriving newtype instance Enum M2
-deriving newtype instance Ix M2
-deriving newtype instance Bounded M2
-deriving newtype instance Bits M2
-deriving newtype instance FiniteBits M2
-deriving newtype instance Integral M2
-deriving newtype instance Num M2
-deriving newtype instance Real M2
-newtype M3 = M3 {un_M3 :: (ConstantArray 3 CInt)}
-deriving newtype instance Storable M3
-deriving stock instance Eq M3
-deriving stock instance Show M3
-newtype M4 = M4 {un_M4 :: (Ptr CInt)}
-deriving newtype instance Storable M4
-deriving stock instance Eq M4
-deriving stock instance Ord M4
-deriving stock instance Show M4
+newtype T1
+    = T1 {un_T1 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype T2
+    = T2 {un_T2 :: CChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype M1
+    = M1 {un_M1 :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype M2
+    = M2 {un_M2 :: CChar}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype M3
+    = M3 {un_M3 :: (ConstantArray 3 CInt)}
+    deriving stock (Eq, Show)
+    deriving newtype Storable
+newtype M4
+    = M4 {un_M4 :: (Ptr CInt)}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable
 data ExampleStruct
     = ExampleStruct {exampleStruct_t1 :: T1,
                      exampleStruct_t2 :: T2,
                      exampleStruct_m1 :: M1,
                      exampleStruct_m2 :: M2}
+    deriving stock (Eq, Show)
 instance Storable ExampleStruct
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -78,28 +70,22 @@ instance Storable ExampleStruct
                                                    exampleStruct_t2_4
                                                    exampleStruct_m1_5
                                                    exampleStruct_m2_6 -> pokeByteOff ptr_1 (0 :: Int) exampleStruct_t1_3 >> (pokeByteOff ptr_1 (4 :: Int) exampleStruct_t2_4 >> (pokeByteOff ptr_1 (8 :: Int) exampleStruct_m1_5 >> pokeByteOff ptr_1 (12 :: Int) exampleStruct_m2_6))}}
-deriving stock instance Show ExampleStruct
-deriving stock instance Eq ExampleStruct
-newtype Uint64_t = Uint64_t {un_Uint64_t :: CInt}
-deriving newtype instance Storable Uint64_t
-deriving stock instance Eq Uint64_t
-deriving stock instance Ord Uint64_t
-deriving stock instance Read Uint64_t
-deriving stock instance Show Uint64_t
-deriving newtype instance Enum Uint64_t
-deriving newtype instance Ix Uint64_t
-deriving newtype instance Bounded Uint64_t
-deriving newtype instance Bits Uint64_t
-deriving newtype instance FiniteBits Uint64_t
-deriving newtype instance Integral Uint64_t
-deriving newtype instance Num Uint64_t
-deriving newtype instance Real Uint64_t
-data Foo = Foo {foo_a :: (Ptr Uint64_t)}
+newtype Uint64_t
+    = Uint64_t {un_Uint64_t :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+data Foo = Foo {foo_a :: (Ptr Uint64_t)} deriving stock (Eq, Show)
 instance Storable Foo
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 8 :: Int;
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo foo_a_3 -> pokeByteOff ptr_1 (0 :: Int) foo_a_3}}
-deriving stock instance Show Foo
-deriving stock instance Eq Foo

--- a/hs-bindgen/fixtures/typedefs.exts.txt
+++ b/hs-bindgen/fixtures/typedefs.exts.txt
@@ -1,3 +1,2 @@
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving

--- a/hs-bindgen/fixtures/typedefs.pp.hs
+++ b/hs-bindgen/fixtures/typedefs.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Example where
 
@@ -15,41 +14,11 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Myint = Myint
   { un_Myint :: FC.CInt
   }
-
-deriving newtype instance F.Storable Myint
-
-deriving stock instance Eq Myint
-
-deriving stock instance Ord Myint
-
-deriving stock instance Read Myint
-
-deriving stock instance Show Myint
-
-deriving newtype instance Enum Myint
-
-deriving newtype instance Ix.Ix Myint
-
-deriving newtype instance Bounded Myint
-
-deriving newtype instance Bits.Bits Myint
-
-deriving newtype instance FiniteBits Myint
-
-deriving newtype instance Integral Myint
-
-deriving newtype instance Num Myint
-
-deriving newtype instance Real Myint
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
 newtype Intptr = Intptr
   { un_Intptr :: F.Ptr FC.CInt
   }
-
-deriving newtype instance F.Storable Intptr
-
-deriving stock instance Eq Intptr
-
-deriving stock instance Ord Intptr
-
-deriving stock instance Show Intptr
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (F.Storable)

--- a/hs-bindgen/fixtures/typedefs.th.txt
+++ b/hs-bindgen/fixtures/typedefs.th.txt
@@ -1,20 +1,17 @@
 -- addDependentFile examples/golden/typedefs.h
-newtype Myint = Myint {un_Myint :: CInt}
-deriving newtype instance Storable Myint
-deriving stock instance Eq Myint
-deriving stock instance Ord Myint
-deriving stock instance Read Myint
-deriving stock instance Show Myint
-deriving newtype instance Enum Myint
-deriving newtype instance Ix Myint
-deriving newtype instance Bounded Myint
-deriving newtype instance Bits Myint
-deriving newtype instance FiniteBits Myint
-deriving newtype instance Integral Myint
-deriving newtype instance Num Myint
-deriving newtype instance Real Myint
-newtype Intptr = Intptr {un_Intptr :: (Ptr CInt)}
-deriving newtype instance Storable Intptr
-deriving stock instance Eq Intptr
-deriving stock instance Ord Intptr
-deriving stock instance Show Intptr
+newtype Myint
+    = Myint {un_Myint :: CInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      Integral,
+                      Ix,
+                      Num,
+                      Real)
+newtype Intptr
+    = Intptr {un_Intptr :: (Ptr CInt)}
+    deriving stock (Eq, Ord, Show)
+    deriving newtype Storable

--- a/hs-bindgen/fixtures/typenames.exts.txt
+++ b/hs-bindgen/fixtures/typenames.exts.txt
@@ -1,5 +1,4 @@
 TypeFamilies
-StandaloneDeriving
 DerivingStrategies
 GeneralizedNewtypeDeriving
 PatternSynonyms

--- a/hs-bindgen/fixtures/typenames.pp.hs
+++ b/hs-bindgen/fixtures/typenames.pp.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Example where
@@ -17,6 +16,8 @@ import qualified Text.Read
 newtype Foo = Foo
   { un_Foo :: FC.CUInt
   }
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)
 
 instance F.Storable Foo where
 
@@ -34,10 +35,6 @@ instance F.Storable Foo where
       \s1 ->
         case s1 of
           Foo un_Foo2 -> F.pokeByteOff ptr0 (0 :: Int) un_Foo2
-
-deriving stock instance Eq Foo
-
-deriving stock instance Ord Foo
 
 instance HsBindgen.Runtime.CEnum.CEnum Foo where
 
@@ -86,27 +83,5 @@ pattern FOO2 = Foo 1
 newtype Foo = Foo
   { un_Foo :: FC.CDouble
   }
-
-deriving newtype instance F.Storable Foo
-
-deriving stock instance Eq Foo
-
-deriving stock instance Ord Foo
-
-deriving stock instance Read Foo
-
-deriving stock instance Show Foo
-
-deriving newtype instance Enum Foo
-
-deriving newtype instance Floating Foo
-
-deriving newtype instance Fractional Foo
-
-deriving newtype instance Num Foo
-
-deriving newtype instance Real Foo
-
-deriving newtype instance RealFloat Foo
-
-deriving newtype instance RealFrac Foo
+  deriving stock (Eq, Ord, Read, Show)
+  deriving newtype (F.Storable, Enum, Floating, Fractional, Num, Real, RealFloat, RealFrac)

--- a/hs-bindgen/fixtures/typenames.th.txt
+++ b/hs-bindgen/fixtures/typenames.th.txt
@@ -1,13 +1,21 @@
 -- addDependentFile examples/golden/typenames.h
-newtype Foo = Foo {un_Foo :: CUInt}
+newtype Foo
+    = Foo {un_Foo :: CUInt}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)
 instance Storable Foo
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure Foo <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Foo un_Foo_3 -> pokeByteOff ptr_1 (0 :: Int) un_Foo_3}}
-deriving stock instance Eq Foo
-deriving stock instance Ord Foo
 instance CEnum Foo
     where {type CEnumZ Foo = CUInt;
            toCEnum = Foo;
@@ -31,16 +39,14 @@ pattern FOO1 :: Foo
 pattern FOO1 = Foo 0
 pattern FOO2 :: Foo
 pattern FOO2 = Foo 1
-newtype Foo = Foo {un_Foo :: CDouble}
-deriving newtype instance Storable Foo
-deriving stock instance Eq Foo
-deriving stock instance Ord Foo
-deriving stock instance Read Foo
-deriving stock instance Show Foo
-deriving newtype instance Enum Foo
-deriving newtype instance Floating Foo
-deriving newtype instance Fractional Foo
-deriving newtype instance Num Foo
-deriving newtype instance Real Foo
-deriving newtype instance RealFloat Foo
-deriving newtype instance RealFrac Foo
+newtype Foo
+    = Foo {un_Foo :: CDouble}
+    deriving stock (Eq, Ord, Read, Show)
+    deriving newtype (Storable,
+                      Enum,
+                      Floating,
+                      Fractional,
+                      Num,
+                      Real,
+                      RealFloat,
+                      RealFrac)

--- a/hs-bindgen/fixtures/unions.pp.hs
+++ b/hs-bindgen/fixtures/unions.pp.hs
@@ -17,6 +17,7 @@ data Dim2 = Dim2
   { dim2_x :: FC.CInt
   , dim2_y :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Dim2 where
 
@@ -38,15 +39,12 @@ instance F.Storable Dim2 where
                F.pokeByteOff ptr0 (0 :: Int) dim2_x2
             >> F.pokeByteOff ptr0 (4 :: Int) dim2_y3
 
-deriving stock instance Show Dim2
-
-deriving stock instance Eq Dim2
-
 data Dim3 = Dim3
   { dim3_x :: FC.CInt
   , dim3_y :: FC.CInt
   , dim3_z :: FC.CInt
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Dim3 where
 
@@ -69,10 +67,6 @@ instance F.Storable Dim3 where
                F.pokeByteOff ptr0 (0 :: Int) dim3_x2
             >> F.pokeByteOff ptr0 (4 :: Int) dim3_y3
             >> F.pokeByteOff ptr0 (8 :: Int) dim3_z4
-
-deriving stock instance Show Dim3
-
-deriving stock instance Eq Dim3
 
 newtype DimPayload = DimPayload
   { un_DimPayload :: Data.Array.Byte.ByteArray
@@ -164,6 +158,7 @@ data AnonA_xy = AnonA_xy
   { anonA_xy_x :: FC.CDouble
   , anonA_xy_y :: FC.CDouble
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable AnonA_xy where
 
@@ -185,14 +180,11 @@ instance F.Storable AnonA_xy where
                F.pokeByteOff ptr0 (0 :: Int) anonA_xy_x2
             >> F.pokeByteOff ptr0 (8 :: Int) anonA_xy_y3
 
-deriving stock instance Show AnonA_xy
-
-deriving stock instance Eq AnonA_xy
-
 data AnonA_polar = AnonA_polar
   { anonA_polar_r :: FC.CDouble
   , anonA_polar_p :: FC.CDouble
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable AnonA_polar where
 
@@ -213,10 +205,6 @@ instance F.Storable AnonA_polar where
           AnonA_polar anonA_polar_r2 anonA_polar_p3 ->
                F.pokeByteOff ptr0 (0 :: Int) anonA_polar_r2
             >> F.pokeByteOff ptr0 (8 :: Int) anonA_polar_p3
-
-deriving stock instance Show AnonA_polar
-
-deriving stock instance Eq AnonA_polar
 
 newtype AnonA = AnonA
   { un_AnonA :: Data.Array.Byte.ByteArray

--- a/hs-bindgen/fixtures/unions.th.txt
+++ b/hs-bindgen/fixtures/unions.th.txt
@@ -1,5 +1,7 @@
 -- addDependentFile examples/golden/unions.h
-data Dim2 = Dim2 {dim2_x :: CInt, dim2_y :: CInt}
+data Dim2
+    = Dim2 {dim2_x :: CInt, dim2_y :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Dim2
     where {sizeOf = \_ -> 8 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -7,9 +9,9 @@ instance Storable Dim2
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Dim2 dim2_x_3
                                           dim2_y_4 -> pokeByteOff ptr_1 (0 :: Int) dim2_x_3 >> pokeByteOff ptr_1 (4 :: Int) dim2_y_4}}
-deriving stock instance Show Dim2
-deriving stock instance Eq Dim2
-data Dim3 = Dim3 {dim3_x :: CInt, dim3_y :: CInt, dim3_z :: CInt}
+data Dim3
+    = Dim3 {dim3_x :: CInt, dim3_y :: CInt, dim3_z :: CInt}
+    deriving stock (Eq, Show)
 instance Storable Dim3
     where {sizeOf = \_ -> 12 :: Int;
            alignment = \_ -> 4 :: Int;
@@ -18,8 +20,6 @@ instance Storable Dim3
                                     {Dim3 dim3_x_3
                                           dim3_y_4
                                           dim3_z_5 -> pokeByteOff ptr_1 (0 :: Int) dim3_x_3 >> (pokeByteOff ptr_1 (4 :: Int) dim3_y_4 >> pokeByteOff ptr_1 (8 :: Int) dim3_z_5)}}
-deriving stock instance Show Dim3
-deriving stock instance Eq Dim3
 newtype DimPayload = DimPayload {un_DimPayload :: ByteArray}
 deriving via (SizedByteArray 8 4) instance Storable DimPayload
 get_dimPayload_dim2 :: DimPayload -> Dim2
@@ -58,6 +58,7 @@ instance Storable DimB
                                           dimB_payload_4 -> pokeByteOff ptr_1 (0 :: Int) dimB_tag_3 >> pokeByteOff ptr_1 (4 :: Int) dimB_payload_4}}
 data AnonA_xy
     = AnonA_xy {anonA_xy_x :: CDouble, anonA_xy_y :: CDouble}
+    deriving stock (Eq, Show)
 instance Storable AnonA_xy
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -65,10 +66,9 @@ instance Storable AnonA_xy
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {AnonA_xy anonA_xy_x_3
                                               anonA_xy_y_4 -> pokeByteOff ptr_1 (0 :: Int) anonA_xy_x_3 >> pokeByteOff ptr_1 (8 :: Int) anonA_xy_y_4}}
-deriving stock instance Show AnonA_xy
-deriving stock instance Eq AnonA_xy
 data AnonA_polar
     = AnonA_polar {anonA_polar_r :: CDouble, anonA_polar_p :: CDouble}
+    deriving stock (Eq, Show)
 instance Storable AnonA_polar
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -76,8 +76,6 @@ instance Storable AnonA_polar
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {AnonA_polar anonA_polar_r_3
                                                  anonA_polar_p_4 -> pokeByteOff ptr_1 (0 :: Int) anonA_polar_r_3 >> pokeByteOff ptr_1 (8 :: Int) anonA_polar_p_4}}
-deriving stock instance Show AnonA_polar
-deriving stock instance Eq AnonA_polar
 newtype AnonA = AnonA {un_AnonA :: ByteArray}
 deriving via (SizedByteArray 16 8) instance Storable AnonA
 get_anonA_xy :: AnonA -> AnonA_xy

--- a/hs-bindgen/fixtures/uses_utf8.exts.txt
+++ b/hs-bindgen/fixtures/uses_utf8.exts.txt
@@ -1,4 +1,3 @@
 TypeFamilies
-StandaloneDeriving
 DerivingStrategies
 PatternSynonyms

--- a/hs-bindgen/fixtures/uses_utf8.pp.hs
+++ b/hs-bindgen/fixtures/uses_utf8.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Example where
@@ -16,6 +15,7 @@ import qualified Text.Read
 newtype MyEnum = MyEnum
   { un_MyEnum :: FC.CUInt
   }
+  deriving stock (Eq, Ord)
 
 instance F.Storable MyEnum where
 
@@ -33,10 +33,6 @@ instance F.Storable MyEnum where
       \s1 ->
         case s1 of
           MyEnum un_MyEnum2 -> F.pokeByteOff ptr0 (0 :: Int) un_MyEnum2
-
-deriving stock instance Eq MyEnum
-
-deriving stock instance Ord MyEnum
 
 instance HsBindgen.Runtime.CEnum.CEnum MyEnum where
 

--- a/hs-bindgen/fixtures/uses_utf8.th.txt
+++ b/hs-bindgen/fixtures/uses_utf8.th.txt
@@ -1,13 +1,13 @@
 -- addDependentFile examples/golden/uses_utf8.h
-newtype MyEnum = MyEnum {un_MyEnum :: CUInt}
+newtype MyEnum
+    = MyEnum {un_MyEnum :: CUInt}
+    deriving stock (Eq, Ord)
 instance Storable MyEnum
     where {sizeOf = \_ -> 4 :: Int;
            alignment = \_ -> 4 :: Int;
            peek = \ptr_0 -> pure MyEnum <*> peekByteOff ptr_0 (0 :: Int);
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {MyEnum un_MyEnum_3 -> pokeByteOff ptr_1 (0 :: Int) un_MyEnum_3}}
-deriving stock instance Eq MyEnum
-deriving stock instance Ord MyEnum
 instance CEnum MyEnum
     where {type CEnumZ MyEnum = CUInt;
            toCEnum = MyEnum;

--- a/hs-bindgen/fixtures/vector.exts.txt
+++ b/hs-bindgen/fixtures/vector.exts.txt
@@ -1,4 +1,3 @@
 CApiFFI
 TemplateHaskell
-StandaloneDeriving
 DerivingStrategies

--- a/hs-bindgen/fixtures/vector.pp.hs
+++ b/hs-bindgen/fixtures/vector.pp.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Example where
@@ -17,6 +16,7 @@ data Vector = Vector
   { vector_x :: FC.CDouble
   , vector_y :: FC.CDouble
   }
+  deriving stock (Eq, Show)
 
 instance F.Storable Vector where
 
@@ -37,9 +37,5 @@ instance F.Storable Vector where
           Vector vector_x2 vector_y3 ->
                F.pokeByteOff ptr0 (0 :: Int) vector_x2
             >> F.pokeByteOff ptr0 (8 :: Int) vector_y3
-
-deriving stock instance Show Vector
-
-deriving stock instance Eq Vector
 
 foreign import ccall safe "testmodule_new_vector" new_vector :: FC.CDouble -> FC.CDouble -> IO (F.Ptr Vector)

--- a/hs-bindgen/fixtures/vector.th.txt
+++ b/hs-bindgen/fixtures/vector.th.txt
@@ -1,7 +1,9 @@
 -- addDependentFile examples/golden/vector.h
 -- #include "vector.h"
 -- vector *test_internal_new_vector (double arg1, double arg2) { return new_vector(arg1, arg2); }
-data Vector = Vector {vector_x :: CDouble, vector_y :: CDouble}
+data Vector
+    = Vector {vector_x :: CDouble, vector_y :: CDouble}
+    deriving stock (Eq, Show)
 instance Storable Vector
     where {sizeOf = \_ -> 16 :: Int;
            alignment = \_ -> 8 :: Int;
@@ -9,7 +11,5 @@ instance Storable Vector
            poke = \ptr_1 -> \s_2 -> case s_2 of
                                     {Vector vector_x_3
                                             vector_y_4 -> pokeByteOff ptr_1 (0 :: Int) vector_x_3 >> pokeByteOff ptr_1 (8 :: Int) vector_y_4}}
-deriving stock instance Show Vector
-deriving stock instance Eq Vector
 foreign import ccall safe "test_internal_new_vector" new_vector :: CDouble ->
                                                                    CDouble -> IO (Ptr Vector)

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -156,6 +156,7 @@ library internal
       HsBindgen.PrettyC
       HsBindgen.Resolve
       HsBindgen.SHs.AST
+      HsBindgen.SHs.Simplify
       HsBindgen.SHs.Translation
       HsBindgen.TraceMsg
       HsBindgen.Util.Monad

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -26,8 +26,9 @@ requiredExtensions = \case
         ]
     DRecord r ->
         recordExtensions r
-    DNewtype{} ->
-        Set.empty
+        <> nestedDeriving (dataDeriv r)
+    DNewtype n ->
+        nestedDeriving (newtypeDeriv n)
     DEmptyData{} ->
         Set.singleton TH.EmptyDataDecls
     DDerivingInstance strategy ty ->
@@ -41,6 +42,12 @@ requiredExtensions = \case
         Set.singleton TH.PatternSynonyms
     DCSource{} ->
         Set.singleton TH.TemplateHaskell
+
+-- | Extensions for deriving clauses that are part of the datatype declaration
+nestedDeriving :: [(Strategy ClosedType, [Global])] -> Set TH.Extension
+nestedDeriving deriv =
+       Set.singleton TH.DerivingStrategies
+    <> mconcat (map (strategyExtensions . fst) deriv)
 
 recordExtensions :: Record -> Set TH.Extension
 recordExtensions r = foldMap fieldExtensions (dataFields r)

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
@@ -50,7 +50,7 @@ data HsPrimType
 
   -- Int8 Int16 Int32 Int64
   -- Word8 Word16 Word32 Word64
-  deriving stock (Eq, Generic, Show)
+  deriving stock (Eq, Ord, Generic, Show)
 
 data HsType =
     HsPrimType HsPrimType

--- a/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Pipeline.hs
@@ -66,6 +66,7 @@ import HsBindgen.Imports
 import HsBindgen.Language.Haskell
 import HsBindgen.ModuleUnique
 import HsBindgen.SHs.AST qualified as SHs
+import HsBindgen.SHs.Simplify (simplifySHs)
 import HsBindgen.SHs.Translation qualified as SHs
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
@@ -135,7 +136,7 @@ genHsDecls mu Opts{..} = Hs.generateDeclarations optsTranslation mu
 
 -- | Generate @SHs@ declarations
 genSHsDecls :: [Hs.Decl] -> [SHs.SDecl]
-genSHsDecls = SHs.translateDecls
+genSHsDecls = simplifySHs . SHs.translateDecls
 
 -- | Generate a preprocessor 'Backend.PP.HsModule'
 genModule :: PPOpts -> [SHs.SDecl] -> Backend.PP.HsModule

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -181,7 +181,7 @@ data Global =
   | ByteArray_type
   | SizedByteArray_type
   | PrimType HsPrimType
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Ord, Show)
 
 type ClosedExpr = SExpr EmptyCtx
 
@@ -285,6 +285,7 @@ data Record = Record {
     , dataCon    :: HsName NsConstr
     , dataFields :: [Field]
     , dataOrigin :: Origin.Decl Origin.Struct
+    , dataDeriv  :: [(Hs.Strategy ClosedType, [Global])]
     }
   deriving stock (Show)
 
@@ -299,6 +300,7 @@ data Newtype = Newtype {
     , newtypeCon    :: HsName NsConstr
     , newtypeField  :: Field
     , newtypeOrigin :: Origin.Decl Origin.Newtype
+    , newtypeDeriv  :: [(Hs.Strategy ClosedType, [Global])]
     }
   deriving stock (Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Simplify.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Simplify.hs
@@ -1,0 +1,92 @@
+-- | Simplification pass on the "HsBindgen.SHs.AST" representation
+module HsBindgen.SHs.Simplify (simplifySHs) where
+
+import Data.Map.Strict qualified as Map
+import Data.Set        qualified as Set
+
+import HsBindgen.Hs.AST.Strategy
+import HsBindgen.Imports
+import HsBindgen.Language.Haskell
+import HsBindgen.SHs.AST
+import Data.Either (partitionEithers)
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+simplifySHs :: [SDecl] -> [SDecl]
+simplifySHs decls =
+    let (decls', simpleInstances) =
+          second (Map.fromListWith (<>)) $
+            partitionMaybe toSimpleInstances decls
+    in reconstruct simpleInstances decls'
+
+reconstruct ::
+     Map (HsName NsTypeConstr) SimpleInstances
+  -> [SDecl] -> [SDecl]
+reconstruct simpleInstances = map aux
+  where
+    aux :: SDecl -> SDecl
+    aux = \case
+        DRecord x@Record{dataType, dataDeriv} ->
+          DRecord x{dataDeriv = dataDeriv ++ instancesFor dataType}
+        DNewtype x@Newtype{newtypeName, newtypeDeriv} ->
+          DNewtype x{newtypeDeriv = newtypeDeriv ++ instancesFor newtypeName}
+        otherDecl ->
+          otherDecl
+
+    instancesFor :: HsName 'NsTypeConstr -> [(Strategy ClosedType, [Global])]
+    instancesFor =
+          maybe [] fromSimpleInstances
+        . flip Map.lookup simpleInstances
+
+{-------------------------------------------------------------------------------
+  Simple instances
+-------------------------------------------------------------------------------}
+
+-- | Simple instances are instances without special constraints
+--
+-- We group these per strategy, so that we can generate the most readable code.
+data SimpleInstances = SimpleInstances{
+      strategyStock   :: Set Global
+    , strategyNewtype :: Set Global
+    }
+  deriving stock (Show)
+
+fromSimpleInstances :: SimpleInstances -> [(Strategy ClosedType, [Global])]
+fromSimpleInstances SimpleInstances{..} =
+    filter (not . null . snd) $ [
+        (DeriveStock   , Set.toList strategyStock)
+      , (DeriveNewtype , Set.toList strategyNewtype)
+      ]
+
+instance Semigroup SimpleInstances where
+  a <> b = SimpleInstances{
+        strategyNewtype = combine strategyNewtype
+      , strategyStock   = combine strategyStock
+      }
+    where
+      combine :: Semigroup a => (SimpleInstances -> a) -> a
+      combine f = f a <> f b
+
+instance Monoid SimpleInstances where
+  mempty = SimpleInstances{
+        strategyStock   = mempty
+      , strategyNewtype = mempty
+      }
+
+toSimpleInstances :: SDecl -> Maybe (HsName NsTypeConstr, SimpleInstances)
+toSimpleInstances = \case
+    DDerivingInstance DeriveStock (TApp (TGlobal cls) (TCon name)) ->
+      Just (name, mempty{strategyStock = Set.singleton cls})
+    DDerivingInstance DeriveNewtype (TApp (TGlobal cls) (TCon name)) ->
+      Just (name, mempty{strategyNewtype = Set.singleton cls})
+    _otherwise
+      -> Nothing
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+partitionMaybe :: (a -> Maybe b) -> [a] -> ([a], [b])
+partitionMaybe f = partitionEithers . map (\x -> maybe (Left x) Right (f x))

--- a/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/Translation.hs
@@ -104,6 +104,7 @@ translateDeclData struct = DRecord $ Record
         case Hs.structOrigin struct of
           Just origin -> origin
           Nothing     -> panicPure "Missing structOrigin"
+    , dataDeriv = []
     }
 
 translateDeclEmpty :: Hs.EmptyData -> SDecl
@@ -122,6 +123,7 @@ translateNewtype n = DNewtype $ Newtype
         , fieldOrigin = Hs.fieldOrigin $ Hs.newtypeField n
         }
     , newtypeOrigin = Hs.newtypeOrigin n
+    , newtypeDeriv  = []
     }
 
 translateDeriveInstance :: Hs.Strategy Hs.HsType -> HsTypeClass -> HsName NsTypeConstr -> SDecl


### PR DESCRIPTION
Instead of

```hs
newtype S2_t = S2_t
  { un_S2_t :: S2
  }

deriving newtype instance F.Storable S2_t

deriving stock instance Eq S2_t

deriving stock instance Show S2_t
```

we now generate

```hs
newtype S2_t = S2_t
  { un_S2_t :: S2
  }
  deriving stock (Eq, Show)
  deriving newtype (F.Storable)
```

This is implemented as a separate simplification pass, so that it does not complicate the actual generation of the `SHs` representation. Also, if we add more complicated instances, that have `hs-bindgen`-specified additional constraints, the simplification pass will automatically just leave these as stand-alone deriving clauses.