### PR TITLE
Simplify evaluation of a selection predicate

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -12,7 +12,6 @@ import Clang.Enum.Simple
 import Clang.HighLevel qualified as HighLevel
 import Clang.HighLevel.Types
 import Clang.LowLevel.Core
-import HsBindgen.C.Predicate qualified as Predicate
 import HsBindgen.Frontend.AST.Internal (ValidPass)
 import HsBindgen.Frontend.AST.Internal qualified as C
 import HsBindgen.Frontend.NonSelectedDecls (NonSelectedDecls)
@@ -54,7 +53,7 @@ instance IsPass Parse where
   -- for strange C input.
   data Msg Parse =
       -- | We skipped over a declaration
-      Skipped Predicate.SkipReason
+      Skipped (C.DeclInfo Parse)
 
       -- | Unsupported type
       --
@@ -171,8 +170,8 @@ getUnparsedMacro unit curr = do
 
 instance PrettyForTrace (Msg Parse) where
   prettyForTrace = \case
-      Skipped reason ->
-          prettyForTrace reason
+      Skipped info ->
+          prettyForTrace info >< " not selected"
       UnsupportedType info err -> noBindingsGenerated info $
           prettyForTrace err
       UnsupportedImplicitFields info -> noBindingsGenerated info $
@@ -207,7 +206,7 @@ instance PrettyForTrace (Msg Parse) where
 -- | Unsupported features are warnings, because we skip over them
 instance HasDefaultLogLevel (Msg Parse) where
   getDefaultLogLevel = \case
-      Skipped reason              -> getDefaultLogLevel reason
+      Skipped{}                   -> Info
       UnsupportedType _ctxt err   -> getDefaultLogLevel err
       UnsupportedImplicitFields{} -> Warning
       UnexpectedAnonInSignature{} -> Warning

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/DeclId.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/DeclId.hs
@@ -82,7 +82,10 @@ instance PrettyForTrace (C.Located DeclId) where
           prettyForTrace anonId
 
 -- | Qualified declaration identity
-data QualDeclId = QualDeclId DeclId C.NameKind
+data QualDeclId = QualDeclId {
+      qualDeclId   :: DeclId
+    , qualDeclKind :: C.NameKind
+    }
   deriving stock (Show, Eq, Ord)
 
 instance PrettyForTrace QualDeclId where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
@@ -138,8 +138,6 @@ dispatch curr k = do
       Right kind -> k kind
       Left  i    -> throwError $ UnexpectedTypeKind (Left i)
 
--- | This is similar to 'HsBindgen.Frontend.Pass.Parse.Decl.Monad.dispatchFold',
--- but we don't deal with folds when parsing types.
 dispatchWithArg ::
      MonadError ParseTypeException m
   => CXType

--- a/hs-bindgen/src-internal/HsBindgen/Language/C/Name.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/C/Name.hs
@@ -3,7 +3,6 @@ module HsBindgen.Language.C.Name (
     AnonId(..)
   , CName(..)
   , NameKind(..)
-  , toNameKindFromCXCursorKind
   , QualName(..)
   , qualNameText
   , parseQualName
@@ -15,8 +14,6 @@ import Data.Text qualified as Text
 import Clang.HighLevel (ShowFile (..))
 import Clang.HighLevel qualified as HighLevel
 import Clang.HighLevel.Types (SingleLoc)
-import Clang.LowLevel.Core
-import HsBindgen.Errors (panicPure)
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer (PrettyForTrace (prettyForTrace))
 import Text.SimplePrettyPrint (showToCtxDoc, textToCtxDoc, (><))
@@ -89,32 +86,6 @@ data NameKind =
 
 instance PrettyForTrace NameKind where
   prettyForTrace = showToCtxDoc
-
-toNameKindFromCXCursorKind :: CXCursorKind -> Maybe NameKind
-toNameKindFromCXCursorKind = \case
-      -- Ordinary.
-      CXCursor_FunctionDecl       -> Just NameKindOrdinary
-      CXCursor_MacroDefinition    -> Just NameKindOrdinary
-      CXCursor_TypedefDecl        -> Just NameKindOrdinary
-      CXCursor_VarDecl            -> Just NameKindOrdinary
-      -- Struct.
-      CXCursor_StructDecl         -> Just NameKindStruct
-      -- Union.
-      CXCursor_UnionDecl          -> Just NameKindUnion
-      -- Enum.
-      CXCursor_EnumDecl           -> Just NameKindEnum
-
-      -- Other.
-      CXCursor_PackedAttr         -> Nothing
-      CXCursor_AlignedAttr        -> Nothing
-      CXCursor_UnexposedAttr      -> Nothing
-      CXCursor_InclusionDirective -> Nothing
-      CXCursor_MacroExpansion     -> Nothing
-
-      -- NOTE: We ensure that we make an informed decision about whether we
-      -- convert a 'CXCursorKind' to a 'NameKind', or not.
-      _kind ->
-        panicPure $ "unhandled CXCursorKind: " <> show _kind
 
 {-------------------------------------------------------------------------------
   QualName


### PR DESCRIPTION
We were trying to construct a _reason_ why a selection predicate matched or failed, but I realized that this is rather difficult to do well in the presence of arbitrary boolean expressions, and indeed we were not doing it correctly (though this was rather hidden: for example, logical conjunction was implemented using monadic `>>`, effectively ignoring the reason why the first predicate matched). In this PR we simplify this, mostly in preparation for further changes.