### PR TITLE
Add public opaque `BindingSpec` type

### DIFF
--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -82,7 +82,10 @@ execMode Cli{cliGlobalOpts=GlobalOpts{..}, ..} = case cliMode of
 
     ModeLiterate input output -> execLiterate input output
 
-    ModeBindingSpec BindingSpecModeStdlib -> BS.putStr stdlibExtBindingSpecYaml
+    ModeBindingSpec BindingSpecModeStdlib -> do
+      spec <- withTracer $ \tracer ->
+        getStdlibBindingSpec tracer globalOptsClangArgs
+      BS.putStr $ encodeBindingSpecYaml spec
 
     ModeResolve{..} -> do
       isSuccess <- withTracer $ \tracer ->

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -225,7 +225,6 @@ library
     , hs-bindgen:internal
   build-depends:
       -- Inherited dependencies
-    , bytestring
     , filepath
     , template-haskell
 

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -34,10 +34,10 @@ module HsBindgen.BindingSpec (
   , writeFile
   , writeFileJson
   , writeFileYaml
-    -- ** Header resolution
-  , resolve
     -- ** Merging
   , merge
+    -- ** Header resolution
+  , resolve
   ) where
 
 import Control.Applicative (asum)
@@ -375,7 +375,7 @@ empty = BindingSpec {
       bindingSpecTypes = Map.empty
     }
 
--- | Load, resolve, and merge binding specifications
+-- | Load, merge, and resolve binding specifications
 --
 -- The format is determined by filename extension.
 load ::
@@ -385,16 +385,18 @@ load ::
   -> ClangArgs
   -> UnresolvedBindingSpec
   -> [FilePath]
-  -> IO ResolvedBindingSpec
+  -> IO (UnresolvedBindingSpec, ResolvedBindingSpec)
 load tracer injResolveHeader args stdSpec paths = do
-    let tracerRead = contramap ReadBindingSpecMsg tracer
     uspecs <- mapM (readFile tracerRead) paths
-    let tracerResolve = contramap ResolveBindingSpecMsg tracer
-    specs <-
-      mapM (resolve tracerResolve injResolveHeader args) (stdSpec : uspecs)
-    let (mergeMsgs, spec) = merge specs
+    let (mergeMsgs, uspec) = merge (stdSpec : uspecs)
     mapM_ (traceWith tracer . MergeBindingSpecMsg) mergeMsgs
-    return spec
+    (uspec,) <$> resolve tracerResolve injResolveHeader args uspec
+  where
+    tracerRead :: Tracer IO ReadBindingSpecMsg
+    tracerRead = contramap ReadBindingSpecMsg tracer
+
+    tracerResolve :: Tracer IO ResolveBindingSpecMsg
+    tracerResolve = contramap ResolveBindingSpecMsg tracer
 
 -- | Lookup the @'Omittable' 'TypeSpec'@ associated with a C type
 lookupTypeSpec ::
@@ -491,6 +493,41 @@ writeFileYaml :: FilePath -> UnresolvedBindingSpec -> IO ()
 writeFileYaml path = BSS.writeFile path . encodeYaml' . toABindingSpec
 
 {-------------------------------------------------------------------------------
+  API: Merging
+-------------------------------------------------------------------------------}
+
+-- | Merge binding specifications
+merge ::
+     [UnresolvedBindingSpec]
+  -> ([MergeBindingSpecMsg], UnresolvedBindingSpec)
+merge = \case
+    [] -> ([], empty)
+    spec:specs ->
+      let (typeErrs, bsTypes) =
+              first mkTypeErrs
+            . foldl' mergeTypes (Set.empty, bindingSpecTypes spec)
+            $ concatMap (Map.toList . bindingSpecTypes) specs
+          spec' = BindingSpec {
+              bindingSpecTypes = bsTypes
+            }
+      in  (typeErrs, spec')
+  where
+    mkTypeErrs :: Set C.QualName -> [MergeBindingSpecMsg]
+    mkTypeErrs = fmap MergeBindingSpecConflict . Set.toList
+
+    mergeTypes ::
+         (Set C.QualName, Map C.QualName [(Set CHeaderIncludePath, a)])
+      -> (C.QualName, [(Set CHeaderIncludePath, a)])
+      -> (Set C.QualName, Map C.QualName [(Set CHeaderIncludePath, a)])
+    mergeTypes (dupSet, acc) (cQualName, rs) =
+      case Map.insertLookupWithKey (const (++)) cQualName rs acc of
+        (Nothing, acc') -> (dupSet, acc')
+        (Just ls, acc')
+          | Set.disjoint (Set.unions (fst <$> ls)) (Set.unions (fst <$> rs)) ->
+              (dupSet, acc')
+          | otherwise -> (Set.insert cQualName dupSet, acc')
+
+{-------------------------------------------------------------------------------
   API: Header resolution
 -------------------------------------------------------------------------------}
 
@@ -541,45 +578,6 @@ resolve tracer injResolveHeader args uSpec = do
             bindingSpecTypes = Map.mapMaybe resolve' types
           }
     return rSpec
-
-{-------------------------------------------------------------------------------
-  API: Merging
--------------------------------------------------------------------------------}
-
--- | Merge binding specifications
-merge ::
-     [ResolvedBindingSpec]
-  -> ([MergeBindingSpecMsg], ResolvedBindingSpec)
-merge = \case
-    [] -> ([], empty)
-    spec:specs ->
-      let (typeErrs, bsTypes) =
-              first mkTypeErrs
-            . foldl' mergeTypes (Set.empty, bindingSpecTypes spec)
-            $ concatMap (Map.toList . bindingSpecTypes) specs
-          spec' = BindingSpec {
-              bindingSpecTypes = bsTypes
-            }
-      in  (typeErrs, spec')
-  where
-    mkTypeErrs :: Set C.QualName -> [MergeBindingSpecMsg]
-    mkTypeErrs = fmap MergeBindingSpecConflict . Set.toList
-
-    mergeTypes ::
-         ( Set C.QualName
-         , Map C.QualName [(Set (CHeaderIncludePath, SourcePath), a)]
-         )
-      -> (C.QualName, [(Set (CHeaderIncludePath, SourcePath), a)])
-      -> ( Set C.QualName
-         , Map C.QualName [(Set (CHeaderIncludePath, SourcePath), a)]
-         )
-    mergeTypes (dupSet, acc) (cQualName, rs) =
-      case Map.insertLookupWithKey (const (++)) cQualName rs acc of
-        (Nothing, acc') -> (dupSet, acc')
-        (Just ls, acc')
-          | Set.disjoint (Set.unions (fst <$> ls)) (Set.unions (fst <$> rs)) ->
-              (dupSet, acc')
-          | otherwise -> (Set.insert cQualName dupSet, acc')
 
 {-------------------------------------------------------------------------------
   Auxiliary: Specification files

--- a/hs-bindgen/src/HsBindgen/Common.hs
+++ b/hs-bindgen/src/HsBindgen/Common.hs
@@ -4,9 +4,9 @@ module HsBindgen.Common (
     Pipeline.Opts(..)
 
     -- * Binding specifications
-  , BindingSpec -- opaque
+  , Pipeline.BindingSpec -- opaque
   , Pipeline.StdlibBindingSpecConf(..)
-  , emptyBindingSpec
+  , Pipeline.emptyBindingSpec
 
     -- ** Clang arguments
   , Args.ClangArgs(..)
@@ -69,7 +69,6 @@ import System.FilePath qualified as FilePath
 import Clang.Args qualified as Args
 import Clang.Paths qualified as Paths
 
-import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Predicate qualified as Predicate
 import HsBindgen.Frontend.Pass.Slice qualified as Slice
 import HsBindgen.Hs.AST qualified as Hs
@@ -80,13 +79,3 @@ import HsBindgen.TraceMsg qualified as TraceMsg
 import HsBindgen.Util.Tracer qualified as Tracer
 
 import HsBindgen.Imports (Default (..))
-
-{-------------------------------------------------------------------------------
-  Binding specifications
--------------------------------------------------------------------------------}
-
- -- TODO use opaque wrapper
-type BindingSpec = BindingSpec.ResolvedBindingSpec
-
-emptyBindingSpec :: BindingSpec.ResolvedBindingSpec
-emptyBindingSpec = BindingSpec.empty

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -35,10 +35,12 @@ module HsBindgen.Lib (
 
     -- ** Binding specifications
   , Common.BindingSpec -- opaque
-  , Pipeline.loadExtBindingSpecs
   , Common.emptyBindingSpec
   , Common.StdlibBindingSpecConf(..)
-  , stdlibExtBindingSpecYaml
+  , Pipeline.loadExtBindingSpecs
+  , Pipeline.getStdlibBindingSpec
+  , Pipeline.encodeBindingSpecJson
+  , Pipeline.encodeBindingSpecYaml
 
     -- ** Translation options
   , Common.TranslationOpts(..)
@@ -95,16 +97,12 @@ module HsBindgen.Lib (
   , Common.Default (..)
   ) where
 
-import Data.ByteString (ByteString)
-
 import HsBindgen.Common qualified as Common
 
 import Clang.Args qualified as Args
 import Clang.Paths qualified as Paths
 import HsBindgen.Backend.PP.Render qualified as Backend.PP
 import HsBindgen.Backend.PP.Translation qualified as Backend.PP
-import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.BindingSpec.Stdlib qualified as Stdlib
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
@@ -159,13 +157,6 @@ genBindingSpec ::
   -> IO ()
 genBindingSpec tracer ppOpts headerIncludePaths fp =
     Pipeline.genBindingSpec tracer ppOpts headerIncludePaths fp . unwrapHsDecls
-
-{-------------------------------------------------------------------------------
-  Binding specifications
--------------------------------------------------------------------------------}
-
-stdlibExtBindingSpecYaml :: ByteString
-stdlibExtBindingSpecYaml = BindingSpec.encodeYaml Stdlib.bindingSpec
 
 {-------------------------------------------------------------------------------
   Test generation

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -25,9 +25,9 @@ module HsBindgen.TH (
 
     -- ** Binding specifications
   , Common.BindingSpec -- opaque
-  , loadExtBindingSpecs
   , Common.emptyBindingSpec
   , Common.StdlibBindingSpecConf(..)
+  , loadExtBindingSpecs
 
     -- ** Translation options
   , Common.TranslationOpts(..)


### PR DESCRIPTION
As discussed, new type `BindingSpec` wraps *both* `UnresolvedBindingSpec` and `ResolvedBindingSpec`, so that it can be used for the `stdlib` binding specification as well.  The public YAML hack has been removed.

The `Pipeline.Opts` is public and configures binding specifications, so this new type must also be defined within `hs-bindgen:internal`.  This commit defines it in the `Pipeline` module.  We will refactor this a bit when we make `Pipeline.Opts` internal, and this constraint will no longer be an issue if we make the `Config` type specify filenames and load/merge/resolve binding specifications internally.