### PR TITLE
Resolve headers in bulk

### DIFF
--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -103,10 +103,10 @@ execResolve GlobalOpts{..} ResolveOpts{..} = do
         case Map.lookup header includes of
           Just path -> (False <$) . putStrLn $
             "#include <" ++ getHashIncludeArg header
-              ++ "> resolves to " ++ show path
+              ++ "> resolved to " ++ show path
           Nothing   -> (True  <$) . putStrLn $
             "#include <" ++ getHashIncludeArg header
-              ++ "> does not resolve (header not found)"
+              ++ "> could not be resolved (header not found)"
     case mErr of
       Just False -> exitSuccess
       Just True  -> exitFailure
@@ -119,7 +119,7 @@ execResolve GlobalOpts{..} ResolveOpts{..} = do
 
     customLogLevel :: CustomLogLevel Level TraceMsg
     customLogLevel = CustomLogLevel $ \case
-      TraceResolveHeader ResolveHeaderSuccess{}  -> Just Debug
+      TraceResolveHeader ResolveHeaderFound{}    -> Just Debug
       TraceResolveHeader ResolveHeaderNotFound{} -> Just Debug
       _otherTrace -> Nothing
 

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -4,10 +4,12 @@ module Main (main) where
 
 import Control.Exception (Exception (..), SomeException (..), fromException,
                           handle, throwIO)
-import Control.Monad (forM_, void, (<=<))
+import Control.Monad (forM, void, (<=<))
 import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Optics
-import System.Exit (ExitCode, exitFailure)
+import System.Exit (ExitCode, exitFailure, exitSuccess)
 import Text.Read (readMaybe)
 
 import HsBindgen.Lib
@@ -90,15 +92,36 @@ execBindingSpec GlobalOpts{..} BindingSpecCmdStdlib{..} = do
 -- https://github.com/well-typed/hs-bindgen/issues/990.
 execResolve :: GlobalOpts -> ResolveOpts -> IO ()
 execResolve GlobalOpts{..} ResolveOpts{..} = do
-    mErr <- withTracer tracerConfig $ \tracer -> do
-      let tracerResolve = contramap TraceResolveHeader tracer
+    mErr <- withTracer tracerConfig' $ \tracer -> do
       hashIncludeArgs <- checkInputs tracer inputs
-      forM_ hashIncludeArgs $ \header -> do
-        mPath <- resolveHeader tracerResolve clangArgs header
-        putStrLn . unwords $ case mPath of
-          Just path -> [show header, "resolves to", show path]
-          Nothing   -> [show header, "not found"]
-    fromMaybeWithFatalError mErr
+      includes <-
+        resolveHeaders
+          (contramap TraceResolveHeader tracer)
+          clangArgs
+          (Set.fromList hashIncludeArgs)
+      fmap or . forM hashIncludeArgs $ \header ->
+        case Map.lookup header includes of
+          Just path -> (False <$) . putStrLn $
+            "#include <" ++ getHashIncludeArg header
+              ++ "> resolves to " ++ show path
+          Nothing   -> (True  <$) . putStrLn $
+            "#include <" ++ getHashIncludeArg header
+              ++ "> does not resolve (header not found)"
+    case mErr of
+      Just False -> exitSuccess
+      Just True  -> exitFailure
+      Nothing    -> fatalError
+  where
+    tracerConfig' :: TracerConfig IO Level TraceMsg
+    tracerConfig' = tracerConfig{
+        tCustomLogLevel = customLogLevel <> tCustomLogLevel tracerConfig
+      }
+
+    customLogLevel :: CustomLogLevel Level TraceMsg
+    customLogLevel = CustomLogLevel $ \case
+      TraceResolveHeader ResolveHeaderSuccess{}  -> Just Debug
+      TraceResolveHeader ResolveHeaderNotFound{} -> Just Debug
+      _otherTrace -> Nothing
 
 {-------------------------------------------------------------------------------
   Exception handling

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -167,6 +167,7 @@ library internal
       HsBindgen.PrettyC
       HsBindgen.Resolve
       HsBindgen.TraceMsg
+      HsBindgen.Util.List
       HsBindgen.Util.Monad
       HsBindgen.Util.Parsec
       HsBindgen.Util.TestEquality
@@ -234,6 +235,7 @@ library
     , hs-bindgen:internal
   build-depends:
       -- Inherited dependencies
+    , containers
     , filepath
 
 executable hs-bindgen-cli
@@ -258,6 +260,7 @@ executable hs-bindgen-cli
   build-depends:
       -- Inherited dependencies
     , bytestring
+    , containers
   build-depends:
       -- External dependencies
     , optics               >= 0.4.2.1   && < 0.5
@@ -310,6 +313,7 @@ executable clang-ast-dump
     , hs-bindgen:internal
   build-depends:
       -- Inherited dependencies
+    , containers
     , data-default
     , text
   build-depends:

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
@@ -25,7 +25,6 @@ module HsBindgen.Frontend.RootHeader (
   , HashIncludeArgMsg(..)
   ) where
 
-import Data.Maybe (listToMaybe)
 import Prelude hiding (lookup)
 import System.FilePath qualified as FilePath
 
@@ -33,6 +32,7 @@ import Clang.HighLevel.Types
 import Clang.Paths
 import HsBindgen.Errors
 import HsBindgen.Imports
+import HsBindgen.Util.List ((!?))
 import HsBindgen.Util.Tracer
 import Text.SimplePrettyPrint qualified as PP
 
@@ -167,17 +167,3 @@ hashIncludeArgMsgs fp = catMaybes [
         then Nothing
         else Just (HashIncludeArgNotRelative fp)
     ]
-
-{-------------------------------------------------------------------------------
-  Auxiliary functions
--------------------------------------------------------------------------------}
-
--- | List index (subscript) operator, starting from 0
---
--- Returns 'Nothing' if the index is out of bounds
-(!?) :: [a] -> Int -> Maybe a
-xs !? n
-    | n < 0     = Nothing
-    | otherwise = listToMaybe $ drop n xs
-infixl 9 !?
-{-# INLINABLE (!?) #-}

--- a/hs-bindgen/src-internal/HsBindgen/Util/List.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/List.hs
@@ -1,0 +1,17 @@
+module HsBindgen.Util.List (
+    (!?)
+  ) where
+
+import Data.Maybe (listToMaybe)
+
+--------------------------------------------------------------------------------
+
+-- | List index (subscript) operator, starting from 0
+--
+-- Returns 'Nothing' if the index is out of bounds
+(!?) :: [a] -> Int -> Maybe a
+xs !? n
+    | n < 0     = Nothing
+    | otherwise = listToMaybe $ drop n xs
+infixl 9 !?
+{-# INLINABLE (!?) #-}

--- a/hs-bindgen/src/HsBindgen/Lib.hs
+++ b/hs-bindgen/src/HsBindgen/Lib.hs
@@ -6,7 +6,7 @@
 module HsBindgen.Lib (
     -- * Run @hs-bindgen@
     HsBindgen.hsBindgen
-  , resolveHeader
+  , resolveHeaders
   , HsBindgen.Artefact(..)
   , HsBindgen.Artefacts
 
@@ -125,6 +125,9 @@ module HsBindgen.Lib (
   , HsBindgen.NP (..)
   ) where
 
+import Data.Map.Strict (Map)
+import Data.Set (Set)
+
 import HsBindgen.Common qualified as Common
 
 import HsBindgen qualified
@@ -137,12 +140,12 @@ import HsBindgen.Util.Tracer qualified as Tracer
 import Clang.Paths qualified as Paths
 import HsBindgen.Resolve qualified as Resolve
 
--- | Resolve a header, used for debugging
-resolveHeader ::
+-- | Resolve headers, used for debugging
+resolveHeaders ::
      Tracer.Tracer IO Common.ResolveHeaderMsg
   -> Common.ClangArgs
-  -> Common.HashIncludeArg -- ^ The header we want to resolve
-  -> IO (Maybe FilePath)
-resolveHeader tracer args path =
+  -> Set Common.HashIncludeArg
+  -> IO (Map Common.HashIncludeArg FilePath)
+resolveHeaders tracer args headers =
     fmap Paths.getSourcePath <$>
-      Resolve.resolveHeader tracer args path
+      Resolve.resolveHeaders tracer args headers


### PR DESCRIPTION
Headers listed in binding specification files are now resolved using a single translation unit.

A benefit of this approach is that Clang parsing of common headers (included by more than one of the resolved headers) is not duplicated.  Note that the previous implementation was able to `break` as soon as the header was resolved, which allowed us to avoid traversing the full Clang AST but did not prevent Clang from creating that AST.  In this implementation, we must traverse the full Clang AST.

We are concerned that there might be a case where some fatal error could be raised that prevents further header resolution.  We tried various ideas but were unable to get this to happen, as all errors are diagnostics (which we ignore when resolving headers).  The implementation is changed to detect this and emit a `ResolveHeaderNotResolved` trace message.

The `hs-bindgen-cli resolve` command is updated to suppress `ResolveHeader` tracing since it outputs results.  The command exit with exit status `1` if any header does not resolve.