### PR TITLE
Improve definition of `UseOfDecl`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
@@ -217,9 +217,5 @@ nameForAnon = \case
         C.qualNameName cQualName <> "_" <> field
       UsedByNamed (UsedInFunction _valOrRef) cQualName ->
         C.qualNameName cQualName
-      UsedByAnon (UsedInTypedef _valOrRef) _useOfAnon ->
-        panicPure $ "nameForAnon: unexpected anonymous typedef"
-      UsedByAnon (UsedInField _valOrRef field) useOfAnon ->
+      UsedByFieldOfAnon _valOrRef field useOfAnon ->
         nameForAnon useOfAnon <> "_" <> field
-      UsedByAnon (UsedInFunction _valOrRef) _useOfAnon ->
-        panicPure $ "nameForAnon: unexpected anonymous argument or return type"


### PR DESCRIPTION
The new definition rules out some impossible definitions; we still have a panic when these impossible definitions occur, but it would now arise when we _construct_ these values, rather than where we consume them; if we are wrong about them being impossible, we can provide a more useful error message there.

With the new definition it is easier to add support for other declarations (such as globals).