### PR TITLE
Never select builtins

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Prop/Selection.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Prop/Selection.hs
@@ -180,6 +180,9 @@ instance Arbitrary NameKind where
 instance Arbitrary QualDeclId where
   arbitrary = makeQualDeclId <$> arbitrary <*> arbitrary
     where
+      -- TODO: We currently never produce anonymous or builtin declarations.
+      -- In this module we check that selection predicates behave as boolean
+      -- functions; this is not true for builtins (which are /never/ selected).
       makeQualDeclId :: CName -> NameKind -> QualDeclId
       makeQualDeclId name kind = QualDeclId (DeclNamed name) kind
 


### PR DESCRIPTION
I introduced a small bug yesterday: the negation of `SelectAll` would select everything but builtins, rather than selecting nothing.

We should separately think about whether we actually ever _want_ to select builtins; opened https://github.com/well-typed/hs-bindgen/issues/901 to track that.