### PR TITLE
Add `declHeader` to `DeclInfo`

### DIFF
--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "Adio'0301s"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "adios.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -156,7 +157,8 @@
             nameHsIdent = HsIdentifier
               "C\25968\23383"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "adios.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -284,8 +286,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "adios.h",
   DeclInlineC
     "void testmodule_\25308\25308 (void) { \25308\25308(); }",
@@ -303,8 +304,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "adios.h",
   DeclInlineC
     "void testmodule_Say\25308\25308 (void) { Say\25308\25308(); }",
@@ -322,5 +322,4 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"}}]
+          functionRes = TypeVoid}}]

--- a/hs-bindgen/fixtures/adios.tree-diff.txt
+++ b/hs-bindgen/fixtures/adios.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Adio'0301s"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "adios.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -34,7 +35,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "C\25968\23383"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "adios.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -60,12 +62,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c\978"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "adios.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -80,12 +82,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "\25308\25308"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "adios.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -100,12 +102,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "say\25308\25308"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "adios.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "adios.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/anonymous.hs
+++ b/hs-bindgen/fixtures/anonymous.hs
@@ -54,7 +54,8 @@
                 "S1_c"},
             declOrigin = NameOriginGenerated
               (AnonId "anonymous.h:3:3"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -149,7 +150,8 @@
                   "S1_c"},
               declOrigin = NameOriginGenerated
                 (AnonId "anonymous.h:3:3"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -249,7 +251,8 @@
                           "S1_c"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:3:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -351,7 +354,8 @@
                           "S1_c"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:3:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -465,7 +469,8 @@
               nameHsIdent = HsIdentifier
                 "S1"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -569,7 +574,8 @@
                 nameHsIdent = HsIdentifier
                   "S1"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -678,7 +684,8 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -789,7 +796,8 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -886,7 +894,8 @@
                 "S2_inner_deep"},
             declOrigin = NameOriginGenerated
               (AnonId "anonymous.h:15:5"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -954,7 +963,8 @@
                   "S2_inner_deep"},
               declOrigin = NameOriginGenerated
                 (AnonId "anonymous.h:15:5"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1027,7 +1037,8 @@
                           "S2_inner_deep"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:15:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1100,7 +1111,8 @@
                           "S2_inner_deep"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:15:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1211,7 +1223,8 @@
                 "S2_inner"},
             declOrigin = NameOriginGenerated
               (AnonId "anonymous.h:13:3"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1318,7 +1331,8 @@
                   "S2_inner"},
               declOrigin = NameOriginGenerated
                 (AnonId "anonymous.h:13:3"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1430,7 +1444,8 @@
                           "S2_inner"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:13:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1544,7 +1559,8 @@
                           "S2_inner"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:13:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1669,7 +1685,8 @@
               nameHsIdent = HsIdentifier
                 "S2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1775,7 +1792,8 @@
                 nameHsIdent = HsIdentifier
                   "S2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1886,7 +1904,8 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1999,7 +2018,8 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2114,7 +2134,8 @@
                 "S3_c"},
             declOrigin = NameOriginGenerated
               (AnonId "anonymous.h:25:3"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2209,7 +2230,8 @@
                   "S3_c"},
               declOrigin = NameOriginGenerated
                 (AnonId "anonymous.h:25:3"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2309,7 +2331,8 @@
                           "S3_c"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:25:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2411,7 +2434,8 @@
                           "S3_c"},
                       declOrigin = NameOriginGenerated
                         (AnonId "anonymous.h:25:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2531,7 +2555,8 @@
               nameHsIdent = HsIdentifier
                 "S3"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "anonymous.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2643,7 +2668,8 @@
                 nameHsIdent = HsIdentifier
                   "S3"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "anonymous.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2760,7 +2786,8 @@
                         nameHsIdent = HsIdentifier
                           "S3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2879,7 +2906,8 @@
                         nameHsIdent = HsIdentifier
                           "S3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "anonymous.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/anonymous.tree-diff.txt
+++ b/hs-bindgen/fixtures/anonymous.tree-diff.txt
@@ -9,7 +9,8 @@ TranslationUnit {
             "S1_c"},
         declOrigin = NameOriginGenerated
           (AnonId "anonymous.h:3:3"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -54,7 +55,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -105,7 +107,8 @@ TranslationUnit {
             "S2_inner_deep"},
         declOrigin = NameOriginGenerated
           (AnonId "anonymous.h:15:5"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -142,7 +145,8 @@ TranslationUnit {
             "S2_inner"},
         declOrigin = NameOriginGenerated
           (AnonId "anonymous.h:13:3"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -192,7 +196,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -243,7 +248,8 @@ TranslationUnit {
             "S3_c"},
         declOrigin = NameOriginGenerated
           (AnonId "anonymous.h:25:3"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -288,7 +294,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "anonymous.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/attributes.hs
+++ b/hs-bindgen/fixtures/attributes.hs
@@ -55,7 +55,8 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -153,7 +154,8 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -256,7 +258,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -361,7 +364,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -474,7 +478,8 @@
               nameHsIdent = HsIdentifier
                 "Bar"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -572,7 +577,8 @@
                 nameHsIdent = HsIdentifier
                   "Bar"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -675,7 +681,8 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -780,7 +787,8 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -894,7 +902,8 @@
                 "Baz"},
             declOrigin = NameOriginGenerated
               (AnonId "attributes.h:22:9"),
-            declAliases = [CName "baz"]},
+            declAliases = [CName "baz"],
+            declHeader = "attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -993,7 +1002,8 @@
                   "Baz"},
               declOrigin = NameOriginGenerated
                 (AnonId "attributes.h:22:9"),
-              declAliases = [CName "baz"]},
+              declAliases = [CName "baz"],
+              declHeader = "attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1097,7 +1107,8 @@
                           "Baz"},
                       declOrigin = NameOriginGenerated
                         (AnonId "attributes.h:22:9"),
-                      declAliases = [CName "baz"]},
+                      declAliases = [CName "baz"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1203,7 +1214,8 @@
                           "Baz"},
                       declOrigin = NameOriginGenerated
                         (AnonId "attributes.h:22:9"),
-                      declAliases = [CName "baz"]},
+                      declAliases = [CName "baz"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1317,7 +1329,8 @@
                 "Qux"},
             declOrigin = NameOriginGenerated
               (AnonId "attributes.h:28:9"),
-            declAliases = [CName "qux"]},
+            declAliases = [CName "qux"],
+            declHeader = "attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1416,7 +1429,8 @@
                   "Qux"},
               declOrigin = NameOriginGenerated
                 (AnonId "attributes.h:28:9"),
-              declAliases = [CName "qux"]},
+              declAliases = [CName "qux"],
+              declHeader = "attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1520,7 +1534,8 @@
                           "Qux"},
                       declOrigin = NameOriginGenerated
                         (AnonId "attributes.h:28:9"),
-                      declAliases = [CName "qux"]},
+                      declAliases = [CName "qux"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1626,7 +1641,8 @@
                           "Qux"},
                       declOrigin = NameOriginGenerated
                         (AnonId "attributes.h:28:9"),
-                      declAliases = [CName "qux"]},
+                      declAliases = [CName "qux"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1760,7 +1776,8 @@
               nameHsIdent = HsIdentifier
                 "C__SFILE"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "FILE"]},
+            declAliases = [CName "FILE"],
+            declHeader = "attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1891,7 +1908,8 @@
                 nameHsIdent = HsIdentifier
                   "C__SFILE"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "FILE"]},
+              declAliases = [CName "FILE"],
+              declHeader = "attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2027,7 +2045,8 @@
                         nameHsIdent = HsIdentifier
                           "C__SFILE"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "FILE"]},
+                      declAliases = [CName "FILE"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2166,7 +2185,8 @@
                         nameHsIdent = HsIdentifier
                           "C__SFILE"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "FILE"]},
+                      declAliases = [CName "FILE"],
+                      declHeader = "attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2265,7 +2285,8 @@
             nameHsIdent = HsIdentifier
               "FILE"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "attributes.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/attributes.tree-diff.txt
+++ b/hs-bindgen/fixtures/attributes.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -55,7 +56,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bar"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -103,7 +105,8 @@ TranslationUnit {
             "Baz"},
         declOrigin = NameOriginGenerated
           (AnonId "attributes.h:22:9"),
-        declAliases = [CName "baz"]},
+        declAliases = [CName "baz"],
+        declHeader = "attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -151,7 +154,8 @@ TranslationUnit {
             "Qux"},
         declOrigin = NameOriginGenerated
           (AnonId "attributes.h:28:9"),
-        declAliases = [CName "qux"]},
+        declAliases = [CName "qux"],
+        declHeader = "attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -198,7 +202,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "C__SFILE"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "FILE"]},
+        declAliases = [CName "FILE"],
+        declHeader = "attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -257,7 +262,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "FILE"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "attributes.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/bitfields.hs
+++ b/hs-bindgen/fixtures/bitfields.hs
@@ -129,7 +129,8 @@
               nameHsIdent = HsIdentifier
                 "Flags"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -347,7 +348,8 @@
                 nameHsIdent = HsIdentifier
                   "Flags"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -570,7 +572,8 @@
                         nameHsIdent = HsIdentifier
                           "Flags"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -799,7 +802,8 @@
                         nameHsIdent = HsIdentifier
                           "Flags"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -995,7 +999,8 @@
               nameHsIdent = HsIdentifier
                 "Overflow32"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1120,7 +1125,8 @@
                 nameHsIdent = HsIdentifier
                   "Overflow32"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1250,7 +1256,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1383,7 +1390,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1537,7 +1545,8 @@
               nameHsIdent = HsIdentifier
                 "Overflow32b"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1662,7 +1671,8 @@
                 nameHsIdent = HsIdentifier
                   "Overflow32b"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1792,7 +1802,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32b"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1925,7 +1936,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32b"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2079,7 +2091,8 @@
               nameHsIdent = HsIdentifier
                 "Overflow32c"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2204,7 +2217,8 @@
                 nameHsIdent = HsIdentifier
                   "Overflow32c"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2334,7 +2348,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32c"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2467,7 +2482,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow32c"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2603,7 +2619,8 @@
               nameHsIdent = HsIdentifier
                 "Overflow64"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2699,7 +2716,8 @@
                 nameHsIdent = HsIdentifier
                   "Overflow64"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2800,7 +2818,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow64"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2903,7 +2922,8 @@
                         nameHsIdent = HsIdentifier
                           "Overflow64"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3024,7 +3044,8 @@
               nameHsIdent = HsIdentifier
                 "AlignA"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -3120,7 +3141,8 @@
                 nameHsIdent = HsIdentifier
                   "AlignA"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -3221,7 +3243,8 @@
                         nameHsIdent = HsIdentifier
                           "AlignA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3324,7 +3347,8 @@
                         nameHsIdent = HsIdentifier
                           "AlignA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3444,7 +3468,8 @@
               nameHsIdent = HsIdentifier
                 "AlignB"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bitfields.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -3540,7 +3565,8 @@
                 nameHsIdent = HsIdentifier
                   "AlignB"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bitfields.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -3641,7 +3667,8 @@
                         nameHsIdent = HsIdentifier
                           "AlignB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3744,7 +3771,8 @@
                         nameHsIdent = HsIdentifier
                           "AlignB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bitfields.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/bitfields.tree-diff.txt
+++ b/hs-bindgen/fixtures/bitfields.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Flags"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -101,7 +102,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Overflow32"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -159,7 +161,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Overflow32b"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -217,7 +220,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Overflow32c"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -275,7 +279,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Overflow64"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -322,7 +327,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "AlignA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -368,7 +374,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "AlignB"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bitfields.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/bool.hs
+++ b/hs-bindgen/fixtures/bool.hs
@@ -51,7 +51,8 @@
               nameHsIdent = HsIdentifier
                 "Bools1"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bool.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -141,7 +142,8 @@
                 nameHsIdent = HsIdentifier
                   "Bools1"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bool.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -236,7 +238,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -333,7 +336,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -442,7 +446,8 @@
               nameHsIdent = HsIdentifier
                 "Bools2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bool.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -532,7 +537,8 @@
                 nameHsIdent = HsIdentifier
                   "Bools2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bool.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -627,7 +633,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -724,7 +731,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -804,7 +812,8 @@
             nameHsIdent = HsIdentifier
               "BOOL"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "bool.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -950,7 +959,8 @@
               nameHsIdent = HsIdentifier
                 "Bools3"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "bool.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1060,7 +1070,8 @@
                 nameHsIdent = HsIdentifier
                   "Bools3"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "bool.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1175,7 +1186,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1292,7 +1304,8 @@
                         nameHsIdent = HsIdentifier
                           "Bools3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "bool.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/bool.tree-diff.txt
+++ b/hs-bindgen/fixtures/bool.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bools1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bool.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -51,7 +52,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bools2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bool.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -94,7 +96,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "BOOL"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bool.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -120,7 +123,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bools3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "bool.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/decls_in_signature.hs
+++ b/hs-bindgen/fixtures/decls_in_signature.hs
@@ -13,7 +13,9 @@
             nameHsIdent = HsIdentifier
               "Opaque"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "decls_in_signature.h"},
         declKind = OpaqueStruct,
         declSpec = DeclSpec
           TypeSpec {
@@ -76,7 +78,9 @@
               nameHsIdent = HsIdentifier
                 "Outside"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "decls_in_signature.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -171,7 +175,9 @@
                 nameHsIdent = HsIdentifier
                   "Outside"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "decls_in_signature.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -271,7 +277,9 @@
                         nameHsIdent = HsIdentifier
                           "Outside"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "decls_in_signature.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -373,7 +381,9 @@
                         nameHsIdent = HsIdentifier
                           "Outside"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "decls_in_signature.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -489,7 +499,5 @@
                 nameHsIdent = HsIdentifier
                   "Outside"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "decls_in_signature.h"}},
+          functionRes = TypeVoid}},
   DeclSimple]

--- a/hs-bindgen/fixtures/decls_in_signature.tree-diff.txt
+++ b/hs-bindgen/fixtures/decls_in_signature.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Opaque"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "decls_in_signature.h"},
       declKind = DeclStructOpaque,
       declSpec = DeclSpec
         TypeSpec {
@@ -26,7 +28,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Outside"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "decls_in_signature.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -72,7 +76,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "normal"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "decls_in_signature.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -96,9 +102,7 @@ TranslationUnit {
                 nameHsIdent = HsIdentifier
                   "Outside"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "decls_in_signature.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -61,7 +61,9 @@
                 "distilled_lib_1.h:9:9"),
             declAliases = [
               CName
-                "another_typedef_struct_t"]},
+                "another_typedef_struct_t"],
+            declHeader =
+            "distilled_lib_1.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -167,7 +169,9 @@
                   "distilled_lib_1.h:9:9"),
               declAliases = [
                 CName
-                  "another_typedef_struct_t"]},
+                  "another_typedef_struct_t"],
+              declHeader =
+              "distilled_lib_1.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -278,7 +282,9 @@
                           "distilled_lib_1.h:9:9"),
                       declAliases = [
                         CName
-                          "another_typedef_struct_t"]},
+                          "another_typedef_struct_t"],
+                      declHeader =
+                      "distilled_lib_1.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -391,7 +397,9 @@
                           "distilled_lib_1.h:9:9"),
                       declAliases = [
                         CName
-                          "another_typedef_struct_t"]},
+                          "another_typedef_struct_t"],
+                      declHeader =
+                      "distilled_lib_1.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -482,8 +490,9 @@
             (AnonId
               "distilled_lib_1.h:10:9"),
           declAliases = [
-            CName
-              "another_typedef_enum_e"]},
+            CName "another_typedef_enum_e"],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -860,7 +869,9 @@
             nameHsIdent = HsIdentifier
               "A_type_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -995,7 +1006,9 @@
             nameHsIdent = HsIdentifier
               "Var_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -2289,7 +2302,9 @@
                 "A_typedef_struct"},
             declOrigin = NameOriginInSource,
             declAliases = [
-              CName "a_typedef_struct_t"]},
+              CName "a_typedef_struct_t"],
+            declHeader =
+            "distilled_lib_1.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -4122,7 +4137,9 @@
                   "A_typedef_struct"},
               declOrigin = NameOriginInSource,
               declAliases = [
-                CName "a_typedef_struct_t"]},
+                CName "a_typedef_struct_t"],
+              declHeader =
+              "distilled_lib_1.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -5960,7 +5977,9 @@
                           "A_typedef_struct"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "a_typedef_struct_t"]},
+                        CName "a_typedef_struct_t"],
+                      declHeader =
+                      "distilled_lib_1.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -7809,7 +7828,9 @@
                           "A_typedef_struct"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "a_typedef_struct_t"]},
+                        CName "a_typedef_struct_t"],
+                      declHeader =
+                      "distilled_lib_1.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -8514,7 +8535,9 @@
             nameHsIdent = HsIdentifier
               "A_typedef_struct_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -8709,7 +8732,9 @@
             (AnonId
               "distilled_lib_1.h:61:9"),
           declAliases = [
-            CName "a_typedef_enum_e"]},
+            CName "a_typedef_enum_e"],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -9769,9 +9794,7 @@
                       InstanceSpec {
                         instanceSpecStrategy = Nothing,
                         instanceSpecConstraints = [
-                          ]})]},
-          functionHeader =
-          "distilled_lib_1.h"}},
+                          ]})]}}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -10021,7 +10044,9 @@
             nameHsIdent = HsIdentifier
               "Callback_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "distilled_lib_1.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.tree-diff.txt
@@ -15,7 +15,9 @@ TranslationUnit {
             "distilled_lib_1.h:9:9"),
         declAliases = [
           CName
-            "another_typedef_struct_t"]},
+            "another_typedef_struct_t"],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -69,8 +71,9 @@ TranslationUnit {
           (AnonId
             "distilled_lib_1.h:10:9"),
         declAliases = [
-          CName
-            "another_typedef_enum_e"]},
+          CName "another_typedef_enum_e"],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -115,7 +118,9 @@ TranslationUnit {
           nameC = CName "A",
           nameHsIdent = HsIdentifier "a"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -142,7 +147,9 @@ TranslationUnit {
           nameC = CName "B",
           nameHsIdent = HsIdentifier "b"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -171,7 +178,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "sOME_DEFINED_CONSTANT"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -199,7 +208,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "A_type_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -226,7 +237,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Var_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -255,7 +268,9 @@ TranslationUnit {
             "A_typedef_struct"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "a_typedef_struct_t"]},
+          CName "a_typedef_struct_t"],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -912,7 +927,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "A_typedef_struct_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -944,7 +961,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "a_DEFINE_0"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -972,7 +991,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "a_DEFINE_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1001,7 +1022,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "a_DEFINE_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1029,7 +1052,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "tWO_ARGS"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -1071,7 +1096,9 @@ TranslationUnit {
           (AnonId
             "distilled_lib_1.h:61:9"),
         declAliases = [
-          CName "a_typedef_enum_e"]},
+          CName "a_typedef_enum_e"],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1134,7 +1161,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "some_fun"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -1487,9 +1516,7 @@ TranslationUnit {
                       InstanceSpec {
                         instanceSpecStrategy = Nothing,
                         instanceSpecConstraints = [
-                          ]})]},
-          functionHeader =
-          "distilled_lib_1.h"},
+                          ]})]}},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -1505,7 +1532,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Callback_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "distilled_lib_1.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/enums.hs
+++ b/hs-bindgen/fixtures/enums.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "First"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -319,7 +320,8 @@
             nameHsIdent = HsIdentifier
               "Second"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -658,7 +660,8 @@
             nameHsIdent = HsIdentifier
               "Same"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -957,7 +960,8 @@
             nameHsIdent = HsIdentifier
               "Nonseq"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -1272,7 +1276,8 @@
             nameHsIdent = HsIdentifier
               "Packed"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -1613,7 +1618,8 @@
               "EnumA"},
           declOrigin = NameOriginGenerated
             (AnonId "enums.h:30:9"),
-          declAliases = [CName "enumA"]},
+          declAliases = [CName "enumA"],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -1914,7 +1920,8 @@
             nameHsIdent = HsIdentifier
               "EnumB"},
           declOrigin = NameOriginInSource,
-          declAliases = [CName "enumB"]},
+          declAliases = [CName "enumB"],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -2215,7 +2222,8 @@
             nameHsIdent = HsIdentifier
               "EnumC"},
           declOrigin = NameOriginInSource,
-          declAliases = [CName "enumC"]},
+          declAliases = [CName "enumC"],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -2516,8 +2524,8 @@
             nameHsIdent = HsIdentifier
               "EnumD"},
           declOrigin = NameOriginInSource,
-          declAliases = [
-            CName "enumD_t"]},
+          declAliases = [CName "enumD_t"],
+          declHeader = "enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -2820,7 +2828,8 @@
             nameHsIdent = HsIdentifier
               "EnumD_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "enums.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/enums.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "First"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -51,7 +52,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Second"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -104,7 +106,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Same"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -149,7 +152,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Nonseq"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -202,7 +206,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Packed"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -257,7 +262,8 @@ TranslationUnit {
             "EnumA"},
         declOrigin = NameOriginGenerated
           (AnonId "enums.h:30:9"),
-        declAliases = [CName "enumA"]},
+        declAliases = [CName "enumA"],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -302,7 +308,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "EnumB"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "enumB"]},
+        declAliases = [CName "enumB"],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -347,7 +354,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "EnumC"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "enumC"]},
+        declAliases = [CName "enumC"],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -392,8 +400,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "EnumD"},
         declOrigin = NameOriginInSource,
-        declAliases = [
-          CName "enumD_t"]},
+        declAliases = [CName "enumD_t"],
+        declHeader = "enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -438,7 +446,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "EnumD_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "enums.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/fixedarray.hs
+++ b/hs-bindgen/fixtures/fixedarray.hs
@@ -23,7 +23,8 @@
             nameHsIdent = HsIdentifier
               "Triple"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "fixedarray.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -127,7 +128,8 @@
               nameHsIdent = HsIdentifier
                 "Example"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "fixedarray.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -237,7 +239,8 @@
                 nameHsIdent = HsIdentifier
                   "Example"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "fixedarray.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -352,7 +355,8 @@
                         nameHsIdent = HsIdentifier
                           "Example"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "fixedarray.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -469,7 +473,8 @@
                         nameHsIdent = HsIdentifier
                           "Example"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "fixedarray.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/fixedarray.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "fixedarray.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -36,7 +37,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Example"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "fixedarray.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/fixedarray_arg.hs
+++ b/hs-bindgen/fixtures/fixedarray_arg.hs
@@ -28,9 +28,7 @@
               (TypePrim
                 (PrimIntegral PrimInt Signed))],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "fixedarray_arg.h"}},
+            (PrimIntegral PrimInt Signed)}},
   DeclSimple,
   DeclNewtype
     Newtype {
@@ -57,7 +55,9 @@
             nameHsIdent = HsIdentifier
               "Triple"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "fixedarray_arg.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -124,7 +124,5 @@
                   nameHsIdent = HsIdentifier
                     "Triple"})],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "fixedarray_arg.h"}},
+            (PrimIntegral PrimInt Signed)}},
   DeclSimple]

--- a/hs-bindgen/fixtures/fixedarray_arg.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedarray_arg.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fun_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "fixedarray_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -20,9 +22,7 @@ TranslationUnit {
               (TypePrim
                 (PrimIntegral PrimInt Signed))],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "fixedarray_arg.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -38,7 +38,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "fixedarray_arg.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -67,7 +69,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fun_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "fixedarray_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -78,9 +82,7 @@ TranslationUnit {
                   nameHsIdent = HsIdentifier
                     "Triple"})],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "fixedarray_arg.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/fixedwidth.hs
+++ b/hs-bindgen/fixtures/fixedwidth.hs
@@ -495,7 +495,8 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "fixedwidth.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1255,7 +1256,8 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "fixedwidth.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2020,7 +2022,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "fixedwidth.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2787,7 +2790,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "fixedwidth.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
+++ b/hs-bindgen/fixtures/fixedwidth.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "fixedwidth.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/flam.hs
+++ b/hs-bindgen/fixtures/flam.hs
@@ -34,7 +34,8 @@
               nameHsIdent = HsIdentifier
                 "Pascal"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "flam.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -109,7 +110,8 @@
                 nameHsIdent = HsIdentifier
                   "Pascal"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -189,7 +191,8 @@
                         nameHsIdent = HsIdentifier
                           "Pascal"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -269,7 +272,8 @@
                         nameHsIdent = HsIdentifier
                           "Pascal"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -363,7 +367,8 @@
                 nameHsIdent = HsIdentifier
                   "Pascal"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -457,7 +462,8 @@
                 "Foo_bar"},
             declOrigin = NameOriginGenerated
               (AnonId "flam.h:10:2"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "flam.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -548,7 +554,8 @@
                   "Foo_bar"},
               declOrigin = NameOriginGenerated
                 (AnonId "flam.h:10:2"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -644,7 +651,8 @@
                           "Foo_bar"},
                       declOrigin = NameOriginGenerated
                         (AnonId "flam.h:10:2"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -742,7 +750,8 @@
                           "Foo_bar"},
                       declOrigin = NameOriginGenerated
                         (AnonId "flam.h:10:2"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -834,7 +843,8 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "flam.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -912,7 +922,8 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -995,7 +1006,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1078,7 +1090,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1171,7 +1184,8 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1272,7 +1286,8 @@
               nameHsIdent = HsIdentifier
                 "Diff"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "flam.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1378,7 +1393,8 @@
                 nameHsIdent = HsIdentifier
                   "Diff"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1489,7 +1505,8 @@
                         nameHsIdent = HsIdentifier
                           "Diff"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1602,7 +1619,8 @@
                         nameHsIdent = HsIdentifier
                           "Diff"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "flam.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1724,7 +1742,8 @@
                 nameHsIdent = HsIdentifier
                   "Diff"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "flam.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames

--- a/hs-bindgen/fixtures/flam.tree-diff.txt
+++ b/hs-bindgen/fixtures/flam.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Pascal"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "flam.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -54,7 +55,8 @@ TranslationUnit {
             "Foo_bar"},
         declOrigin = NameOriginGenerated
           (AnonId "flam.h:10:2"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "flam.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -97,7 +99,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "flam.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -145,7 +148,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Diff"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "flam.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/forward_declaration.hs
+++ b/hs-bindgen/fixtures/forward_declaration.hs
@@ -36,7 +36,9 @@
               nameHsIdent = HsIdentifier
                 "S1"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "S1_t"]},
+            declAliases = [CName "S1_t"],
+            declHeader =
+            "forward_declaration.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -102,7 +104,9 @@
                 nameHsIdent = HsIdentifier
                   "S1"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "S1_t"]},
+              declAliases = [CName "S1_t"],
+              declHeader =
+              "forward_declaration.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -173,7 +177,9 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S1_t"]},
+                      declAliases = [CName "S1_t"],
+                      declHeader =
+                      "forward_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -244,7 +250,9 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S1_t"]},
+                      declAliases = [CName "S1_t"],
+                      declHeader =
+                      "forward_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -311,7 +319,9 @@
             nameHsIdent = HsIdentifier
               "S1_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "forward_declaration.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -383,7 +393,9 @@
               nameHsIdent = HsIdentifier
                 "S2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "forward_declaration.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -449,7 +461,9 @@
                 nameHsIdent = HsIdentifier
                   "S2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "forward_declaration.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -520,7 +534,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "forward_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -591,7 +607,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "forward_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/forward_declaration.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S1"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "S1_t"]},
+        declAliases = [CName "S1_t"],
+        declHeader =
+        "forward_declaration.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -44,7 +46,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S1_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "forward_declaration.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -74,7 +78,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "forward_declaration.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/macro_functions.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_functions.tree-diff.txt
@@ -10,7 +10,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "iNCR"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -44,7 +46,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "aDD"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -75,7 +79,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "iD"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -99,7 +105,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "cONST"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -125,7 +133,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "cMP"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -157,7 +167,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fUN1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -199,7 +211,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fUN2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -240,7 +254,9 @@ TranslationUnit {
           nameC = CName "G",
           nameHsIdent = HsIdentifier "g"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -287,7 +303,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "dIV1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -329,7 +347,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "dIV2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_functions.h"},
       declKind =
       DeclMacro
         (MacroExpr

--- a/hs-bindgen/fixtures/macro_in_fundecl.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.hs
@@ -22,7 +22,9 @@
             nameC = CName "I",
             nameHsIdent = HsIdentifier "I"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -130,7 +132,9 @@
             nameC = CName "C",
             nameHsIdent = HsIdentifier "C"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -239,7 +243,9 @@
             nameC = CName "F",
             nameHsIdent = HsIdentifier "F"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -342,7 +348,9 @@
             nameC = CName "L",
             nameHsIdent = HsIdentifier "L"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -450,7 +458,9 @@
             nameC = CName "S",
             nameHsIdent = HsIdentifier "S"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -571,9 +581,7 @@
                 (PrimSignImplicit Nothing))],
           functionRes = TypePrim
             (PrimChar
-              (PrimSignImplicit Nothing)),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+              (PrimSignImplicit Nothing))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -616,9 +624,7 @@
               NamePair {
                 nameC = CName "C",
                 nameHsIdent = HsIdentifier "C"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+              NameOriginInSource)}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -661,9 +667,7 @@
             (TypePrim
               (PrimChar
                 (PrimSignImplicit
-                  (Just Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                  (Just Signed))))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -709,9 +713,7 @@
           functionRes = TypePointer
             (TypePrim
               (PrimChar
-                (PrimSignImplicit Nothing))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                (PrimSignImplicit Nothing)))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -758,9 +760,7 @@
               NamePair {
                 nameC = CName "C",
                 nameHsIdent = HsIdentifier "C"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+              NameOriginInSource)}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -794,9 +794,9 @@
                 TypePrim
                   (PrimIntegral PrimShort Signed)]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -834,9 +834,9 @@
                 TypePrim
                   (PrimIntegral PrimShort Signed)]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -874,9 +874,9 @@
                     nameHsIdent = HsIdentifier "S"}
                   NameOriginInSource]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -916,9 +916,7 @@
                 NamePair {
                   nameC = CName "I",
                   nameHsIdent = HsIdentifier "I"}
-                NameOriginInSource)),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                NameOriginInSource))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -955,9 +953,7 @@
                 (TypePrim
                   (PrimIntegral
                     PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                    Signed))))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -998,9 +994,7 @@
                 (TypePrim
                   (PrimIntegral
                     PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                    Signed))))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -1041,9 +1035,7 @@
                   NamePair {
                     nameC = CName "I",
                     nameHsIdent = HsIdentifier "I"}
-                  NameOriginInSource))),
-          functionHeader =
-          "macro_in_fundecl.h"}},
+                  NameOriginInSource)))}},
   DeclInlineCInclude
     "macro_in_fundecl.h",
   DeclInlineC
@@ -1068,6 +1060,4 @@
             NamePair {
               nameC = CName "I",
               nameHsIdent = HsIdentifier "I"}
-            NameOriginInSource,
-          functionHeader =
-          "macro_in_fundecl.h"}}]
+            NameOriginInSource}}]

--- a/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl.tree-diff.txt
@@ -8,7 +8,9 @@ TranslationUnit {
           nameC = CName "I",
           nameHsIdent = HsIdentifier "I"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -35,7 +37,9 @@ TranslationUnit {
           nameC = CName "C",
           nameHsIdent = HsIdentifier "C"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -63,7 +67,9 @@ TranslationUnit {
           nameC = CName "F",
           nameHsIdent = HsIdentifier "F"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -90,7 +96,9 @@ TranslationUnit {
           nameC = CName "L",
           nameHsIdent = HsIdentifier "L"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -119,7 +127,9 @@ TranslationUnit {
           nameC = CName "S",
           nameHsIdent = HsIdentifier "S"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -149,7 +159,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "quux"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -163,9 +175,7 @@ TranslationUnit {
                 (PrimSignImplicit Nothing))],
           functionRes = TypePrim
             (PrimChar
-              (PrimSignImplicit Nothing)),
-          functionHeader =
-          "macro_in_fundecl.h"},
+              (PrimSignImplicit Nothing))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -181,7 +191,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "wam"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -198,9 +210,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "C",
                 nameHsIdent = HsIdentifier "C"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl.h"},
+              NameOriginInSource)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -216,7 +226,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "foo1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -235,9 +247,7 @@ TranslationUnit {
             (TypePrim
               (PrimChar
                 (PrimSignImplicit
-                  (Just Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                  (Just Signed))))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -253,7 +263,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "foo2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -274,9 +286,7 @@ TranslationUnit {
           functionRes = TypePointer
             (TypePrim
               (PrimChar
-                (PrimSignImplicit Nothing))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                (PrimSignImplicit Nothing)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -292,7 +302,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "foo3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -312,9 +324,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "C",
                 nameHsIdent = HsIdentifier "C"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl.h"},
+              NameOriginInSource)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -330,7 +340,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bar1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -342,9 +354,9 @@ TranslationUnit {
                 TypePrim
                   (PrimIntegral PrimShort Signed)]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -360,7 +372,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bar2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -375,9 +389,9 @@ TranslationUnit {
                 TypePrim
                   (PrimIntegral PrimShort Signed)]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -393,7 +407,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bar3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -408,9 +424,9 @@ TranslationUnit {
                     nameHsIdent = HsIdentifier "S"}
                   NameOriginInSource]
               (TypePrim
-                (PrimIntegral PrimInt Signed))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                (PrimIntegral
+                  PrimInt
+                  Signed)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -426,7 +442,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bar4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -441,9 +459,7 @@ TranslationUnit {
                 NamePair {
                   nameC = CName "I",
                   nameHsIdent = HsIdentifier "I"}
-                NameOriginInSource)),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                NameOriginInSource))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -459,7 +475,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "baz1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -473,9 +491,7 @@ TranslationUnit {
                 (TypePrim
                   (PrimIntegral
                     PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                    Signed))))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -491,7 +507,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "baz2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -508,9 +526,7 @@ TranslationUnit {
                 (TypePrim
                   (PrimIntegral
                     PrimInt
-                    Signed)))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                    Signed))))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -526,7 +542,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "baz3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -541,9 +559,7 @@ TranslationUnit {
                   NamePair {
                     nameC = CName "I",
                     nameHsIdent = HsIdentifier "I"}
-                  NameOriginInSource))),
-          functionHeader =
-          "macro_in_fundecl.h"},
+                  NameOriginInSource)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -559,7 +575,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "no_args_no_void"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
@@ -567,9 +585,7 @@ TranslationUnit {
             NamePair {
               nameC = CName "I",
               nameHsIdent = HsIdentifier "I"}
-            NameOriginInSource,
-          functionHeader =
-          "macro_in_fundecl.h"},
+            NameOriginInSource},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.hs
@@ -23,7 +23,9 @@
             nameHsIdent = HsIdentifier
               "MC"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl_vs_typedef.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -133,7 +135,9 @@
             nameHsIdent = HsIdentifier
               "TC"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl_vs_typedef.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -258,9 +262,7 @@
                     "TC"})],
           functionRes = TypePrim
             (PrimChar
-              (PrimSignImplicit Nothing)),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+              (PrimSignImplicit Nothing))}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -301,9 +303,7 @@
               NamePair {
                 nameC = CName "TC",
                 nameHsIdent = HsIdentifier
-                  "TC"}),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+                  "TC"})}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -347,9 +347,7 @@
               NamePair {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+              NameOriginInSource)}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -393,9 +391,7 @@
                 NamePair {
                   nameC = CName "TC",
                   nameHsIdent = HsIdentifier
-                    "TC"})),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+                    "TC"}))}},
   DeclData
     Struct {
       structName = HsName
@@ -433,7 +429,9 @@
               nameHsIdent = HsIdentifier
                 "Struct1"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "macro_in_fundecl_vs_typedef.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -499,7 +497,9 @@
                 nameHsIdent = HsIdentifier
                   "Struct1"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "macro_in_fundecl_vs_typedef.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -570,7 +570,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -641,7 +643,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -727,8 +731,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "macro_in_fundecl_vs_typedef.h:19:9"),
-            declAliases = [
-              CName "struct2"]},
+            declAliases = [CName "struct2"],
+            declHeader =
+            "macro_in_fundecl_vs_typedef.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -796,8 +801,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "macro_in_fundecl_vs_typedef.h:19:9"),
-              declAliases = [
-                CName "struct2"]},
+              declAliases = [CName "struct2"],
+              declHeader =
+              "macro_in_fundecl_vs_typedef.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -870,8 +876,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "macro_in_fundecl_vs_typedef.h:19:9"),
-                      declAliases = [
-                        CName "struct2"]},
+                      declAliases = [CName "struct2"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -944,8 +951,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "macro_in_fundecl_vs_typedef.h:19:9"),
-                      declAliases = [
-                        CName "struct2"]},
+                      declAliases = [CName "struct2"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1030,7 +1038,9 @@
                 "Struct3"},
             declOrigin = NameOriginInSource,
             declAliases = [
-              CName "struct3_t"]},
+              CName "struct3_t"],
+            declHeader =
+            "macro_in_fundecl_vs_typedef.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1097,7 +1107,9 @@
                   "Struct3"},
               declOrigin = NameOriginInSource,
               declAliases = [
-                CName "struct3_t"]},
+                CName "struct3_t"],
+              declHeader =
+              "macro_in_fundecl_vs_typedef.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1169,7 +1181,9 @@
                           "Struct3"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "struct3_t"]},
+                        CName "struct3_t"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1241,7 +1255,9 @@
                           "Struct3"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "struct3_t"]},
+                        CName "struct3_t"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1314,7 +1330,9 @@
             nameHsIdent = HsIdentifier
               "Struct3_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_in_fundecl_vs_typedef.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -1393,8 +1411,9 @@
               nameHsIdent = HsIdentifier
                 "Struct4"},
             declOrigin = NameOriginInSource,
-            declAliases = [
-              CName "struct4"]},
+            declAliases = [CName "struct4"],
+            declHeader =
+            "macro_in_fundecl_vs_typedef.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1460,8 +1479,9 @@
                 nameHsIdent = HsIdentifier
                   "Struct4"},
               declOrigin = NameOriginInSource,
-              declAliases = [
-                CName "struct4"]},
+              declAliases = [CName "struct4"],
+              declHeader =
+              "macro_in_fundecl_vs_typedef.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1532,8 +1552,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct4"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [
-                        CName "struct4"]},
+                      declAliases = [CName "struct4"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1604,8 +1625,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct4"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [
-                        CName "struct4"]},
+                      declAliases = [CName "struct4"],
+                      declHeader =
+                      "macro_in_fundecl_vs_typedef.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1696,9 +1718,7 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -1738,9 +1758,7 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -1783,9 +1801,7 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -1825,9 +1841,7 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -1867,9 +1881,7 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "macro_in_fundecl_vs_typedef.h",
   DeclInlineC
@@ -1909,6 +1921,4 @@
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"}}]
+          functionRes = TypeVoid}}]

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "MC"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -38,7 +40,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "TC"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -67,7 +71,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "quux1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -84,9 +90,7 @@ TranslationUnit {
                     "TC"})],
           functionRes = TypePrim
             (PrimChar
-              (PrimSignImplicit Nothing)),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+              (PrimSignImplicit Nothing))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -102,7 +106,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "quux2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -119,9 +125,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "TC",
                 nameHsIdent = HsIdentifier
-                  "TC"}),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+                  "TC"})},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -137,7 +141,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "wam1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -155,9 +161,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
-              NameOriginInSource),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+              NameOriginInSource)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -173,7 +177,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "wam2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -191,9 +197,7 @@ TranslationUnit {
                 NamePair {
                   nameC = CName "TC",
                   nameHsIdent = HsIdentifier
-                    "TC"})),
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+                    "TC"}))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -209,7 +213,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Struct1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -246,8 +252,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "macro_in_fundecl_vs_typedef.h:19:9"),
-        declAliases = [
-          CName "struct2"]},
+        declAliases = [CName "struct2"],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -283,7 +290,9 @@ TranslationUnit {
             "Struct3"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "struct3_t"]},
+          CName "struct3_t"],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -318,7 +327,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Struct3_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -349,8 +360,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Struct4"},
         declOrigin = NameOriginInSource,
-        declAliases = [
-          CName "struct4"]},
+        declAliases = [CName "struct4"],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -385,7 +397,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_typedef1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -406,9 +420,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -424,7 +436,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_typedef2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -440,9 +454,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -458,7 +470,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_typedef3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -477,9 +491,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -495,7 +507,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_name1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -511,9 +525,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -529,7 +541,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_name2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -545,9 +559,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -563,7 +575,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "struct_name3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_in_fundecl_vs_typedef.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -579,9 +593,7 @@ TranslationUnit {
                 nameC = CName "MC",
                 nameHsIdent = HsIdentifier "MC"}
               NameOriginInSource],
-          functionRes = TypeVoid,
-          functionHeader =
-          "macro_in_fundecl_vs_typedef.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/macro_strings.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_strings.tree-diff.txt
@@ -9,7 +9,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -37,7 +38,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -66,7 +68,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -94,7 +97,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -123,7 +127,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c5"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -151,7 +156,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c6"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -180,7 +186,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c7"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -209,7 +216,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c8"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -237,7 +245,8 @@ TranslationUnit {
           nameC = CName "D",
           nameHsIdent = HsIdentifier "d"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -266,7 +275,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "j1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -297,7 +307,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "j2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -328,7 +339,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "j3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -359,7 +371,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -391,7 +404,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -424,7 +438,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -457,7 +472,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -490,7 +506,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s5"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -523,7 +540,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s6"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -555,7 +573,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s7"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -587,7 +606,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "s8"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -619,7 +639,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "t1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -654,7 +675,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "t2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -689,7 +711,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "t3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -729,7 +752,8 @@ TranslationUnit {
           nameC = CName "U",
           nameHsIdent = HsIdentifier "u"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -773,7 +797,8 @@ TranslationUnit {
           nameC = CName "V",
           nameHsIdent = HsIdentifier "v"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -826,7 +851,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "w1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -872,7 +898,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "w2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_strings.h"},
       declKind =
       DeclMacro
         (MacroExpr

--- a/hs-bindgen/fixtures/macro_typedef_scope.hs
+++ b/hs-bindgen/fixtures/macro_typedef_scope.hs
@@ -23,7 +23,9 @@
             nameHsIdent = HsIdentifier
               "T1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_typedef_scope.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -132,7 +134,9 @@
             nameHsIdent = HsIdentifier
               "T2"},
           declOrigin = NameOriginInSource,
-          declAliases = [CName "T4"]},
+          declAliases = [CName "T4"],
+          declHeader =
+          "macro_typedef_scope.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -244,7 +248,9 @@
             nameHsIdent = HsIdentifier
               "T3"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_typedef_scope.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -357,7 +363,9 @@
             nameHsIdent = HsIdentifier
               "T4"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_typedef_scope.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/macro_typedef_scope.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_typedef_scope.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_typedef_scope.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -37,7 +39,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T2"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "T4"]},
+        declAliases = [CName "T4"],
+        declHeader =
+        "macro_typedef_scope.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -67,7 +71,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_typedef_scope.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -99,7 +105,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_typedef_scope.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/macro_typedef_struct.hs
+++ b/hs-bindgen/fixtures/macro_typedef_struct.hs
@@ -23,7 +23,9 @@
             nameHsIdent = HsIdentifier
               "MY_TYPE"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "macro_typedef_struct.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -198,7 +200,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "macro_typedef_struct.h:3:9"),
-            declAliases = [CName "bar"]},
+            declAliases = [CName "bar"],
+            declHeader =
+            "macro_typedef_struct.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -307,7 +311,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "macro_typedef_struct.h:3:9"),
-              declAliases = [CName "bar"]},
+              declAliases = [CName "bar"],
+              declHeader =
+              "macro_typedef_struct.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -421,7 +427,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "macro_typedef_struct.h:3:9"),
-                      declAliases = [CName "bar"]},
+                      declAliases = [CName "bar"],
+                      declHeader =
+                      "macro_typedef_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -537,7 +545,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "macro_typedef_struct.h:3:9"),
-                      declAliases = [CName "bar"]},
+                      declAliases = [CName "bar"],
+                      declHeader =
+                      "macro_typedef_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/macro_typedef_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_typedef_struct.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "MY_TYPE"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "macro_typedef_struct.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -39,7 +41,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "macro_typedef_struct.h:3:9"),
-        declAliases = [CName "bar"]},
+        declAliases = [CName "bar"],
+        declHeader =
+        "macro_typedef_struct.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/macro_types.hs
+++ b/hs-bindgen/fixtures/macro_types.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "PtrInt"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -91,7 +92,8 @@
             nameHsIdent = HsIdentifier
               "PtrPtrChar"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -162,7 +164,8 @@
             nameHsIdent = HsIdentifier
               "Arr1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -221,7 +224,8 @@
             nameHsIdent = HsIdentifier
               "Arr2"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -284,7 +288,8 @@
             nameHsIdent = HsIdentifier
               "Arr3"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -349,7 +354,8 @@
             nameHsIdent = HsIdentifier
               "Fun1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -403,7 +409,8 @@
             nameHsIdent = HsIdentifier
               "Fun2"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -477,7 +484,8 @@
             nameHsIdent = HsIdentifier
               "Fun3"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -557,7 +565,8 @@
             nameHsIdent = HsIdentifier
               "Fun4"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -626,7 +635,8 @@
             nameHsIdent = HsIdentifier
               "Fun5"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -682,7 +692,8 @@
             nameHsIdent = HsIdentifier
               "MTy"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -785,7 +796,8 @@
             nameHsIdent = HsIdentifier
               "Tty"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -892,7 +904,8 @@
             nameHsIdent = HsIdentifier
               "UINT8_T"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1029,7 +1042,8 @@
             nameHsIdent = HsIdentifier
               "BOOLEAN_T"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1169,7 +1183,8 @@
             nameHsIdent = HsIdentifier
               "Boolean_T"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "macro_types.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/macro_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/macro_types.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "PtrInt"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -38,7 +39,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "PtrPtrChar"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -68,7 +70,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -99,7 +102,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -129,7 +133,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -163,7 +168,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Fun1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -195,7 +201,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Fun2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -232,7 +239,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Fun3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -268,7 +276,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Fun4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -313,7 +322,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Fun5"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -353,7 +363,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "MTy"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -380,7 +391,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Tty"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -410,7 +422,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "UINT8_T"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -438,7 +451,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "BOOLEAN_T"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -469,7 +483,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Boolean_T"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macro_types.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/macros.tree-diff.txt
+++ b/hs-bindgen/fixtures/macros.tree-diff.txt
@@ -9,7 +9,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "oBJECTLIKE1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -36,7 +37,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "oBJECTLIKE2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -63,7 +65,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "oBJECTLIKE3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -99,7 +102,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "oBJECTLIKE4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -136,7 +140,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mEANING_OF_LIFE1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -164,7 +169,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mEANING_OF_LIFE2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -192,7 +198,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mEANING_OF_LIFE3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -220,7 +227,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mEANING_OF_LIFE4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -248,7 +256,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mEANING_OF_LIFE5"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -275,7 +284,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "lONG_INT_TOKEN1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -305,7 +315,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "lONG_INT_TOKEN2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -335,7 +346,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "lONG_INT_TOKEN3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -365,7 +377,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "lONG_INT_TOKEN4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -395,7 +408,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "tUPLE1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -432,7 +446,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "tUPLE2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -469,7 +484,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "tUPLE3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -506,7 +522,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT1_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -537,7 +554,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT1_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -568,7 +586,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT1_3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -598,7 +617,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT2_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -629,7 +649,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT2_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -660,7 +681,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT2_3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -690,7 +712,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT3_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -721,7 +744,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT3_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -752,7 +776,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT3_3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -783,7 +808,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT3_4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -813,7 +839,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT4_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -844,7 +871,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT4_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -875,7 +903,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT4_3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -906,7 +935,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT5_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -937,7 +967,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT5_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -968,7 +999,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT6_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1000,7 +1032,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT6_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1031,7 +1064,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fLT6_3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1062,7 +1096,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bAD1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -1101,7 +1136,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bAD2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "macros.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {

--- a/hs-bindgen/fixtures/manual_examples.hs
+++ b/hs-bindgen/fixtures/manual_examples.hs
@@ -72,7 +72,9 @@
               nameHsIdent = HsIdentifier
                 "Triple"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "triple"]},
+            declAliases = [CName "triple"],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -196,7 +198,9 @@
                 nameHsIdent = HsIdentifier
                   "Triple"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "triple"]},
+              declAliases = [CName "triple"],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -325,7 +329,9 @@
                         nameHsIdent = HsIdentifier
                           "Triple"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "triple"]},
+                      declAliases = [CName "triple"],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -457,7 +463,9 @@
                         nameHsIdent = HsIdentifier
                           "Triple"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "triple"]},
+                      declAliases = [CName "triple"],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -575,9 +583,7 @@
                       nameHsIdent = HsIdentifier
                         "Triple"}
                     NameOriginInSource)))],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"}},
+          functionRes = TypeVoid}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -602,7 +608,9 @@
             nameHsIdent = HsIdentifier
               "Index"},
           declOrigin = NameOriginInSource,
-          declAliases = [CName "index"]},
+          declAliases = [CName "index"],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -953,9 +961,7 @@
                       "Index"}
                   NameOriginInSource))],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "manual_examples.h"}},
+            (PrimIntegral PrimInt Signed)}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -980,7 +986,9 @@
             nameHsIdent = HsIdentifier
               "Sum"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -1089,7 +1097,9 @@
             nameHsIdent = HsIdentifier
               "Average"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -1236,9 +1246,7 @@
               NamePair {
                 nameC = CName "sum",
                 nameHsIdent = HsIdentifier
-                  "Sum"}),
-          functionHeader =
-          "manual_examples.h"}},
+                  "Sum"})}},
   DeclInlineCInclude
     "manual_examples.h",
   DeclInlineC
@@ -1282,9 +1290,7 @@
               NamePair {
                 nameC = CName "average",
                 nameHsIdent = HsIdentifier
-                  "Average"}),
-          functionHeader =
-          "manual_examples.h"}},
+                  "Average"})}},
   DeclVar
     VarDecl {
       varDeclName = HsName
@@ -1415,7 +1421,9 @@
             nameHsIdent = HsIdentifier
               "YEAR"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1524,7 +1532,9 @@
             nameHsIdent = HsIdentifier
               "MONTH"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1659,7 +1669,9 @@
             nameHsIdent = HsIdentifier
               "DAY"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1834,7 +1846,9 @@
               nameHsIdent = HsIdentifier
                 "Date"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "date"]},
+            declAliases = [CName "date"],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1990,7 +2004,9 @@
                 nameHsIdent = HsIdentifier
                   "Date"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "date"]},
+              declAliases = [CName "date"],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2151,7 +2167,9 @@
                         nameHsIdent = HsIdentifier
                           "Date"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "date"]},
+                      declAliases = [CName "date"],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2315,7 +2333,9 @@
                         nameHsIdent = HsIdentifier
                           "Date"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "date"]},
+                      declAliases = [CName "date"],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2440,9 +2460,7 @@
               nameC = CName "YEAR",
               nameHsIdent = HsIdentifier
                 "YEAR"}
-            NameOriginInSource,
-          functionHeader =
-          "manual_examples.h"}},
+            NameOriginInSource}},
   DeclData
     Struct {
       structName = HsName
@@ -2501,7 +2519,9 @@
               nameHsIdent = HsIdentifier
                 "Student"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2602,7 +2622,9 @@
                 nameHsIdent = HsIdentifier
                   "Student"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2708,7 +2730,9 @@
                         nameHsIdent = HsIdentifier
                           "Student"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2816,7 +2840,9 @@
                         nameHsIdent = HsIdentifier
                           "Student"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2892,7 +2918,9 @@
             nameHsIdent = HsIdentifier
               "Person"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = OpaqueStruct,
         declSpec = DeclSpec
           TypeSpec {
@@ -2984,7 +3012,9 @@
               nameHsIdent = HsIdentifier
                 "Employee"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -3127,7 +3157,9 @@
                 nameHsIdent = HsIdentifier
                   "Employee"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -3275,7 +3307,9 @@
                         nameHsIdent = HsIdentifier
                           "Employee"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3426,7 +3460,9 @@
                         nameHsIdent = HsIdentifier
                           "Employee"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3529,7 +3565,9 @@
               "Occupation"},
           declOrigin = NameOriginInSource,
           declAliases = [
-            CName "occupation"]},
+            CName "occupation"],
+          declHeader =
+          "manual_examples.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -3665,9 +3703,7 @@
                       nameHsIdent = HsIdentifier
                         "Occupation"}
                     NameOriginInSource)))],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"}},
+          functionRes = TypeVoid}},
   DeclData
     Struct {
       structName = HsName
@@ -3725,7 +3761,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "manual_examples.h:89:3"),
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -3824,7 +3862,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "manual_examples.h:89:3"),
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -3928,7 +3968,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:89:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -4034,7 +4076,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:89:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -4153,7 +4197,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "manual_examples.h:94:3"),
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -4253,7 +4299,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "manual_examples.h:94:3"),
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -4358,7 +4406,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:94:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -4465,7 +4515,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:94:3"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -4598,7 +4650,9 @@
               nameHsIdent = HsIdentifier
                 "Rect"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -4723,7 +4777,9 @@
                 nameHsIdent = HsIdentifier
                   "Rect"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -4853,7 +4909,9 @@
                         nameHsIdent = HsIdentifier
                           "Rect"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -4985,7 +5043,9 @@
                         nameHsIdent = HsIdentifier
                           "Rect"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -5110,7 +5170,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "manual_examples.h:100:9"),
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "manual_examples.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -5209,7 +5271,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "manual_examples.h:100:9"),
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "manual_examples.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -5313,7 +5377,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:100:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -5419,7 +5485,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "manual_examples.h:100:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "manual_examples.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -5507,7 +5575,9 @@
             nameHsIdent = HsIdentifier
               "Config"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -5582,7 +5652,9 @@
             nameHsIdent = HsIdentifier
               "Adio'0301s"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -5712,9 +5784,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"}},
+          functionRes = TypeVoid}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -5739,7 +5809,9 @@
             nameHsIdent = HsIdentifier
               "C\25968\23383"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -5869,9 +5941,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"}},
+          functionRes = TypeVoid}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -5896,7 +5966,9 @@
             nameHsIdent = HsIdentifier
               "Data"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -6000,9 +6072,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"}},
+          functionRes = TypeVoid}},
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -6027,7 +6097,9 @@
             nameHsIdent = HsIdentifier
               "Signal"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -6389,7 +6461,9 @@
             nameHsIdent = HsIdentifier
               "HTTP_status"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -6765,7 +6839,9 @@
             nameHsIdent = HsIdentifier
               "Descending"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -7122,7 +7198,9 @@
             nameHsIdent = HsIdentifier
               "Result"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -7492,7 +7570,9 @@
             nameHsIdent = HsIdentifier
               "Vote"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -7825,7 +7905,9 @@
             nameHsIdent = HsIdentifier
               "CXCursorKind"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "manual_examples.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -8456,6 +8538,4 @@
             TypePrim
               (PrimIntegral PrimInt Signed)],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "manual_examples.h"}}]
+            (PrimIntegral PrimInt Signed)}}]

--- a/hs-bindgen/fixtures/manual_examples.tree-diff.txt
+++ b/hs-bindgen/fixtures/manual_examples.tree-diff.txt
@@ -10,7 +10,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Triple"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "triple"]},
+        declAliases = [CName "triple"],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -67,7 +69,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mk_triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -87,9 +91,7 @@ TranslationUnit {
                       nameHsIdent = HsIdentifier
                         "Triple"}
                     NameOriginInSource)))],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -105,7 +107,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Index"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "index"]},
+        declAliases = [CName "index"],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -156,7 +160,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "index_triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -180,9 +186,7 @@ TranslationUnit {
                       "Index"}
                   NameOriginInSource))],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "manual_examples.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -198,7 +202,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Sum"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -225,7 +231,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Average"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -252,7 +260,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "sum_triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -271,9 +281,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "sum",
                 nameHsIdent = HsIdentifier
-                  "Sum"}),
-          functionHeader =
-          "manual_examples.h"},
+                  "Sum"})},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -289,7 +297,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "average_triple"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -308,9 +318,7 @@ TranslationUnit {
               NamePair {
                 nameC = CName "average",
                 nameHsIdent = HsIdentifier
-                  "Average"}),
-          functionHeader =
-          "manual_examples.h"},
+                  "Average"})},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -326,7 +334,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fIELD_OFFSET"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -354,7 +364,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ePSILON"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -385,7 +397,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "pTR_TO_FIELD"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -419,7 +433,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "YEAR"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -447,7 +463,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "MONTH"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -475,7 +493,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "DAY"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -503,7 +523,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Date"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "date"]},
+        declAliases = [CName "date"],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -575,7 +597,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "getYear"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -594,9 +618,7 @@ TranslationUnit {
               nameC = CName "YEAR",
               nameHsIdent = HsIdentifier
                 "YEAR"}
-            NameOriginInSource,
-          functionHeader =
-          "manual_examples.h"},
+            NameOriginInSource},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -612,7 +634,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Student"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -661,7 +685,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Person"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStructOpaque,
       declSpec = DeclSpec
         TypeSpec {
@@ -678,7 +704,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Employee"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -744,7 +772,9 @@ TranslationUnit {
             "Occupation"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "occupation"]},
+          CName "occupation"],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -799,7 +829,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "print_occupation"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -815,9 +847,7 @@ TranslationUnit {
                       nameHsIdent = HsIdentifier
                         "Occupation"}
                     NameOriginInSource)))],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -835,7 +865,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "manual_examples.h:89:3"),
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -886,7 +918,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "manual_examples.h:94:3"),
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -934,7 +968,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Rect"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -995,7 +1031,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "manual_examples.h:100:9"),
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -1043,7 +1081,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Config"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -1077,7 +1117,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Adio'0301s"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -1104,13 +1146,13 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "\25308\25308"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -1126,7 +1168,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "C\25968\23383"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -1153,13 +1197,13 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "c\978"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -1175,7 +1219,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Data"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -1202,13 +1248,13 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "import'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "manual_examples.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -1224,7 +1270,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Signal"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1286,7 +1334,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "HTTP_status"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1356,7 +1406,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Descending"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1415,7 +1467,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Result"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1477,7 +1531,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Vote"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1532,7 +1588,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "CXCursorKind"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -1670,16 +1728,16 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mod_10"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "manual_examples.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
             TypePrim
               (PrimIntegral PrimInt Signed)],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "manual_examples.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/names.hs
+++ b/hs-bindgen/fixtures/names.hs
@@ -16,8 +16,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_forall (void) { forall(); }",
@@ -35,8 +34,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_mdo (void) { mdo(); }",
@@ -54,8 +52,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_pattern (void) { pattern(); }",
@@ -73,8 +70,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_proc (void) { proc(); }",
@@ -92,8 +88,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_rec (void) { rec(); }",
@@ -111,8 +106,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_using (void) { using(); }",
@@ -130,8 +124,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_anyclass (void) { anyclass(); }",
@@ -149,8 +142,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_capi (void) { capi(); }",
@@ -168,8 +160,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_cases (void) { cases(); }",
@@ -187,8 +178,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_ccall (void) { ccall(); }",
@@ -206,8 +196,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_dynamic (void) { dynamic(); }",
@@ -225,8 +214,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_export (void) { export(); }",
@@ -244,8 +232,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_family (void) { family(); }",
@@ -263,8 +250,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_group (void) { group(); }",
@@ -282,8 +268,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_interruptible (void) { interruptible(); }",
@@ -301,8 +286,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_javascript (void) { javascript(); }",
@@ -320,8 +304,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_label (void) { label(); }",
@@ -339,8 +322,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_prim (void) { prim(); }",
@@ -358,8 +340,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_role (void) { role(); }",
@@ -377,8 +358,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_safe (void) { safe(); }",
@@ -396,8 +376,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_stdcall (void) { stdcall(); }",
@@ -415,8 +394,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_stock (void) { stock(); }",
@@ -434,8 +412,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_unsafe (void) { unsafe(); }",
@@ -453,8 +430,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude "names.h",
   DeclInlineC
     "void testmodule_via (void) { via(); }",
@@ -472,5 +448,4 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"}}]
+          functionRes = TypeVoid}}]

--- a/hs-bindgen/fixtures/names.tree-diff.txt
+++ b/hs-bindgen/fixtures/names.tree-diff.txt
@@ -8,12 +8,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "by'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -28,12 +28,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "forall'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -48,12 +48,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "mdo'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -68,12 +68,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "pattern'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -88,12 +88,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "proc'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -108,12 +108,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "rec'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -128,12 +128,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "using'"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -148,12 +148,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "anyclass"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -168,12 +168,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "capi"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -188,12 +188,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "cases"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -208,12 +208,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ccall"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -228,12 +228,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "dynamic"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -248,12 +248,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "export"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -268,12 +268,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "family"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -288,12 +288,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "group"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -308,12 +308,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "interruptible"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -328,12 +328,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "javascript"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -348,12 +348,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "label"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -368,12 +368,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "prim"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -388,12 +388,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "role"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -408,12 +408,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "safe"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -428,12 +428,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "stdcall"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -448,12 +448,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "stock"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -468,12 +468,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "unsafe"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -488,12 +488,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "via"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "names.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "names.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/nested_enums.hs
+++ b/hs-bindgen/fixtures/nested_enums.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "EnumA"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "nested_enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -342,7 +343,8 @@
               nameHsIdent = HsIdentifier
                 "ExA"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_enums.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -417,7 +419,8 @@
                 nameHsIdent = HsIdentifier
                   "ExA"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_enums.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -497,7 +500,8 @@
                         nameHsIdent = HsIdentifier
                           "ExA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_enums.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -577,7 +581,8 @@
                         nameHsIdent = HsIdentifier
                           "ExA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_enums.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -648,7 +653,8 @@
               "ExB_fieldB1"},
           declOrigin = NameOriginGenerated
             (AnonId "nested_enums.h:9:9"),
-          declAliases = []},
+          declAliases = [],
+          declHeader = "nested_enums.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -969,7 +975,8 @@
               nameHsIdent = HsIdentifier
                 "ExB"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_enums.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1046,7 +1053,8 @@
                 nameHsIdent = HsIdentifier
                   "ExB"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_enums.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1128,7 +1136,8 @@
                         nameHsIdent = HsIdentifier
                           "ExB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_enums.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1210,7 +1219,8 @@
                         nameHsIdent = HsIdentifier
                           "ExB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_enums.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/nested_enums.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_enums.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "EnumA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -53,7 +54,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ExA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_enums.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -92,7 +94,8 @@ TranslationUnit {
             "ExB_fieldB1"},
         declOrigin = NameOriginGenerated
           (AnonId "nested_enums.h:9:9"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_enums.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -137,7 +140,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ExB"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_enums.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/nested_types.hs
+++ b/hs-bindgen/fixtures/nested_types.hs
@@ -55,7 +55,8 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -153,7 +154,8 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -256,7 +258,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -361,7 +364,8 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -480,7 +484,8 @@
               nameHsIdent = HsIdentifier
                 "Bar"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -590,7 +595,8 @@
                 nameHsIdent = HsIdentifier
                   "Bar"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -705,7 +711,8 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -822,7 +829,8 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -942,7 +950,8 @@
                 "Ex3_ex3_struct"},
             declOrigin = NameOriginGenerated
               (AnonId "nested_types.h:12:5"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1043,7 +1052,8 @@
                   "Ex3_ex3_struct"},
               declOrigin = NameOriginGenerated
                 (AnonId "nested_types.h:12:5"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1149,7 +1159,8 @@
                           "Ex3_ex3_struct"},
                       declOrigin = NameOriginGenerated
                         (AnonId "nested_types.h:12:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1257,7 +1268,8 @@
                           "Ex3_ex3_struct"},
                       declOrigin = NameOriginGenerated
                         (AnonId "nested_types.h:12:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1381,7 +1393,8 @@
               nameHsIdent = HsIdentifier
                 "Ex3"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1487,7 +1500,8 @@
                 nameHsIdent = HsIdentifier
                   "Ex3"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1598,7 +1612,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1711,7 +1726,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1834,7 +1850,8 @@
               nameHsIdent = HsIdentifier
                 "Ex4_even"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1942,7 +1959,8 @@
                 nameHsIdent = HsIdentifier
                   "Ex4_even"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2055,7 +2073,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex4_even"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2170,7 +2189,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex4_even"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2296,7 +2316,8 @@
               nameHsIdent = HsIdentifier
                 "Ex4_odd"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2403,7 +2424,8 @@
                 nameHsIdent = HsIdentifier
                   "Ex4_odd"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2515,7 +2537,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex4_odd"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2629,7 +2652,8 @@
                         nameHsIdent = HsIdentifier
                           "Ex4_odd"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/nested_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_types.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -55,7 +56,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bar"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -109,7 +111,8 @@ TranslationUnit {
             "Ex3_ex3_struct"},
         declOrigin = NameOriginGenerated
           (AnonId "nested_types.h:12:5"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -158,7 +161,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Ex3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -209,7 +213,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Ex4_even"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -259,7 +264,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Ex4_odd"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/nested_unions.hs
+++ b/hs-bindgen/fixtures/nested_unions.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "UnionA"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "nested_unions.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -144,7 +145,8 @@
               nameHsIdent = HsIdentifier
                 "ExA"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -219,7 +221,8 @@
                 nameHsIdent = HsIdentifier
                   "ExA"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -299,7 +302,8 @@
                         nameHsIdent = HsIdentifier
                           "ExA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -379,7 +383,8 @@
                         nameHsIdent = HsIdentifier
                           "ExA"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -441,7 +446,8 @@
               "ExB_fieldB1"},
           declOrigin = NameOriginGenerated
             (AnonId "nested_unions.h:9:9"),
-          declAliases = []},
+          declAliases = [],
+          declHeader = "nested_unions.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -564,7 +570,8 @@
               nameHsIdent = HsIdentifier
                 "ExB"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "nested_unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -641,7 +648,8 @@
                 nameHsIdent = HsIdentifier
                   "ExB"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "nested_unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -723,7 +731,8 @@
                         nameHsIdent = HsIdentifier
                           "ExB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -805,7 +814,8 @@
                         nameHsIdent = HsIdentifier
                           "ExB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "nested_unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/nested_unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/nested_unions.tree-diff.txt
@@ -9,7 +9,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "UnionA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_unions.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -56,7 +57,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ExA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -95,7 +97,8 @@ TranslationUnit {
             "ExB_fieldB1"},
         declOrigin = NameOriginGenerated
           (AnonId "nested_unions.h:9:9"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_unions.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -142,7 +145,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ExB"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "nested_unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/opaque_declaration.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.hs
@@ -13,7 +13,9 @@
             nameHsIdent = HsIdentifier
               "Foo"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "opaque_declaration.h"},
         declKind = OpaqueStruct,
         declSpec = DeclSpec
           TypeSpec {
@@ -88,7 +90,9 @@
               nameHsIdent = HsIdentifier
                 "Bar"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "opaque_declaration.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -205,7 +209,9 @@
                 nameHsIdent = HsIdentifier
                   "Bar"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "opaque_declaration.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -327,7 +333,9 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "opaque_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -451,7 +459,9 @@
                         nameHsIdent = HsIdentifier
                           "Bar"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "opaque_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -535,7 +545,9 @@
               nameHsIdent = HsIdentifier
                 "Baz"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "opaque_declaration.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -572,7 +584,9 @@
                 nameHsIdent = HsIdentifier
                   "Baz"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "opaque_declaration.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -614,7 +628,9 @@
                         nameHsIdent = HsIdentifier
                           "Baz"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "opaque_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -656,7 +672,9 @@
                         nameHsIdent = HsIdentifier
                           "Baz"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "opaque_declaration.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -697,7 +715,9 @@
             nameHsIdent = HsIdentifier
               "Quu"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "opaque_declaration.h"},
         declKind = OpaqueEnum,
         declSpec = DeclSpec
           TypeSpec {
@@ -719,7 +739,9 @@
             nameHsIdent = HsIdentifier
               "Opaque_union"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "opaque_declaration.h"},
         declKind = OpaqueUnion,
         declSpec = DeclSpec
           TypeSpec {

--- a/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
+++ b/hs-bindgen/fixtures/opaque_declaration.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "opaque_declaration.h"},
       declKind = DeclStructOpaque,
       declSpec = DeclSpec
         TypeSpec {
@@ -26,7 +28,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Bar"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "opaque_declaration.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -82,7 +86,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Baz"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "opaque_declaration.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -106,7 +112,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Quu"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "opaque_declaration.h"},
       declKind = DeclEnumOpaque,
       declSpec = DeclSpec
         TypeSpec {
@@ -123,7 +131,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Opaque_union"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "opaque_declaration.h"},
       declKind = DeclUnionOpaque,
       declSpec = DeclSpec
         TypeSpec {

--- a/hs-bindgen/fixtures/primitive_types.hs
+++ b/hs-bindgen/fixtures/primitive_types.hs
@@ -546,7 +546,9 @@
               nameHsIdent = HsIdentifier
                 "Primitive"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "primitive_types.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1445,7 +1447,9 @@
                 nameHsIdent = HsIdentifier
                   "Primitive"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "primitive_types.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2349,7 +2353,9 @@
                         nameHsIdent = HsIdentifier
                           "Primitive"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "primitive_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3281,7 +3287,9 @@
                         nameHsIdent = HsIdentifier
                           "Primitive"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "primitive_types.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/primitive_types.tree-diff.txt
+++ b/hs-bindgen/fixtures/primitive_types.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Primitive"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "primitive_types.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/program_slicing.hs
+++ b/hs-bindgen/fixtures/program_slicing.hs
@@ -25,7 +25,9 @@
           declAliases = [
             CName "uint_fast16_t",
             CName "uint_fast32_t",
-            CName "uint_least32_t"]},
+            CName "uint_least32_t"],
+          declHeader =
+          "program_slicing.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -420,7 +422,9 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "program_slicing.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -858,7 +862,9 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "program_slicing.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1301,7 +1307,9 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "program_slicing.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1746,7 +1754,9 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "program_slicing.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/program_slicing.tree-diff.txt
+++ b/hs-bindgen/fixtures/program_slicing.tree-diff.txt
@@ -11,7 +11,9 @@ TranslationUnit {
         declAliases = [
           CName "uint_fast16_t",
           CName "uint_fast32_t",
-          CName "uint_least32_t"]},
+          CName "uint_least32_t"],
+        declHeader =
+        "program_slicing.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -40,7 +42,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "program_slicing.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/recursive_struct.hs
+++ b/hs-bindgen/fixtures/recursive_struct.hs
@@ -63,7 +63,9 @@
                 "Linked_list_A_s"},
             declOrigin = NameOriginInSource,
             declAliases = [
-              CName "linked_list_A_t"]},
+              CName "linked_list_A_t"],
+            declHeader =
+            "recursive_struct.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -174,7 +176,9 @@
                   "Linked_list_A_s"},
               declOrigin = NameOriginInSource,
               declAliases = [
-                CName "linked_list_A_t"]},
+                CName "linked_list_A_t"],
+              declHeader =
+              "recursive_struct.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -290,7 +294,9 @@
                           "Linked_list_A_s"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "linked_list_A_t"]},
+                        CName "linked_list_A_t"],
+                      declHeader =
+                      "recursive_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -408,7 +414,9 @@
                           "Linked_list_A_s"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "linked_list_A_t"]},
+                        CName "linked_list_A_t"],
+                      declHeader =
+                      "recursive_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -500,7 +508,9 @@
             nameHsIdent = HsIdentifier
               "Linked_list_A_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "recursive_struct.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -609,7 +619,9 @@
                 "Linked_list_B_t"},
             declOrigin = NameOriginInSource,
             declAliases = [
-              CName "linked_list_B_t"]},
+              CName "linked_list_B_t"],
+            declHeader =
+            "recursive_struct.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -726,7 +738,9 @@
                   "Linked_list_B_t"},
               declOrigin = NameOriginInSource,
               declAliases = [
-                CName "linked_list_B_t"]},
+                CName "linked_list_B_t"],
+              declHeader =
+              "recursive_struct.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -848,7 +862,9 @@
                           "Linked_list_B_t"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "linked_list_B_t"]},
+                        CName "linked_list_B_t"],
+                      declHeader =
+                      "recursive_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -972,7 +988,9 @@
                           "Linked_list_B_t"},
                       declOrigin = NameOriginInSource,
                       declAliases = [
-                        CName "linked_list_B_t"]},
+                        CName "linked_list_B_t"],
+                      declHeader =
+                      "recursive_struct.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
+++ b/hs-bindgen/fixtures/recursive_struct.tree-diff.txt
@@ -10,7 +10,9 @@ TranslationUnit {
             "Linked_list_A_s"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "linked_list_A_t"]},
+          CName "linked_list_A_t"],
+        declHeader =
+        "recursive_struct.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -63,7 +65,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Linked_list_A_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "recursive_struct.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -95,7 +99,9 @@ TranslationUnit {
             "Linked_list_B_t"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "linked_list_B_t"]},
+          CName "linked_list_B_t"],
+        declHeader =
+        "recursive_struct.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/redeclaration_identical.tree-diff.txt
+++ b/hs-bindgen/fixtures/redeclaration_identical.tree-diff.txt
@@ -8,7 +8,9 @@ TranslationUnit {
           nameC = CName "A",
           nameHsIdent = HsIdentifier "a"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "redeclaration_identical.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {

--- a/hs-bindgen/fixtures/simple_func.hs
+++ b/hs-bindgen/fixtures/simple_func.hs
@@ -23,9 +23,7 @@
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimFloating PrimDouble),
-          functionHeader =
-          "simple_func.h"}},
+            (PrimFloating PrimDouble)}},
   DeclInlineCInclude
     "simple_func.h",
   DeclInlineC
@@ -58,9 +56,7 @@
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimFloating PrimDouble),
-          functionHeader =
-          "simple_func.h"}},
+            (PrimFloating PrimDouble)}},
   DeclInlineCInclude
     "simple_func.h",
   DeclInlineC
@@ -80,9 +76,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "simple_func.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "simple_func.h",
   DeclInlineC
@@ -102,9 +96,7 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "simple_func.h"}},
+          functionRes = TypeVoid}},
   DeclInlineCInclude
     "simple_func.h",
   DeclInlineC
@@ -134,6 +126,4 @@
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "simple_func.h"}}]
+            (PrimIntegral PrimInt Signed)}}]

--- a/hs-bindgen/fixtures/simple_func.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_func.tree-diff.txt
@@ -8,16 +8,15 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "erf"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "simple_func.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimFloating PrimDouble),
-          functionHeader =
-          "simple_func.h"},
+            (PrimFloating PrimDouble)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -32,7 +31,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "bad_fma"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "simple_func.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -43,9 +43,7 @@ TranslationUnit {
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimFloating PrimDouble),
-          functionHeader =
-          "simple_func.h"},
+            (PrimFloating PrimDouble)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -60,13 +58,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "no_args"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "simple_func.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "simple_func.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -81,13 +78,12 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "no_args_no_void"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "simple_func.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader =
-          "simple_func.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -102,7 +98,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fun"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "simple_func.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -113,9 +110,7 @@ TranslationUnit {
             TypePrim
               (PrimFloating PrimDouble)],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "simple_func.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/simple_structs.hs
+++ b/hs-bindgen/fixtures/simple_structs.hs
@@ -56,7 +56,9 @@
               nameHsIdent = HsIdentifier
                 "S1"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -155,7 +157,9 @@
                 nameHsIdent = HsIdentifier
                   "S1"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -259,7 +263,9 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -365,7 +371,9 @@
                         nameHsIdent = HsIdentifier
                           "S1"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -497,7 +505,9 @@
               nameHsIdent = HsIdentifier
                 "S2"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "S2_t"]},
+            declAliases = [CName "S2_t"],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -625,7 +635,9 @@
                 nameHsIdent = HsIdentifier
                   "S2"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "S2_t"]},
+              declAliases = [CName "S2_t"],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -758,7 +770,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S2_t"]},
+                      declAliases = [CName "S2_t"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -894,7 +908,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S2_t"]},
+                      declAliases = [CName "S2_t"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -987,7 +1003,9 @@
             nameHsIdent = HsIdentifier
               "S2_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "simple_structs.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -1063,7 +1081,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "simple_structs.h:15:9"),
-            declAliases = [CName "S3_t"]},
+            declAliases = [CName "S3_t"],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1135,7 +1155,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "simple_structs.h:15:9"),
-              declAliases = [CName "S3_t"]},
+              declAliases = [CName "S3_t"],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1212,7 +1234,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:15:9"),
-                      declAliases = [CName "S3_t"]},
+                      declAliases = [CName "S3_t"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1289,7 +1313,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:15:9"),
-                      declAliases = [CName "S3_t"]},
+                      declAliases = [CName "S3_t"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1410,7 +1436,9 @@
               nameHsIdent = HsIdentifier
                 "S4"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1540,7 +1568,9 @@
                 nameHsIdent = HsIdentifier
                   "S4"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1675,7 +1705,9 @@
                         nameHsIdent = HsIdentifier
                           "S4"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1813,7 +1845,9 @@
                         nameHsIdent = HsIdentifier
                           "S4"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1940,7 +1974,9 @@
               nameHsIdent = HsIdentifier
                 "S5"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "S5"]},
+            declAliases = [CName "S5"],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2039,7 +2075,9 @@
                 nameHsIdent = HsIdentifier
                   "S5"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "S5"]},
+              declAliases = [CName "S5"],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2143,7 +2181,9 @@
                         nameHsIdent = HsIdentifier
                           "S5"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S5"]},
+                      declAliases = [CName "S5"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2249,7 +2289,9 @@
                         nameHsIdent = HsIdentifier
                           "S5"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S5"]},
+                      declAliases = [CName "S5"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2363,7 +2405,9 @@
               nameHsIdent = HsIdentifier
                 "S6"},
             declOrigin = NameOriginInSource,
-            declAliases = [CName "S6"]},
+            declAliases = [CName "S6"],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2462,7 +2506,9 @@
                 nameHsIdent = HsIdentifier
                   "S6"},
               declOrigin = NameOriginInSource,
-              declAliases = [CName "S6"]},
+              declAliases = [CName "S6"],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2566,7 +2612,9 @@
                         nameHsIdent = HsIdentifier
                           "S6"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S6"]},
+                      declAliases = [CName "S6"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2672,7 +2720,9 @@
                         nameHsIdent = HsIdentifier
                           "S6"},
                       declOrigin = NameOriginInSource,
-                      declAliases = [CName "S6"]},
+                      declAliases = [CName "S6"],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2788,7 +2838,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "simple_structs.h:34:9"),
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2891,7 +2943,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "simple_structs.h:34:9"),
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2999,7 +3053,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:34:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3109,7 +3165,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:34:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3199,7 +3257,9 @@
             nameHsIdent = HsIdentifier
               "S7a"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "simple_structs.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -3301,7 +3361,9 @@
             declOrigin = NameOriginGenerated
               (AnonId
                 "simple_structs.h:35:9"),
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "simple_structs.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -3404,7 +3466,9 @@
               declOrigin = NameOriginGenerated
                 (AnonId
                   "simple_structs.h:35:9"),
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "simple_structs.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -3512,7 +3576,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:35:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3622,7 +3688,9 @@
                       declOrigin = NameOriginGenerated
                         (AnonId
                           "simple_structs.h:35:9"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "simple_structs.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -3714,7 +3782,9 @@
             nameHsIdent = HsIdentifier
               "S7b"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "simple_structs.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/simple_structs.tree-diff.txt
+++ b/hs-bindgen/fixtures/simple_structs.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -57,7 +59,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S2"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "S2_t"]},
+        declAliases = [CName "S2_t"],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -116,7 +120,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S2_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -148,7 +154,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "simple_structs.h:15:9"),
-        declAliases = [CName "S3_t"]},
+        declAliases = [CName "S3_t"],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -185,7 +193,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -245,7 +255,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S5"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "S5"]},
+        declAliases = [CName "S5"],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -293,7 +305,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S6"},
         declOrigin = NameOriginInSource,
-        declAliases = [CName "S6"]},
+        declAliases = [CName "S6"],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -343,7 +357,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "simple_structs.h:34:9"),
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -393,7 +409,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S7a"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -429,7 +447,9 @@ TranslationUnit {
         declOrigin = NameOriginGenerated
           (AnonId
             "simple_structs.h:35:9"),
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -479,7 +499,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S7b"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "simple_structs.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/skip_over_long_double.hs
+++ b/hs-bindgen/fixtures/skip_over_long_double.hs
@@ -21,9 +21,7 @@
           functionArgs = [
             TypePrim
               (PrimIntegral PrimInt Signed)],
-          functionRes = TypeVoid,
-          functionHeader =
-          "skip_over_long_double.h"}},
+          functionRes = TypeVoid}},
   DeclData
     Struct {
       structName = HsName
@@ -61,7 +59,9 @@
               nameHsIdent = HsIdentifier
                 "Struct2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "skip_over_long_double.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -127,7 +127,9 @@
                 nameHsIdent = HsIdentifier
                   "Struct2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "skip_over_long_double.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -198,7 +200,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "skip_over_long_double.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -269,7 +273,9 @@
                         nameHsIdent = HsIdentifier
                           "Struct2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "skip_over_long_double.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/skip_over_long_double.tree-diff.txt
+++ b/hs-bindgen/fixtures/skip_over_long_double.tree-diff.txt
@@ -9,15 +9,15 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "fun2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "skip_over_long_double.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
             TypePrim
               (PrimIntegral PrimInt Signed)],
-          functionRes = TypeVoid,
-          functionHeader =
-          "skip_over_long_double.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -33,7 +33,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Struct2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "skip_over_long_double.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/struct_arg.hs
+++ b/hs-bindgen/fixtures/struct_arg.hs
@@ -35,7 +35,8 @@
               nameHsIdent = HsIdentifier
                 "Thing"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "struct_arg.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -100,7 +101,8 @@
                 nameHsIdent = HsIdentifier
                   "Thing"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "struct_arg.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -170,7 +172,8 @@
                         nameHsIdent = HsIdentifier
                           "Thing"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "struct_arg.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -240,7 +243,8 @@
                         nameHsIdent = HsIdentifier
                           "Thing"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "struct_arg.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -318,9 +322,7 @@
                   "Thing"}
               NameOriginInSource],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "struct_arg.h"}},
+            (PrimIntegral PrimInt Signed)}},
   DeclSimple,
   DeclInlineCInclude
     "struct_arg.h",
@@ -355,9 +357,7 @@
               nameC = CName "thing",
               nameHsIdent = HsIdentifier
                 "Thing"}
-            NameOriginInSource,
-          functionHeader =
-          "struct_arg.h"}},
+            NameOriginInSource}},
   DeclSimple,
   DeclInlineCInclude
     "struct_arg.h",
@@ -409,9 +409,7 @@
               nameC = CName "thing",
               nameHsIdent = HsIdentifier
                 "Thing"}
-            NameOriginInSource,
-          functionHeader =
-          "struct_arg.h"}},
+            NameOriginInSource}},
   DeclSimple,
   DeclInlineCInclude
     "struct_arg.h",
@@ -455,7 +453,5 @@
           functionRes = TypePrim
             (PrimChar
               (PrimSignImplicit
-                (Just Signed))),
-          functionHeader =
-          "struct_arg.h"}},
+                (Just Signed)))}},
   DeclSimple]

--- a/hs-bindgen/fixtures/struct_arg.tree-diff.txt
+++ b/hs-bindgen/fixtures/struct_arg.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Thing"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "struct_arg.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -42,7 +43,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "thing_fun_1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "struct_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -53,9 +55,7 @@ TranslationUnit {
                   "Thing"}
               NameOriginInSource],
           functionRes = TypePrim
-            (PrimIntegral PrimInt Signed),
-          functionHeader =
-          "struct_arg.h"},
+            (PrimIntegral PrimInt Signed)},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -70,7 +70,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "thing_fun_2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "struct_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -81,9 +82,7 @@ TranslationUnit {
               nameC = CName "thing",
               nameHsIdent = HsIdentifier
                 "Thing"}
-            NameOriginInSource,
-          functionHeader =
-          "struct_arg.h"},
+            NameOriginInSource},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -98,7 +97,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "thing_fun_3a"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "struct_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -117,9 +117,7 @@ TranslationUnit {
               nameC = CName "thing",
               nameHsIdent = HsIdentifier
                 "Thing"}
-            NameOriginInSource,
-          functionHeader =
-          "struct_arg.h"},
+            NameOriginInSource},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,
@@ -134,7 +132,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "thing_fun_3b"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "struct_arg.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -151,9 +150,7 @@ TranslationUnit {
           functionRes = TypePrim
             (PrimChar
               (PrimSignImplicit
-                (Just Signed))),
-          functionHeader =
-          "struct_arg.h"},
+                (Just Signed)))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/type_attributes.hs
+++ b/hs-bindgen/fixtures/type_attributes.hs
@@ -40,7 +40,9 @@
               nameC = CName "S",
               nameHsIdent = HsIdentifier "S"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "type_attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -114,7 +116,9 @@
                 nameC = CName "S",
                 nameHsIdent = HsIdentifier "S"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "type_attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -193,7 +197,9 @@
                         nameC = CName "S",
                         nameHsIdent = HsIdentifier "S"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -272,7 +278,9 @@
                         nameC = CName "S",
                         nameHsIdent = HsIdentifier "S"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -344,7 +352,9 @@
             nameHsIdent = HsIdentifier
               "More_aligned_int"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "type_attributes.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -497,7 +507,9 @@
               nameHsIdent = HsIdentifier
                 "S2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "type_attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -572,7 +584,9 @@
                 nameHsIdent = HsIdentifier
                   "S2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "type_attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -652,7 +666,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -732,7 +748,9 @@
                         nameHsIdent = HsIdentifier
                           "S2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -837,7 +855,9 @@
               nameHsIdent = HsIdentifier
                 "My_unpacked_struct"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "type_attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -939,7 +959,9 @@
                 nameHsIdent = HsIdentifier
                   "My_unpacked_struct"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "type_attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1046,7 +1068,9 @@
                         nameHsIdent = HsIdentifier
                           "My_unpacked_struct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1155,7 +1179,9 @@
                         nameHsIdent = HsIdentifier
                           "My_unpacked_struct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1301,7 +1327,9 @@
               nameHsIdent = HsIdentifier
                 "My_packed_struct"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "type_attributes.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1444,7 +1472,9 @@
                 nameHsIdent = HsIdentifier
                   "My_packed_struct"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "type_attributes.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1592,7 +1622,9 @@
                         nameHsIdent = HsIdentifier
                           "My_packed_struct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1743,7 +1775,9 @@
                         nameHsIdent = HsIdentifier
                           "My_packed_struct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "type_attributes.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1837,7 +1871,9 @@
             nameHsIdent = HsIdentifier
               "Wait"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "type_attributes.h"},
         declKind = OpaqueUnion,
         declSpec = DeclSpec
           TypeSpec {
@@ -1872,7 +1908,9 @@
             (AnonId
               "type_attributes.h:26:9"),
           declAliases = [
-            CName "wait_status_ptr_t"]},
+            CName "wait_status_ptr_t"],
+          declHeader =
+          "type_attributes.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -1988,7 +2026,9 @@
             nameHsIdent = HsIdentifier
               "T1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "type_attributes.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -2097,7 +2137,9 @@
             nameHsIdent = HsIdentifier
               "Short_a"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "type_attributes.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/type_attributes.tree-diff.txt
+++ b/hs-bindgen/fixtures/type_attributes.tree-diff.txt
@@ -8,7 +8,9 @@ TranslationUnit {
           nameC = CName "S",
           nameHsIdent = HsIdentifier "S"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -48,7 +50,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "More_aligned_int"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -75,7 +79,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "S2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -115,7 +121,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "My_unpacked_struct"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -166,7 +174,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "My_packed_struct"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -232,7 +242,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Wait"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclUnionOpaque,
       declSpec = DeclSpec
         TypeSpec {
@@ -253,7 +265,9 @@ TranslationUnit {
           (AnonId
             "type_attributes.h:26:9"),
         declAliases = [
-          CName "wait_status_ptr_t"]},
+          CName "wait_status_ptr_t"],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -305,7 +319,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -332,7 +348,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Short_a"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "type_attributes.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/type_naturals.hs
+++ b/hs-bindgen/fixtures/type_naturals.hs
@@ -522,7 +522,8 @@
             nameHsIdent = HsIdentifier
               "Arr1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "type_naturals.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -581,7 +582,8 @@
             nameHsIdent = HsIdentifier
               "Arr2"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "type_naturals.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -640,7 +642,8 @@
             nameHsIdent = HsIdentifier
               "Arr3"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "type_naturals.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -699,7 +702,8 @@
             nameHsIdent = HsIdentifier
               "Arr4"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "type_naturals.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {

--- a/hs-bindgen/fixtures/type_naturals.tree-diff.txt
+++ b/hs-bindgen/fixtures/type_naturals.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameC = CName "N",
           nameHsIdent = HsIdentifier "n"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -34,7 +35,8 @@ TranslationUnit {
           nameC = CName "M",
           nameHsIdent = HsIdentifier "m"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroExpr
           CheckedMacroExpr {
@@ -65,7 +67,8 @@ TranslationUnit {
           nameC = CName "F",
           nameHsIdent = HsIdentifier "f"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -113,7 +116,8 @@ TranslationUnit {
           nameC = CName "G",
           nameHsIdent = HsIdentifier "g"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -162,7 +166,8 @@ TranslationUnit {
           nameC = CName "K",
           nameHsIdent = HsIdentifier "k"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind =
       DeclMacro
         (MacroExpr
@@ -223,7 +228,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -255,7 +261,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -287,7 +294,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -319,7 +327,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Arr4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "type_naturals.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {

--- a/hs-bindgen/fixtures/typedef_vs_macro.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.hs
@@ -23,7 +23,9 @@
             nameHsIdent = HsIdentifier
               "T1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -132,7 +134,9 @@
             nameHsIdent = HsIdentifier
               "T2"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -243,7 +247,9 @@
             nameHsIdent = HsIdentifier
               "M1"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -352,7 +358,9 @@
             nameHsIdent = HsIdentifier
               "M2"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -463,7 +471,9 @@
             nameHsIdent = HsIdentifier
               "M3"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -521,7 +531,9 @@
             nameHsIdent = HsIdentifier
               "M4"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -665,7 +677,9 @@
               nameHsIdent = HsIdentifier
                 "ExampleStruct"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "typedef_vs_macro.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -852,7 +866,9 @@
                 nameHsIdent = HsIdentifier
                   "ExampleStruct"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "typedef_vs_macro.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1044,7 +1060,9 @@
                         nameHsIdent = HsIdentifier
                           "ExampleStruct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "typedef_vs_macro.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1240,7 +1258,9 @@
                         nameHsIdent = HsIdentifier
                           "ExampleStruct"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "typedef_vs_macro.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1365,7 +1385,9 @@
             nameHsIdent = HsIdentifier
               "Uint64_t"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader =
+          "typedef_vs_macro.h"},
         declKind = Macro
           CheckedMacroType {
             macroTypeNames = NewtypeNames {
@@ -1521,7 +1543,9 @@
               nameHsIdent = HsIdentifier
                 "Foo"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader =
+            "typedef_vs_macro.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1600,7 +1624,9 @@
                 nameHsIdent = HsIdentifier
                   "Foo"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader =
+              "typedef_vs_macro.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1684,7 +1710,9 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "typedef_vs_macro.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1768,7 +1796,9 @@
                         nameHsIdent = HsIdentifier
                           "Foo"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader =
+                      "typedef_vs_macro.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames

--- a/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedef_vs_macro.tree-diff.txt
@@ -9,7 +9,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -36,7 +38,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "T2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -65,7 +69,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "M1"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -93,7 +99,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "M2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -122,7 +130,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "M3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -154,7 +164,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "M4"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -185,7 +197,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "ExampleStruct"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -271,7 +285,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Uint64_t"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclMacro
         (MacroType
           CheckedMacroType {
@@ -299,7 +315,9 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader =
+        "typedef_vs_macro.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "Myint"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "typedefs.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {
@@ -156,7 +157,8 @@
             nameHsIdent = HsIdentifier
               "Intptr"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "typedefs.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/typedefs.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedefs.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Myint"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "typedefs.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {
@@ -34,7 +35,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Intptr"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "typedefs.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/typenames.hs
+++ b/hs-bindgen/fixtures/typenames.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "Foo"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "typenames.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {
@@ -319,7 +320,8 @@
             nameHsIdent = HsIdentifier
               "Foo"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "typenames.h"},
         declKind = Typedef
           Typedef {
             typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/typenames.tree-diff.txt
+++ b/hs-bindgen/fixtures/typenames.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "typenames.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {
@@ -53,7 +54,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Foo"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "typenames.h"},
       declKind = DeclTypedef
         Typedef {
           typedefNames = NewtypeNames {

--- a/hs-bindgen/fixtures/unions.hs
+++ b/hs-bindgen/fixtures/unions.hs
@@ -51,7 +51,8 @@
               nameHsIdent = HsIdentifier
                 "Dim2"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -141,7 +142,8 @@
                 nameHsIdent = HsIdentifier
                   "Dim2"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -236,7 +238,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -333,7 +336,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim2"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -455,7 +459,8 @@
               nameHsIdent = HsIdentifier
                 "Dim3"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -572,7 +577,8 @@
                 nameHsIdent = HsIdentifier
                   "Dim3"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -694,7 +700,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -819,7 +826,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim3"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -905,7 +913,8 @@
             nameHsIdent = HsIdentifier
               "DimPayload"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "unions.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -1055,7 +1064,8 @@
               nameHsIdent = HsIdentifier
                 "Dim"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1159,7 +1169,8 @@
                 nameHsIdent = HsIdentifier
                   "Dim"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1268,7 +1279,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1379,7 +1391,8 @@
                         nameHsIdent = HsIdentifier
                           "Dim"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1453,7 +1466,8 @@
               "DimPayloadB"},
           declOrigin = NameOriginInSource,
           declAliases = [
-            CName "DimPayloadB"]},
+            CName "DimPayloadB"],
+          declHeader = "unions.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {
@@ -1606,7 +1620,8 @@
               nameHsIdent = HsIdentifier
                 "DimB"},
             declOrigin = NameOriginInSource,
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -1716,7 +1731,8 @@
                 nameHsIdent = HsIdentifier
                   "DimB"},
               declOrigin = NameOriginInSource,
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -1831,7 +1847,8 @@
                         nameHsIdent = HsIdentifier
                           "DimB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -1948,7 +1965,8 @@
                         nameHsIdent = HsIdentifier
                           "DimB"},
                       declOrigin = NameOriginInSource,
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2057,7 +2075,8 @@
                 "AnonA_xy"},
             declOrigin = NameOriginGenerated
               (AnonId "unions.h:35:5"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2152,7 +2171,8 @@
                   "AnonA_xy"},
               declOrigin = NameOriginGenerated
                 (AnonId "unions.h:35:5"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2252,7 +2272,8 @@
                           "AnonA_xy"},
                       declOrigin = NameOriginGenerated
                         (AnonId "unions.h:35:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2354,7 +2375,8 @@
                           "AnonA_xy"},
                       declOrigin = NameOriginGenerated
                         (AnonId "unions.h:35:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2468,7 +2490,8 @@
                 "AnonA_polar"},
             declOrigin = NameOriginGenerated
               (AnonId "unions.h:36:5"),
-            declAliases = []},
+            declAliases = [],
+            declHeader = "unions.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -2565,7 +2588,8 @@
                   "AnonA_polar"},
               declOrigin = NameOriginGenerated
                 (AnonId "unions.h:36:5"),
-              declAliases = []},
+              declAliases = [],
+              declHeader = "unions.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -2667,7 +2691,8 @@
                           "AnonA_polar"},
                       declOrigin = NameOriginGenerated
                         (AnonId "unions.h:36:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2771,7 +2796,8 @@
                           "AnonA_polar"},
                       declOrigin = NameOriginGenerated
                         (AnonId "unions.h:36:5"),
-                      declAliases = []},
+                      declAliases = [],
+                      declHeader = "unions.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -2854,7 +2880,8 @@
             nameHsIdent = HsIdentifier
               "AnonA"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "unions.h"},
         declKind = Union
           Union {
             unionNames = NewtypeNames {

--- a/hs-bindgen/fixtures/unions.tree-diff.txt
+++ b/hs-bindgen/fixtures/unions.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Dim2"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -51,7 +52,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Dim3"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -104,7 +106,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "DimPayload"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -157,7 +160,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "Dim"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -207,7 +211,8 @@ TranslationUnit {
             "DimPayloadB"},
         declOrigin = NameOriginInSource,
         declAliases = [
-          CName "DimPayloadB"]},
+          CName "DimPayloadB"],
+        declHeader = "unions.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {
@@ -260,7 +265,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "DimB"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -313,7 +319,8 @@ TranslationUnit {
             "AnonA_xy"},
         declOrigin = NameOriginGenerated
           (AnonId "unions.h:35:5"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -359,7 +366,8 @@ TranslationUnit {
             "AnonA_polar"},
         declOrigin = NameOriginGenerated
           (AnonId "unions.h:36:5"),
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -406,7 +414,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "AnonA"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "unions.h"},
       declKind = DeclUnion
         Union {
           unionNames = NewtypeNames {

--- a/hs-bindgen/fixtures/uses_utf8.hs
+++ b/hs-bindgen/fixtures/uses_utf8.hs
@@ -22,7 +22,8 @@
             nameHsIdent = HsIdentifier
               "MyEnum"},
           declOrigin = NameOriginInSource,
-          declAliases = []},
+          declAliases = [],
+          declHeader = "uses_utf8.h"},
         declKind = Enum
           Enum {
             enumNames = NewtypeNames {

--- a/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
+++ b/hs-bindgen/fixtures/uses_utf8.tree-diff.txt
@@ -8,7 +8,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "MyEnum"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "uses_utf8.h"},
       declKind = DeclEnum
         Enum {
           enumNames = NewtypeNames {

--- a/hs-bindgen/fixtures/varargs.hs
+++ b/hs-bindgen/fixtures/varargs.hs
@@ -17,5 +17,4 @@
       Function
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "varargs.h"}}]
+          functionRes = TypeVoid}}]

--- a/hs-bindgen/fixtures/varargs.tree-diff.txt
+++ b/hs-bindgen/fixtures/varargs.tree-diff.txt
@@ -7,12 +7,12 @@ TranslationUnit {
           nameC = CName "g",
           nameHsIdent = HsIdentifier "g"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "varargs.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [],
-          functionRes = TypeVoid,
-          functionHeader = "varargs.h"},
+          functionRes = TypeVoid},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/fixtures/vector.hs
+++ b/hs-bindgen/fixtures/vector.hs
@@ -54,7 +54,8 @@
                 "Vector"},
             declOrigin = NameOriginGenerated
               (AnonId "vector.h:1:9"),
-            declAliases = [CName "vector"]},
+            declAliases = [CName "vector"],
+            declHeader = "vector.h"},
           declKind = Struct
             Struct {
               structNames = RecordNames
@@ -149,7 +150,8 @@
                   "Vector"},
               declOrigin = NameOriginGenerated
                 (AnonId "vector.h:1:9"),
-              declAliases = [CName "vector"]},
+              declAliases = [CName "vector"],
+              declHeader = "vector.h"},
             declKind = Struct
               Struct {
                 structNames = RecordNames
@@ -249,7 +251,8 @@
                           "Vector"},
                       declOrigin = NameOriginGenerated
                         (AnonId "vector.h:1:9"),
-                      declAliases = [CName "vector"]},
+                      declAliases = [CName "vector"],
+                      declHeader = "vector.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -351,7 +354,8 @@
                           "Vector"},
                       declOrigin = NameOriginGenerated
                         (AnonId "vector.h:1:9"),
-                      declAliases = [CName "vector"]},
+                      declAliases = [CName "vector"],
+                      declHeader = "vector.h"},
                     declKind = Struct
                       Struct {
                         structNames = RecordNames
@@ -450,5 +454,4 @@
                     nameHsIdent = HsIdentifier
                       "Vector"}
                   (NameOriginGenerated
-                    (AnonId "vector.h:1:9"))))),
-          functionHeader = "vector.h"}}]
+                    (AnonId "vector.h:1:9")))))}}]

--- a/hs-bindgen/fixtures/vector.tree-diff.txt
+++ b/hs-bindgen/fixtures/vector.tree-diff.txt
@@ -9,7 +9,8 @@ TranslationUnit {
             "Vector"},
         declOrigin = NameOriginGenerated
           (AnonId "vector.h:1:9"),
-        declAliases = [CName "vector"]},
+        declAliases = [CName "vector"],
+        declHeader = "vector.h"},
       declKind = DeclStruct
         Struct {
           structNames = RecordNames
@@ -54,7 +55,8 @@ TranslationUnit {
           nameHsIdent = HsIdentifier
             "new_vector"},
         declOrigin = NameOriginInSource,
-        declAliases = []},
+        declAliases = [],
+        declHeader = "vector.h"},
       declKind = DeclFunction
         Function {
           functionArgs = [
@@ -72,8 +74,7 @@ TranslationUnit {
                     nameHsIdent = HsIdentifier
                       "Vector"}
                   (NameOriginGenerated
-                    (AnonId "vector.h:1:9"))))),
-          functionHeader = "vector.h"},
+                    (AnonId "vector.h:1:9")))))},
       declSpec = DeclSpec
         TypeSpec {
           typeSpecModule = Nothing,

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -36,12 +36,9 @@ instance (
 instance (
       Id p ~ Id p'
     ) => CoercePass DeclInfo p p' where
-  coercePass DeclInfo{declLoc, declId, declOrigin, declAliases} = DeclInfo{
-        declLoc
-      , declId
-      , declOrigin
-      , declAliases
-      }
+  coercePass info = DeclInfo{..}
+    where
+      DeclInfo{declLoc, declId, declOrigin, declAliases, declHeader} = info
 
 instance (
       CoercePass Struct   p p'
@@ -149,7 +146,6 @@ instance (
         functionArgs = map coercePass functionArgs
       , functionRes  = coercePass functionRes
       , functionAnn
-      , functionHeader
       }
 
 instance (

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
@@ -96,6 +96,7 @@ data DeclInfo = DeclInfo{
     , declId      :: MangleNames.NamePair
     , declOrigin  :: C.NameOrigin
     , declAliases :: [CName]
+    , declHeader  :: CHeaderIncludePath
     }
   deriving stock (Show, Eq, Generic)
 
@@ -191,9 +192,8 @@ data Typedef = Typedef {
 -------------------------------------------------------------------------------}
 
 data Function = Function {
-      functionArgs   :: [Type]
-    , functionRes    :: Type
-    , functionHeader :: CHeaderIncludePath
+      functionArgs :: [Type]
+    , functionRes  :: Type
     }
   deriving stock (Show, Eq, Generic)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
@@ -65,6 +65,7 @@ instance Finalize Int.DeclInfo where
       , declId
       , declOrigin
       , declAliases
+      , declHeader
       }
     where
       Int.DeclInfo{
@@ -72,6 +73,7 @@ instance Finalize Int.DeclInfo where
         , declId
         , declOrigin
         , declAliases
+        , declHeader
         } = info
 
 instance Finalize Int.DeclKind where
@@ -211,16 +213,14 @@ instance Finalize Int.Function where
   type Finalized Int.Function = Ext.Function
 
   finalize function = Ext.Function{
-        functionArgs   = map finalize functionArgs
-      , functionRes    = finalize functionRes
-      , functionHeader = functionHeader
+        functionArgs = map finalize functionArgs
+      , functionRes  = finalize functionRes
       }
     where
       Int.Function {
           functionArgs
         , functionRes
         , functionAnn = NoAnn
-        , functionHeader
         } = function
 
 instance Finalize Int.CheckedMacro where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -95,6 +95,21 @@ data DeclInfo p = DeclInfo{
     , declId      :: Id p
     , declOrigin  :: C.NameOrigin
     , declAliases :: [CName]
+
+      -- | User-specified header that provides this declaration
+      --
+      -- Note that the declaration may not be in this header directly, but in
+      -- one of its (transitive) includes.
+      --
+      -- If the user specifies /multiple/ headers, all of which directly or
+      -- indirectly contain the same declaration, then either
+      --
+      -- 1. the C headers will need to explicitly check
+      --    (if this is already defined, do nothing), or
+      -- 2. This is an error in the C code.
+      --
+      -- This means that there is always a /single/ header to choose here.
+    , declHeader :: CHeaderIncludePath
     }
 
 data DeclKind p =
@@ -177,21 +192,6 @@ data Function p = Function {
       functionArgs :: [Type p]
     , functionRes  :: Type p
     , functionAnn  :: Ann "Function" p
-
-      -- | User-specified header that includes the declaration of this function
-      --
-      -- Note that the function may not be declared in this header directly, but
-      -- in one of its transitive includes.
-      --
-      -- If the user specifies /multiple/ headers, all of which directly or
-      -- indirectly define the same function, then either
-      --
-      -- 1. the C headers will need to explicitly check
-      --    (if this is already defined, do nothing), or
-      -- 2. This is an error in the C code.
-      --
-      -- This means that there is always a /single/ header to choose here.
-    , functionHeader :: CHeaderIncludePath
     }
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -60,10 +60,8 @@ processDecl C.Decl{declInfo, declKind} =
       C.DeclEnumOpaque      -> Just <$> processOpaque C.DeclEnumOpaque info'
       C.DeclFunction fun    -> Just <$> processFunction info' fun
   where
-    C.DeclInfo{declId, declLoc, declOrigin, declAliases} = declInfo
-
     info' :: C.DeclInfo HandleMacros
-    info' = C.DeclInfo{declId, declLoc, declOrigin, declAliases}
+    info' = coercePass declInfo
 
 {-------------------------------------------------------------------------------
   Function for each kind of declaration

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
@@ -65,16 +65,17 @@ nameDecl env decl = do
     return $ C.Decl{
         declInfo = C.DeclInfo{
             declId      = name
-          , declLoc
           , declOrigin  = origin
           , declAliases = findAliasesOf env qid
+          , declLoc
+          , declHeader
           }
       , declKind = nameUseSites env declKind
       , declAnn
       }
   where
     C.Decl{declInfo, declKind, declAnn} = decl
-    C.DeclInfo{declLoc, declId} = declInfo
+    C.DeclInfo{declId, declLoc, declHeader} = declInfo
 
     qid :: QualDeclId
     qid = declQualDeclId decl

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -1032,13 +1032,13 @@ functionDecs ::
   -> C.DeclSpec
   -> [Hs.Decl]
 functionDecs mu typedefs info f _spec =
-    [ Hs.DeclInlineCInclude $ getCHeaderIncludePath $ C.functionHeader f
+    [ Hs.DeclInlineCInclude $ getCHeaderIncludePath $ C.declHeader info
     , Hs.DeclInlineC $ PC.prettyDecl (wrapperDecl innerName wrapperName res args) ""
     , Hs.DeclForeignImport $ Hs.ForeignImportDecl
         { foreignImportName       = importName
         , foreignImportType       = importType
         , foreignImportOrigName   = T.pack wrapperName
-        , foreignImportHeader     = getCHeaderIncludePath $ C.functionHeader f
+        , foreignImportHeader     = getCHeaderIncludePath $ C.declHeader info
         , foreignImportDeclOrigin = Origin.Function f
         }
     ] ++


### PR DESCRIPTION
This replaces `functionHeader`, which we recorded _only_ for functions. We have this information available everywhere anyway, it might be useful for generating of documentation (#26), and it will certainly be useful for globals (#42) and constants (#41).

/cc @TravisCardwell 