### PR TITLE
Add `--prescriptive-binding-spec`

### DIFF
--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -49,12 +49,14 @@ execPreprocess globalOpts PreprocessOpts{..} = do
   where
     doTranslate :: IO HsDecls
     doTranslate = withTracer globalOpts $ \tracer -> do
-      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      extSpec <- loadExtBindingSpecs' tracer globalOpts
+      pSpec   <- loadPrescriptiveBindingSpec' tracer globalOpts
       let mu = getModuleUnique preprocessModuleOpts
           opts = (getOpts globalOpts) {
-              optsExtBindingSpec = extBindingSpec
-            , optsTranslation    = preprocessTranslationOpts
-            , optsTracer         = tracer
+              optsExtBindingSpec          = extSpec
+            , optsPrescriptiveBindingSpec = pSpec
+            , optsTranslation             = preprocessTranslationOpts
+            , optsTracer                  = tracer
             }
       translateCHeaders mu opts preprocessInputs
 
@@ -71,12 +73,14 @@ execGenTests globalOpts GenTestsOpts{..} = do
   where
     doTranslate :: IO HsDecls
     doTranslate = withTracer globalOpts $ \tracer -> do
-      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      extSpec <- loadExtBindingSpecs' tracer globalOpts
+      pSpec   <- loadPrescriptiveBindingSpec' tracer globalOpts
       let mu = getModuleUnique genTestsModuleOpts
           opts = (getOpts globalOpts) {
-              optsExtBindingSpec = extBindingSpec
-            , optsTranslation    = genTestsTranslationOpts
-            , optsTracer         = tracer
+              optsExtBindingSpec          = extSpec
+            , optsPrescriptiveBindingSpec = pSpec
+            , optsTranslation             = genTestsTranslationOpts
+            , optsTracer                  = tracer
             }
       translateCHeaders mu opts genTestsInputs
 

--- a/hs-bindgen/app/hs-bindgen-dev.hs
+++ b/hs-bindgen/app/hs-bindgen-dev.hs
@@ -22,9 +22,11 @@ execParse globalOpts ParseOpts{..} = print =<< doParse
   where
     doParse :: IO TranslationUnit
     doParse = withTracer globalOpts $ \tracer -> do
-      extBindingSpec <- loadExtBindingSpecs' tracer globalOpts
+      extSpec <- loadExtBindingSpecs' tracer globalOpts
+      pSpec   <- loadPrescriptiveBindingSpec' tracer globalOpts
       let opts = (getOpts globalOpts) {
-              optsExtBindingSpec = extBindingSpec
-            , optsTracer         = tracer
+              optsExtBindingSpec          = extSpec
+            , optsPrescriptiveBindingSpec = pSpec
+            , optsTracer                  = tracer
             }
       Pipeline.parseCHeaders opts parseInputPaths

--- a/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
+++ b/hs-bindgen/src-internal/HsBindgen/C/Parser.hs
@@ -39,15 +39,17 @@ parseCHeaders ::
   -> ClangArgs
   -> Predicate
   -> ProgramSlicing
-  -> ResolvedBindingSpec
+  -> ResolvedBindingSpec -- ^ External binding specification
+  -> ResolvedBindingSpec -- ^ Prescriptive binding specification
   -> [CHeaderIncludePath]
   -> IO C.TranslationUnit
-parseCHeaders tracer args predicate programSlicing extSpec mainFiles =
+parseCHeaders tracer args predicate programSlicing extSpec pSpec mainFiles =
     fmap (fromMaybe C.emptyTranslationUnit) $
     withClang (contramap TraceClang tracer) setup $ \unit -> Just <$> do
       processTranslationUnit
         (contramap TraceFrontend tracer)
         extSpec
+        pSpec
         rootHeader
         predicate
         programSlicing

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -10,7 +10,6 @@ import Control.Monad
 
 import Clang.LowLevel.Core
 import HsBindgen.BindingSpec (ResolvedBindingSpec)
-import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Predicate (Predicate (SelectAll))
 import HsBindgen.Frontend.AST.External qualified as Ext
 import HsBindgen.Frontend.AST.Finalize
@@ -78,12 +77,20 @@ import Text.SimplePrettyPrint (showToCtxDoc)
 --   the 'Hs' phase, but we have to draw the line somewhere.
 processTranslationUnit ::
      Tracer IO FrontendMsg
-  -> ResolvedBindingSpec
+  -> ResolvedBindingSpec -- ^ External binding specification
+  -> ResolvedBindingSpec -- ^ Prescriptive binding specification
   -> RootHeader
   -> Predicate
   -> ProgramSlicing
   -> CXTranslationUnit -> IO Ext.TranslationUnit
-processTranslationUnit tracer extSpec rootHeader selectionPredicate programSlicing unit = do
+processTranslationUnit
+  tracer
+  extSpec
+  pSpec
+  rootHeader
+  selectionPredicate
+  programSlicing
+  unit = do
 
     (includeGraph, isMainFile, getMainHeader) <- processIncludes rootHeader unit
     let selectionPredicateParse = case programSlicing of
@@ -101,10 +108,6 @@ processTranslationUnit tracer extSpec rootHeader selectionPredicate programSlici
         unit
 
     -- writeFile "includegraph.mermaid" $ IncludeGraph.dumpMermaid includeGraph
-
-    -- TODO receive prescriptive binding specification via argument
-    let pSpec :: ResolvedBindingSpec
-        pSpec = BindingSpec.empty
 
     let (afterSort, sortErrors) =
           sortDecls afterParse

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -38,6 +38,7 @@ module HsBindgen.Lib (
   , Common.emptyBindingSpec
   , Common.StdlibBindingSpecConf(..)
   , Pipeline.loadExtBindingSpecs
+  , Pipeline.loadPrescriptiveBindingSpec
   , Pipeline.getStdlibBindingSpec
   , Pipeline.encodeBindingSpecJson
   , Pipeline.encodeBindingSpecYaml

--- a/manual/LowLevel/ExternalBindings.md
+++ b/manual/LowLevel/ExternalBindings.md
@@ -73,8 +73,8 @@ mapped to the type called `Vector` defined in module `Vector` from the
 `hs-vector` package (rather than _generating_ a definition for it).
 
 We can then use these external bindings when processing `vector_rotate.h`
-(command line flag `--external-bindings`). This will result in something like
-this:
+(command line flag `--external-binding-spec`). This will result in something
+like this:
 
 ```haskell
 import qualified Vector
@@ -123,9 +123,9 @@ types:
   identifier: Length
 ```
 
-If we then use `--external-bindings` _twice_ when processing `vector_length.h`
-(once for the external bindings for `vector.h` and once for the external bindings
-for `Length`), we get
+If we then use `--external-binding-spec` _twice_ when processing
+`vector_length.h` (once for the external bindings for `vector.h` and once for
+the external bindings for `Length`), we get
 
 ```haskell
 import qualified Vector

--- a/manual/generate.sh
+++ b/manual/generate.sh
@@ -43,7 +43,7 @@ cabal run hs-bindgen-cli -- \
   preprocess \
     -I c \
     -o hs/hs-vector/generated/Vector/Rotate.hs \
-    --external-bindings external/vector.yaml \
+    --external-binding-spec external/vector.yaml \
     --module Vector.Rotate \
     vector_rotate.h
 
@@ -51,7 +51,7 @@ cabal run hs-bindgen-cli -- \
   preprocess \
     -I c \
     -o hs/hs-vector/generated/Vector/Length.hs \
-    --external-bindings external/vector.yaml \
+    --external-binding-spec external/vector.yaml \
     --module Vector.Length \
     vector_length.h
 
@@ -73,7 +73,7 @@ cabal run hs-bindgen-cli -- \
   preprocess \
     -I c \
     -o hs/hs-game/generated/Game/World.hs \
-    --external-bindings external/game.yaml \
+    --external-binding-spec external/game.yaml \
     --module Game.World \
     game_world.h
 
@@ -81,6 +81,6 @@ cabal run hs-bindgen-cli -- \
   preprocess \
     -I c \
     -o hs/hs-game/generated/Game/Player.hs \
-    --external-bindings external/game.yaml \
+    --external-binding-spec external/game.yaml \
     --module Game.Player \
     game_player.h


### PR DESCRIPTION
This PR adds the `--prescriptive-binding-spec` (global) option.  When specified, the binding specification is loaded and passed to the frontend.

Note that option `--external-bindings` is also renamed to `--external-binding-spec`, which I missed when refactoring the terminology.  The option specifies a single binding specification file, so it should be singular.  Multiple external binding specifications are specified using multiple options.

This PR does not include tests.  We should discuss how we should organize tests that use binding specifications.  At a minimum, we can test with `pp` and `th` tests, but perhaps we should make it possible to use binding specifications in golden tests as well?

----

Minimal example:

```c
struct foo {
  char c;
  int i;
};
```

Without a prescriptive binding specification:

```
$ cabal run hs-bindgen-dev -- parse example.h | friendly
...
        , declId = NamePair {nameC = "foo", nameHsIdent = "Foo"}
...
```

Prescriptive binding specification:

```yaml
types:
  - headers: example.h
    cname: struct foo
    identifier: MyFoo
```

With that prescriptive binding specification:

```
$ cabal run hs-bindgen-dev -- \
    parse --prescriptive-binding-spec spec.yaml example.h \
  | friendly
...
        , declId = NamePair {nameC = "foo", nameHsIdent = "MyFoo"}
...
```