### PR TITLE
Change CLI include options

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -224,15 +224,15 @@ parseGnuOption = switch $ mconcat [
 
 parseSystemIncludeDirOptions :: Parser [CIncludePathDir]
 parseSystemIncludeDirOptions = many . strOption $ mconcat [
-      long "system-include-path"
+      short 'I'
+    , long "system-include-path"
     , metavar "DIR"
     , help "System include search path directory"
     ]
 
 parseQuoteIncludeDirOptions :: Parser [CIncludePathDir]
 parseQuoteIncludeDirOptions = many . strOption $ mconcat [
-      short 'I'
-    , long "include-path"
+      long "quote-include-path"
     , metavar "DIR"
     , help "Quote include search path directory"
     ]
@@ -254,9 +254,11 @@ parseOtherArgs = many . option (eitherReader readOtherArg) $ mconcat [
     readOtherArg :: String -> Either String String
     readOtherArg s
       | "-I" `List.isPrefixOf` s =
-          Left "Include path must be set using hs-bindgen --include-path options"
+          Left "Include path must be set using hs-bindgen -I/--system-include-path options"
       | "-isystem" `List.isPrefixOf` s =
-          Left "System include path must be set using hs-bindgen --system-include-path options"
+          Left "System include path must be set using hs-bindgen -I/--system-include-path options"
+      | "-iquote" `List.isPrefixOf` s =
+          Left "Quote include path must be set using hs-bindgen --quote-include-path options"
       | s == "-nostdinc" =
           Left "No standard includes option must be set using hs-bindgen --no-stdinc option"
       | s == "-std" || "-std=" `List.isPrefixOf` s =

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -457,15 +457,15 @@ main = clangAstDump . uncurry applyAll =<< OA.execParser pinfo
 
     systemIncludePathOption :: OA.Parser [CIncludePathDir]
     systemIncludePathOption = OA.many . OA.strOption $ mconcat
-      [ OA.long "system-include-path"
+      [ OA.short 'I'
+      , OA.long "system-include-path"
       , OA.metavar "DIR"
       , OA.help "System include search path directory"
       ]
 
     quoteIncludePathOption :: OA.Parser [CIncludePathDir]
     quoteIncludePathOption = OA.many . OA.strOption $ mconcat
-      [ OA.short 'I'
-      , OA.long "include-path"
+      [ OA.long "quote-include-path"
       , OA.metavar "DIR"
       , OA.help "Quote include search path directory"
       ]

--- a/hs-bindgen/test/pp/Test/PP/Test01.lhs
+++ b/hs-bindgen/test/pp/Test/PP/Test01.lhs
@@ -1,4 +1,4 @@
-[ "--include-path=examples"
+[ "--quote-include-path=examples"
 , "--module=Test.PP.Test01"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/Test02.lhs
+++ b/hs-bindgen/test/pp/Test/PP/Test02.lhs
@@ -1,4 +1,4 @@
-[ "--include-path=examples"
+[ "--quote-include-path=examples"
 , "--module=Test.PP.Test02"
 , "test_02.h"
 ]

--- a/manual/LowLevel/Invocation.md
+++ b/manual/LowLevel/Invocation.md
@@ -55,5 +55,5 @@ Note that when using `hs-bindgen-cli`, users can fully configure `libclang`
 with command-line arguments. For instance, they can set:
 
 - `--system-include-path DIR`,
-- `--include-path DIR`, and
+- `--quote-include-path DIR`, and
 - `--clang-option OPTION` (for other options passed directly to `libclang`).


### PR DESCRIPTION
When initially designing the command-line options, we decided to make `-I` add to the quote include path.  Users must use `--system-include-path` to add to the system include path.

```
--no-stdinc                 Disable standard include directories
--system-include-path DIR   System include search path directory
-I,--include-path DIR       Quote include search path directory
```

I propose that we instead make `-I` add to the system include path, for consistency with Clang and GCC.  Include directories specified in `.cabal` or `cabal.project(.local)` configuration are passed to the C compiler using `-I`, so they are added to the system include path as well.

```
--no-stdinc                    Disable standard include directories
-I,--system-include-path DIR   System include search path directory
--quote-include-path DIR       Quote include search path directory
```

Note that the long options now both explicitly specify `system` or `quote`.  I think that this will be easiest for users to understand/use.