### PR TITLE
Cancel the Simple GHA job automatically when pushing to a PR

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   native:
     name: "Simple: GHC ${{ matrix.ghc }} with LLVM ${{ matrix.llvm }} on ${{ matrix.os }}"


### PR DESCRIPTION
If a new version of a branch is pushed to a PR, we currently don't cancel outdated jobs. They run until they finish. With this change, such "obsolete" jobs will be cancelled automatically.