### PR TITLE
Tidy up custom log level settings

### DIFF
--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -90,9 +90,9 @@ parseCustomLogLevel = do
     -- Generic modifiers.
     makeWarningsErrors <- optional parseMakeWarningsErrors
     -- Specific setters.
-    makeMacroTracesWarnings <- optional parseMakeMacroTracesWarnings
+    enableMacroWarnings <- optional parseEnableMacroWarnings
     pure $ getCustomLogLevel $ catMaybes [
-        makeMacroTracesWarnings
+        enableMacroWarnings
       , makeWarningsErrors
       ]
       ++ makeTraceInfos
@@ -115,10 +115,10 @@ parseShowCallStack = flag DisableCallStack EnableCallStack $ mconcat [
   Custom log level settings
 -------------------------------------------------------------------------------}
 
-parseMakeMacroTracesWarnings :: Parser CustomLogLevelSetting
-parseMakeMacroTracesWarnings = flag' MakeMacroTracesWarnings $
+parseEnableMacroWarnings :: Parser CustomLogLevelSetting
+parseEnableMacroWarnings = flag' EnableMacroWarnings $
     mconcat [
-        long "log-as-warning-macro-traces"
+        long "log-enable-macro-warnings"
       , help "Set log level of macro reparse and typecheck errors to warning (default: info)"
       ]
 

--- a/hs-bindgen/app/HsBindgen/App/Common.hs
+++ b/hs-bindgen/app/HsBindgen/App/Common.hs
@@ -87,14 +87,12 @@ parseCustomLogLevel = do
     makeTraceInfos    <- many $ parseMakeTrace Info
     makeTraceWarnings <- many $ parseMakeTrace Warning
     makeTraceErrors   <- many $ parseMakeTrace Error
-    -- Specific setters.
-    makeMacroTracesWarnings      <- optional parseMakeMacroTracesWarnings
-    makeUCharResolutionTraceInfo <- optional parseMakeUCharResolutionTraceInfo
     -- Generic modifiers.
     makeWarningsErrors <- optional parseMakeWarningsErrors
+    -- Specific setters.
+    makeMacroTracesWarnings <- optional parseMakeMacroTracesWarnings
     pure $ getCustomLogLevel $ catMaybes [
         makeMacroTracesWarnings
-      , makeUCharResolutionTraceInfo
       , makeWarningsErrors
       ]
       ++ makeTraceInfos
@@ -122,13 +120,6 @@ parseMakeMacroTracesWarnings = flag' MakeMacroTracesWarnings $
     mconcat [
         long "log-as-warning-macro-traces"
       , help "Set log level of macro reparse and typecheck errors to warning (default: info)"
-      ]
-
-parseMakeUCharResolutionTraceInfo :: Parser CustomLogLevelSetting
-parseMakeUCharResolutionTraceInfo = flag' MakeUCharResolutionTraceInfo $
-    mconcat [
-        long "log-as-info-uchar-header-resolution-trace"
-      , help "Set log level of `uchar.h` header resolution errors to info"
       ]
 
 parseMakeTrace :: Level -> Parser CustomLogLevelSetting

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -72,13 +72,6 @@ instance PrettyForTrace HandleMacrosMsg where
         "Unsupported type: " >< string err
 
 -- | Default log level
---
--- Reparse and typechecking errors may indicate that something went wrong, or
--- they may be caused by macro syntax that we do not yet support.  They are
--- 'Info' by default because there are many unsupported macros in standard
--- library implementations.  Users may optionally make them 'Warning' instead.
---
--- Other errors are 'Info' because they are /always/ unsupported.
 instance IsTrace Level HandleMacrosMsg where
   getDefaultLogLevel = const Info
   getSource          = const HsBindgen

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -45,7 +45,7 @@ import HsBindgen.Frontend.Pass.Parse.Type.Monad (ParseTypeException (..))
 import HsBindgen.Frontend.Pass.ResolveBindingSpec.IsPass (ResolveBindingSpecMsg (..))
 import HsBindgen.Frontend.Pass.Select.IsPass (SelectMsg (..))
 import HsBindgen.Frontend.Pass.Sort.IsPass (SortMsg (..))
-import HsBindgen.Frontend.RootHeader (HashIncludeArgMsg (..), getHashIncludeArg)
+import HsBindgen.Frontend.RootHeader (HashIncludeArgMsg (..))
 import HsBindgen.Imports
 import HsBindgen.Resolve (ResolveHeaderMsg (..))
 import HsBindgen.Util.Tracer
@@ -77,9 +77,6 @@ data CustomLogLevelSetting =
     MakeTrace Level TraceId
 
     -- * Specific setters
-    -- | The header `uchar.h` is not available on MacOS. Set the log level to
-    -- 'Info'.
-  | MakeUCharResolutionTraceInfo
     -- | Set the log level of macro-related parsing traces to 'Warning'. By
     -- default, traces emitted while parsing macros have log level 'Info'.
   | MakeMacroTracesWarnings
@@ -109,7 +106,6 @@ fromSetting = \case
     MakeTrace level traceId      -> makeTrace level traceId
     -- Specific setters.
     MakeMacroTracesWarnings      -> makeMacroTracesWarnings
-    MakeUCharResolutionTraceInfo -> makeUCharResolutionTraceInfo
     -- Generic modifiers.
     MakeWarningsErrors           -> makeWarningsErrors
   where
@@ -121,11 +117,6 @@ fromSetting = \case
           -> const Warning
         _otherTrace
           -> id
-    makeUCharResolutionTraceInfo :: CustomLogLevel Level TraceMsg
-    makeUCharResolutionTraceInfo = CustomLogLevel $ \case
-        TraceResolveHeader (ResolveHeaderNotFound h)
-          | getHashIncludeArg h == "uchar.h" -> const Info
-        _otherTrace                          -> id
     makeTrace :: Level -> TraceId -> CustomLogLevel Level TraceMsg
     makeTrace desiredLevel traceId = CustomLogLevel $ \trace actualLevel ->
       if getTraceId trace == traceId

--- a/hs-bindgen/test/th/Test/TH/Test02.hs
+++ b/hs-bindgen/test/th/Test/TH/Test02.hs
@@ -8,9 +8,6 @@ import HsBindgen.Runtime.Prelude qualified
 import HsBindgen.TH
 
 let opts = def {
-      extraIncludeDirs   = [ RelativeToPkgRoot "examples"]
-    , tracerConfig = tracerConfigDefTH {
-          tCustomLogLevel = getCustomLogLevel [MakeUCharResolutionTraceInfo]
-        }
+      extraIncludeDirs = [ RelativeToPkgRoot "examples"]
     }
  in withHsBindgen opts $ hashInclude "test_02.h"


### PR DESCRIPTION
- Remove `MakeUCharResoltuionTraceInfo`: Not required anymore since header resolution traces while loading binding specification are not errors anymore. @TravisCardwell is this OK with you?
- Improve macro parsing custom log level setting
  - Improve documentation and move to implementation site.
  - Rename constructor and command line option.