### PR TITLE
Update `--select-by-decl-name` usage info

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -374,12 +374,12 @@ parseSelectPredicate = fmap aux . many . asum $ [
         ]
     , fmap (Right . PIf . Right . DeclNameMatches) $ strOption $ mconcat [
           long "select-by-decl-name"
-        , help "Select declarations with names that match PCRE"
+        , help "Select declarations with C names that match PCRE"
         , metavar "PCRE"
         ]
     , fmap (Left . PIf . Right . DeclNameMatches) $ strOption $ mconcat [
           long "select-except-by-decl-name"
-        , help "Select except declarations with names that match PCRE"
+        , help "Select except declarations with C names that match PCRE"
         , metavar "PCRE"
         ]
     ]


### PR DESCRIPTION
The CLI usage info for both `--select-by-decl-name` and `--select-except-by-decl-name` is updated to specify that *C* names are matched, not Haskell names.