### PR TITLE
Clean TH language extension check

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/TH.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/TH.hs
@@ -51,11 +51,8 @@ check testResources test =
         (I deps :* I decls :* Nil) <-
           runTestHsBindgen testResources test artefacts
 
-        let requiredExts :: Set TH.Extension
-            requiredExts = getExtensions decls
-
-            thDecls :: Qu [TH.Dec]
-            thDecls = getThDecls deps decls requiredExts
+        let thDecls :: Qu [TH.Dec]
+            thDecls = getThDecls deps decls
 
             (QuState{..}, thdecs) = runQu thDecls
 

--- a/hs-bindgen/test/th/Test/TH/Test01.hs
+++ b/hs-bindgen/test/th/Test/TH/Test01.hs
@@ -1,16 +1,12 @@
 -- {-# OPTIONS_GHC -ddump-splices #-}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
+
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Test.TH.Test01 where
 

--- a/hs-bindgen/test/th/Test/TH/Test02.hs
+++ b/hs-bindgen/test/th/Test/TH/Test02.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 module Test.TH.Test02 where
 


### PR DESCRIPTION
Closes #823 
Closes #732 

The language extension check was already present, but needed some refactoring.
When we remove a language pragma (e.g., `DerivingStrategies` from `Test02.hs`) the following error is reported:
```
Missing language extension(s): 
    - DerivingStrategies
```