### PR TITLE
Improve test output

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -329,6 +329,7 @@ library test-common
   hs-source-dirs: test/common
 
   exposed-modules:
+      Test.Common.HsBindgen.Trace
       Test.Common.HsBindgen.TracePredicate
       Test.Common.Util.Cabal
       Test.Common.Util.Tasty

--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace.hs
@@ -1,0 +1,18 @@
+module Test.Common.HsBindgen.Trace (
+  reportTrace
+  ) where
+
+import HsBindgen.Util.Tracer
+
+import Text.SimplePrettyPrint (CtxDoc, (><))
+import Text.SimplePrettyPrint qualified as PP
+
+-- Seeing both, the pretty trace and the 'Show' instance greatly simplifies test
+-- design and debugging.
+reportTrace :: forall l a. (IsTrace l a, Show a) => a -> CtxDoc
+reportTrace trace = PP.vcat $
+              [ "[" >< ppTraceId >< "][pretty] " >< prettyForTrace trace
+              , "[" >< ppTraceId >< "][show  ] " >< PP.showToCtxDoc trace
+              ]
+  where
+    ppTraceId = PP.string $ unTraceId $ getTraceId trace

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
@@ -39,6 +39,7 @@ import HsBindgen.Imports
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
 
+import Test.Common.HsBindgen.Trace (reportTrace)
 import Test.Common.HsBindgen.TracePredicate
 import Test.HsBindgen.Resources
 
@@ -219,7 +220,7 @@ withTestTraceConfig TestCase{testTracePredicate} =
 
 -- | Run 'hsBindgen'.
 --
--- On trace exceptions, print error traces.
+-- On 'TraceException's, print error traces.
 runTestHsBindgen :: IO TestResources -> TestCase -> Artefacts as -> IO (NP I as)
 runTestHsBindgen testResources test artefacts =
     handle exceptionHandler $ runTestHsBindgen' testResources test artefacts
@@ -227,8 +228,9 @@ runTestHsBindgen testResources test artefacts =
     exceptionHandler :: SomeException -> IO a
     exceptionHandler e@(SomeException e')
       | Just (TraceException @TraceMsg es) <- fromException e =
-          mapM_ print es >> throwIO e'
+          mapM_  printTrace es >> throwIO e'
       | otherwise = throwIO e'
+    printTrace = print . reportTrace
 
 -- | Like 'runTestHsBindgen', but do not print error traces.
 runTestHsBindgen' :: IO TestResources -> TestCase -> Artefacts as -> IO (NP I as)


### PR DESCRIPTION
In particular, print the pretty trace with trace ID, and the output of `show`.

Also fix bug that trace predicates were not tested for failing tests.