### PR TITLE
Refactor `optparse-applicative` usage

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cli.hs
@@ -108,7 +108,7 @@ parsePreprocessOpts =
       <*> parseHsRenderOpts
       <*> parseOutput
       <*> optional parseGenBindingSpec
-      <*> some parseInput
+      <*> parseInputs
 
 {-------------------------------------------------------------------------------
   Test generation command
@@ -130,7 +130,7 @@ parseGenTestsOpts =
       <*> parseHsModuleOpts
       <*> parseHsRenderOpts
       <*> parseGenTestsOutput
-      <*> some parseInput
+      <*> parseInputs
 
 {-------------------------------------------------------------------------------
   Literate command
@@ -177,7 +177,7 @@ data ResolveOpts = ResolveOpts {
 parseResolveOpts :: Parser ResolveOpts
 parseResolveOpts =
     ResolveOpts
-      <$> some parseInput
+      <$> parseInputs
 
 {-------------------------------------------------------------------------------
   Translation options

--- a/hs-bindgen/app/HsBindgen/App/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/App/Cli.hs
@@ -52,9 +52,7 @@ parseCli =
       <*> parseCliCmd
 
 data CliCmd =
-    -- | The main command: preprocess C headers to Haskell modules
     CliCmdPreprocess  PreprocessOpts
-    -- | Generate tests for generated Haskell code
   | CliCmdGenTests    GenTestsOpts
   | CliCmdLiterate    LiterateOpts
   | CliCmdBindingSpec BindingSpecCmd

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -4,7 +4,7 @@ module HsBindgen.App.Common (
     GlobalOpts(..)
   , parseGlobalOpts
     -- * Input option
-  , parseInput
+  , parseInputs
     -- * Auxiliary hs-bindgen functions
   , withTracer
   , loadExtBindingSpecs'
@@ -262,16 +262,21 @@ parseExtBindings = many . strOption $ mconcat [
     ]
 
 {-------------------------------------------------------------------------------
-  Input option
+  Input arguments
 -------------------------------------------------------------------------------}
 
-parseInput :: Parser CHeaderIncludePath
-parseInput =
-    argument (eitherReader $ first displayException . parseCHeaderIncludePath) $
-      mconcat $ [
-          help "Input C header, relative to an include path directory"
-        , metavar "HEADER"
-        ]
+-- | Parse one or more input header arguments
+--
+-- This uses standard syntax for one or more arguments, which
+-- @optparse-applicative@ does not get right when just using 'some'.
+parseInputs :: Parser [CHeaderIncludePath]
+parseInputs = some . argument (eitherReader parseHeader) $ mconcat [
+      help "Input C header(s), relative to an include path directory"
+    , metavar "HEADER..."
+    ]
+  where
+    parseHeader :: String -> Either String CHeaderIncludePath
+    parseHeader = first displayException . parseCHeaderIncludePath
 
 {-------------------------------------------------------------------------------
   Auxiliary hs-bindgen functions

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -6,6 +6,9 @@ module HsBindgen.App.Common (
     -- * Input option
   , parseInput
     -- * Auxiliary hs-bindgen functions
+  , withTracer
+  , loadExtBindingSpecs'
+  , getOpts
   , footerWith
     -- * Auxiliary optparse-applicative functions
   , cmd
@@ -273,6 +276,25 @@ parseInput =
 {-------------------------------------------------------------------------------
   Auxiliary hs-bindgen functions
 -------------------------------------------------------------------------------}
+
+withTracer :: GlobalOpts -> (Tracer IO TraceMsg -> IO b) -> IO b
+withTracer GlobalOpts{..} =
+    withTracerStdOut globalOptsTracerConf DefaultLogLevel
+
+loadExtBindingSpecs' :: Tracer IO TraceMsg -> GlobalOpts -> IO BindingSpec
+loadExtBindingSpecs' tracer GlobalOpts{..} =
+    loadExtBindingSpecs
+      tracer
+      globalOptsClangArgs
+      globalOptsStdlibSpecConf
+      globalOptsExtBindings
+
+getOpts :: GlobalOpts -> Opts
+getOpts GlobalOpts{..} = def {
+      optsClangArgs      = globalOptsClangArgs
+    , optsPredicate      = globalOptsPredicate
+    , optsProgramSlicing = globalOptsProgramSlicing
+    }
 
 -- | Footer of command line help.
 footerWith :: ParserPrefs -> Doc

--- a/hs-bindgen/app/HsBindgen/App/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/App/Dev.hs
@@ -1,7 +1,7 @@
 module HsBindgen.App.Dev (
     Dev(..)
-  , DevMode(..)
-  , ParseMode(..)
+  , DevCmd(..)
+  , ParseOpts(..)
   , getDev
   ) where
 
@@ -33,7 +33,7 @@ getDev = customExecParser p opts
 -- | Command line arguments
 data Dev = Dev {
       devGlobalOpts :: GlobalOpts
-    , devMode       :: DevMode
+    , devCmd        :: DevCmd
     }
   deriving (Show)
 
@@ -41,30 +41,30 @@ parseDev :: Parser Dev
 parseDev =
     Dev
       <$> parseGlobalOpts
-      <*> parseDevMode
+      <*> parseDevCmd
 
-data DevMode =
+data DevCmd =
     -- | Just parse the C headers
-    DevModeParse ParseMode
+    DevCmdParse ParseOpts
   deriving (Show)
 
-parseDevMode :: Parser DevMode
-parseDevMode = subparser $ mconcat [
-      cmd "parse" (DevModeParse <$> parseParseMode) $ mconcat [
+parseDevCmd :: Parser DevCmd
+parseDevCmd = subparser $ mconcat [
+      cmd "parse" (DevCmdParse <$> parseParseOpts) $ mconcat [
           progDesc "Parse C header (primarily for debugging hs-bindgen itself)"
         ]
     ]
 
 {-------------------------------------------------------------------------------
-  Parse mode
+  Parse command
 -------------------------------------------------------------------------------}
 
-data ParseMode = ParseMode {
+newtype ParseOpts = ParseOpts {
       parseInputPaths :: [CHeaderIncludePath]
     }
   deriving (Show)
 
-parseParseMode :: Parser ParseMode
-parseParseMode =
-    ParseMode
+parseParseOpts :: Parser ParseOpts
+parseParseOpts =
+    ParseOpts
       <$> some parseInput

--- a/hs-bindgen/app/HsBindgen/App/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/App/Dev.hs
@@ -1,6 +1,7 @@
 module HsBindgen.App.Dev (
     Dev(..)
-  , Mode(..)
+  , DevMode(..)
+  , ParseMode(..)
   , getDev
   ) where
 
@@ -32,43 +33,38 @@ getDev = customExecParser p opts
 -- | Command line arguments
 data Dev = Dev {
       devGlobalOpts :: GlobalOpts
-    , devMode       :: Mode
+    , devMode       :: DevMode
     }
   deriving (Show)
-
-newtype Mode =
-    -- | Just parse the C headers
-    ModeParse {
-        parseInputPaths :: [CHeaderIncludePath]
-      }
-  deriving (Show)
-
-{-------------------------------------------------------------------------------
-  Parser
--------------------------------------------------------------------------------}
 
 parseDev :: Parser Dev
 parseDev =
     Dev
       <$> parseGlobalOpts
-      <*> parseMode
+      <*> parseDevMode
 
-{-------------------------------------------------------------------------------
-  Mode selection
--------------------------------------------------------------------------------}
+data DevMode =
+    -- | Just parse the C headers
+    DevModeParse ParseMode
+  deriving (Show)
 
-parseMode :: Parser Mode
-parseMode = subparser $ mconcat [
-      cmd "parse" parseModeParse $ mconcat [
+parseDevMode :: Parser DevMode
+parseDevMode = subparser $ mconcat [
+      cmd "parse" (DevModeParse <$> parseParseMode) $ mconcat [
           progDesc "Parse C header (primarily for debugging hs-bindgen itself)"
         ]
     ]
 
 {-------------------------------------------------------------------------------
-  Dev modes
+  Parse mode
 -------------------------------------------------------------------------------}
 
-parseModeParse :: Parser Mode
-parseModeParse =
-    ModeParse
+data ParseMode = ParseMode {
+      parseInputPaths :: [CHeaderIncludePath]
+    }
+  deriving (Show)
+
+parseParseMode :: Parser ParseMode
+parseParseMode =
+    ParseMode
       <$> some parseInput

--- a/hs-bindgen/app/HsBindgen/App/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/App/Dev.hs
@@ -67,4 +67,4 @@ newtype ParseOpts = ParseOpts {
 parseParseOpts :: Parser ParseOpts
 parseParseOpts =
     ParseOpts
-      <$> some parseInput
+      <$> parseInputs

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import Control.Exception (Exception (..), SomeException (..), fromException,
                           handle, throwIO)
-import Control.Monad (foldM, unless)
+import Control.Monad (forM_)
 import Data.ByteString qualified as BS
 import Data.Char (isLetter)
 import System.Exit (ExitCode, exitFailure)
@@ -18,9 +18,7 @@ import HsBindgen.Lib
 -------------------------------------------------------------------------------}
 
 main :: IO ()
-main = handle exceptionHandler $ do
-    cli <- getCli
-    execMode cli
+main = handle exceptionHandler $ execCli =<< getCli
 
 data LiterateFileException = LiterateFileException FilePath String
   deriving Show
@@ -31,96 +29,100 @@ instance Exception LiterateFileException where
     displayException (LiterateFileException path err) =
       "error loading " ++ path ++ ": " ++ err
 
-execMode :: Cli -> IO ()
-execMode Cli{cliGlobalOpts=GlobalOpts{..}, ..} = case cliMode of
-    ModePreprocess{..} -> do
-      hsDecls <- withTracer $ \tracer -> do
-        extBindingSpec <-
-          loadExtBindingSpecs
-            tracer
-            globalOptsClangArgs
-            globalOptsStdlibSpecConf
-            globalOptsExtBindings
-        -- to avoid potential issues it would be great to include unitid in module
-        -- unique but AFAIK there is no way to get one for preprocessor
-        -- https://github.com/well-typed/hs-bindgen/issues/502
-        let mu :: ModuleUnique
-            mu = ModuleUnique $
-              filter isLetter (hsModuleOptsName preprocessModuleOpts)
-            opts = cmdOpts {
-                optsExtBindingSpec = extBindingSpec
-              , optsTranslation    = preprocessTranslationOpts
-              , optsTracer         = tracer
-              }
-        translateCHeaders mu opts preprocessInputs
-      withTracer $ \tracer -> do
-        let ppOpts = (def :: PPOpts) {
-                ppOptsModule = preprocessModuleOpts
-              , ppOptsRender = preprocessRenderOpts
-              }
-        preprocessIO ppOpts preprocessOutput hsDecls
-        case preprocessGenBindingSpec of
-          Nothing   -> return ()
-          Just path ->
-            genBindingSpec tracer ppOpts preprocessInputs path hsDecls
+execCli :: Cli -> IO ()
+execCli Cli{..} = case cliMode of
+    CliModePreprocess  mode -> execPreprocess      cliGlobalOpts mode
+    CliModeGenTests    mode -> execGenTests        cliGlobalOpts mode
+    CliModeLiterate    mode -> execLiterate                      mode
+    CliModeBindingSpec mode -> execModeBindingSpec cliGlobalOpts mode
+    CliModeResolve     mode -> execModeResolve     cliGlobalOpts mode
 
-    ModeGenTests{..} -> do
-      extBindingSpec <- withTracer $ \tracer ->
-        loadExtBindingSpecs tracer
-          globalOptsClangArgs
-          globalOptsStdlibSpecConf
-          globalOptsExtBindings
-      let opts = cmdOpts {
-              optsExtBindingSpec = extBindingSpec
-            }
-          ppOpts = (def :: PPOpts) {
-              ppOptsModule = genTestsModuleOpts
-            , ppOptsRender = genTestsRenderOpts
-            }
-      genTests ppOpts genTestsInputs genTestsOutput
-        =<< translateCHeaders "TODO" opts genTestsInputs
+execPreprocess :: GlobalOpts -> PreprocessMode -> IO ()
+execPreprocess globalOpts PreprocessMode{..} = do
+    hsDecls <- doTranslate
+    preprocessIO ppOpts preprocessOutput hsDecls
+    case preprocessGenBindingSpec of
+      Nothing   -> return ()
+      Just path -> withTracer globalOpts $ \tracer ->
+        genBindingSpec tracer ppOpts preprocessInputs path hsDecls
 
-    ModeLiterate input output -> execLiterate input output
-
-    ModeBindingSpec BindingSpecModeStdlib -> do
-      spec <- withTracer $ \tracer ->
-        getStdlibBindingSpec tracer globalOptsClangArgs
-      BS.putStr $ encodeBindingSpecYaml spec
-
-    ModeResolve{..} -> do
-      isSuccess <- withTracer $ \tracer ->
-        let tracerResolve = contramap TraceResolveHeader  tracer
-            args          = optsClangArgs cmdOpts
-            step isSuccess header =
-              resolveHeader tracerResolve args header >>= \case
-                Just path -> isSuccess <$ putStrLn path
-                Nothing ->
-                  False <$ putStrLn ("header not found: " ++ show header)
-        in  foldM step True resolveInputs
-      unless isSuccess exitFailure
   where
-    cmdOpts :: Opts
-    cmdOpts = def {
-        optsClangArgs       = globalOptsClangArgs
-      , optsPredicate       = globalOptsPredicate
-      , optsProgramSlicing  = globalOptsProgramSlicing
-      }
-    withTracer :: (Tracer IO TraceMsg -> IO b) -> IO b
-    withTracer = withTracerStdOut globalOptsTracerConf DefaultLogLevel
+    doTranslate :: IO HsDecls
+    doTranslate = withTracer globalOpts $ \tracer -> do
+      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      let mu = getModuleUnique preprocessModuleOpts
+          opts = (getOpts globalOpts) {
+              optsExtBindingSpec = extBindingSpec
+            , optsTranslation    = preprocessTranslationOpts
+            , optsTracer         = tracer
+            }
+      translateCHeaders mu opts preprocessInputs
 
-execLiterate :: FilePath -> FilePath -> IO ()
-execLiterate input output = do
+    ppOpts :: PPOpts
+    ppOpts = def {
+        ppOptsModule = preprocessModuleOpts
+      , ppOptsRender = preprocessRenderOpts
+      }
+
+execGenTests :: GlobalOpts -> GenTestsMode -> IO ()
+execGenTests globalOpts GenTestsMode{..} = do
+    hsDecls <- doTranslate
+    genTests ppOpts genTestsInputs genTestsOutput hsDecls
+  where
+    doTranslate :: IO HsDecls
+    doTranslate = withTracer globalOpts $ \tracer -> do
+      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      let mu = getModuleUnique genTestsModuleOpts
+          opts = (getOpts globalOpts) {
+              optsExtBindingSpec = extBindingSpec
+            , optsTranslation    = genTestsTranslationOpts
+            , optsTracer         = tracer
+            }
+      translateCHeaders mu opts genTestsInputs
+
+    ppOpts :: PPOpts
+    ppOpts = def {
+        ppOptsModule = genTestsModuleOpts
+      , ppOptsRender = genTestsRenderOpts
+      }
+
+execLiterate :: LiterateMode -> IO ()
+execLiterate LiterateMode{..} = do
     args <- maybe (throw' "cannot parse literate file") return . readMaybe
-      =<< readFile input
+      =<< readFile literateInput
     case pureParseModePreprocess args of
-      Just cli -> execMode cli { cliMode = case cliMode cli of
-        mode@ModePreprocess{} -> mode { preprocessOutput = Just output }
-        mode                  -> mode
+      Just cli -> execCli cli {
+          cliMode = case cliMode cli of
+            CliModePreprocess mode -> CliModePreprocess $
+              mode { preprocessOutput = Just literateOutput }
+            cliMode'               -> cliMode'
         }
       Nothing -> throw' "cannot parse arguments in literate file"
   where
     throw' :: String -> IO a
-    throw' = throwIO . LiterateFileException input
+    throw' = throwIO . LiterateFileException literateInput
+
+execModeBindingSpec :: GlobalOpts -> BindingSpecMode -> IO ()
+execModeBindingSpec globalOpts@GlobalOpts{..} BindingSpecModeStdlib = do
+    spec <- withTracer globalOpts $ \tracer ->
+      getStdlibBindingSpec tracer globalOptsClangArgs
+    BS.putStr $ encodeBindingSpecYaml spec
+
+execModeResolve :: GlobalOpts -> ResolveMode -> IO ()
+execModeResolve globalOpts@GlobalOpts{..} ResolveMode{..} =
+    withTracer globalOpts $ \tracer -> do
+      let tracerResolve = contramap TraceResolveHeader  tracer
+      forM_ resolveInputs $ \header -> do
+        mPath <- resolveHeader tracerResolve globalOptsClangArgs header
+        putStrLn . unwords $ case mPath of
+          Just path -> [show header, "resolves to", show path]
+          Nothing   -> [show header, "not found"]
+
+-- to avoid potential issues it would be great to include unitid in module
+-- unique but AFAIK there is no way to get one for preprocessor
+-- https://github.com/well-typed/hs-bindgen/issues/502
+getModuleUnique :: HsModuleOpts -> ModuleUnique
+getModuleUnique = ModuleUnique . filter isLetter . hsModuleOptsName
 
 {-------------------------------------------------------------------------------
   Exception handling

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -11,29 +11,20 @@ import HsBindgen.Pipeline qualified as Pipeline
 -------------------------------------------------------------------------------}
 
 main :: IO ()
-main = do
-    dev@Dev{..} <- getDev
-    execMode dev devMode
+main = execDev =<< getDev
 
-execMode :: Dev -> Mode -> IO ()
-execMode Dev{..} = \case
-    ModeParse{..} -> genBindings parseInputPaths >>= print
+execDev :: Dev -> IO ()
+execDev Dev{..} = case devMode of
+    DevModeParse mode -> execParse devGlobalOpts mode
+
+execParse :: GlobalOpts -> ParseMode -> IO ()
+execParse globalOpts ParseMode{..} = print =<< doParse
   where
-    genBindings :: [CHeaderIncludePath] -> IO TranslationUnit
-    genBindings inputPaths =
-      withTracerStdOut (globalOptsTracerConf devGlobalOpts) DefaultLogLevel $
-        \tracer -> do
-          extBindingSpec <-
-            loadExtBindingSpecs tracer
-              (globalOptsClangArgs devGlobalOpts)
-              (globalOptsStdlibSpecConf devGlobalOpts)
-              (globalOptsExtBindings devGlobalOpts)
-          let opts :: Opts
-              opts = def {
-                  optsClangArgs      = globalOptsClangArgs devGlobalOpts
-                , optsExtBindingSpec = extBindingSpec
-                , optsPredicate      = globalOptsPredicate devGlobalOpts
-                , optsProgramSlicing = globalOptsProgramSlicing devGlobalOpts
-                , optsTracer         = tracer
-                }
-          Pipeline.parseCHeaders opts inputPaths
+    doParse :: IO TranslationUnit
+    doParse = withTracer globalOpts $ \tracer -> do
+      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      let opts = (getOpts globalOpts) {
+              optsExtBindingSpec = extBindingSpec
+            , optsTracer         = tracer
+            }
+      Pipeline.parseCHeaders opts parseInputPaths

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -14,11 +14,11 @@ main :: IO ()
 main = execDev =<< getDev
 
 execDev :: Dev -> IO ()
-execDev Dev{..} = case devMode of
-    DevModeParse mode -> execParse devGlobalOpts mode
+execDev Dev{..} = case devCmd of
+    DevCmdParse cmdOpts -> execParse devGlobalOpts cmdOpts
 
-execParse :: GlobalOpts -> ParseMode -> IO ()
-execParse globalOpts ParseMode{..} = print =<< doParse
+execParse :: GlobalOpts -> ParseOpts -> IO ()
+execParse globalOpts ParseOpts{..} = print =<< doParse
   where
     doParse :: IO TranslationUnit
     doParse = withTracer globalOpts $ \tracer -> do


### PR DESCRIPTION
The primary change is the separation of commands (implemented using sum types) and options (implemented using product types).  This allows us to easily dispatch commands to separate functions that implement them.

Note that we previously used (internal) terminology *mode*, which I refactored to *command*.  This is consistent with `optparse-applicative` terminology and works better with hierarchical commands, which I assume we will have more of as we develop more CLI utilities.  I had already implemented `binding-spec` as a hierarchical command since we plan on providing various utilities for working with binding specifications.

The `gentests` command had some issues, as a result of refactoring code that is not actively developed/tested/used.  It used a tracer for loading binding specifications but not for generating tests (where the default `nullTracer` was used), and the `ModuleUnique` was `TODO`.  This PR resolves both of those issues.

This PR also fixes the `HEADER...` syntax, used to indicate that one or more headers may be specified.  `optparse-applicative` does not get this right when just using `some`.