### PR TITLE
Refactor `BindingSpec` API

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -398,18 +398,16 @@ loadBindingSpecs ::
      Tracer IO TraceMsg
   -> ClangArgs
   -> BindingSpecConfig
-  -> IO (BindingSpec, BindingSpec)
+  -> IO (ExternalBindingSpec, PrescriptiveBindingSpec)
 loadBindingSpecs tracer clangArgs opts = do
+    let tracer' = contramap TraceBindingSpec tracer
     extSpecs <- loadExtBindingSpecs
-                  tracer
+                  tracer'
                   clangArgs
                   opts.stdlibSpec
                   opts.extBindingSpecs
     pSpec <- case opts.prescriptiveBindingSpec of
-               Just path -> loadPrescriptiveBindingSpec
-                              tracer
-                              clangArgs
-                              path
+               Just path -> loadPrescriptiveBindingSpec tracer' clangArgs path
                Nothing   -> pure emptyBindingSpec
     pure (extSpecs, pSpec)
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -76,8 +76,8 @@ library internal
       HsBindgen.Backend.TH.Translation
       HsBindgen.BindingSpec
       HsBindgen.BindingSpec.Gen
-      HsBindgen.BindingSpec.Stdlib
-      HsBindgen.BindingSpec.Internal
+      HsBindgen.BindingSpec.Private
+      HsBindgen.BindingSpec.Private.Stdlib
       HsBindgen.C.Parser
       HsBindgen.C.Predicate
       HsBindgen.C.Reparse
@@ -385,7 +385,6 @@ test-suite test-hs-bindgen
     , test-common
   build-depends:
       -- Inherited dependencies
-    , containers
     , debruijn
     , directory
     , filepath

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private.hs
@@ -1,9 +1,12 @@
 -- | Binding specification
 --
+-- This /private/ module may only be used by "HsBindgen.BindingSpec" and
+-- sub-modules.
+--
 -- Intended for qualified import.
 --
--- > import HsBindgen.BindingSpec.Internal qualified as BindingSpec
-module HsBindgen.BindingSpec.Internal (
+-- > import HsBindgen.BindingSpec.Private qualified as BindingSpec
+module HsBindgen.BindingSpec.Private (
     -- * Types
     BindingSpec(..)
   , UnresolvedBindingSpec

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
@@ -1,12 +1,14 @@
 -- | Standard library external binding specification
 --
+-- This /private/ module may only be used by "HsBindgen.BindingSpec".
+--
 -- Intended for qualified import.
 --
--- > import HsBindgen.BindingSpec.Stdlib qualified as Stdlib
+-- > import HsBindgen.BindingSpec.Private.Stdlib qualified as Stdlib
 --
 -- The types for these bindings are defined in @HsBindgen.Runtime.Prelude@ in
 -- the @hs-bindgen-runtime@ library, in the same order.
-module HsBindgen.BindingSpec.Stdlib (
+module HsBindgen.BindingSpec.Private.Stdlib (
     -- * Binding specification
     bindingSpec
   ) where
@@ -15,7 +17,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
 import Clang.Paths
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec.Private qualified as BindingSpec
 import HsBindgen.Errors
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs/IsPass.hs
@@ -4,7 +4,7 @@ module HsBindgen.Frontend.Pass.HandleTypedefs.IsPass (
   , Msg(..)
   ) where
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.AST.Internal (ValidPass)
 import HsBindgen.Frontend.AST.Internal qualified as C
 import HsBindgen.Frontend.Naming

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -7,7 +7,7 @@ import Control.Monad.State
 import Data.Map qualified as Map
 import Data.Proxy
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Config.FixCandidate (FixCandidate (..))
 import HsBindgen.Config.FixCandidate qualified as FixCandidate
 import HsBindgen.Frontend.AST.Internal qualified as C

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -10,7 +10,7 @@ module HsBindgen.Frontend.Pass.MangleNames.IsPass (
   , Msg(..)
   ) where
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec/IsPass.hs
@@ -7,7 +7,7 @@ module HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass (
 import Control.Exception (Exception (..))
 import Data.Text qualified as Text
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Errors
 import HsBindgen.Frontend.AST.Internal (CheckedMacro, ValidPass)
 import HsBindgen.Frontend.Naming

--- a/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/AST/Type.hs
@@ -5,7 +5,7 @@ module HsBindgen.Hs.AST.Type (
   hsPrimFloatTy
 ) where
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell
 

--- a/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Hs/Translation.hs
@@ -20,7 +20,7 @@ import GHC.Exts qualified as IsList (IsList (..))
 import C.Char qualified
 import C.Type qualified (FloatingType (..), IntegralType (IntLike))
 import Clang.Paths
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Tc.Macro qualified as Macro
 import HsBindgen.Config.FixCandidate (FixCandidate)
 import HsBindgen.Config.FixCandidate qualified as FixCandidate

--- a/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/SHs/AST.hs
@@ -21,7 +21,7 @@ module HsBindgen.SHs.AST (
 
 import DeBruijn (Ctx, EmptyCtx, Idx, Add)
 
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Hs.AST.Strategy qualified as Hs
 import HsBindgen.Hs.AST.Type
 import HsBindgen.Hs.CallConv

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -17,7 +17,7 @@ module HsBindgen.TraceMsg (
   ) where
 
 import Clang.HighLevel.Types (Diagnostic (..))
-import HsBindgen.BindingSpec.Internal (BindingSpecMsg (..))
+import HsBindgen.BindingSpec (BindingSpecMsg (..))
 import HsBindgen.C.Reparse.Infra (ReparseError (..))
 import HsBindgen.C.Tc.Macro (TcMacroError (..))
 import HsBindgen.Clang (ClangMsg (..))

--- a/hs-bindgen/src/HsBindgen/Common.hs
+++ b/hs-bindgen/src/HsBindgen/Common.hs
@@ -4,9 +4,9 @@ module HsBindgen.Common (
     Config.Config(..)
 
     -- * Binding specifications
-  , Pipeline.BindingSpec -- opaque
-  , Pipeline.EnableStdlibBindingSpec(..)
-  , Pipeline.emptyBindingSpec
+  , BindingSpec.BindingSpec -- opaque
+  , BindingSpec.EnableStdlibBindingSpec(..)
+  , BindingSpec.emptyBindingSpec
 
     -- ** Clang arguments
   , Args.ClangArgs(..)
@@ -67,12 +67,12 @@ import System.FilePath qualified as FilePath
 import Clang.Args qualified as Args
 import Clang.Paths qualified as Paths
 
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Predicate qualified as Predicate
 import HsBindgen.Config qualified as Config
 import HsBindgen.Frontend.Pass.Slice.IsPass qualified as Slice
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Hs.Translation qualified as Hs
-import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
 import HsBindgen.TraceMsg qualified as TraceMsg
 import HsBindgen.Util.Tracer qualified as Tracer

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -36,12 +36,14 @@ module HsBindgen.Lib (
     -- ** Binding specifications
   , Common.BindingSpec -- opaque
   , Common.emptyBindingSpec
+  , BindingSpec.ExternalBindingSpec
+  , BindingSpec.PrescriptiveBindingSpec
   , Common.EnableStdlibBindingSpec(..)
-  , Pipeline.loadExtBindingSpecs
-  , Pipeline.loadPrescriptiveBindingSpec
-  , Pipeline.getStdlibBindingSpec
-  , Pipeline.encodeBindingSpecJson
-  , Pipeline.encodeBindingSpecYaml
+  , BindingSpec.loadExtBindingSpecs
+  , BindingSpec.loadPrescriptiveBindingSpec
+  , BindingSpec.getStdlibBindingSpec
+  , BindingSpec.encodeBindingSpecJson
+  , BindingSpec.encodeBindingSpecYaml
 
     -- ** Translation options
   , Common.TranslationOpts(..)
@@ -103,6 +105,8 @@ import Clang.Args qualified as Args
 import Clang.Paths qualified as Paths
 import HsBindgen.Backend.PP.Render qualified as Backend.PP
 import HsBindgen.Backend.PP.Translation qualified as Backend.PP
+import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.BindingSpec.Gen qualified as BindingSpec
 import HsBindgen.Hs.AST qualified as Hs
 import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.Resolve qualified as Resolve
@@ -169,10 +173,7 @@ genBindingSpec ::
   -> HsDecls
   -> IO ()
 genBindingSpec config headerIncludePaths path =
-      Pipeline.genBindingSpec
-        config
-        headerIncludePaths
-        path
+      BindingSpec.genBindingSpec config headerIncludePaths path
     . unwrapHsDecls
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -82,8 +82,8 @@ import Language.Haskell.TH qualified as TH
 import HsBindgen.Common qualified as Common
 
 import Clang.Args qualified as Args
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Pipeline qualified as Pipeline
-
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
 
@@ -107,11 +107,11 @@ import Language.Haskell.TH.Syntax qualified as THSyntax
 loadExtBindingSpecs ::
      Tracer TH.Q TraceMsg
   -> Args.ClangArgs
-  -> Pipeline.EnableStdlibBindingSpec
+  -> Common.EnableStdlibBindingSpec
   -> [FilePath]
   -> TH.Q Common.BindingSpec
 loadExtBindingSpecs tracer args stdlibConf =
-    TH.runIO . Pipeline.loadExtBindingSpecs tracer' args stdlibConf
+    TH.runIO . BindingSpec.loadExtBindingSpecs tracer' args stdlibConf
   where
-    tracer' :: Tracer IO TraceMsg
-    tracer' = natTracer TH.runQ tracer
+    tracer' :: Tracer IO BindingSpec.BindingSpecMsg
+    tracer' = natTracer TH.runQ $ contramap TraceBindingSpec tracer

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -2,21 +2,18 @@
 module Test.HsBindgen.Golden (tests) where
 
 import Data.List qualified as List
-import Data.Map qualified as Map
 import Data.Text qualified as Text
 import Test.Tasty
 
 import Clang.Args
 import Clang.Version
-import HsBindgen.BindingSpec
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Predicate (Predicate (..))
 import HsBindgen.Config
 import HsBindgen.Frontend.AST.Internal qualified as C
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Slice.IsPass as Slice
 import HsBindgen.Language.C qualified as C
-import HsBindgen.Pipeline qualified as Pipeline
 import HsBindgen.TraceMsg
 
 import Test.Common.HsBindgen.TracePredicate
@@ -313,25 +310,10 @@ testCases = [
               configPredicate      = SelectFromMainFiles
             , configProgramSlicing = EnableProgramSlicing
             }
-        , testOnExtSpec = \extSpec ->
-            let uInt32T = C.QualName {
-                    qualNameName = "uint32_t"
-                  , qualNameKind = C.NameKindOrdinary
-                  }
-            in Pipeline.BindingSpec {
-                bindingSpecUnresolved =
-                    BindingSpec.BindingSpec
-                  . Map.delete uInt32T
-                  . BindingSpec.bindingSpecTypes
-                  . Pipeline.bindingSpecUnresolved
-                  $ extSpec
-              , bindingSpecResolved =
-                    BindingSpec.BindingSpec
-                  . Map.delete uInt32T
-                  . BindingSpec.bindingSpecTypes
-                  . Pipeline.bindingSpecResolved
-                  $ extSpec
-              }
+        , testOnExtSpec = BindingSpec.deleteType C.QualName{
+              qualNameName = "uint32_t"
+            , qualNameKind = C.NameKindOrdinary
+            }
         , testTracePredicate = customTracePredicate [
               "ReparseError"
             , "SelectedUInt32"

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/BindingSpec.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/BindingSpec.hs
@@ -6,7 +6,6 @@ import System.FilePath ((</>))
 import Test.Tasty (TestTree)
 
 import HsBindgen.BindingSpec.Gen qualified as BindingSpec
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
 import HsBindgen.Language.Haskell qualified as Hs
 
 import Test.Common.Util.Tasty
@@ -24,8 +23,8 @@ check testResources test =
       decls <- runTestTranslate testResources test
 
       let output :: String
-          output = UTF8.toString . BindingSpec.encodeYaml $
-              BindingSpec.genBindingSpec [testInputInclude test]
+          output = UTF8.toString $
+              BindingSpec.genBindingSpecYaml [testInputInclude test]
                 (Hs.HsModuleName "Example")
                 decls
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
@@ -34,6 +34,7 @@ import Test.Tasty (TestName)
 import Clang.HighLevel.Types qualified as Clang
 import Clang.Paths
 import HsBindgen.BindingSpec (ExternalBindingSpec, PrescriptiveBindingSpec)
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Clang (ClangMsg (..))
 import HsBindgen.Config (Config (..))
 import HsBindgen.Frontend.AST.External qualified as C
@@ -199,7 +200,7 @@ getTestExtSpec testResources TestCase{testOnExtSpec} =
 --
 -- TODO: We're not testing with prescriptive binding specifications yet.
 getTestPSpec :: IO TestResources -> TestCase -> IO PrescriptiveBindingSpec
-getTestPSpec _ _ = return Pipeline.emptyBindingSpec
+getTestPSpec _ _ = return BindingSpec.emptyBindingSpec
 
 withTestTracer ::
      TestCase

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Orphans/TreeDiff.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Orphans/TreeDiff.hs
@@ -14,7 +14,7 @@ import System.FilePath qualified as FilePath
 import Clang.Enum.Simple
 import Clang.HighLevel.Types qualified as C
 import Clang.Paths qualified as Paths
-import HsBindgen.BindingSpec.Internal qualified as BindingSpec
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.C.Reparse.Decl qualified as C
 import HsBindgen.C.Tc.Macro qualified as CMacro
 import HsBindgen.Frontend.AST.External qualified as C


### PR DESCRIPTION
Module `HsBindgen.BindingSpec.Internal` is renamed to `HsBindgen.BindingSpec.Private`, and the `StdLib` is moved to `HsBindgen.BindingSpec.Private.Stdlib`.  The code is refactored so that these modules are only used within `HsBindgen.BindingSpec` and `HsBindgen.BindingSpec.Gen` (which must be kept separate due to the dependency graph).

Module `HsBindgen.BindingSpec` exports a public as well as an internal API, both using the `BindingSpec` type that wraps unresolved and resolved binding specifications.  Functions are added to unwrap this opaque public type and call the private implementations.