### PR TITLE
Distinguish anonymous declarations

### DIFF
--- a/hs-bindgen/fixtures/anonymous.bindingspec.yaml
+++ b/hs-bindgen/fixtures/anonymous.bindingspec.yaml
@@ -8,33 +8,9 @@ types:
   - Show
   - Storable
 - headers: anonymous.h
-  cname: S1_c
-  module: Example
-  identifier: S1_c
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
   cname: struct S2
   module: Example
   identifier: S2
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
-  cname: S2_inner
-  module: Example
-  identifier: S2_inner
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: anonymous.h
-  cname: S2_inner_deep
-  module: Example
-  identifier: S2_inner_deep
   instances:
   - Eq
   - Show
@@ -48,7 +24,31 @@ types:
   - Show
   - Storable
 - headers: anonymous.h
-  cname: S3_c
+  cname: '@S1_c'
+  module: Example
+  identifier: S1_c
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: '@S2_inner'
+  module: Example
+  identifier: S2_inner
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: '@S2_inner_deep'
+  module: Example
+  identifier: S2_inner_deep
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: anonymous.h
+  cname: '@S3_c'
   module: Example
   identifier: S3_c
   instances:

--- a/hs-bindgen/fixtures/attributes.bindingspec.yaml
+++ b/hs-bindgen/fixtures/attributes.bindingspec.yaml
@@ -16,14 +16,6 @@ types:
   - Show
   - Storable
 - headers: attributes.h
-  cname: baz
-  module: Example
-  identifier: Baz
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: attributes.h
   cname: struct foo
   module: Example
   identifier: Foo
@@ -32,7 +24,15 @@ types:
   - Show
   - Storable
 - headers: attributes.h
-  cname: qux
+  cname: '@baz'
+  module: Example
+  identifier: Baz
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: attributes.h
+  cname: '@qux'
   module: Example
   identifier: Qux
   instances:

--- a/hs-bindgen/fixtures/distilled_lib_1.bindingspec.yaml
+++ b/hs-bindgen/fixtures/distilled_lib_1.bindingspec.yaml
@@ -18,37 +18,9 @@ types:
   - Real
   - Storable
 - headers: distilled_lib_1.h
-  cname: a_typedef_enum_e
-  module: Example
-  identifier: A_typedef_enum_e
-  instances:
-  - Eq
-  - Ord
-  - Read
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
   cname: struct a_typedef_struct
   module: Example
   identifier: A_typedef_struct_t
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
-  cname: another_typedef_enum_e
-  module: Example
-  identifier: Another_typedef_enum_e
-  instances:
-  - Eq
-  - Ord
-  - Read
-  - Show
-  - Storable
-- headers: distilled_lib_1.h
-  cname: another_typedef_struct_t
-  module: Example
-  identifier: Another_typedef_struct_t
   instances:
   - Eq
   - Show
@@ -79,4 +51,32 @@ types:
   - Integral
   - Num
   - Real
+  - Storable
+- headers: distilled_lib_1.h
+  cname: '@a_typedef_enum_e'
+  module: Example
+  identifier: A_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: distilled_lib_1.h
+  cname: '@another_typedef_enum_e'
+  module: Example
+  identifier: Another_typedef_enum_e
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: distilled_lib_1.h
+  cname: '@another_typedef_struct_t'
+  module: Example
+  identifier: Another_typedef_struct_t
+  instances:
+  - Eq
+  - Show
   - Storable

--- a/hs-bindgen/fixtures/enum_cpp_syntax.bindingspec.yaml
+++ b/hs-bindgen/fixtures/enum_cpp_syntax.bindingspec.yaml
@@ -1,6 +1,6 @@
 types:
 - headers: enum_cpp_syntax.h
-  cname: foo_enum
+  cname: '@foo_enum'
   module: Example
   identifier: Foo_enum
   instances:

--- a/hs-bindgen/fixtures/enums.bindingspec.yaml
+++ b/hs-bindgen/fixtures/enums.bindingspec.yaml
@@ -1,15 +1,5 @@
 types:
 - headers: enums.h
-  cname: enumA
-  module: Example
-  identifier: EnumA
-  instances:
-  - Eq
-  - Ord
-  - Read
-  - Show
-  - Storable
-- headers: enums.h
   cname: enum enumB
   module: Example
   identifier: EnumB
@@ -83,6 +73,16 @@ types:
   cname: enum second
   module: Example
   identifier: Second
+  instances:
+  - Eq
+  - Ord
+  - Read
+  - Show
+  - Storable
+- headers: enums.h
+  cname: '@enumA'
+  module: Example
+  identifier: EnumA
   instances:
   - Eq
   - Ord

--- a/hs-bindgen/fixtures/flam.bindingspec.yaml
+++ b/hs-bindgen/fixtures/flam.bindingspec.yaml
@@ -16,17 +16,17 @@ types:
   - Show
   - Storable
 - headers: flam.h
-  cname: foo_bar
+  cname: struct pascal
   module: Example
-  identifier: Foo_bar
+  identifier: Pascal
   instances:
   - Eq
   - Show
   - Storable
 - headers: flam.h
-  cname: struct pascal
+  cname: '@foo_bar'
   module: Example
-  identifier: Pascal
+  identifier: Foo_bar
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/fun_attributes.bindingspec.yaml
+++ b/hs-bindgen/fixtures/fun_attributes.bindingspec.yaml
@@ -1,13 +1,5 @@
 types:
 - headers: fun_attributes.h
-  cname: FILE
-  module: Example
-  identifier: FILE
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: fun_attributes.h
   cname: size_t
   module: Example
   identifier: Size_t
@@ -24,4 +16,12 @@ types:
   - Integral
   - Num
   - Real
+  - Storable
+- headers: fun_attributes.h
+  cname: '@FILE'
+  module: Example
+  identifier: FILE
+  instances:
+  - Eq
+  - Show
   - Storable

--- a/hs-bindgen/fixtures/globals.bindingspec.yaml
+++ b/hs-bindgen/fixtures/globals.bindingspec.yaml
@@ -16,7 +16,7 @@ types:
   - Show
   - Storable
 - headers: globals.h
-  cname: struct1_t
+  cname: '@struct1_t'
   module: Example
   identifier: Struct1_t
   instances:
@@ -24,7 +24,7 @@ types:
   - Show
   - Storable
 - headers: globals.h
-  cname: struct2_t
+  cname: '@struct2_t'
   module: Example
   identifier: Struct2_t
   instances:
@@ -32,7 +32,7 @@ types:
   - Show
   - Storable
 - headers: globals.h
-  cname: version_t
+  cname: '@version_t'
   module: Example
   identifier: Version_t
   instances:

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.bindingspec.yaml
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.bindingspec.yaml
@@ -44,14 +44,6 @@ types:
   - Show
   - Storable
 - headers: macro_in_fundecl_vs_typedef.h
-  cname: struct2
-  module: Example
-  identifier: Struct2
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: macro_in_fundecl_vs_typedef.h
   cname: struct struct3
   module: Example
   identifier: Struct3
@@ -71,6 +63,14 @@ types:
   cname: struct struct4
   module: Example
   identifier: Struct4
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: macro_in_fundecl_vs_typedef.h
+  cname: '@struct2'
+  module: Example
+  identifier: Struct2
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/macro_typedef_struct.bindingspec.yaml
+++ b/hs-bindgen/fixtures/macro_typedef_struct.bindingspec.yaml
@@ -18,7 +18,7 @@ types:
   - Real
   - Storable
 - headers: macro_typedef_struct.h
-  cname: bar
+  cname: '@bar'
   module: Example
   identifier: Bar
   instances:

--- a/hs-bindgen/fixtures/named_vs_anon.bindingspec.yaml
+++ b/hs-bindgen/fixtures/named_vs_anon.bindingspec.yaml
@@ -40,30 +40,6 @@ types:
   - Show
   - Storable
 - headers: named_vs_anon.h
-  cname: f
-  module: Example
-  identifier: F
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: named_vs_anon.h
-  cname: g
-  module: Example
-  identifier: G
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: named_vs_anon.h
-  cname: h
-  module: Example
-  identifier: H
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: named_vs_anon.h
   cname: struct struct1
   module: Example
   identifier: Struct1
@@ -104,7 +80,31 @@ types:
   - Show
   - Storable
 - headers: named_vs_anon.h
-  cname: typedef1
+  cname: '@f'
+  module: Example
+  identifier: F
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: named_vs_anon.h
+  cname: '@g'
+  module: Example
+  identifier: G
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: named_vs_anon.h
+  cname: '@h'
+  module: Example
+  identifier: H
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: named_vs_anon.h
+  cname: '@typedef1'
   module: Example
   identifier: Typedef1
   instances:
@@ -112,7 +112,7 @@ types:
   - Show
   - Storable
 - headers: named_vs_anon.h
-  cname: typedef2
+  cname: '@typedef2'
   module: Example
   identifier: Typedef2
   instances:
@@ -120,7 +120,7 @@ types:
   - Show
   - Storable
 - headers: named_vs_anon.h
-  cname: typedef3
+  cname: '@typedef3'
   module: Example
   identifier: Typedef3
   instances:

--- a/hs-bindgen/fixtures/nested_enums.bindingspec.yaml
+++ b/hs-bindgen/fixtures/nested_enums.bindingspec.yaml
@@ -26,7 +26,7 @@ types:
   - Show
   - Storable
 - headers: nested_enums.h
-  cname: exB_fieldB1
+  cname: '@exB_fieldB1'
   module: Example
   identifier: ExB_fieldB1
   instances:

--- a/hs-bindgen/fixtures/nested_types.bindingspec.yaml
+++ b/hs-bindgen/fixtures/nested_types.bindingspec.yaml
@@ -16,14 +16,6 @@ types:
   - Show
   - Storable
 - headers: nested_types.h
-  cname: ex3_ex3_struct
-  module: Example
-  identifier: Ex3_ex3_struct
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: nested_types.h
   cname: struct ex4_even
   module: Example
   identifier: Ex4_even
@@ -43,6 +35,14 @@ types:
   cname: struct foo
   module: Example
   identifier: Foo
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: nested_types.h
+  cname: '@ex3_ex3_struct'
+  module: Example
+  identifier: Ex3_ex3_struct
   instances:
   - Eq
   - Show

--- a/hs-bindgen/fixtures/nested_unions.bindingspec.yaml
+++ b/hs-bindgen/fixtures/nested_unions.bindingspec.yaml
@@ -12,14 +12,14 @@ types:
   instances:
   - Storable
 - headers: nested_unions.h
-  cname: exB_fieldB1
-  module: Example
-  identifier: ExB_fieldB1
-  instances:
-  - Storable
-- headers: nested_unions.h
   cname: union unionA
   module: Example
   identifier: UnionA
+  instances:
+  - Storable
+- headers: nested_unions.h
+  cname: '@exB_fieldB1'
+  module: Example
+  identifier: ExB_fieldB1
   instances:
   - Storable

--- a/hs-bindgen/fixtures/simple_structs.bindingspec.yaml
+++ b/hs-bindgen/fixtures/simple_structs.bindingspec.yaml
@@ -16,14 +16,6 @@ types:
   - Show
   - Storable
 - headers: simple_structs.h
-  cname: S3_t
-  module: Example
-  identifier: S3_t
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: simple_structs.h
   cname: struct S4
   module: Example
   identifier: S4
@@ -57,14 +49,6 @@ types:
   - Show
   - Storable
 - headers: simple_structs.h
-  cname: S7a_Deref
-  module: Example
-  identifier: S7a_Deref
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: simple_structs.h
   cname: S7b
   module: Example
   identifier: S7b
@@ -74,7 +58,23 @@ types:
   - Show
   - Storable
 - headers: simple_structs.h
-  cname: S7b_Deref
+  cname: '@S3_t'
+  module: Example
+  identifier: S3_t
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: simple_structs.h
+  cname: '@S7a_Deref'
+  module: Example
+  identifier: S7a_Deref
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: simple_structs.h
+  cname: '@S7b_Deref'
   module: Example
   identifier: S7b_Deref
   instances:

--- a/hs-bindgen/fixtures/spec_examples.bindingspec.yaml
+++ b/hs-bindgen/fixtures/spec_examples.bindingspec.yaml
@@ -20,14 +20,6 @@ types:
   module: Example
   identifier: C
 - headers: spec_examples.h
-  cname: cint16_T
-  module: Example
-  identifier: Cint16_T
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: spec_examples.h
   cname: int16_T
   module: Example
   identifier: Int16_T
@@ -80,4 +72,12 @@ types:
   - Integral
   - Num
   - Real
+  - Storable
+- headers: spec_examples.h
+  cname: '@cint16_T'
+  module: Example
+  identifier: Cint16_T
+  instances:
+  - Eq
+  - Show
   - Storable

--- a/hs-bindgen/fixtures/type_attributes.bindingspec.yaml
+++ b/hs-bindgen/fixtures/type_attributes.bindingspec.yaml
@@ -90,7 +90,7 @@ types:
   module: Example
   identifier: Wait
 - headers: type_attributes.h
-  cname: wait_status_ptr_t
+  cname: '@wait_status_ptr_t'
   module: Example
   identifier: Wait_status_ptr_t
   instances:

--- a/hs-bindgen/fixtures/unions.bindingspec.yaml
+++ b/hs-bindgen/fixtures/unions.bindingspec.yaml
@@ -6,22 +6,6 @@ types:
   instances:
   - Storable
 - headers: unions.h
-  cname: AnonA_polar
-  module: Example
-  identifier: AnonA_polar
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: unions.h
-  cname: AnonA_xy
-  module: Example
-  identifier: AnonA_xy
-  instances:
-  - Eq
-  - Show
-  - Storable
-- headers: unions.h
   cname: struct Dim
   module: Example
   identifier: Dim
@@ -60,4 +44,20 @@ types:
   module: Example
   identifier: DimPayloadB
   instances:
+  - Storable
+- headers: unions.h
+  cname: '@AnonA_polar'
+  module: Example
+  identifier: AnonA_polar
+  instances:
+  - Eq
+  - Show
+  - Storable
+- headers: unions.h
+  cname: '@AnonA_xy'
+  module: Example
+  identifier: AnonA_xy
+  instances:
+  - Eq
+  - Show
   - Storable

--- a/hs-bindgen/fixtures/vector.bindingspec.yaml
+++ b/hs-bindgen/fixtures/vector.bindingspec.yaml
@@ -1,6 +1,6 @@
 types:
 - headers: vector.h
-  cname: vector
+  cname: '@vector'
   module: Example
   identifier: Vector
   instances:

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -13,7 +13,6 @@ module HsBindgen.BindingSpec.Gen (
 
 import Data.ByteString (ByteString)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (listToMaybe)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 
@@ -173,12 +172,10 @@ getNewtypeSpec hsModuleName hsNewtype =
 
 getCQualName :: C.DeclInfo -> C.NameKind -> C.QualName
 getCQualName declInfo cNameKind = case C.declOrigin declInfo of
-    C.NameOriginInSource -> C.QualName cName cNameKind
-    C.NameOriginGenerated{} ->
-      let cName' = fromMaybe cName (listToMaybe (C.declAliases declInfo))
-      in  C.QualName cName' C.NameKindOrdinary
+    C.NameOriginInSource              -> C.QualName cName cNameKind
+    C.NameOriginGenerated{}           -> C.QualNameAnon cName
     C.NameOriginRenamedFrom fromCName -> C.QualName fromCName cNameKind
-    C.NameOriginBuiltin -> C.QualName cName C.NameKindOrdinary
+    C.NameOriginBuiltin               -> C.QualName cName C.NameKindOrdinary
   where
     cName :: C.Name
     cName = MangleNames.nameC (C.declId declInfo)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -476,8 +476,7 @@ declQualDeclId Decl{declInfo = DeclInfo{declId}, declKind} = C.QualDeclId {
     }
 
 declQualName :: Id p ~ C.DeclId => Decl p -> C.QualName
-declQualName Decl{declInfo = DeclInfo{declId}, declKind} =
-    C.QualName (C.declIdName declId) (declKindNameKind declKind)
+declQualName = C.qualDeclIdQualName . declQualDeclId
 
 declKindNameKind :: DeclKind p -> C.NameKind
 declKindNameKind = \case

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
@@ -46,6 +46,7 @@ module HsBindgen.Frontend.Naming (
     -- ** QualDeclId
   , QualDeclId(..)
   , qualDeclId
+  , qualDeclIdQualName
   , qualDeclIdText
   , qualDeclIdNsPrelimDeclId
 
@@ -192,30 +193,43 @@ nameKindPrefix = \case
   QualName
 -------------------------------------------------------------------------------}
 
--- | C name, qualified by the 'NameKind'
---
--- This is the parsed representation of a @libclang@ C spelling.
-data QualName = QualName {
-      qualNameName :: Name
-    , qualNameKind :: NameKind
-    }
+-- | C name, qualified to distinguish kinds and anonymous names
+data QualName =
+    -- | Valid C name
+    --
+    -- This is the parsed representation of a @libclang@ C spelling.
+    QualName {
+        qualNameName :: Name
+      , qualNameKind :: NameKind
+      }
+
+    -- | Generated name for an anonymous C type
+    --
+    -- Syntax: @\@foo@ references an anonymous C type with generated name @foo@.
+  | QualNameAnon {
+        qualNameAnonGeneratedName :: Name
+      }
   deriving stock (Eq, Generic, Ord, Show)
 
 instance PrettyForTrace QualName where
   prettyForTrace = PP.textToCtxDoc . qualNameText
 
 qualNameText :: QualName -> Text
-qualNameText QualName{..} = case nameKindPrefix qualNameKind of
-    Nothing     -> getName qualNameName
-    Just prefix -> prefix <> " " <> getName qualNameName
+qualNameText = \case
+    QualName{..}     -> case nameKindPrefix qualNameKind of
+      Nothing     -> getName qualNameName
+      Just prefix -> Text.unwords [prefix, getName qualNameName]
+    QualNameAnon{..} -> "@" <> getName qualNameAnonGeneratedName
 
 parseQualName :: Text -> Maybe QualName
-parseQualName t = case Text.words t of
-    [n]           -> Just $ QualName (Name n) NameKindOrdinary
-    ["struct", n] -> Just $ QualName (Name n) (NameKindTagged TagKindStruct)
-    ["union",  n] -> Just $ QualName (Name n) (NameKindTagged TagKindUnion)
-    ["enum",   n] -> Just $ QualName (Name n) (NameKindTagged TagKindEnum)
-    _otherwise    -> Nothing
+parseQualName t = case Text.stripPrefix "@" t of
+    Nothing -> case Text.words t of
+      [n]           -> Just $ QualName (Name n) NameKindOrdinary
+      ["struct", n] -> Just $ QualName (Name n) (NameKindTagged TagKindStruct)
+      ["union",  n] -> Just $ QualName (Name n) (NameKindTagged TagKindUnion)
+      ["enum",   n] -> Just $ QualName (Name n) (NameKindTagged TagKindEnum)
+      _otherwise    -> Nothing
+    Just n  -> Just $ QualNameAnon (Name n)
 
 {-------------------------------------------------------------------------------
   AnonId
@@ -442,10 +456,13 @@ qualDeclId DeclId{..} nameKind = QualDeclId {
     , qualDeclIdKind   = nameKind
     }
 
+qualDeclIdQualName :: QualDeclId -> QualName
+qualDeclIdQualName QualDeclId{..} = case qualDeclIdOrigin of
+    NameOriginGenerated{} -> QualNameAnon qualDeclIdName
+    _otherwise            -> QualName qualDeclIdName qualDeclIdKind
+
 qualDeclIdText :: QualDeclId -> Text
-qualDeclIdText QualDeclId{..} = case qualDeclIdOrigin of
-    NameOriginGenerated{} -> "anon:" <> getName qualDeclIdName
-    _otherwise -> qualNameText $ QualName qualDeclIdName qualDeclIdKind
+qualDeclIdText = qualNameText . qualDeclIdQualName
 
 qualDeclIdNsPrelimDeclId :: QualDeclId -> NsPrelimDeclId
 qualDeclIdNsPrelimDeclId QualDeclId{..} = case qualDeclIdOrigin of

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -53,7 +53,7 @@ mangleNames unit =
   even if there are errors.
 -------------------------------------------------------------------------------}
 
-type NameMap = Map C.QualName  HsIdentifier
+type NameMap = Map C.QualName HsIdentifier
 
 chooseNames ::
      FixCandidate Maybe
@@ -138,10 +138,13 @@ class MangleDecl a where
     -> a HandleTypedefs -> M (a MangleNames)
 
 mangleQualName :: C.QualName -> C.NameOrigin -> M (NamePair, C.NameOrigin)
-mangleQualName cQualName@(C.QualName cName _namespace) nameOrigin = do
+mangleQualName cQualName cNameOrigin = do
+    let cName = case cQualName of
+          C.QualName{..}     -> qualNameName
+          C.QualNameAnon{..} -> qualNameAnonGeneratedName
     nm <- asks envNameMap
     case Map.lookup cQualName nm of
-      Just hsName -> return (NamePair cName hsName, nameOrigin)
+      Just hsName -> return (NamePair cName hsName, cNameOrigin)
       Nothing     -> do
         -- NB: We did not register any declaration with the given ID. This is
         -- most likely because the user did not select the declaration. If the
@@ -149,7 +152,13 @@ mangleQualName cQualName@(C.QualName cName _namespace) nameOrigin = do
         -- already.
         modify (MangleNamesMissingDeclaration cQualName :)
         -- Use a fake Haskell ID.
-        return (NamePair cName (HsIdentifier "MissingDeclaration"), nameOrigin)
+        return (NamePair cName (HsIdentifier "MissingDeclaration"), cNameOrigin)
+
+mangleQualName' :: C.DeclId -> C.NameKind -> M (NamePair, C.NameOrigin)
+mangleQualName' cDeclId cNameKind =
+    mangleQualName
+      (C.qualDeclIdQualName (C.qualDeclId cDeclId cNameKind))
+      (C.declIdOrigin cDeclId)
 
 {-------------------------------------------------------------------------------
   Additional name mangling functionality
@@ -385,20 +394,14 @@ instance MangleDecl C.CheckedMacroType where
 
 instance Mangle C.Type where
   mangle = \case
-      C.TypeStruct C.DeclId{..} -> C.TypeStruct <$>
-        mangleQualName
-          (C.QualName declIdName (C.NameKindTagged C.TagKindStruct))
-          declIdOrigin
-      C.TypeUnion C.DeclId{..} -> C.TypeUnion <$>
-        mangleQualName
-          (C.QualName declIdName (C.NameKindTagged C.TagKindUnion))
-          declIdOrigin
-      C.TypeEnum C.DeclId{..} -> C.TypeEnum <$>
-        mangleQualName
-          (C.QualName declIdName (C.NameKindTagged C.TagKindEnum))
-          declIdOrigin
-      C.TypeMacroTypedef C.DeclId{..} -> C.TypeMacroTypedef <$>
-        mangleQualName (C.QualName declIdName C.NameKindOrdinary) declIdOrigin
+      C.TypeStruct       cDeclId -> C.TypeStruct <$>
+        mangleQualName' cDeclId (C.NameKindTagged C.TagKindStruct)
+      C.TypeUnion        cDeclId -> C.TypeUnion <$>
+        mangleQualName' cDeclId (C.NameKindTagged C.TagKindUnion)
+      C.TypeEnum         cDeclId -> C.TypeEnum <$>
+        mangleQualName' cDeclId (C.NameKindTagged C.TagKindEnum)
+      C.TypeMacroTypedef cDeclId -> C.TypeMacroTypedef <$>
+        mangleQualName' cDeclId C.NameKindOrdinary
 
       -- Recursive cases
       C.TypeTypedef ref         -> C.TypeTypedef <$> mangle ref
@@ -414,10 +417,11 @@ instance Mangle C.Type where
       C.TypeExtBinding ext -> return $ C.TypeExtBinding ext
 
 instance Mangle RenamedTypedefRef where
-  mangle (TypedefRegular C.DeclId{..}) = TypedefRegular <$>
-    mangleQualName (C.QualName declIdName C.NameKindOrdinary) declIdOrigin
-  mangle (TypedefSquashed cName ty) =
-    TypedefSquashed cName <$> mangle ty
+  mangle = \case
+      TypedefRegular cDeclId ->
+        TypedefRegular <$> mangleQualName' cDeclId C.NameKindOrdinary
+      TypedefSquashed cName ty ->
+        TypedefSquashed cName <$> mangle ty
 
 {-------------------------------------------------------------------------------
   Internal auxiliary

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
@@ -175,7 +175,7 @@ recordNonParsedDecl declInfo nameKind =
             }
       Nothing ->
         -- We __do not track unselected anonymous declarations__. If we want to
-        -- use descriptive binding specification with anonymous declarations, we
+        -- use an external binding specification with anonymous declarations, we
         -- __must__ select these declarations.
         return ()
   where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpec.hs
@@ -387,8 +387,8 @@ instance Resolve C.Type where
         -> M (Set C.NsPrelimDeclId, C.Type ResolveBindingSpec)
       aux mk cQualDeclId@C.QualDeclId{..} =
         RWS.ask >>= \MEnv{..} -> RWS.get >>= \MState{..} -> do
-          let cQualName = C.QualName qualDeclIdName qualDeclIdKind
-              nsid = C.qualDeclIdNsPrelimDeclId cQualDeclId
+          let cQualName = C.qualDeclIdQualName cQualDeclId
+              nsid      = C.qualDeclIdNsPrelimDeclId cQualDeclId
           -- check for type omitted by binding specification
           when (Set.member cQualName stateOmitTypes) $
             RWS.modify' $

--- a/manual/external/vector.yaml
+++ b/manual/external/vector.yaml
@@ -1,6 +1,6 @@
 types:
 - headers: vector.h
-  cname: vector
+  cname: @vector
   module: Vector
   identifier: Vector
   instances:


### PR DESCRIPTION
New type constructor `QualNameAnon` is added to the `QualName` type to distinguish anonymous declarations in binding specifications and select predicates.  The string representation uses an `@` prefix.

Example: `@SC_c`

This character should not cause issues with regular expressions.

This character is reserved for future use by YAML and must therefore be quoted.

Example:

```yaml
cname: '@S1_c'
```