### PR TITLE
Golden tests: make sure to show `msgs` on errors

### DIFF
--- a/hs-bindgen/test/common/Test/Common/Util/Tasty/Golden.hs
+++ b/hs-bindgen/test/common/Test/Common/Util/Tasty/Golden.hs
@@ -116,7 +116,10 @@ runGoldenSteps GoldenSteps{..} progress opts = do
       Left (e :: SomeException) ->
         case fromException @AsyncException e of
           Just e' -> throwIO e'
-          Nothing -> return $ testFailed $ displayException e
+          Nothing -> return $ testFailed $ concat [
+              displayException e
+            , unlines msgs
+            ]
 
       Right (ActualSkipped reason) ->
         testPassedWith $ "skipped: " ++ reason


### PR DESCRIPTION
If say `rust-bingden` fails, so that we cannot construct `mbNew`, then it can be quite helpful to see which messages `rust-bingden` actually output.