### PR TITLE
Make foreign imports of address stubs return in `IO`

### DIFF
--- a/hs-bindgen/fixtures/adios.hs
+++ b/hs-bindgen/fixtures/adios.hs
@@ -417,11 +417,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "c\978\978_ptr",
+        "hs_bindgen_test_adios_52f5e750c2f31c7b",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_adios_52f5e750c2f31c7b",
       foreignImportCallConv =
@@ -430,7 +432,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "adios.h",
   DeclInlineC
     "/* get_\978\978\978_ptr */ __attribute__ ((const)) const signed int *hs_bindgen_test_adios_13030842ed540098 (void) { return &\978\978\978; } ",
@@ -438,11 +442,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "c\978\978\978_ptr",
+        "hs_bindgen_test_adios_13030842ed540098",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_adios_13030842ed540098",
       foreignImportCallConv =
@@ -451,7 +457,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "adios.h",

--- a/hs-bindgen/fixtures/adios.pp.hs
+++ b/hs-bindgen/fixtures/adios.pp.hs
@@ -33,11 +33,23 @@ newtype C数字 = C数字
 foreign import ccall safe "hs_bindgen_test_adios_8e1936b23d816eb2" cϒ
   :: IO ()
 
-foreign import ccall safe "hs_bindgen_test_adios_52f5e750c2f31c7b" cϒϒ_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_adios_52f5e750c2f31c7b" hs_bindgen_test_adios_52f5e750c2f31c7b
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_adios_13030842ed540098" cϒϒϒ_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE cϒϒ_ptr #-}
+
+cϒϒ_ptr :: F.Ptr FC.CInt
+cϒϒ_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_adios_52f5e750c2f31c7b
+
+foreign import ccall unsafe "hs_bindgen_test_adios_13030842ed540098" hs_bindgen_test_adios_13030842ed540098
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE cϒϒϒ_ptr #-}
+
+cϒϒϒ_ptr :: F.Ptr FC.CInt
+cϒϒϒ_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_adios_13030842ed540098
 
 {-# NOINLINE cϒϒϒ #-}
 

--- a/hs-bindgen/fixtures/adios.th.txt
+++ b/hs-bindgen/fixtures/adios.th.txt
@@ -31,8 +31,14 @@ newtype C数字
                       Real)
 {-| -}
 foreign import ccall safe "hs_bindgen_test_adios_8e1936b23d816eb2" cϒ :: IO Unit
-foreign import ccall safe "hs_bindgen_test_adios_52f5e750c2f31c7b" cϒϒ_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_adios_13030842ed540098" cϒϒϒ_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_adios_52f5e750c2f31c7b" hs_bindgen_test_adios_52f5e750c2f31c7b :: IO (Ptr CInt)
+{-# NOINLINE cϒϒ_ptr #-}
+cϒϒ_ptr :: Ptr CInt
+cϒϒ_ptr = unsafePerformIO hs_bindgen_test_adios_52f5e750c2f31c7b
+foreign import ccall safe "hs_bindgen_test_adios_13030842ed540098" hs_bindgen_test_adios_13030842ed540098 :: IO (Ptr CInt)
+{-# NOINLINE cϒϒϒ_ptr #-}
+cϒϒϒ_ptr :: Ptr CInt
+cϒϒϒ_ptr = unsafePerformIO hs_bindgen_test_adios_13030842ed540098
 {-# NOINLINE cϒϒϒ #-}
 cϒϒϒ :: CInt
 cϒϒϒ = unsafePerformIO (peek cϒϒϒ_ptr)

--- a/hs-bindgen/fixtures/array.hs
+++ b/hs-bindgen/fixtures/array.hs
@@ -6,14 +6,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr0_ptr",
+        "hs_bindgen_test_array_5c54826466f2e87b",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_5c54826466f2e87b",
       foreignImportCallConv =
@@ -31,7 +32,9 @@
                 "Global, complete, not initialised"],
           commentOrigin = Just "arr0",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr1_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_ec6a481a47ca4eb1 (void))[3] { return &arr1; } ",
@@ -39,14 +42,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr1_ptr",
+        "hs_bindgen_test_array_ec6a481a47ca4eb1",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_ec6a481a47ca4eb1",
       foreignImportCallConv =
@@ -64,7 +68,9 @@
                 "Global, complete, initialised"],
           commentOrigin = Just "arr1",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr2_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_34db8d8b69220fcc (void))[3] { return &arr2; } ",
@@ -72,14 +78,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr2_ptr",
+        "hs_bindgen_test_array_34db8d8b69220fcc",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_34db8d8b69220fcc",
       foreignImportCallConv =
@@ -97,7 +104,9 @@
                 "Global, extern, complete, not initialised"],
           commentOrigin = Just "arr2",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr3_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_f4e746193b856003 (void))[3] { return &arr3; } ",
@@ -105,14 +114,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr3_ptr",
+        "hs_bindgen_test_array_f4e746193b856003",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_f4e746193b856003",
       foreignImportCallConv =
@@ -130,7 +140,9 @@
                 "Global, extern, complete, initialised"],
           commentOrigin = Just "arr3",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr6_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_bf91904b3049fdd2 (void))[1] { return &arr6; } ",
@@ -138,14 +150,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr6_ptr",
+        "hs_bindgen_test_array_bf91904b3049fdd2",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            1
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              1
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_bf91904b3049fdd2",
       foreignImportCallConv =
@@ -163,7 +176,9 @@
                 "Global, incomplete"],
           commentOrigin = Just "arr6",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr7_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_9be06c66ecc3a933 (void))[] { return &arr7; } ",
@@ -171,13 +186,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr7_ptr",
+        "hs_bindgen_test_array_9be06c66ecc3a933",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsIncompleteArray
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsIncompleteArray
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_9be06c66ecc3a933",
       foreignImportCallConv =
@@ -194,7 +210,9 @@
                 "Global, extern, incomplete"],
           commentOrigin = Just "arr7",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclNewtype
     Newtype {
       newtypeName = HsName
@@ -1015,14 +1033,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_1_ptr",
+        "hs_bindgen_test_array_16bca3ac468967d9",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_16bca3ac468967d9",
       foreignImportCallConv =
@@ -1040,7 +1059,9 @@
                 "Array of known size"],
           commentOrigin = Just "arr_1",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_2_ptr */ __attribute__ ((const)) triplet *hs_bindgen_test_array_07e58c5432be4a35 (void) { return &arr_2; } ",
@@ -1048,15 +1069,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_2_ptr",
+        "hs_bindgen_test_array_07e58c5432be4a35",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Triplet"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Triplet")))),
       foreignImportOrigName =
       "hs_bindgen_test_array_07e58c5432be4a35",
       foreignImportCallConv =
@@ -1076,7 +1098,9 @@
                 "Array of known size, typedef"],
           commentOrigin = Just "arr_2",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_3_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_63e072530b04d3b9 (void))[] { return &arr_3; } ",
@@ -1084,13 +1108,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_3_ptr",
+        "hs_bindgen_test_array_63e072530b04d3b9",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsIncompleteArray
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsIncompleteArray
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_array_63e072530b04d3b9",
       foreignImportCallConv =
@@ -1107,7 +1132,9 @@
                 "Array of unknown size"],
           commentOrigin = Just "arr_3",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_4_ptr */ __attribute__ ((const)) list *hs_bindgen_test_array_3db8d1257bc10233 (void) { return &arr_4; } ",
@@ -1115,15 +1142,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_4_ptr",
+        "hs_bindgen_test_array_3db8d1257bc10233",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "List"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "List")))),
       foreignImportOrigName =
       "hs_bindgen_test_array_3db8d1257bc10233",
       foreignImportCallConv =
@@ -1143,7 +1171,9 @@
                 "Array of unknown size, typedef"],
           commentOrigin = Just "arr_4",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_5_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_0f74917ee2000dc5 (void))[4][3] { return &arr_5; } ",
@@ -1151,16 +1181,17 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_5_ptr",
+        "hs_bindgen_test_array_0f74917ee2000dc5",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            4
+        (HsIO
+          (HsPtr
             (HsConstArray
-              3
-              (HsPrimType HsPrimCInt)))),
+              4
+              (HsConstArray
+                3
+                (HsPrimType HsPrimCInt))))),
       foreignImportOrigName =
       "hs_bindgen_test_array_0f74917ee2000dc5",
       foreignImportCallConv =
@@ -1182,7 +1213,9 @@
                 "Multi-dimensional array of known size"],
           commentOrigin = Just "arr_5",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_6_ptr */ __attribute__ ((const)) matrix *hs_bindgen_test_array_a48940bd219530d0 (void) { return &arr_6; } ",
@@ -1190,15 +1223,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_6_ptr",
+        "hs_bindgen_test_array_a48940bd219530d0",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Matrix"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Matrix")))),
       foreignImportOrigName =
       "hs_bindgen_test_array_a48940bd219530d0",
       foreignImportCallConv =
@@ -1218,7 +1252,9 @@
                 "Multi-dimensional array of known size, typedef"],
           commentOrigin = Just "arr_6",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_7_ptr */ __attribute__ ((const)) signed int (*hs_bindgen_test_array_1196efca365094f7 (void))[][3] { return &arr_7; } ",
@@ -1226,15 +1262,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_7_ptr",
+        "hs_bindgen_test_array_1196efca365094f7",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsIncompleteArray
-            (HsConstArray
-              3
-              (HsPrimType HsPrimCInt)))),
+        (HsIO
+          (HsPtr
+            (HsIncompleteArray
+              (HsConstArray
+                3
+                (HsPrimType HsPrimCInt))))),
       foreignImportOrigName =
       "hs_bindgen_test_array_1196efca365094f7",
       foreignImportCallConv =
@@ -1255,7 +1292,9 @@
                 "Multi-dimensional array of unknown size"],
           commentOrigin = Just "arr_7",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "/* get_arr_8_ptr */ __attribute__ ((const)) tripletlist *hs_bindgen_test_array_31b6cf83380518c3 (void) { return &arr_8; } ",
@@ -1263,15 +1302,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "arr_8_ptr",
+        "hs_bindgen_test_array_31b6cf83380518c3",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Tripletlist"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Tripletlist")))),
       foreignImportOrigName =
       "hs_bindgen_test_array_31b6cf83380518c3",
       foreignImportCallConv =
@@ -1291,7 +1331,9 @@
                 "Multi-dimensional array of unknown size, typedef"],
           commentOrigin = Just "arr_8",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "array.h",
   DeclInlineC
     "signed int hs_bindgen_test_array_c3dd28889d5b2858 (signed int arg1, signed int *arg2) { return fun_1(arg1, arg2); }",

--- a/hs-bindgen/fixtures/array.pp.hs
+++ b/hs-bindgen/fixtures/array.pp.hs
@@ -9,6 +9,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.IncompleteArray
@@ -20,43 +21,79 @@ $(CAPI.addCSource "#include <array.h>\n/* get_arr0_ptr */ __attribute__ ((const)
 
   __from C:__ @arr0@
 -}
-foreign import ccall safe "hs_bindgen_test_array_5c54826466f2e87b" arr0_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_5c54826466f2e87b" hs_bindgen_test_array_5c54826466f2e87b
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+
+{-# NOINLINE arr0_ptr #-}
+
+arr0_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+arr0_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_5c54826466f2e87b
 
 {-| Global, complete, initialised
 
   __from C:__ @arr1@
 -}
-foreign import ccall safe "hs_bindgen_test_array_ec6a481a47ca4eb1" arr1_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_ec6a481a47ca4eb1" hs_bindgen_test_array_ec6a481a47ca4eb1
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+
+{-# NOINLINE arr1_ptr #-}
+
+arr1_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+arr1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_ec6a481a47ca4eb1
 
 {-| Global, extern, complete, not initialised
 
   __from C:__ @arr2@
 -}
-foreign import ccall safe "hs_bindgen_test_array_34db8d8b69220fcc" arr2_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_34db8d8b69220fcc" hs_bindgen_test_array_34db8d8b69220fcc
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+
+{-# NOINLINE arr2_ptr #-}
+
+arr2_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+arr2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_34db8d8b69220fcc
 
 {-| Global, extern, complete, initialised
 
   __from C:__ @arr3@
 -}
-foreign import ccall safe "hs_bindgen_test_array_f4e746193b856003" arr3_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_f4e746193b856003" hs_bindgen_test_array_f4e746193b856003
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+
+{-# NOINLINE arr3_ptr #-}
+
+arr3_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+arr3_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_f4e746193b856003
 
 {-| Global, incomplete
 
   __from C:__ @arr6@
 -}
-foreign import ccall safe "hs_bindgen_test_array_bf91904b3049fdd2" arr6_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_bf91904b3049fdd2" hs_bindgen_test_array_bf91904b3049fdd2
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt))
+
+{-# NOINLINE arr6_ptr #-}
+
+arr6_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt)
+arr6_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_bf91904b3049fdd2
 
 {-| Global, extern, incomplete
 
   __from C:__ @arr7@
 -}
-foreign import ccall safe "hs_bindgen_test_array_9be06c66ecc3a933" arr7_ptr
-  :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_9be06c66ecc3a933" hs_bindgen_test_array_9be06c66ecc3a933
+  :: IO (F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
+
+{-# NOINLINE arr7_ptr #-}
+
+arr7_ptr :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+arr7_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_9be06c66ecc3a933
 
 newtype Triplet = Triplet
   { un_Triplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
@@ -110,57 +147,105 @@ instance F.Storable Example where
 
   __from C:__ @arr_1@
 -}
-foreign import ccall safe "hs_bindgen_test_array_16bca3ac468967d9" arr_1_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_16bca3ac468967d9" hs_bindgen_test_array_16bca3ac468967d9
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+
+{-# NOINLINE arr_1_ptr #-}
+
+arr_1_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+arr_1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_16bca3ac468967d9
 
 {-| Array of known size, typedef
 
   __from C:__ @arr_2@
 -}
-foreign import ccall safe "hs_bindgen_test_array_07e58c5432be4a35" arr_2_ptr
-  :: F.Ptr Triplet
+foreign import ccall unsafe "hs_bindgen_test_array_07e58c5432be4a35" hs_bindgen_test_array_07e58c5432be4a35
+  :: IO (F.Ptr Triplet)
+
+{-# NOINLINE arr_2_ptr #-}
+
+arr_2_ptr :: F.Ptr Triplet
+arr_2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_07e58c5432be4a35
 
 {-| Array of unknown size
 
   __from C:__ @arr_3@
 -}
-foreign import ccall safe "hs_bindgen_test_array_63e072530b04d3b9" arr_3_ptr
-  :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_array_63e072530b04d3b9" hs_bindgen_test_array_63e072530b04d3b9
+  :: IO (F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
+
+{-# NOINLINE arr_3_ptr #-}
+
+arr_3_ptr :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+arr_3_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_63e072530b04d3b9
 
 {-| Array of unknown size, typedef
 
   __from C:__ @arr_4@
 -}
-foreign import ccall safe "hs_bindgen_test_array_3db8d1257bc10233" arr_4_ptr
-  :: F.Ptr List
+foreign import ccall unsafe "hs_bindgen_test_array_3db8d1257bc10233" hs_bindgen_test_array_3db8d1257bc10233
+  :: IO (F.Ptr List)
+
+{-# NOINLINE arr_4_ptr #-}
+
+arr_4_ptr :: F.Ptr List
+arr_4_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_3db8d1257bc10233
 
 {-| Multi-dimensional array of known size
 
   __from C:__ @arr_5@
 -}
-foreign import ccall safe "hs_bindgen_test_array_0f74917ee2000dc5" arr_5_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+foreign import ccall unsafe "hs_bindgen_test_array_0f74917ee2000dc5" hs_bindgen_test_array_0f74917ee2000dc5
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
+
+{-# NOINLINE arr_5_ptr #-}
+
+arr_5_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+arr_5_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_0f74917ee2000dc5
 
 {-| Multi-dimensional array of known size, typedef
 
   __from C:__ @arr_6@
 -}
-foreign import ccall safe "hs_bindgen_test_array_a48940bd219530d0" arr_6_ptr
-  :: F.Ptr Matrix
+foreign import ccall unsafe "hs_bindgen_test_array_a48940bd219530d0" hs_bindgen_test_array_a48940bd219530d0
+  :: IO (F.Ptr Matrix)
+
+{-# NOINLINE arr_6_ptr #-}
+
+arr_6_ptr :: F.Ptr Matrix
+arr_6_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_a48940bd219530d0
 
 {-| Multi-dimensional array of unknown size
 
   __from C:__ @arr_7@
 -}
-foreign import ccall safe "hs_bindgen_test_array_1196efca365094f7" arr_7_ptr
-  :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+foreign import ccall unsafe "hs_bindgen_test_array_1196efca365094f7" hs_bindgen_test_array_1196efca365094f7
+  :: IO (F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
+
+{-# NOINLINE arr_7_ptr #-}
+
+arr_7_ptr :: F.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+arr_7_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_1196efca365094f7
 
 {-| Multi-dimensional array of unknown size, typedef
 
   __from C:__ @arr_8@
 -}
-foreign import ccall safe "hs_bindgen_test_array_31b6cf83380518c3" arr_8_ptr
-  :: F.Ptr Tripletlist
+foreign import ccall unsafe "hs_bindgen_test_array_31b6cf83380518c3" hs_bindgen_test_array_31b6cf83380518c3
+  :: IO (F.Ptr Tripletlist)
+
+{-# NOINLINE arr_8_ptr #-}
+
+arr_8_ptr :: F.Ptr Tripletlist
+arr_8_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_array_31b6cf83380518c3
 
 {-| Array of known size
 

--- a/hs-bindgen/fixtures/array.th.txt
+++ b/hs-bindgen/fixtures/array.th.txt
@@ -33,32 +33,50 @@
 {-| Global, complete, not initialised
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_5c54826466f2e87b" arr0_ptr :: Ptr (ConstantArray 3
-                                                                                                  CInt)
+foreign import ccall safe "hs_bindgen_test_array_5c54826466f2e87b" hs_bindgen_test_array_5c54826466f2e87b :: IO (Ptr (ConstantArray 3
+                                                                                                                                    CInt))
+{-# NOINLINE arr0_ptr #-}
+arr0_ptr :: Ptr (ConstantArray 3 CInt)
+arr0_ptr = unsafePerformIO hs_bindgen_test_array_5c54826466f2e87b
 {-| Global, complete, initialised
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_ec6a481a47ca4eb1" arr1_ptr :: Ptr (ConstantArray 3
-                                                                                                  CInt)
+foreign import ccall safe "hs_bindgen_test_array_ec6a481a47ca4eb1" hs_bindgen_test_array_ec6a481a47ca4eb1 :: IO (Ptr (ConstantArray 3
+                                                                                                                                    CInt))
+{-# NOINLINE arr1_ptr #-}
+arr1_ptr :: Ptr (ConstantArray 3 CInt)
+arr1_ptr = unsafePerformIO hs_bindgen_test_array_ec6a481a47ca4eb1
 {-| Global, extern, complete, not initialised
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_34db8d8b69220fcc" arr2_ptr :: Ptr (ConstantArray 3
-                                                                                                  CInt)
+foreign import ccall safe "hs_bindgen_test_array_34db8d8b69220fcc" hs_bindgen_test_array_34db8d8b69220fcc :: IO (Ptr (ConstantArray 3
+                                                                                                                                    CInt))
+{-# NOINLINE arr2_ptr #-}
+arr2_ptr :: Ptr (ConstantArray 3 CInt)
+arr2_ptr = unsafePerformIO hs_bindgen_test_array_34db8d8b69220fcc
 {-| Global, extern, complete, initialised
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_f4e746193b856003" arr3_ptr :: Ptr (ConstantArray 3
-                                                                                                  CInt)
+foreign import ccall safe "hs_bindgen_test_array_f4e746193b856003" hs_bindgen_test_array_f4e746193b856003 :: IO (Ptr (ConstantArray 3
+                                                                                                                                    CInt))
+{-# NOINLINE arr3_ptr #-}
+arr3_ptr :: Ptr (ConstantArray 3 CInt)
+arr3_ptr = unsafePerformIO hs_bindgen_test_array_f4e746193b856003
 {-| Global, incomplete
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_bf91904b3049fdd2" arr6_ptr :: Ptr (ConstantArray 1
-                                                                                                  CInt)
+foreign import ccall safe "hs_bindgen_test_array_bf91904b3049fdd2" hs_bindgen_test_array_bf91904b3049fdd2 :: IO (Ptr (ConstantArray 1
+                                                                                                                                    CInt))
+{-# NOINLINE arr6_ptr #-}
+arr6_ptr :: Ptr (ConstantArray 1 CInt)
+arr6_ptr = unsafePerformIO hs_bindgen_test_array_bf91904b3049fdd2
 {-| Global, extern, incomplete
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_9be06c66ecc3a933" arr7_ptr :: Ptr (IncompleteArray CInt)
+foreign import ccall safe "hs_bindgen_test_array_9be06c66ecc3a933" hs_bindgen_test_array_9be06c66ecc3a933 :: IO (Ptr (IncompleteArray CInt))
+{-# NOINLINE arr7_ptr #-}
+arr7_ptr :: Ptr (IncompleteArray CInt)
+arr7_ptr = unsafePerformIO hs_bindgen_test_array_9be06c66ecc3a933
 newtype Triplet
     = Triplet {un_Triplet :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Show)
@@ -88,39 +106,63 @@ instance Storable Example
 {-| Array of known size
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_16bca3ac468967d9" arr_1_ptr :: Ptr (ConstantArray 3
-                                                                                                   CInt)
+foreign import ccall safe "hs_bindgen_test_array_16bca3ac468967d9" hs_bindgen_test_array_16bca3ac468967d9 :: IO (Ptr (ConstantArray 3
+                                                                                                                                    CInt))
+{-# NOINLINE arr_1_ptr #-}
+arr_1_ptr :: Ptr (ConstantArray 3 CInt)
+arr_1_ptr = unsafePerformIO hs_bindgen_test_array_16bca3ac468967d9
 {-| Array of known size, typedef
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_07e58c5432be4a35" arr_2_ptr :: Ptr Triplet
+foreign import ccall safe "hs_bindgen_test_array_07e58c5432be4a35" hs_bindgen_test_array_07e58c5432be4a35 :: IO (Ptr Triplet)
+{-# NOINLINE arr_2_ptr #-}
+arr_2_ptr :: Ptr Triplet
+arr_2_ptr = unsafePerformIO hs_bindgen_test_array_07e58c5432be4a35
 {-| Array of unknown size
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_63e072530b04d3b9" arr_3_ptr :: Ptr (IncompleteArray CInt)
+foreign import ccall safe "hs_bindgen_test_array_63e072530b04d3b9" hs_bindgen_test_array_63e072530b04d3b9 :: IO (Ptr (IncompleteArray CInt))
+{-# NOINLINE arr_3_ptr #-}
+arr_3_ptr :: Ptr (IncompleteArray CInt)
+arr_3_ptr = unsafePerformIO hs_bindgen_test_array_63e072530b04d3b9
 {-| Array of unknown size, typedef
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_3db8d1257bc10233" arr_4_ptr :: Ptr List
+foreign import ccall safe "hs_bindgen_test_array_3db8d1257bc10233" hs_bindgen_test_array_3db8d1257bc10233 :: IO (Ptr List)
+{-# NOINLINE arr_4_ptr #-}
+arr_4_ptr :: Ptr List
+arr_4_ptr = unsafePerformIO hs_bindgen_test_array_3db8d1257bc10233
 {-| Multi-dimensional array of known size
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_0f74917ee2000dc5" arr_5_ptr :: Ptr (ConstantArray 4
-                                                                                                   (ConstantArray 3
-                                                                                                                  CInt))
+foreign import ccall safe "hs_bindgen_test_array_0f74917ee2000dc5" hs_bindgen_test_array_0f74917ee2000dc5 :: IO (Ptr (ConstantArray 4
+                                                                                                                                    (ConstantArray 3
+                                                                                                                                                   CInt)))
+{-# NOINLINE arr_5_ptr #-}
+arr_5_ptr :: Ptr (ConstantArray 4 (ConstantArray 3 CInt))
+arr_5_ptr = unsafePerformIO hs_bindgen_test_array_0f74917ee2000dc5
 {-| Multi-dimensional array of known size, typedef
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_a48940bd219530d0" arr_6_ptr :: Ptr Matrix
+foreign import ccall safe "hs_bindgen_test_array_a48940bd219530d0" hs_bindgen_test_array_a48940bd219530d0 :: IO (Ptr Matrix)
+{-# NOINLINE arr_6_ptr #-}
+arr_6_ptr :: Ptr Matrix
+arr_6_ptr = unsafePerformIO hs_bindgen_test_array_a48940bd219530d0
 {-| Multi-dimensional array of unknown size
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_1196efca365094f7" arr_7_ptr :: Ptr (IncompleteArray (ConstantArray 3
-                                                                                                                    CInt))
+foreign import ccall safe "hs_bindgen_test_array_1196efca365094f7" hs_bindgen_test_array_1196efca365094f7 :: IO (Ptr (IncompleteArray (ConstantArray 3
+                                                                                                                                                     CInt)))
+{-# NOINLINE arr_7_ptr #-}
+arr_7_ptr :: Ptr (IncompleteArray (ConstantArray 3 CInt))
+arr_7_ptr = unsafePerformIO hs_bindgen_test_array_1196efca365094f7
 {-| Multi-dimensional array of unknown size, typedef
 
 -}
-foreign import ccall safe "hs_bindgen_test_array_31b6cf83380518c3" arr_8_ptr :: Ptr Tripletlist
+foreign import ccall safe "hs_bindgen_test_array_31b6cf83380518c3" hs_bindgen_test_array_31b6cf83380518c3 :: IO (Ptr Tripletlist)
+{-# NOINLINE arr_8_ptr #-}
+arr_8_ptr :: Ptr Tripletlist
+arr_8_ptr = unsafePerformIO hs_bindgen_test_array_31b6cf83380518c3
 {-| Array of known size
 
 -}

--- a/hs-bindgen/fixtures/asm.hs
+++ b/hs-bindgen/fixtures/asm.hs
@@ -6,11 +6,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "asm_labeled_variable_ptr",
+        "hs_bindgen_test_asm_d2d42e5b0c00988a",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_asm_d2d42e5b0c00988a",
       foreignImportCallConv =
@@ -19,7 +21,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "asm.h",
   DeclInlineC
     "signed int hs_bindgen_test_asm_54c5278e738a284f (signed int arg1, signed int arg2) { return asm_labeled_function(arg1, arg2); }",

--- a/hs-bindgen/fixtures/asm.pp.hs
+++ b/hs-bindgen/fixtures/asm.pp.hs
@@ -6,13 +6,20 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 
 $(CAPI.addCSource "#include <asm.h>\n/* get_asm_labeled_variable_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_asm_d2d42e5b0c00988a (void) { return &asm_labeled_variable; } \nsigned int hs_bindgen_test_asm_54c5278e738a284f (signed int arg1, signed int arg2) { return asm_labeled_function(arg1, arg2); }\n")
 
-foreign import ccall safe "hs_bindgen_test_asm_d2d42e5b0c00988a" asm_labeled_variable_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_asm_d2d42e5b0c00988a" hs_bindgen_test_asm_d2d42e5b0c00988a
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE asm_labeled_variable_ptr #-}
+
+asm_labeled_variable_ptr :: F.Ptr FC.CInt
+asm_labeled_variable_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_asm_d2d42e5b0c00988a
 
 {-| __from C:__ @asm_labeled_function@ -}
 foreign import ccall safe "hs_bindgen_test_asm_54c5278e738a284f" asm_labeled_function

--- a/hs-bindgen/fixtures/asm.th.txt
+++ b/hs-bindgen/fixtures/asm.th.txt
@@ -2,7 +2,10 @@
 -- #include <asm.h>
 -- /* get_asm_labeled_variable_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_asm_d2d42e5b0c00988a (void) { return &asm_labeled_variable; } 
 -- signed int hs_bindgen_test_asm_54c5278e738a284f (signed int arg1, signed int arg2) { return asm_labeled_function(arg1, arg2); }
-foreign import ccall safe "hs_bindgen_test_asm_d2d42e5b0c00988a" asm_labeled_variable_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_asm_d2d42e5b0c00988a" hs_bindgen_test_asm_d2d42e5b0c00988a :: IO (Ptr CInt)
+{-# NOINLINE asm_labeled_variable_ptr #-}
+asm_labeled_variable_ptr :: Ptr CInt
+asm_labeled_variable_ptr = unsafePerformIO hs_bindgen_test_asm_d2d42e5b0c00988a
 {-| -}
 foreign import ccall safe "hs_bindgen_test_asm_54c5278e738a284f" asm_labeled_function :: CInt ->
                                                                                          CInt ->

--- a/hs-bindgen/fixtures/bool_c23.hs
+++ b/hs-bindgen/fixtures/bool_c23.hs
@@ -6,12 +6,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "b_ptr",
+        "hs_bindgen_test_bool_c23_401ecb7e80957164",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsPrimType HsPrimCBool)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCBool))),
       foreignImportOrigName =
       "hs_bindgen_test_bool_c23_401ecb7e80957164",
       foreignImportCallConv =
@@ -19,4 +20,6 @@
       foreignImportOrigin = Global
         (TypePrim PrimBool),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe}]
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple]

--- a/hs-bindgen/fixtures/bool_c23.pp.hs
+++ b/hs-bindgen/fixtures/bool_c23.pp.hs
@@ -6,9 +6,17 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
+import Prelude (IO)
 
 $(CAPI.addCSource "#include <bool_c23.h>\n/* get_b_ptr */ __attribute__ ((const)) _Bool *hs_bindgen_test_bool_c23_401ecb7e80957164 (void) { return &b; } \n")
 
-foreign import ccall safe "hs_bindgen_test_bool_c23_401ecb7e80957164" b_ptr
-  :: F.Ptr FC.CBool
+foreign import ccall unsafe "hs_bindgen_test_bool_c23_401ecb7e80957164" hs_bindgen_test_bool_c23_401ecb7e80957164
+  :: IO (F.Ptr FC.CBool)
+
+{-# NOINLINE b_ptr #-}
+
+b_ptr :: F.Ptr FC.CBool
+b_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_bool_c23_401ecb7e80957164

--- a/hs-bindgen/fixtures/bool_c23.th.txt
+++ b/hs-bindgen/fixtures/bool_c23.th.txt
@@ -1,4 +1,7 @@
 -- addDependentFile examples/golden/bool_c23.h
 -- #include <bool_c23.h>
 -- /* get_b_ptr */ __attribute__ ((const)) _Bool *hs_bindgen_test_bool_c23_401ecb7e80957164 (void) { return &b; } 
-foreign import ccall safe "hs_bindgen_test_bool_c23_401ecb7e80957164" b_ptr :: Ptr CBool
+foreign import ccall safe "hs_bindgen_test_bool_c23_401ecb7e80957164" hs_bindgen_test_bool_c23_401ecb7e80957164 :: IO (Ptr CBool)
+{-# NOINLINE b_ptr #-}
+b_ptr :: Ptr CBool
+b_ptr = unsafePerformIO hs_bindgen_test_bool_c23_401ecb7e80957164

--- a/hs-bindgen/fixtures/definitions.hs
+++ b/hs-bindgen/fixtures/definitions.hs
@@ -55,11 +55,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "n_ptr",
+        "hs_bindgen_test_definitions_fc2aad2af9befead",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_definitions_fc2aad2af9befead",
       foreignImportCallConv =
@@ -68,7 +70,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclData
     Struct {
       structName = HsName

--- a/hs-bindgen/fixtures/definitions.pp.hs
+++ b/hs-bindgen/fixtures/definitions.pp.hs
@@ -11,6 +11,7 @@ module Example where
 import qualified Data.Array.Byte
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.SizedByteArray
@@ -24,8 +25,14 @@ foreign import ccall safe "hs_bindgen_test_definitions_a7d624773bb0585c" foo
      {- ^ __from C:__ @x@ -}
   -> IO FC.CInt
 
-foreign import ccall safe "hs_bindgen_test_definitions_fc2aad2af9befead" n_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_definitions_fc2aad2af9befead" hs_bindgen_test_definitions_fc2aad2af9befead
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE n_ptr #-}
+
+n_ptr :: F.Ptr FC.CInt
+n_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_definitions_fc2aad2af9befead
 
 data X = X
   { x_n :: FC.CInt

--- a/hs-bindgen/fixtures/definitions.th.txt
+++ b/hs-bindgen/fixtures/definitions.th.txt
@@ -5,7 +5,10 @@
 {-| -}
 foreign import ccall safe "hs_bindgen_test_definitions_a7d624773bb0585c" foo :: CDouble ->
                                                                                 IO CInt
-foreign import ccall safe "hs_bindgen_test_definitions_fc2aad2af9befead" n_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_definitions_fc2aad2af9befead" hs_bindgen_test_definitions_fc2aad2af9befead :: IO (Ptr CInt)
+{-# NOINLINE n_ptr #-}
+n_ptr :: Ptr CInt
+n_ptr = unsafePerformIO hs_bindgen_test_definitions_fc2aad2af9befead
 data X = X {x_n :: CInt} deriving stock (Eq, Show)
 instance Storable X
     where sizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/distilled_lib_1.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.hs
@@ -10790,15 +10790,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "v_ptr",
+        "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Var_t"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Var_t")))),
       foreignImportOrigName =
       "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365",
       foreignImportCallConv =
@@ -10811,4 +10812,6 @@
               nameHsIdent = HsIdentifier
                 "Var_t"})),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe}]
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple]

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -17,6 +17,7 @@ import qualified Data.List.NonEmpty
 import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.CEnum
 import qualified HsBindgen.Runtime.ConstantArray
@@ -326,5 +327,11 @@ newtype Callback_t = Callback_t
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable)
 
-foreign import ccall safe "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365" v_ptr
-  :: F.Ptr Var_t
+foreign import ccall unsafe "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365" hs_bindgen_test_distilled_lib_1_0f967c83f73d0365
+  :: IO (F.Ptr Var_t)
+
+{-# NOINLINE v_ptr #-}
+
+v_ptr :: F.Ptr Var_t
+v_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_distilled_lib_1_0f967c83f73d0365

--- a/hs-bindgen/fixtures/distilled_lib_1.th.txt
+++ b/hs-bindgen/fixtures/distilled_lib_1.th.txt
@@ -176,4 +176,7 @@ newtype Callback_t
                                             IO HsBindgen.Runtime.Prelude.Word32))}
     deriving stock (Eq, Ord, Show)
     deriving newtype Storable
-foreign import ccall safe "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365" v_ptr :: Ptr Var_t
+foreign import ccall safe "hs_bindgen_test_distilled_lib_1_0f967c83f73d0365" hs_bindgen_test_distilled_lib_1_0f967c83f73d0365 :: IO (Ptr Var_t)
+{-# NOINLINE v_ptr #-}
+v_ptr :: Ptr Var_t
+v_ptr = unsafePerformIO hs_bindgen_test_distilled_lib_1_0f967c83f73d0365

--- a/hs-bindgen/fixtures/doxygen_docs.th.txt
+++ b/hs-bindgen/fixtures/doxygen_docs.th.txt
@@ -59,7 +59,10 @@ newtype Size_type
   This variable tracks the number of operations performed.
 
 -}
-foreign import ccall safe "hs_bindgen_test_doxygen_docs_7c3b3bc7cc470742" global_counter_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_doxygen_docs_7c3b3bc7cc470742" hs_bindgen_test_doxygen_docs_7c3b3bc7cc470742 :: IO (Ptr CInt)
+{-# NOINLINE global_counter_ptr #-}
+global_counter_ptr :: Ptr CInt
+global_counter_ptr = unsafePerformIO hs_bindgen_test_doxygen_docs_7c3b3bc7cc470742
 {-|
 
   > extern const char* version_string
@@ -67,7 +70,10 @@ foreign import ccall safe "hs_bindgen_test_doxygen_docs_7c3b3bc7cc470742" global
   Version string constant
 
 -}
-foreign import ccall safe "hs_bindgen_test_doxygen_docs_a8499810bd5203c6" version_string_ptr :: Ptr (Ptr CChar)
+foreign import ccall safe "hs_bindgen_test_doxygen_docs_a8499810bd5203c6" hs_bindgen_test_doxygen_docs_a8499810bd5203c6 :: IO (Ptr (Ptr CChar))
+{-# NOINLINE version_string_ptr #-}
+version_string_ptr :: Ptr (Ptr CChar)
+version_string_ptr = unsafePerformIO hs_bindgen_test_doxygen_docs_a8499810bd5203c6
 {-| This is the comment @title@
 
   Forward declaration with documentation

--- a/hs-bindgen/fixtures/fun_attributes.hs
+++ b/hs-bindgen/fixtures/fun_attributes.hs
@@ -1459,11 +1459,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i_ptr",
+        "hs_bindgen_test_fun_attributes_fe81510d355aff25",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_fun_attributes_fe81510d355aff25",
       foreignImportCallConv =
@@ -1472,7 +1474,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "fun_attributes.h",
   DeclInlineC

--- a/hs-bindgen/fixtures/fun_attributes.pp.hs
+++ b/hs-bindgen/fixtures/fun_attributes.pp.hs
@@ -12,6 +12,7 @@ import qualified Data.Ix as Ix
 import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 
@@ -156,8 +157,14 @@ foreign import ccall safe "hs_bindgen_test_fun_attributes_f50d1e8063148c18" sse3
 foreign import ccall safe "hs_bindgen_test_fun_attributes_1b95ce9d55223970" f3
   :: IO ()
 
-foreign import ccall safe "hs_bindgen_test_fun_attributes_fe81510d355aff25" i_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_fun_attributes_fe81510d355aff25" hs_bindgen_test_fun_attributes_fe81510d355aff25
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i_ptr #-}
+
+i_ptr :: F.Ptr FC.CInt
+i_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_fun_attributes_fe81510d355aff25
 
 {-| __from C:__ @fn@ -}
 foreign import ccall safe "hs_bindgen_test_fun_attributes_43b222bddec511f3" fn

--- a/hs-bindgen/fixtures/fun_attributes.th.txt
+++ b/hs-bindgen/fixtures/fun_attributes.th.txt
@@ -118,7 +118,10 @@ foreign import ccall safe "hs_bindgen_test_fun_attributes_ab8f0d32c1f84295" core
 foreign import ccall safe "hs_bindgen_test_fun_attributes_f50d1e8063148c18" sse3_func :: IO CInt
 {-| -}
 foreign import ccall safe "hs_bindgen_test_fun_attributes_1b95ce9d55223970" f3 :: IO Unit
-foreign import ccall safe "hs_bindgen_test_fun_attributes_fe81510d355aff25" i_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_fun_attributes_fe81510d355aff25" hs_bindgen_test_fun_attributes_fe81510d355aff25 :: IO (Ptr CInt)
+{-# NOINLINE i_ptr #-}
+i_ptr :: Ptr CInt
+i_ptr = unsafePerformIO hs_bindgen_test_fun_attributes_fe81510d355aff25
 {-| -}
 foreign import ccall safe "hs_bindgen_test_fun_attributes_43b222bddec511f3" fn :: IO CInt
 {-| -}

--- a/hs-bindgen/fixtures/globals.hs
+++ b/hs-bindgen/fixtures/globals.hs
@@ -6,11 +6,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "simpleGlobal_ptr",
+        "hs_bindgen_test_globals_9e13cdab849fd6a3",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_9e13cdab849fd6a3",
       foreignImportCallConv =
@@ -26,7 +28,9 @@
           commentOrigin = Just
             "simpleGlobal",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclData
     Struct {
       structName = HsName
@@ -489,15 +493,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "compoundGlobal1_ptr",
+        "hs_bindgen_test_globals_9093ee3b5b63dbb9",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Config"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Config")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_9093ee3b5b63dbb9",
       foreignImportCallConv =
@@ -510,7 +515,9 @@
               "Config"}
           NameOriginInSource),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclData
     Struct {
       structName = HsName
@@ -981,15 +988,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "compoundGlobal2_ptr",
+        "hs_bindgen_test_globals_35cfb530c6e3b540",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Inline_struct"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Inline_struct")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_35cfb530c6e3b540",
       foreignImportCallConv =
@@ -1002,7 +1010,9 @@
               "Inline_struct"}
           NameOriginInSource),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesInteger_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_d0e555bab6218b45 (void) { return &nesInteger; } ",
@@ -1010,11 +1020,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesInteger_ptr",
+        "hs_bindgen_test_globals_d0e555bab6218b45",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_d0e555bab6218b45",
       foreignImportCallConv =
@@ -1053,7 +1065,9 @@
               [
                 TextContent
                   "[1]: https://clang.llvm.org/doxygen/group__CINDEX.html#gaaccc432245b4cd9f2d470913f9ef0013"]]},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesFloating_ptr */ __attribute__ ((const)) float *hs_bindgen_test_globals_620d3eeb41be6814 (void) { return &nesFloating; } ",
@@ -1061,12 +1075,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesFloating_ptr",
+        "hs_bindgen_test_globals_620d3eeb41be6814",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsPrimType HsPrimCFloat)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCFloat))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_620d3eeb41be6814",
       foreignImportCallConv =
@@ -1075,7 +1090,9 @@
         (TypePrim
           (PrimFloating PrimFloat)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesString1_ptr */ __attribute__ ((const)) char **hs_bindgen_test_globals_58609a874bbd4939 (void) { return &nesString1; } ",
@@ -1083,13 +1100,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesString1_ptr",
+        "hs_bindgen_test_globals_58609a874bbd4939",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
+        (HsIO
           (HsPtr
-            (HsPrimType HsPrimCChar))),
+            (HsPtr
+              (HsPrimType HsPrimCChar)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_58609a874bbd4939",
       foreignImportCallConv =
@@ -1101,7 +1119,9 @@
               (PrimSignImplicit
                 (Just Signed))))),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesString2_ptr */ __attribute__ ((const)) char (*hs_bindgen_test_globals_d24d15726a247083 (void))[3] { return &nesString2; } ",
@@ -1109,14 +1129,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesString2_ptr",
+        "hs_bindgen_test_globals_d24d15726a247083",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            3
-            (HsPrimType HsPrimCChar))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              3
+              (HsPrimType HsPrimCChar)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_d24d15726a247083",
       foreignImportCallConv =
@@ -1129,7 +1150,9 @@
               (PrimSignImplicit
                 (Just Signed))))),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesCharacter_ptr */ __attribute__ ((const)) char *hs_bindgen_test_globals_472e8cff06767166 (void) { return &nesCharacter; } ",
@@ -1137,12 +1160,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesCharacter_ptr",
+        "hs_bindgen_test_globals_472e8cff06767166",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsPrimType HsPrimCChar)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCChar))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_472e8cff06767166",
       foreignImportCallConv =
@@ -1153,7 +1177,9 @@
             (PrimSignImplicit
               (Just Signed)))),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesParen_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_3535fbeb41ad5a41 (void) { return &nesParen; } ",
@@ -1161,11 +1187,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesParen_ptr",
+        "hs_bindgen_test_globals_3535fbeb41ad5a41",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_3535fbeb41ad5a41",
       foreignImportCallConv =
@@ -1174,7 +1202,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesUnary_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_c2e1dc65064ad658 (void) { return &nesUnary; } ",
@@ -1182,11 +1212,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesUnary_ptr",
+        "hs_bindgen_test_globals_c2e1dc65064ad658",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_c2e1dc65064ad658",
       foreignImportCallConv =
@@ -1195,7 +1227,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesBinary_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_3d0448526008a072 (void) { return &nesBinary; } ",
@@ -1203,11 +1237,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesBinary_ptr",
+        "hs_bindgen_test_globals_3d0448526008a072",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_3d0448526008a072",
       foreignImportCallConv =
@@ -1216,7 +1252,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesConditional_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_6733c2e7c59bc620 (void) { return &nesConditional; } ",
@@ -1224,11 +1262,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesConditional_ptr",
+        "hs_bindgen_test_globals_6733c2e7c59bc620",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_6733c2e7c59bc620",
       foreignImportCallConv =
@@ -1237,7 +1277,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesCast_ptr */ __attribute__ ((const)) float *hs_bindgen_test_globals_d6e6e72f287d9b41 (void) { return &nesCast; } ",
@@ -1245,12 +1287,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesCast_ptr",
+        "hs_bindgen_test_globals_d6e6e72f287d9b41",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsPrimType HsPrimCFloat)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCFloat))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_d6e6e72f287d9b41",
       foreignImportCallConv =
@@ -1259,7 +1302,9 @@
         (TypePrim
           (PrimFloating PrimFloat)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesCompound_ptr */ __attribute__ ((const)) signed int **hs_bindgen_test_globals_032905c6b7a5e39f (void) { return &nesCompound; } ",
@@ -1267,13 +1312,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesCompound_ptr",
+        "hs_bindgen_test_globals_032905c6b7a5e39f",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
+        (HsIO
           (HsPtr
-            (HsPrimType HsPrimCInt))),
+            (HsPtr
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_032905c6b7a5e39f",
       foreignImportCallConv =
@@ -1283,7 +1329,9 @@
           (TypePrim
             (PrimIntegral PrimInt Signed))),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesInitList_ptr */ __attribute__ ((const)) uint8_t (*hs_bindgen_test_globals_4012de1fec3423a7 (void))[4] { return &nesInitList; } ",
@@ -1291,124 +1339,125 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesInitList_ptr",
+        "hs_bindgen_test_globals_4012de1fec3423a7",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            4
-            (HsExtBinding
-              ExtHsRef {
-                extHsRefModule = HsModuleName
-                  "HsBindgen.Runtime.Prelude",
-                extHsRefIdentifier =
-                HsIdentifier "Word8"}
-              TypeSpec {
-                typeSpecModule = Just
-                  (HsModuleName
-                    "HsBindgen.Runtime.Prelude"),
-                typeSpecIdentifier = Just
-                  (HsIdentifier "Word8"),
-                typeSpecInstances = Map.fromList
-                  [
-                    _×_
-                      Eq
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Ord
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Enum
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Ix
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Bounded
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Read
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Show
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Bits
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      FiniteBits
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Integral
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Num
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Real
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      StaticSize
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      ReadRaw
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      WriteRaw
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Storable
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = [
-                            ]})]}))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              4
+              (HsExtBinding
+                ExtHsRef {
+                  extHsRefModule = HsModuleName
+                    "HsBindgen.Runtime.Prelude",
+                  extHsRefIdentifier =
+                  HsIdentifier "Word8"}
+                TypeSpec {
+                  typeSpecModule = Just
+                    (HsModuleName
+                      "HsBindgen.Runtime.Prelude"),
+                  typeSpecIdentifier = Just
+                    (HsIdentifier "Word8"),
+                  typeSpecInstances = Map.fromList
+                    [
+                      _×_
+                        Eq
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Ord
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Enum
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Ix
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Bounded
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Read
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Show
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Bits
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        FiniteBits
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Integral
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Num
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Real
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        StaticSize
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        ReadRaw
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        WriteRaw
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Storable
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = [
+                              ]})]})))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_4012de1fec3423a7",
       foreignImportCallConv =
@@ -1533,7 +1582,9 @@
                           instanceSpecConstraints = [
                             ]})]}})),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_nesBool_ptr */ __attribute__ ((const)) _Bool *hs_bindgen_test_globals_f9fb23513d064767 (void) { return &nesBool; } ",
@@ -1541,12 +1592,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nesBool_ptr",
+        "hs_bindgen_test_globals_f9fb23513d064767",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsPrimType HsPrimCBool)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCBool))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_f9fb23513d064767",
       foreignImportCallConv =
@@ -1554,7 +1606,9 @@
       foreignImportOrigin = Global
         (TypePrim PrimBool),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_streamBinary_ptr */ __attribute__ ((const)) uint8_t (*hs_bindgen_test_globals_92e68af3ae2ed3fb (void))[4096] { return &streamBinary; } ",
@@ -1562,124 +1616,125 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "streamBinary_ptr",
+        "hs_bindgen_test_globals_92e68af3ae2ed3fb",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            4096
-            (HsExtBinding
-              ExtHsRef {
-                extHsRefModule = HsModuleName
-                  "HsBindgen.Runtime.Prelude",
-                extHsRefIdentifier =
-                HsIdentifier "Word8"}
-              TypeSpec {
-                typeSpecModule = Just
-                  (HsModuleName
-                    "HsBindgen.Runtime.Prelude"),
-                typeSpecIdentifier = Just
-                  (HsIdentifier "Word8"),
-                typeSpecInstances = Map.fromList
-                  [
-                    _×_
-                      Eq
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Ord
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Enum
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Ix
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Bounded
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Read
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Show
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Bits
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      FiniteBits
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Integral
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Num
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Real
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      StaticSize
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      ReadRaw
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      WriteRaw
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = []}),
-                    _×_
-                      Storable
-                      (Require
-                        InstanceSpec {
-                          instanceSpecStrategy = Nothing,
-                          instanceSpecConstraints = [
-                            ]})]}))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              4096
+              (HsExtBinding
+                ExtHsRef {
+                  extHsRefModule = HsModuleName
+                    "HsBindgen.Runtime.Prelude",
+                  extHsRefIdentifier =
+                  HsIdentifier "Word8"}
+                TypeSpec {
+                  typeSpecModule = Just
+                    (HsModuleName
+                      "HsBindgen.Runtime.Prelude"),
+                  typeSpecIdentifier = Just
+                    (HsIdentifier "Word8"),
+                  typeSpecInstances = Map.fromList
+                    [
+                      _×_
+                        Eq
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Ord
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Enum
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Ix
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Bounded
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Read
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Show
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Bits
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        FiniteBits
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Integral
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Num
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Real
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        StaticSize
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        ReadRaw
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        WriteRaw
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = []}),
+                      _×_
+                        Storable
+                        (Require
+                          InstanceSpec {
+                            instanceSpecStrategy = Nothing,
+                            instanceSpecConstraints = [
+                              ]})]})))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_92e68af3ae2ed3fb",
       foreignImportCallConv =
@@ -1830,7 +1885,9 @@
               [
                 TextContent
                   "[1]: https://github.com/analogdevicesinc/no-OS/blob/855c4b3c34f2297865e448661ba4fcc0931bf430/drivers/rf-transceiver/talise/firmware/talise_stream_binary.h#L322-L325"]]},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_streamBinary_len_ptr */ __attribute__ ((const)) uint32_t *hs_bindgen_test_globals_8d6f9f3043208163 (void) { return &streamBinary_len; } ",
@@ -1838,122 +1895,123 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "streamBinary_len_ptr",
+        "hs_bindgen_test_globals_8d6f9f3043208163",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsExtBinding
-            ExtHsRef {
-              extHsRefModule = HsModuleName
-                "HsBindgen.Runtime.Prelude",
-              extHsRefIdentifier =
-              HsIdentifier "Word32"}
-            TypeSpec {
-              typeSpecModule = Just
-                (HsModuleName
-                  "HsBindgen.Runtime.Prelude"),
-              typeSpecIdentifier = Just
-                (HsIdentifier "Word32"),
-              typeSpecInstances = Map.fromList
-                [
-                  _×_
-                    Eq
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Ord
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Enum
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Ix
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Bounded
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Read
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Show
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Bits
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    FiniteBits
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Integral
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Num
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Real
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    StaticSize
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    ReadRaw
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    WriteRaw
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = []}),
-                  _×_
-                    Storable
-                    (Require
-                      InstanceSpec {
-                        instanceSpecStrategy = Nothing,
-                        instanceSpecConstraints = [
-                          ]})]})),
+        (HsIO
+          (HsPtr
+            (HsExtBinding
+              ExtHsRef {
+                extHsRefModule = HsModuleName
+                  "HsBindgen.Runtime.Prelude",
+                extHsRefIdentifier =
+                HsIdentifier "Word32"}
+              TypeSpec {
+                typeSpecModule = Just
+                  (HsModuleName
+                    "HsBindgen.Runtime.Prelude"),
+                typeSpecIdentifier = Just
+                  (HsIdentifier "Word32"),
+                typeSpecInstances = Map.fromList
+                  [
+                    _×_
+                      Eq
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Ord
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Enum
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Ix
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Bounded
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Read
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Show
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Bits
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      FiniteBits
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Integral
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Num
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Real
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      StaticSize
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      ReadRaw
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      WriteRaw
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = []}),
+                    _×_
+                      Storable
+                      (Require
+                        InstanceSpec {
+                          instanceSpecStrategy = Nothing,
+                          instanceSpecConstraints = [
+                            ]})]}))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_8d6f9f3043208163",
       foreignImportCallConv =
@@ -2076,7 +2134,9 @@
                         instanceSpecConstraints = [
                           ]})]}}),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclData
     Struct {
       structName = HsName
@@ -9162,15 +9222,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "some_global_struct_ptr",
+        "hs_bindgen_test_globals_88ad1f87a451c285",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Struct2_t"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Struct2_t")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_88ad1f87a451c285",
       foreignImportCallConv =
@@ -9187,7 +9248,9 @@
               (NameOriginGenerated
                 (AnonId "globals.h:420:9"))))),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_globalConstant_ptr */ __attribute__ ((const)) const signed int *hs_bindgen_test_globals_2875ba0f7feba4fd (void) { return &globalConstant; } ",
@@ -9195,11 +9258,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "globalConstant_ptr",
+        "hs_bindgen_test_globals_2875ba0f7feba4fd",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_2875ba0f7feba4fd",
       foreignImportCallConv =
@@ -9221,7 +9286,9 @@
                 TextContent
                   "Although this is a constant, we don't expect an initializer (since it's",
                 TextContent "`extern`)."]]},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclNewtype
@@ -9434,15 +9501,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "anotherGlobalConstant_ptr",
+        "hs_bindgen_test_globals_6ebecf881bce1334",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "ConstInt"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "ConstInt")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_6ebecf881bce1334",
       foreignImportCallConv =
@@ -9455,7 +9523,9 @@
               nameHsIdent = HsIdentifier
                 "ConstInt"})),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "globals.h",
@@ -9465,11 +9535,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "staticConst_ptr",
+        "hs_bindgen_test_globals_2eea936ed4beec74",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_2eea936ed4beec74",
       foreignImportCallConv =
@@ -9492,7 +9564,9 @@
               [
                 TextContent
                   "Unlike with `extern`, in this we _do_ expect an initializer."]]},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "globals.h",
@@ -9502,11 +9576,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "classless_ptr",
+        "hs_bindgen_test_globals_5d631acbb16c0e7e",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_5d631acbb16c0e7e",
       foreignImportCallConv =
@@ -9523,7 +9599,9 @@
           commentOrigin = Just
             "classless",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "globals.h",
@@ -9533,14 +9611,15 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "constArray1_ptr",
+        "hs_bindgen_test_globals_0d7a9340f4ef8b2e",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsConstArray
-            4
-            (HsPrimType HsPrimCInt))),
+        (HsIO
+          (HsPtr
+            (HsConstArray
+              4
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_0d7a9340f4ef8b2e",
       foreignImportCallConv =
@@ -9559,7 +9638,9 @@
           commentOrigin = Just
             "constArray1",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclNewtype
@@ -9651,15 +9732,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "constArray2_ptr",
+        "hs_bindgen_test_globals_7e09340985caec8d",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "ConstIntArray"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "ConstIntArray")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_7e09340985caec8d",
       foreignImportCallConv =
@@ -9672,7 +9754,9 @@
               nameHsIdent = HsIdentifier
                 "ConstIntArray"})),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclData
     Struct {
       structName = HsName
@@ -10135,15 +10219,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "constTuple_ptr",
+        "hs_bindgen_test_globals_6f2e1968e15f0b9b",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Tuple"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Tuple")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_6f2e1968e15f0b9b",
       foreignImportCallConv =
@@ -10163,7 +10248,9 @@
           commentOrigin = Just
             "constTuple",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "globals.h",
@@ -10173,15 +10260,16 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "nonConstTuple_ptr",
+        "hs_bindgen_test_globals_e8e62512a4e5d162",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
-          (HsTypRef
-            (HsName
-              "@NsTypeConstr"
-              "Tuple"))),
+        (HsIO
+          (HsPtr
+            (HsTypRef
+              (HsName
+                "@NsTypeConstr"
+                "Tuple")))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_e8e62512a4e5d162",
       foreignImportCallConv =
@@ -10202,7 +10290,9 @@
           commentOrigin = Just
             "nonConstTuple",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_ptrToConstInt_ptr */ __attribute__ ((const)) signed int **hs_bindgen_test_globals_e41146f6df20fe0d (void) { return &ptrToConstInt; } ",
@@ -10210,13 +10300,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "ptrToConstInt_ptr",
+        "hs_bindgen_test_globals_e41146f6df20fe0d",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
+        (HsIO
           (HsPtr
-            (HsPrimType HsPrimCInt))),
+            (HsPtr
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_e41146f6df20fe0d",
       foreignImportCallConv =
@@ -10234,7 +10325,9 @@
           commentOrigin = Just
             "ptrToConstInt",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude "globals.h",
   DeclInlineC
     "/* get_constPtrToInt_ptr */ __attribute__ ((const)) const signed int **hs_bindgen_test_globals_83b0d0f5488b6a03 (void) { return &constPtrToInt; } ",
@@ -10242,13 +10335,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "constPtrToInt_ptr",
+        "hs_bindgen_test_globals_83b0d0f5488b6a03",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
+        (HsIO
           (HsPtr
-            (HsPrimType HsPrimCInt))),
+            (HsPtr
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_83b0d0f5488b6a03",
       foreignImportCallConv =
@@ -10266,7 +10360,9 @@
           commentOrigin = Just
             "constPtrToInt",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple,
   DeclInlineCInclude "globals.h",
@@ -10276,13 +10372,14 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "constPtrToConstInt_ptr",
+        "hs_bindgen_test_globals_247c0c91ce28a18d",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr
+        (HsIO
           (HsPtr
-            (HsPrimType HsPrimCInt))),
+            (HsPtr
+              (HsPrimType HsPrimCInt)))),
       foreignImportOrigName =
       "hs_bindgen_test_globals_247c0c91ce28a18d",
       foreignImportCallConv =
@@ -10300,6 +10397,8 @@
           commentOrigin = Just
             "constPtrToConstInt",
           commentChildren = []},
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclSimple,
   DeclSimple]

--- a/hs-bindgen/fixtures/globals.pp.hs
+++ b/hs-bindgen/fixtures/globals.pp.hs
@@ -17,7 +17,7 @@ import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Prelude
-import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
+import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 $(CAPI.addCSource "#include <globals.h>\n/* get_simpleGlobal_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_9e13cdab849fd6a3 (void) { return &simpleGlobal; } \n/* get_compoundGlobal1_ptr */ __attribute__ ((const)) struct config *hs_bindgen_test_globals_9093ee3b5b63dbb9 (void) { return &compoundGlobal1; } \n/* get_compoundGlobal2_ptr */ __attribute__ ((const)) struct inline_struct *hs_bindgen_test_globals_35cfb530c6e3b540 (void) { return &compoundGlobal2; } \n/* get_nesInteger_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_d0e555bab6218b45 (void) { return &nesInteger; } \n/* get_nesFloating_ptr */ __attribute__ ((const)) float *hs_bindgen_test_globals_620d3eeb41be6814 (void) { return &nesFloating; } \n/* get_nesString1_ptr */ __attribute__ ((const)) char **hs_bindgen_test_globals_58609a874bbd4939 (void) { return &nesString1; } \n/* get_nesString2_ptr */ __attribute__ ((const)) char (*hs_bindgen_test_globals_d24d15726a247083 (void))[3] { return &nesString2; } \n/* get_nesCharacter_ptr */ __attribute__ ((const)) char *hs_bindgen_test_globals_472e8cff06767166 (void) { return &nesCharacter; } \n/* get_nesParen_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_3535fbeb41ad5a41 (void) { return &nesParen; } \n/* get_nesUnary_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_c2e1dc65064ad658 (void) { return &nesUnary; } \n/* get_nesBinary_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_3d0448526008a072 (void) { return &nesBinary; } \n/* get_nesConditional_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_globals_6733c2e7c59bc620 (void) { return &nesConditional; } \n/* get_nesCast_ptr */ __attribute__ ((const)) float *hs_bindgen_test_globals_d6e6e72f287d9b41 (void) { return &nesCast; } \n/* get_nesCompound_ptr */ __attribute__ ((const)) signed int **hs_bindgen_test_globals_032905c6b7a5e39f (void) { return &nesCompound; } \n/* get_nesInitList_ptr */ __attribute__ ((const)) uint8_t (*hs_bindgen_test_globals_4012de1fec3423a7 (void))[4] { return &nesInitList; } \n/* get_nesBool_ptr */ __attribute__ ((const)) _Bool *hs_bindgen_test_globals_f9fb23513d064767 (void) { return &nesBool; } \n/* get_streamBinary_ptr */ __attribute__ ((const)) uint8_t (*hs_bindgen_test_globals_92e68af3ae2ed3fb (void))[4096] { return &streamBinary; } \n/* get_streamBinary_len_ptr */ __attribute__ ((const)) uint32_t *hs_bindgen_test_globals_8d6f9f3043208163 (void) { return &streamBinary_len; } \n/* get_some_global_struct_ptr */ __attribute__ ((const)) struct2_t *hs_bindgen_test_globals_88ad1f87a451c285 (void) { return &some_global_struct; } \n/* get_globalConstant_ptr */ __attribute__ ((const)) const signed int *hs_bindgen_test_globals_2875ba0f7feba4fd (void) { return &globalConstant; } \n/* get_anotherGlobalConstant_ptr */ __attribute__ ((const)) const ConstInt *hs_bindgen_test_globals_6ebecf881bce1334 (void) { return &anotherGlobalConstant; } \n/* get_staticConst_ptr */ __attribute__ ((const)) const signed int *hs_bindgen_test_globals_2eea936ed4beec74 (void) { return &staticConst; } \n/* get_classless_ptr */ __attribute__ ((const)) const signed int *hs_bindgen_test_globals_5d631acbb16c0e7e (void) { return &classless; } \n/* get_constArray1_ptr */ __attribute__ ((const)) const signed int (*hs_bindgen_test_globals_0d7a9340f4ef8b2e (void))[4] { return &constArray1; } \n/* get_constArray2_ptr */ __attribute__ ((const)) const ConstIntArray *hs_bindgen_test_globals_7e09340985caec8d (void) { return &constArray2; } \n/* get_constTuple_ptr */ __attribute__ ((const)) const struct tuple *hs_bindgen_test_globals_6f2e1968e15f0b9b (void) { return &constTuple; } \n/* get_nonConstTuple_ptr */ __attribute__ ((const)) struct tuple *hs_bindgen_test_globals_e8e62512a4e5d162 (void) { return &nonConstTuple; } \n/* get_ptrToConstInt_ptr */ __attribute__ ((const)) signed int **hs_bindgen_test_globals_e41146f6df20fe0d (void) { return &ptrToConstInt; } \n/* get_constPtrToInt_ptr */ __attribute__ ((const)) const signed int **hs_bindgen_test_globals_83b0d0f5488b6a03 (void) { return &constPtrToInt; } \n/* get_constPtrToConstInt_ptr */ __attribute__ ((const)) const signed int **hs_bindgen_test_globals_247c0c91ce28a18d (void) { return &constPtrToConstInt; } \n")
 
@@ -25,8 +25,14 @@ $(CAPI.addCSource "#include <globals.h>\n/* get_simpleGlobal_ptr */ __attribute_
 
   __from C:__ @simpleGlobal@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_9e13cdab849fd6a3" simpleGlobal_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_9e13cdab849fd6a3" hs_bindgen_test_globals_9e13cdab849fd6a3
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE simpleGlobal_ptr #-}
+
+simpleGlobal_ptr :: F.Ptr FC.CInt
+simpleGlobal_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_9e13cdab849fd6a3
 
 data Config = Config
   { config_x :: FC.CInt
@@ -54,8 +60,14 @@ instance F.Storable Config where
                F.pokeByteOff ptr0 (0 :: Int) config_x2
             >> F.pokeByteOff ptr0 (4 :: Int) config_y3
 
-foreign import ccall safe "hs_bindgen_test_globals_9093ee3b5b63dbb9" compoundGlobal1_ptr
-  :: F.Ptr Config
+foreign import ccall unsafe "hs_bindgen_test_globals_9093ee3b5b63dbb9" hs_bindgen_test_globals_9093ee3b5b63dbb9
+  :: IO (F.Ptr Config)
+
+{-# NOINLINE compoundGlobal1_ptr #-}
+
+compoundGlobal1_ptr :: F.Ptr Config
+compoundGlobal1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_9093ee3b5b63dbb9
 
 data Inline_struct = Inline_struct
   { inline_struct_x :: FC.CInt
@@ -83,8 +95,14 @@ instance F.Storable Inline_struct where
                F.pokeByteOff ptr0 (0 :: Int) inline_struct_x2
             >> F.pokeByteOff ptr0 (4 :: Int) inline_struct_y3
 
-foreign import ccall safe "hs_bindgen_test_globals_35cfb530c6e3b540" compoundGlobal2_ptr
-  :: F.Ptr Inline_struct
+foreign import ccall unsafe "hs_bindgen_test_globals_35cfb530c6e3b540" hs_bindgen_test_globals_35cfb530c6e3b540
+  :: IO (F.Ptr Inline_struct)
+
+{-# NOINLINE compoundGlobal2_ptr #-}
+
+compoundGlobal2_ptr :: F.Ptr Inline_struct
+compoundGlobal2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_35cfb530c6e3b540
 
 {-| Non-extern non-static global variables
 
@@ -96,44 +114,122 @@ foreign import ccall safe "hs_bindgen_test_globals_35cfb530c6e3b540" compoundGlo
 
   __from C:__ @nesInteger@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_d0e555bab6218b45" nesInteger_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_d0e555bab6218b45" hs_bindgen_test_globals_d0e555bab6218b45
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_globals_620d3eeb41be6814" nesFloating_ptr
-  :: F.Ptr FC.CFloat
+{-# NOINLINE nesInteger_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_globals_58609a874bbd4939" nesString1_ptr
-  :: F.Ptr (F.Ptr FC.CChar)
+nesInteger_ptr :: F.Ptr FC.CInt
+nesInteger_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_d0e555bab6218b45
 
-foreign import ccall safe "hs_bindgen_test_globals_d24d15726a247083" nesString2_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CChar)
+foreign import ccall unsafe "hs_bindgen_test_globals_620d3eeb41be6814" hs_bindgen_test_globals_620d3eeb41be6814
+  :: IO (F.Ptr FC.CFloat)
 
-foreign import ccall safe "hs_bindgen_test_globals_472e8cff06767166" nesCharacter_ptr
-  :: F.Ptr FC.CChar
+{-# NOINLINE nesFloating_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_globals_3535fbeb41ad5a41" nesParen_ptr
-  :: F.Ptr FC.CInt
+nesFloating_ptr :: F.Ptr FC.CFloat
+nesFloating_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_620d3eeb41be6814
 
-foreign import ccall safe "hs_bindgen_test_globals_c2e1dc65064ad658" nesUnary_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_58609a874bbd4939" hs_bindgen_test_globals_58609a874bbd4939
+  :: IO (F.Ptr (F.Ptr FC.CChar))
 
-foreign import ccall safe "hs_bindgen_test_globals_3d0448526008a072" nesBinary_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE nesString1_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_globals_6733c2e7c59bc620" nesConditional_ptr
-  :: F.Ptr FC.CInt
+nesString1_ptr :: F.Ptr (F.Ptr FC.CChar)
+nesString1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_58609a874bbd4939
 
-foreign import ccall safe "hs_bindgen_test_globals_d6e6e72f287d9b41" nesCast_ptr
-  :: F.Ptr FC.CFloat
+foreign import ccall unsafe "hs_bindgen_test_globals_d24d15726a247083" hs_bindgen_test_globals_d24d15726a247083
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CChar))
 
-foreign import ccall safe "hs_bindgen_test_globals_032905c6b7a5e39f" nesCompound_ptr
-  :: F.Ptr (F.Ptr FC.CInt)
+{-# NOINLINE nesString2_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_globals_4012de1fec3423a7" nesInitList_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.Prelude.Word8)
+nesString2_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CChar)
+nesString2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_d24d15726a247083
 
-foreign import ccall safe "hs_bindgen_test_globals_f9fb23513d064767" nesBool_ptr
-  :: F.Ptr FC.CBool
+foreign import ccall unsafe "hs_bindgen_test_globals_472e8cff06767166" hs_bindgen_test_globals_472e8cff06767166
+  :: IO (F.Ptr FC.CChar)
+
+{-# NOINLINE nesCharacter_ptr #-}
+
+nesCharacter_ptr :: F.Ptr FC.CChar
+nesCharacter_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_472e8cff06767166
+
+foreign import ccall unsafe "hs_bindgen_test_globals_3535fbeb41ad5a41" hs_bindgen_test_globals_3535fbeb41ad5a41
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE nesParen_ptr #-}
+
+nesParen_ptr :: F.Ptr FC.CInt
+nesParen_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_3535fbeb41ad5a41
+
+foreign import ccall unsafe "hs_bindgen_test_globals_c2e1dc65064ad658" hs_bindgen_test_globals_c2e1dc65064ad658
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE nesUnary_ptr #-}
+
+nesUnary_ptr :: F.Ptr FC.CInt
+nesUnary_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_c2e1dc65064ad658
+
+foreign import ccall unsafe "hs_bindgen_test_globals_3d0448526008a072" hs_bindgen_test_globals_3d0448526008a072
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE nesBinary_ptr #-}
+
+nesBinary_ptr :: F.Ptr FC.CInt
+nesBinary_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_3d0448526008a072
+
+foreign import ccall unsafe "hs_bindgen_test_globals_6733c2e7c59bc620" hs_bindgen_test_globals_6733c2e7c59bc620
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE nesConditional_ptr #-}
+
+nesConditional_ptr :: F.Ptr FC.CInt
+nesConditional_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_6733c2e7c59bc620
+
+foreign import ccall unsafe "hs_bindgen_test_globals_d6e6e72f287d9b41" hs_bindgen_test_globals_d6e6e72f287d9b41
+  :: IO (F.Ptr FC.CFloat)
+
+{-# NOINLINE nesCast_ptr #-}
+
+nesCast_ptr :: F.Ptr FC.CFloat
+nesCast_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_d6e6e72f287d9b41
+
+foreign import ccall unsafe "hs_bindgen_test_globals_032905c6b7a5e39f" hs_bindgen_test_globals_032905c6b7a5e39f
+  :: IO (F.Ptr (F.Ptr FC.CInt))
+
+{-# NOINLINE nesCompound_ptr #-}
+
+nesCompound_ptr :: F.Ptr (F.Ptr FC.CInt)
+nesCompound_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_032905c6b7a5e39f
+
+foreign import ccall unsafe "hs_bindgen_test_globals_4012de1fec3423a7" hs_bindgen_test_globals_4012de1fec3423a7
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.Prelude.Word8))
+
+{-# NOINLINE nesInitList_ptr #-}
+
+nesInitList_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.Prelude.Word8)
+nesInitList_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_4012de1fec3423a7
+
+foreign import ccall unsafe "hs_bindgen_test_globals_f9fb23513d064767" hs_bindgen_test_globals_f9fb23513d064767
+  :: IO (F.Ptr FC.CBool)
+
+{-# NOINLINE nesBool_ptr #-}
+
+nesBool_ptr :: F.Ptr FC.CBool
+nesBool_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_f9fb23513d064767
 
 {-| Additional examples of global variables, abstracted from real examples
 
@@ -143,11 +239,23 @@ foreign import ccall safe "hs_bindgen_test_globals_f9fb23513d064767" nesBool_ptr
 
   __from C:__ @streamBinary@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_92e68af3ae2ed3fb" streamBinary_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4096) HsBindgen.Runtime.Prelude.Word8)
+foreign import ccall unsafe "hs_bindgen_test_globals_92e68af3ae2ed3fb" hs_bindgen_test_globals_92e68af3ae2ed3fb
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4096) HsBindgen.Runtime.Prelude.Word8))
 
-foreign import ccall safe "hs_bindgen_test_globals_8d6f9f3043208163" streamBinary_len_ptr
-  :: F.Ptr HsBindgen.Runtime.Prelude.Word32
+{-# NOINLINE streamBinary_ptr #-}
+
+streamBinary_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4096) HsBindgen.Runtime.Prelude.Word8)
+streamBinary_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_92e68af3ae2ed3fb
+
+foreign import ccall unsafe "hs_bindgen_test_globals_8d6f9f3043208163" hs_bindgen_test_globals_8d6f9f3043208163
+  :: IO (F.Ptr HsBindgen.Runtime.Prelude.Word32)
+
+{-# NOINLINE streamBinary_len_ptr #-}
+
+streamBinary_len_ptr :: F.Ptr HsBindgen.Runtime.Prelude.Word32
+streamBinary_len_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_8d6f9f3043208163
 
 data Version_t = Version_t
   { version_t_major :: HsBindgen.Runtime.Prelude.Word8
@@ -230,8 +338,14 @@ instance F.Storable Struct2_t where
           Struct2_t struct2_t_field12 ->
             F.pokeByteOff ptr0 (0 :: Int) struct2_t_field12
 
-foreign import ccall safe "hs_bindgen_test_globals_88ad1f87a451c285" some_global_struct_ptr
-  :: F.Ptr Struct2_t
+foreign import ccall unsafe "hs_bindgen_test_globals_88ad1f87a451c285" hs_bindgen_test_globals_88ad1f87a451c285
+  :: IO (F.Ptr Struct2_t)
+
+{-# NOINLINE some_global_struct_ptr #-}
+
+some_global_struct_ptr :: F.Ptr Struct2_t
+some_global_struct_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_88ad1f87a451c285
 
 {-| Constant
 
@@ -239,8 +353,14 @@ foreign import ccall safe "hs_bindgen_test_globals_88ad1f87a451c285" some_global
 
   __from C:__ @globalConstant@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_2875ba0f7feba4fd" globalConstant_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_2875ba0f7feba4fd" hs_bindgen_test_globals_2875ba0f7feba4fd
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE globalConstant_ptr #-}
+
+globalConstant_ptr :: F.Ptr FC.CInt
+globalConstant_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_2875ba0f7feba4fd
 
 {-# NOINLINE globalConstant #-}
 
@@ -258,8 +378,14 @@ newtype ConstInt = ConstInt
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
 
-foreign import ccall safe "hs_bindgen_test_globals_6ebecf881bce1334" anotherGlobalConstant_ptr
-  :: F.Ptr ConstInt
+foreign import ccall unsafe "hs_bindgen_test_globals_6ebecf881bce1334" hs_bindgen_test_globals_6ebecf881bce1334
+  :: IO (F.Ptr ConstInt)
+
+{-# NOINLINE anotherGlobalConstant_ptr #-}
+
+anotherGlobalConstant_ptr :: F.Ptr ConstInt
+anotherGlobalConstant_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_6ebecf881bce1334
 
 {-# NOINLINE anotherGlobalConstant #-}
 
@@ -273,8 +399,14 @@ anotherGlobalConstant =
 
   __from C:__ @staticConst@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_2eea936ed4beec74" staticConst_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_2eea936ed4beec74" hs_bindgen_test_globals_2eea936ed4beec74
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE staticConst_ptr #-}
+
+staticConst_ptr :: F.Ptr FC.CInt
+staticConst_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_2eea936ed4beec74
 
 {-# NOINLINE staticConst #-}
 
@@ -286,8 +418,14 @@ staticConst =
 
   __from C:__ @classless@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_5d631acbb16c0e7e" classless_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_globals_5d631acbb16c0e7e" hs_bindgen_test_globals_5d631acbb16c0e7e
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE classless_ptr #-}
+
+classless_ptr :: F.Ptr FC.CInt
+classless_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_5d631acbb16c0e7e
 
 {-# NOINLINE classless #-}
 
@@ -299,8 +437,14 @@ classless =
 
   __from C:__ @constArray1@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_0d7a9340f4ef8b2e" constArray1_ptr
-  :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_globals_0d7a9340f4ef8b2e" hs_bindgen_test_globals_0d7a9340f4ef8b2e
+  :: IO (F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) FC.CInt))
+
+{-# NOINLINE constArray1_ptr #-}
+
+constArray1_ptr :: F.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) FC.CInt)
+constArray1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_0d7a9340f4ef8b2e
 
 {-# NOINLINE constArray1 #-}
 
@@ -317,8 +461,14 @@ newtype ConstIntArray = ConstIntArray
   }
   deriving stock (Eq, Show)
 
-foreign import ccall safe "hs_bindgen_test_globals_7e09340985caec8d" constArray2_ptr
-  :: F.Ptr ConstIntArray
+foreign import ccall unsafe "hs_bindgen_test_globals_7e09340985caec8d" hs_bindgen_test_globals_7e09340985caec8d
+  :: IO (F.Ptr ConstIntArray)
+
+{-# NOINLINE constArray2_ptr #-}
+
+constArray2_ptr :: F.Ptr ConstIntArray
+constArray2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_7e09340985caec8d
 
 data Tuple = Tuple
   { tuple_x :: FC.CInt
@@ -350,8 +500,14 @@ instance F.Storable Tuple where
 
   __from C:__ @constTuple@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_6f2e1968e15f0b9b" constTuple_ptr
-  :: F.Ptr Tuple
+foreign import ccall unsafe "hs_bindgen_test_globals_6f2e1968e15f0b9b" hs_bindgen_test_globals_6f2e1968e15f0b9b
+  :: IO (F.Ptr Tuple)
+
+{-# NOINLINE constTuple_ptr #-}
+
+constTuple_ptr :: F.Ptr Tuple
+constTuple_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_6f2e1968e15f0b9b
 
 {-# NOINLINE constTuple #-}
 
@@ -363,22 +519,40 @@ constTuple =
 
   __from C:__ @nonConstTuple@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_e8e62512a4e5d162" nonConstTuple_ptr
-  :: F.Ptr Tuple
+foreign import ccall unsafe "hs_bindgen_test_globals_e8e62512a4e5d162" hs_bindgen_test_globals_e8e62512a4e5d162
+  :: IO (F.Ptr Tuple)
+
+{-# NOINLINE nonConstTuple_ptr #-}
+
+nonConstTuple_ptr :: F.Ptr Tuple
+nonConstTuple_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_e8e62512a4e5d162
 
 {-| A pointer to const int
 
   __from C:__ @ptrToConstInt@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_e41146f6df20fe0d" ptrToConstInt_ptr
-  :: F.Ptr (F.Ptr FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_globals_e41146f6df20fe0d" hs_bindgen_test_globals_e41146f6df20fe0d
+  :: IO (F.Ptr (F.Ptr FC.CInt))
+
+{-# NOINLINE ptrToConstInt_ptr #-}
+
+ptrToConstInt_ptr :: F.Ptr (F.Ptr FC.CInt)
+ptrToConstInt_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_e41146f6df20fe0d
 
 {-| A const pointer to int
 
   __from C:__ @constPtrToInt@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_83b0d0f5488b6a03" constPtrToInt_ptr
-  :: F.Ptr (F.Ptr FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_globals_83b0d0f5488b6a03" hs_bindgen_test_globals_83b0d0f5488b6a03
+  :: IO (F.Ptr (F.Ptr FC.CInt))
+
+{-# NOINLINE constPtrToInt_ptr #-}
+
+constPtrToInt_ptr :: F.Ptr (F.Ptr FC.CInt)
+constPtrToInt_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_83b0d0f5488b6a03
 
 {-# NOINLINE constPtrToInt #-}
 
@@ -390,8 +564,14 @@ constPtrToInt =
 
   __from C:__ @constPtrToConstInt@
 -}
-foreign import ccall safe "hs_bindgen_test_globals_247c0c91ce28a18d" constPtrToConstInt_ptr
-  :: F.Ptr (F.Ptr FC.CInt)
+foreign import ccall unsafe "hs_bindgen_test_globals_247c0c91ce28a18d" hs_bindgen_test_globals_247c0c91ce28a18d
+  :: IO (F.Ptr (F.Ptr FC.CInt))
+
+{-# NOINLINE constPtrToConstInt_ptr #-}
+
+constPtrToConstInt_ptr :: F.Ptr (F.Ptr FC.CInt)
+constPtrToConstInt_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globals_247c0c91ce28a18d
 
 {-# NOINLINE constPtrToConstInt #-}
 

--- a/hs-bindgen/fixtures/globals.th.txt
+++ b/hs-bindgen/fixtures/globals.th.txt
@@ -37,7 +37,10 @@
 {-| Global variables
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_9e13cdab849fd6a3" simpleGlobal_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_globals_9e13cdab849fd6a3" hs_bindgen_test_globals_9e13cdab849fd6a3 :: IO (Ptr CInt)
+{-# NOINLINE simpleGlobal_ptr #-}
+simpleGlobal_ptr :: Ptr CInt
+simpleGlobal_ptr = unsafePerformIO hs_bindgen_test_globals_9e13cdab849fd6a3
 data Config
     = Config {config_x :: CInt, config_y :: CInt}
     deriving stock (Eq, Show)
@@ -48,7 +51,10 @@ instance Storable Config
           poke = \ptr_1 -> \s_2 -> case s_2 of
                                    Config config_x_3
                                           config_y_4 -> pokeByteOff ptr_1 (0 :: Int) config_x_3 >> pokeByteOff ptr_1 (4 :: Int) config_y_4
-foreign import ccall safe "hs_bindgen_test_globals_9093ee3b5b63dbb9" compoundGlobal1_ptr :: Ptr Config
+foreign import ccall safe "hs_bindgen_test_globals_9093ee3b5b63dbb9" hs_bindgen_test_globals_9093ee3b5b63dbb9 :: IO (Ptr Config)
+{-# NOINLINE compoundGlobal1_ptr #-}
+compoundGlobal1_ptr :: Ptr Config
+compoundGlobal1_ptr = unsafePerformIO hs_bindgen_test_globals_9093ee3b5b63dbb9
 data Inline_struct
     = Inline_struct {inline_struct_x :: CInt, inline_struct_y :: CInt}
     deriving stock (Eq, Show)
@@ -59,7 +65,10 @@ instance Storable Inline_struct
           poke = \ptr_1 -> \s_2 -> case s_2 of
                                    Inline_struct inline_struct_x_3
                                                  inline_struct_y_4 -> pokeByteOff ptr_1 (0 :: Int) inline_struct_x_3 >> pokeByteOff ptr_1 (4 :: Int) inline_struct_y_4
-foreign import ccall safe "hs_bindgen_test_globals_35cfb530c6e3b540" compoundGlobal2_ptr :: Ptr Inline_struct
+foreign import ccall safe "hs_bindgen_test_globals_35cfb530c6e3b540" hs_bindgen_test_globals_35cfb530c6e3b540 :: IO (Ptr Inline_struct)
+{-# NOINLINE compoundGlobal2_ptr #-}
+compoundGlobal2_ptr :: Ptr Inline_struct
+compoundGlobal2_ptr = unsafePerformIO hs_bindgen_test_globals_35cfb530c6e3b540
 {-| Non-extern non-static global variables
 
   These kinds of variables need to be treated with care, to avoid duplicate symbols, but do exist in the wild.
@@ -69,21 +78,61 @@ foreign import ccall safe "hs_bindgen_test_globals_35cfb530c6e3b540" compoundGlo
   [1]: https://clang.llvm.org/doxygen/group__CINDEX.html#gaaccc432245b4cd9f2d470913f9ef0013
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_d0e555bab6218b45" nesInteger_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_globals_620d3eeb41be6814" nesFloating_ptr :: Ptr CFloat
-foreign import ccall safe "hs_bindgen_test_globals_58609a874bbd4939" nesString1_ptr :: Ptr (Ptr CChar)
-foreign import ccall safe "hs_bindgen_test_globals_d24d15726a247083" nesString2_ptr :: Ptr (ConstantArray 3
-                                                                                                          CChar)
-foreign import ccall safe "hs_bindgen_test_globals_472e8cff06767166" nesCharacter_ptr :: Ptr CChar
-foreign import ccall safe "hs_bindgen_test_globals_3535fbeb41ad5a41" nesParen_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_globals_c2e1dc65064ad658" nesUnary_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_globals_3d0448526008a072" nesBinary_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_globals_6733c2e7c59bc620" nesConditional_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_globals_d6e6e72f287d9b41" nesCast_ptr :: Ptr CFloat
-foreign import ccall safe "hs_bindgen_test_globals_032905c6b7a5e39f" nesCompound_ptr :: Ptr (Ptr CInt)
-foreign import ccall safe "hs_bindgen_test_globals_4012de1fec3423a7" nesInitList_ptr :: Ptr (ConstantArray 4
-                                                                                                           HsBindgen.Runtime.Prelude.Word8)
-foreign import ccall safe "hs_bindgen_test_globals_f9fb23513d064767" nesBool_ptr :: Ptr CBool
+foreign import ccall safe "hs_bindgen_test_globals_d0e555bab6218b45" hs_bindgen_test_globals_d0e555bab6218b45 :: IO (Ptr CInt)
+{-# NOINLINE nesInteger_ptr #-}
+nesInteger_ptr :: Ptr CInt
+nesInteger_ptr = unsafePerformIO hs_bindgen_test_globals_d0e555bab6218b45
+foreign import ccall safe "hs_bindgen_test_globals_620d3eeb41be6814" hs_bindgen_test_globals_620d3eeb41be6814 :: IO (Ptr CFloat)
+{-# NOINLINE nesFloating_ptr #-}
+nesFloating_ptr :: Ptr CFloat
+nesFloating_ptr = unsafePerformIO hs_bindgen_test_globals_620d3eeb41be6814
+foreign import ccall safe "hs_bindgen_test_globals_58609a874bbd4939" hs_bindgen_test_globals_58609a874bbd4939 :: IO (Ptr (Ptr CChar))
+{-# NOINLINE nesString1_ptr #-}
+nesString1_ptr :: Ptr (Ptr CChar)
+nesString1_ptr = unsafePerformIO hs_bindgen_test_globals_58609a874bbd4939
+foreign import ccall safe "hs_bindgen_test_globals_d24d15726a247083" hs_bindgen_test_globals_d24d15726a247083 :: IO (Ptr (ConstantArray 3
+                                                                                                                                        CChar))
+{-# NOINLINE nesString2_ptr #-}
+nesString2_ptr :: Ptr (ConstantArray 3 CChar)
+nesString2_ptr = unsafePerformIO hs_bindgen_test_globals_d24d15726a247083
+foreign import ccall safe "hs_bindgen_test_globals_472e8cff06767166" hs_bindgen_test_globals_472e8cff06767166 :: IO (Ptr CChar)
+{-# NOINLINE nesCharacter_ptr #-}
+nesCharacter_ptr :: Ptr CChar
+nesCharacter_ptr = unsafePerformIO hs_bindgen_test_globals_472e8cff06767166
+foreign import ccall safe "hs_bindgen_test_globals_3535fbeb41ad5a41" hs_bindgen_test_globals_3535fbeb41ad5a41 :: IO (Ptr CInt)
+{-# NOINLINE nesParen_ptr #-}
+nesParen_ptr :: Ptr CInt
+nesParen_ptr = unsafePerformIO hs_bindgen_test_globals_3535fbeb41ad5a41
+foreign import ccall safe "hs_bindgen_test_globals_c2e1dc65064ad658" hs_bindgen_test_globals_c2e1dc65064ad658 :: IO (Ptr CInt)
+{-# NOINLINE nesUnary_ptr #-}
+nesUnary_ptr :: Ptr CInt
+nesUnary_ptr = unsafePerformIO hs_bindgen_test_globals_c2e1dc65064ad658
+foreign import ccall safe "hs_bindgen_test_globals_3d0448526008a072" hs_bindgen_test_globals_3d0448526008a072 :: IO (Ptr CInt)
+{-# NOINLINE nesBinary_ptr #-}
+nesBinary_ptr :: Ptr CInt
+nesBinary_ptr = unsafePerformIO hs_bindgen_test_globals_3d0448526008a072
+foreign import ccall safe "hs_bindgen_test_globals_6733c2e7c59bc620" hs_bindgen_test_globals_6733c2e7c59bc620 :: IO (Ptr CInt)
+{-# NOINLINE nesConditional_ptr #-}
+nesConditional_ptr :: Ptr CInt
+nesConditional_ptr = unsafePerformIO hs_bindgen_test_globals_6733c2e7c59bc620
+foreign import ccall safe "hs_bindgen_test_globals_d6e6e72f287d9b41" hs_bindgen_test_globals_d6e6e72f287d9b41 :: IO (Ptr CFloat)
+{-# NOINLINE nesCast_ptr #-}
+nesCast_ptr :: Ptr CFloat
+nesCast_ptr = unsafePerformIO hs_bindgen_test_globals_d6e6e72f287d9b41
+foreign import ccall safe "hs_bindgen_test_globals_032905c6b7a5e39f" hs_bindgen_test_globals_032905c6b7a5e39f :: IO (Ptr (Ptr CInt))
+{-# NOINLINE nesCompound_ptr #-}
+nesCompound_ptr :: Ptr (Ptr CInt)
+nesCompound_ptr = unsafePerformIO hs_bindgen_test_globals_032905c6b7a5e39f
+foreign import ccall safe "hs_bindgen_test_globals_4012de1fec3423a7" hs_bindgen_test_globals_4012de1fec3423a7 :: IO (Ptr (ConstantArray 4
+                                                                                                                                        HsBindgen.Runtime.Prelude.Word8))
+{-# NOINLINE nesInitList_ptr #-}
+nesInitList_ptr :: Ptr (ConstantArray 4
+                                      HsBindgen.Runtime.Prelude.Word8)
+nesInitList_ptr = unsafePerformIO hs_bindgen_test_globals_4012de1fec3423a7
+foreign import ccall safe "hs_bindgen_test_globals_f9fb23513d064767" hs_bindgen_test_globals_f9fb23513d064767 :: IO (Ptr CBool)
+{-# NOINLINE nesBool_ptr #-}
+nesBool_ptr :: Ptr CBool
+nesBool_ptr = unsafePerformIO hs_bindgen_test_globals_f9fb23513d064767
 {-| Additional examples of global variables, abstracted from real examples
 
   The `streamBinary`/`streamBinary_len` example comes from [1], and is an example of a non-extern non-static global (indeed, the header does not even use  once @ or similar).
@@ -91,9 +140,16 @@ foreign import ccall safe "hs_bindgen_test_globals_f9fb23513d064767" nesBool_ptr
   [1]: https://github.com/analogdevicesinc/no-OS/blob/855c4b3c34f2297865e448661ba4fcc0931bf430/drivers/rf-transceiver/talise/firmware/talise_stream_binary.h#L322-L325
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_92e68af3ae2ed3fb" streamBinary_ptr :: Ptr (ConstantArray 4096
-                                                                                                            HsBindgen.Runtime.Prelude.Word8)
-foreign import ccall safe "hs_bindgen_test_globals_8d6f9f3043208163" streamBinary_len_ptr :: Ptr HsBindgen.Runtime.Prelude.Word32
+foreign import ccall safe "hs_bindgen_test_globals_92e68af3ae2ed3fb" hs_bindgen_test_globals_92e68af3ae2ed3fb :: IO (Ptr (ConstantArray 4096
+                                                                                                                                        HsBindgen.Runtime.Prelude.Word8))
+{-# NOINLINE streamBinary_ptr #-}
+streamBinary_ptr :: Ptr (ConstantArray 4096
+                                       HsBindgen.Runtime.Prelude.Word8)
+streamBinary_ptr = unsafePerformIO hs_bindgen_test_globals_92e68af3ae2ed3fb
+foreign import ccall safe "hs_bindgen_test_globals_8d6f9f3043208163" hs_bindgen_test_globals_8d6f9f3043208163 :: IO (Ptr HsBindgen.Runtime.Prelude.Word32)
+{-# NOINLINE streamBinary_len_ptr #-}
+streamBinary_len_ptr :: Ptr HsBindgen.Runtime.Prelude.Word32
+streamBinary_len_ptr = unsafePerformIO hs_bindgen_test_globals_8d6f9f3043208163
 data Version_t
     = Version_t {version_t_major :: HsBindgen.Runtime.Prelude.Word8,
                  version_t_minor :: HsBindgen.Runtime.Prelude.Word16,
@@ -129,13 +185,19 @@ instance Storable Struct2_t
           peek = \ptr_0 -> pure Struct2_t <*> peekByteOff ptr_0 (0 :: Int)
           poke = \ptr_1 -> \s_2 -> case s_2 of
                                    Struct2_t struct2_t_field1_3 -> pokeByteOff ptr_1 (0 :: Int) struct2_t_field1_3
-foreign import ccall safe "hs_bindgen_test_globals_88ad1f87a451c285" some_global_struct_ptr :: Ptr Struct2_t
+foreign import ccall safe "hs_bindgen_test_globals_88ad1f87a451c285" hs_bindgen_test_globals_88ad1f87a451c285 :: IO (Ptr Struct2_t)
+{-# NOINLINE some_global_struct_ptr #-}
+some_global_struct_ptr :: Ptr Struct2_t
+some_global_struct_ptr = unsafePerformIO hs_bindgen_test_globals_88ad1f87a451c285
 {-| Constant
 
   Although this is a constant, we don't expect an initializer (since it's `extern`).
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_2875ba0f7feba4fd" globalConstant_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_globals_2875ba0f7feba4fd" hs_bindgen_test_globals_2875ba0f7feba4fd :: IO (Ptr CInt)
+{-# NOINLINE globalConstant_ptr #-}
+globalConstant_ptr :: Ptr CInt
+globalConstant_ptr = unsafePerformIO hs_bindgen_test_globals_2875ba0f7feba4fd
 {-# NOINLINE globalConstant #-}
 globalConstant :: CInt
 globalConstant = unsafePerformIO (peek globalConstant_ptr)
@@ -157,7 +219,10 @@ newtype ConstInt
                       Ix,
                       Num,
                       Real)
-foreign import ccall safe "hs_bindgen_test_globals_6ebecf881bce1334" anotherGlobalConstant_ptr :: Ptr ConstInt
+foreign import ccall safe "hs_bindgen_test_globals_6ebecf881bce1334" hs_bindgen_test_globals_6ebecf881bce1334 :: IO (Ptr ConstInt)
+{-# NOINLINE anotherGlobalConstant_ptr #-}
+anotherGlobalConstant_ptr :: Ptr ConstInt
+anotherGlobalConstant_ptr = unsafePerformIO hs_bindgen_test_globals_6ebecf881bce1334
 {-# NOINLINE anotherGlobalConstant #-}
 anotherGlobalConstant :: ConstInt
 anotherGlobalConstant = unsafePerformIO (peek anotherGlobalConstant_ptr)
@@ -166,22 +231,31 @@ anotherGlobalConstant = unsafePerformIO (peek anotherGlobalConstant_ptr)
   Unlike with `extern`, in this we _do_ expect an initializer.
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_2eea936ed4beec74" staticConst_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_globals_2eea936ed4beec74" hs_bindgen_test_globals_2eea936ed4beec74 :: IO (Ptr CInt)
+{-# NOINLINE staticConst_ptr #-}
+staticConst_ptr :: Ptr CInt
+staticConst_ptr = unsafePerformIO hs_bindgen_test_globals_2eea936ed4beec74
 {-# NOINLINE staticConst #-}
 staticConst :: CInt
 staticConst = unsafePerformIO (peek staticConst_ptr)
 {-| No storage class specified
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_5d631acbb16c0e7e" classless_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_globals_5d631acbb16c0e7e" hs_bindgen_test_globals_5d631acbb16c0e7e :: IO (Ptr CInt)
+{-# NOINLINE classless_ptr #-}
+classless_ptr :: Ptr CInt
+classless_ptr = unsafePerformIO hs_bindgen_test_globals_5d631acbb16c0e7e
 {-# NOINLINE classless #-}
 classless :: CInt
 classless = unsafePerformIO (peek classless_ptr)
 {-| A an array of size 4 containing constant integers
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_0d7a9340f4ef8b2e" constArray1_ptr :: Ptr (ConstantArray 4
-                                                                                                           CInt)
+foreign import ccall safe "hs_bindgen_test_globals_0d7a9340f4ef8b2e" hs_bindgen_test_globals_0d7a9340f4ef8b2e :: IO (Ptr (ConstantArray 4
+                                                                                                                                        CInt))
+{-# NOINLINE constArray1_ptr #-}
+constArray1_ptr :: Ptr (ConstantArray 4 CInt)
+constArray1_ptr = unsafePerformIO hs_bindgen_test_globals_0d7a9340f4ef8b2e
 {-# NOINLINE constArray1 #-}
 constArray1 :: ConstantArray 4 CInt
 constArray1 = unsafePerformIO (peek constArray1_ptr)
@@ -194,7 +268,10 @@ newtype ConstIntArray
 
       -}
     deriving stock (Eq, Show)
-foreign import ccall safe "hs_bindgen_test_globals_7e09340985caec8d" constArray2_ptr :: Ptr ConstIntArray
+foreign import ccall safe "hs_bindgen_test_globals_7e09340985caec8d" hs_bindgen_test_globals_7e09340985caec8d :: IO (Ptr ConstIntArray)
+{-# NOINLINE constArray2_ptr #-}
+constArray2_ptr :: Ptr ConstIntArray
+constArray2_ptr = unsafePerformIO hs_bindgen_test_globals_7e09340985caec8d
 data Tuple
     = Tuple {tuple_x :: CInt, tuple_y :: CInt}
     deriving stock (Eq, Show)
@@ -208,29 +285,44 @@ instance Storable Tuple
 {-| A constant tuple
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_6f2e1968e15f0b9b" constTuple_ptr :: Ptr Tuple
+foreign import ccall safe "hs_bindgen_test_globals_6f2e1968e15f0b9b" hs_bindgen_test_globals_6f2e1968e15f0b9b :: IO (Ptr Tuple)
+{-# NOINLINE constTuple_ptr #-}
+constTuple_ptr :: Ptr Tuple
+constTuple_ptr = unsafePerformIO hs_bindgen_test_globals_6f2e1968e15f0b9b
 {-# NOINLINE constTuple #-}
 constTuple :: Tuple
 constTuple = unsafePerformIO (peek constTuple_ptr)
 {-| A non-constant tuple with a constant member
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_e8e62512a4e5d162" nonConstTuple_ptr :: Ptr Tuple
+foreign import ccall safe "hs_bindgen_test_globals_e8e62512a4e5d162" hs_bindgen_test_globals_e8e62512a4e5d162 :: IO (Ptr Tuple)
+{-# NOINLINE nonConstTuple_ptr #-}
+nonConstTuple_ptr :: Ptr Tuple
+nonConstTuple_ptr = unsafePerformIO hs_bindgen_test_globals_e8e62512a4e5d162
 {-| A pointer to const int
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_e41146f6df20fe0d" ptrToConstInt_ptr :: Ptr (Ptr CInt)
+foreign import ccall safe "hs_bindgen_test_globals_e41146f6df20fe0d" hs_bindgen_test_globals_e41146f6df20fe0d :: IO (Ptr (Ptr CInt))
+{-# NOINLINE ptrToConstInt_ptr #-}
+ptrToConstInt_ptr :: Ptr (Ptr CInt)
+ptrToConstInt_ptr = unsafePerformIO hs_bindgen_test_globals_e41146f6df20fe0d
 {-| A const pointer to int
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_83b0d0f5488b6a03" constPtrToInt_ptr :: Ptr (Ptr CInt)
+foreign import ccall safe "hs_bindgen_test_globals_83b0d0f5488b6a03" hs_bindgen_test_globals_83b0d0f5488b6a03 :: IO (Ptr (Ptr CInt))
+{-# NOINLINE constPtrToInt_ptr #-}
+constPtrToInt_ptr :: Ptr (Ptr CInt)
+constPtrToInt_ptr = unsafePerformIO hs_bindgen_test_globals_83b0d0f5488b6a03
 {-# NOINLINE constPtrToInt #-}
 constPtrToInt :: Ptr CInt
 constPtrToInt = unsafePerformIO (peek constPtrToInt_ptr)
 {-| A const pointer to const int
 
 -}
-foreign import ccall safe "hs_bindgen_test_globals_247c0c91ce28a18d" constPtrToConstInt_ptr :: Ptr (Ptr CInt)
+foreign import ccall safe "hs_bindgen_test_globals_247c0c91ce28a18d" hs_bindgen_test_globals_247c0c91ce28a18d :: IO (Ptr (Ptr CInt))
+{-# NOINLINE constPtrToConstInt_ptr #-}
+constPtrToConstInt_ptr :: Ptr (Ptr CInt)
+constPtrToConstInt_ptr = unsafePerformIO hs_bindgen_test_globals_247c0c91ce28a18d
 {-# NOINLINE constPtrToConstInt #-}
 constPtrToConstInt :: Ptr CInt
 constPtrToConstInt = unsafePerformIO (peek constPtrToConstInt_ptr)

--- a/hs-bindgen/fixtures/redeclaration.hs
+++ b/hs-bindgen/fixtures/redeclaration.hs
@@ -7,11 +7,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "x_ptr",
+        "hs_bindgen_test_redeclaration_59f22ffbb8d28119",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_redeclaration_59f22ffbb8d28119",
       foreignImportCallConv =
@@ -20,7 +22,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclNewtype
     Newtype {
       newtypeName = HsName

--- a/hs-bindgen/fixtures/redeclaration.pp.hs
+++ b/hs-bindgen/fixtures/redeclaration.pp.hs
@@ -16,15 +16,22 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.SizedByteArray
-import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
+import Prelude ((<*>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 $(CAPI.addCSource "#include <redeclaration.h>\n/* get_x_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_redeclaration_59f22ffbb8d28119 (void) { return &x; } \n")
 
-foreign import ccall safe "hs_bindgen_test_redeclaration_59f22ffbb8d28119" x_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_redeclaration_59f22ffbb8d28119" hs_bindgen_test_redeclaration_59f22ffbb8d28119
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE x_ptr #-}
+
+x_ptr :: F.Ptr FC.CInt
+x_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_redeclaration_59f22ffbb8d28119
 
 newtype Int_t = Int_t
   { un_Int_t :: FC.CInt

--- a/hs-bindgen/fixtures/redeclaration.th.txt
+++ b/hs-bindgen/fixtures/redeclaration.th.txt
@@ -1,7 +1,10 @@
 -- addDependentFile examples/golden/redeclaration.h
 -- #include <redeclaration.h>
 -- /* get_x_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_redeclaration_59f22ffbb8d28119 (void) { return &x; } 
-foreign import ccall safe "hs_bindgen_test_redeclaration_59f22ffbb8d28119" x_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_redeclaration_59f22ffbb8d28119" hs_bindgen_test_redeclaration_59f22ffbb8d28119 :: IO (Ptr CInt)
+{-# NOINLINE x_ptr #-}
+x_ptr :: Ptr CInt
+x_ptr = unsafePerformIO hs_bindgen_test_redeclaration_59f22ffbb8d28119
 newtype Int_t
     = Int_t {un_Int_t :: CInt}
     deriving stock (Eq, Ord, Read, Show)

--- a/hs-bindgen/fixtures/tentative_definitions.hs
+++ b/hs-bindgen/fixtures/tentative_definitions.hs
@@ -7,11 +7,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i1_ptr",
+        "hs_bindgen_test_tentative_definitions_736e69defba46ab4",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_tentative_definitions_736e69defba46ab4",
       foreignImportCallConv =
@@ -20,7 +22,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "tentative_definitions.h",
   DeclInlineC
@@ -29,11 +33,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i2_ptr",
+        "hs_bindgen_test_tentative_definitions_210c547ae5abcc02",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_tentative_definitions_210c547ae5abcc02",
       foreignImportCallConv =
@@ -42,7 +48,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "tentative_definitions.h",
   DeclInlineC
@@ -51,11 +59,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i3_ptr",
+        "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274",
       foreignImportCallConv =
@@ -64,4 +74,6 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe}]
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple]

--- a/hs-bindgen/fixtures/tentative_definitions.pp.hs
+++ b/hs-bindgen/fixtures/tentative_definitions.pp.hs
@@ -6,15 +6,35 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
+import Prelude (IO)
 
 $(CAPI.addCSource "#include <tentative_definitions.h>\n/* get_i1_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_736e69defba46ab4 (void) { return &i1; } \n/* get_i2_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_210c547ae5abcc02 (void) { return &i2; } \n/* get_i3_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_d6bb66d7f7107274 (void) { return &i3; } \n")
 
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_736e69defba46ab4" i1_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_tentative_definitions_736e69defba46ab4" hs_bindgen_test_tentative_definitions_736e69defba46ab4
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_210c547ae5abcc02" i2_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i1_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274" i3_ptr
-  :: F.Ptr FC.CInt
+i1_ptr :: F.Ptr FC.CInt
+i1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_tentative_definitions_736e69defba46ab4
+
+foreign import ccall unsafe "hs_bindgen_test_tentative_definitions_210c547ae5abcc02" hs_bindgen_test_tentative_definitions_210c547ae5abcc02
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i2_ptr #-}
+
+i2_ptr :: F.Ptr FC.CInt
+i2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_tentative_definitions_210c547ae5abcc02
+
+foreign import ccall unsafe "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274" hs_bindgen_test_tentative_definitions_d6bb66d7f7107274
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i3_ptr #-}
+
+i3_ptr :: F.Ptr FC.CInt
+i3_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_tentative_definitions_d6bb66d7f7107274

--- a/hs-bindgen/fixtures/tentative_definitions.th.txt
+++ b/hs-bindgen/fixtures/tentative_definitions.th.txt
@@ -3,6 +3,15 @@
 -- /* get_i1_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_736e69defba46ab4 (void) { return &i1; } 
 -- /* get_i2_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_210c547ae5abcc02 (void) { return &i2; } 
 -- /* get_i3_ptr */ __attribute__ ((const)) signed int *hs_bindgen_test_tentative_definitions_d6bb66d7f7107274 (void) { return &i3; } 
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_736e69defba46ab4" i1_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_210c547ae5abcc02" i2_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274" i3_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_tentative_definitions_736e69defba46ab4" hs_bindgen_test_tentative_definitions_736e69defba46ab4 :: IO (Ptr CInt)
+{-# NOINLINE i1_ptr #-}
+i1_ptr :: Ptr CInt
+i1_ptr = unsafePerformIO hs_bindgen_test_tentative_definitions_736e69defba46ab4
+foreign import ccall safe "hs_bindgen_test_tentative_definitions_210c547ae5abcc02" hs_bindgen_test_tentative_definitions_210c547ae5abcc02 :: IO (Ptr CInt)
+{-# NOINLINE i2_ptr #-}
+i2_ptr :: Ptr CInt
+i2_ptr = unsafePerformIO hs_bindgen_test_tentative_definitions_210c547ae5abcc02
+foreign import ccall safe "hs_bindgen_test_tentative_definitions_d6bb66d7f7107274" hs_bindgen_test_tentative_definitions_d6bb66d7f7107274 :: IO (Ptr CInt)
+{-# NOINLINE i3_ptr #-}
+i3_ptr :: Ptr CInt
+i3_ptr = unsafePerformIO hs_bindgen_test_tentative_definitions_d6bb66d7f7107274

--- a/hs-bindgen/fixtures/visibility_attributes.hs
+++ b/hs-bindgen/fixtures/visibility_attributes.hs
@@ -907,11 +907,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i0_ptr",
+        "hs_bindgen_test_visibility_attributes_724fd59489c94c9f",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_724fd59489c94c9f",
       foreignImportCallConv =
@@ -920,7 +922,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -929,11 +933,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i1_ptr",
+        "hs_bindgen_test_visibility_attributes_736e69defba46ab4",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_736e69defba46ab4",
       foreignImportCallConv =
@@ -942,7 +948,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -951,11 +959,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i2_ptr",
+        "hs_bindgen_test_visibility_attributes_210c547ae5abcc02",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_210c547ae5abcc02",
       foreignImportCallConv =
@@ -964,7 +974,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -973,11 +985,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i3_ptr",
+        "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274",
       foreignImportCallConv =
@@ -986,7 +1000,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -995,11 +1011,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i4_ptr",
+        "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434",
       foreignImportCallConv =
@@ -1008,7 +1026,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1017,11 +1037,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i5_ptr",
+        "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3",
       foreignImportCallConv =
@@ -1030,7 +1052,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1039,11 +1063,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i6_ptr",
+        "hs_bindgen_test_visibility_attributes_3bd2208d8e850002",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_3bd2208d8e850002",
       foreignImportCallConv =
@@ -1052,7 +1078,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1061,11 +1089,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i7_ptr",
+        "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014",
       foreignImportCallConv =
@@ -1074,7 +1104,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1083,11 +1115,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i8_ptr",
+        "hs_bindgen_test_visibility_attributes_696700c5194eb184",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_696700c5194eb184",
       foreignImportCallConv =
@@ -1096,7 +1130,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1105,11 +1141,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i9_ptr",
+        "hs_bindgen_test_visibility_attributes_27bb5845debfdd10",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_27bb5845debfdd10",
       foreignImportCallConv =
@@ -1118,7 +1156,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1127,11 +1167,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i10_ptr",
+        "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d",
       foreignImportCallConv =
@@ -1140,7 +1182,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1149,11 +1193,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i11_ptr",
+        "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7",
       foreignImportCallConv =
@@ -1162,7 +1208,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1171,11 +1219,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i12_ptr",
+        "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb",
       foreignImportCallConv =
@@ -1184,7 +1234,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1193,11 +1245,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i13_ptr",
+        "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e",
       foreignImportCallConv =
@@ -1206,7 +1260,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1215,11 +1271,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i14_ptr",
+        "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5",
       foreignImportCallConv =
@@ -1228,7 +1286,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1237,11 +1297,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i15_ptr",
+        "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9",
       foreignImportCallConv =
@@ -1250,7 +1312,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1259,11 +1323,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i16_ptr",
+        "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44",
       foreignImportCallConv =
@@ -1272,7 +1338,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1281,11 +1349,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i17_ptr",
+        "hs_bindgen_test_visibility_attributes_e60a43107858a2bc",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_e60a43107858a2bc",
       foreignImportCallConv =
@@ -1294,7 +1364,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1303,11 +1375,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i18_ptr",
+        "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f",
       foreignImportCallConv =
@@ -1316,7 +1390,9 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe},
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple,
   DeclInlineCInclude
     "visibility_attributes.h",
   DeclInlineC
@@ -1325,11 +1401,13 @@
     ForeignImportDecl {
       foreignImportName = HsName
         "@NsVar"
-        "i19_ptr",
+        "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1",
       foreignImportParameters = [],
       foreignImportResultType =
       NormalResultType
-        (HsPtr (HsPrimType HsPrimCInt)),
+        (HsIO
+          (HsPtr
+            (HsPrimType HsPrimCInt))),
       foreignImportOrigName =
       "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1",
       foreignImportCallConv =
@@ -1338,4 +1416,6 @@
         (TypePrim
           (PrimIntegral PrimInt Signed)),
       foreignImportComment = Nothing,
-      foreignImportSafety = Safe}]
+      foreignImportSafety = Unsafe},
+  DeclSimple,
+  DeclSimple]

--- a/hs-bindgen/fixtures/visibility_attributes.pp.hs
+++ b/hs-bindgen/fixtures/visibility_attributes.pp.hs
@@ -6,6 +6,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 
@@ -131,62 +132,182 @@ foreign import ccall safe "hs_bindgen_test_visibility_attributes_358fecb39951c1e
 foreign import ccall safe "hs_bindgen_test_visibility_attributes_8255bfc1a96b601c" f29
   :: IO ()
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_724fd59489c94c9f" i0_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_724fd59489c94c9f" hs_bindgen_test_visibility_attributes_724fd59489c94c9f
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_736e69defba46ab4" i1_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i0_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_210c547ae5abcc02" i2_ptr
-  :: F.Ptr FC.CInt
+i0_ptr :: F.Ptr FC.CInt
+i0_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_724fd59489c94c9f
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274" i3_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_736e69defba46ab4" hs_bindgen_test_visibility_attributes_736e69defba46ab4
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434" i4_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i1_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3" i5_ptr
-  :: F.Ptr FC.CInt
+i1_ptr :: F.Ptr FC.CInt
+i1_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_736e69defba46ab4
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_3bd2208d8e850002" i6_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_210c547ae5abcc02" hs_bindgen_test_visibility_attributes_210c547ae5abcc02
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014" i7_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i2_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_696700c5194eb184" i8_ptr
-  :: F.Ptr FC.CInt
+i2_ptr :: F.Ptr FC.CInt
+i2_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_210c547ae5abcc02
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_27bb5845debfdd10" i9_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274" hs_bindgen_test_visibility_attributes_d6bb66d7f7107274
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d" i10_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i3_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7" i11_ptr
-  :: F.Ptr FC.CInt
+i3_ptr :: F.Ptr FC.CInt
+i3_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_d6bb66d7f7107274
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb" i12_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434" hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e" i13_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i4_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5" i14_ptr
-  :: F.Ptr FC.CInt
+i4_ptr :: F.Ptr FC.CInt
+i4_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9" i15_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3" hs_bindgen_test_visibility_attributes_6ff6b816265f91d3
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44" i16_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i5_ptr #-}
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_e60a43107858a2bc" i17_ptr
-  :: F.Ptr FC.CInt
+i5_ptr :: F.Ptr FC.CInt
+i5_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_6ff6b816265f91d3
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f" i18_ptr
-  :: F.Ptr FC.CInt
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_3bd2208d8e850002" hs_bindgen_test_visibility_attributes_3bd2208d8e850002
+  :: IO (F.Ptr FC.CInt)
 
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1" i19_ptr
-  :: F.Ptr FC.CInt
+{-# NOINLINE i6_ptr #-}
+
+i6_ptr :: F.Ptr FC.CInt
+i6_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_3bd2208d8e850002
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014" hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i7_ptr #-}
+
+i7_ptr :: F.Ptr FC.CInt
+i7_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_696700c5194eb184" hs_bindgen_test_visibility_attributes_696700c5194eb184
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i8_ptr #-}
+
+i8_ptr :: F.Ptr FC.CInt
+i8_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_696700c5194eb184
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_27bb5845debfdd10" hs_bindgen_test_visibility_attributes_27bb5845debfdd10
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i9_ptr #-}
+
+i9_ptr :: F.Ptr FC.CInt
+i9_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_27bb5845debfdd10
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d" hs_bindgen_test_visibility_attributes_254dda0b2c3c245d
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i10_ptr #-}
+
+i10_ptr :: F.Ptr FC.CInt
+i10_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_254dda0b2c3c245d
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7" hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i11_ptr #-}
+
+i11_ptr :: F.Ptr FC.CInt
+i11_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb" hs_bindgen_test_visibility_attributes_75789ceaef5e5feb
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i12_ptr #-}
+
+i12_ptr :: F.Ptr FC.CInt
+i12_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_75789ceaef5e5feb
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e" hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i13_ptr #-}
+
+i13_ptr :: F.Ptr FC.CInt
+i13_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5" hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i14_ptr #-}
+
+i14_ptr :: F.Ptr FC.CInt
+i14_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9" hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i15_ptr #-}
+
+i15_ptr :: F.Ptr FC.CInt
+i15_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44" hs_bindgen_test_visibility_attributes_56cec68bd1e37a44
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i16_ptr #-}
+
+i16_ptr :: F.Ptr FC.CInt
+i16_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_56cec68bd1e37a44
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_e60a43107858a2bc" hs_bindgen_test_visibility_attributes_e60a43107858a2bc
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i17_ptr #-}
+
+i17_ptr :: F.Ptr FC.CInt
+i17_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_e60a43107858a2bc
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f" hs_bindgen_test_visibility_attributes_86247c32f4f34e6f
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i18_ptr #-}
+
+i18_ptr :: F.Ptr FC.CInt
+i18_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_86247c32f4f34e6f
+
+foreign import ccall unsafe "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1" hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1
+  :: IO (F.Ptr FC.CInt)
+
+{-# NOINLINE i19_ptr #-}
+
+i19_ptr :: F.Ptr FC.CInt
+i19_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1

--- a/hs-bindgen/fixtures/visibility_attributes.th.txt
+++ b/hs-bindgen/fixtures/visibility_attributes.th.txt
@@ -110,23 +110,83 @@ foreign import ccall safe "hs_bindgen_test_visibility_attributes_d40140ee49300df
 foreign import ccall safe "hs_bindgen_test_visibility_attributes_358fecb39951c1ed" f28 :: IO Unit
 {-| -}
 foreign import ccall safe "hs_bindgen_test_visibility_attributes_8255bfc1a96b601c" f29 :: IO Unit
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_724fd59489c94c9f" i0_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_736e69defba46ab4" i1_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_210c547ae5abcc02" i2_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274" i3_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434" i4_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3" i5_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_3bd2208d8e850002" i6_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014" i7_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_696700c5194eb184" i8_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_27bb5845debfdd10" i9_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d" i10_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7" i11_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb" i12_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e" i13_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5" i14_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9" i15_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44" i16_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_e60a43107858a2bc" i17_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f" i18_ptr :: Ptr CInt
-foreign import ccall safe "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1" i19_ptr :: Ptr CInt
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_724fd59489c94c9f" hs_bindgen_test_visibility_attributes_724fd59489c94c9f :: IO (Ptr CInt)
+{-# NOINLINE i0_ptr #-}
+i0_ptr :: Ptr CInt
+i0_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_724fd59489c94c9f
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_736e69defba46ab4" hs_bindgen_test_visibility_attributes_736e69defba46ab4 :: IO (Ptr CInt)
+{-# NOINLINE i1_ptr #-}
+i1_ptr :: Ptr CInt
+i1_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_736e69defba46ab4
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_210c547ae5abcc02" hs_bindgen_test_visibility_attributes_210c547ae5abcc02 :: IO (Ptr CInt)
+{-# NOINLINE i2_ptr #-}
+i2_ptr :: Ptr CInt
+i2_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_210c547ae5abcc02
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_d6bb66d7f7107274" hs_bindgen_test_visibility_attributes_d6bb66d7f7107274 :: IO (Ptr CInt)
+{-# NOINLINE i3_ptr #-}
+i3_ptr :: Ptr CInt
+i3_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_d6bb66d7f7107274
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434" hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434 :: IO (Ptr CInt)
+{-# NOINLINE i4_ptr #-}
+i4_ptr :: Ptr CInt
+i4_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_8c4485c2eb6e1434
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_6ff6b816265f91d3" hs_bindgen_test_visibility_attributes_6ff6b816265f91d3 :: IO (Ptr CInt)
+{-# NOINLINE i5_ptr #-}
+i5_ptr :: Ptr CInt
+i5_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_6ff6b816265f91d3
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_3bd2208d8e850002" hs_bindgen_test_visibility_attributes_3bd2208d8e850002 :: IO (Ptr CInt)
+{-# NOINLINE i6_ptr #-}
+i6_ptr :: Ptr CInt
+i6_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_3bd2208d8e850002
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014" hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014 :: IO (Ptr CInt)
+{-# NOINLINE i7_ptr #-}
+i7_ptr :: Ptr CInt
+i7_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_a3aa6eb624f2c014
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_696700c5194eb184" hs_bindgen_test_visibility_attributes_696700c5194eb184 :: IO (Ptr CInt)
+{-# NOINLINE i8_ptr #-}
+i8_ptr :: Ptr CInt
+i8_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_696700c5194eb184
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_27bb5845debfdd10" hs_bindgen_test_visibility_attributes_27bb5845debfdd10 :: IO (Ptr CInt)
+{-# NOINLINE i9_ptr #-}
+i9_ptr :: Ptr CInt
+i9_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_27bb5845debfdd10
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_254dda0b2c3c245d" hs_bindgen_test_visibility_attributes_254dda0b2c3c245d :: IO (Ptr CInt)
+{-# NOINLINE i10_ptr #-}
+i10_ptr :: Ptr CInt
+i10_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_254dda0b2c3c245d
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7" hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7 :: IO (Ptr CInt)
+{-# NOINLINE i11_ptr #-}
+i11_ptr :: Ptr CInt
+i11_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_5ca63f16dc0b48e7
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_75789ceaef5e5feb" hs_bindgen_test_visibility_attributes_75789ceaef5e5feb :: IO (Ptr CInt)
+{-# NOINLINE i12_ptr #-}
+i12_ptr :: Ptr CInt
+i12_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_75789ceaef5e5feb
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e" hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e :: IO (Ptr CInt)
+{-# NOINLINE i13_ptr #-}
+i13_ptr :: Ptr CInt
+i13_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_6e3778cc97c78a2e
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5" hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5 :: IO (Ptr CInt)
+{-# NOINLINE i14_ptr #-}
+i14_ptr :: Ptr CInt
+i14_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_9ec03118dd66d7c5
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9" hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9 :: IO (Ptr CInt)
+{-# NOINLINE i15_ptr #-}
+i15_ptr :: Ptr CInt
+i15_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_4b5a349cc99cdac9
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_56cec68bd1e37a44" hs_bindgen_test_visibility_attributes_56cec68bd1e37a44 :: IO (Ptr CInt)
+{-# NOINLINE i16_ptr #-}
+i16_ptr :: Ptr CInt
+i16_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_56cec68bd1e37a44
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_e60a43107858a2bc" hs_bindgen_test_visibility_attributes_e60a43107858a2bc :: IO (Ptr CInt)
+{-# NOINLINE i17_ptr #-}
+i17_ptr :: Ptr CInt
+i17_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_e60a43107858a2bc
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_86247c32f4f34e6f" hs_bindgen_test_visibility_attributes_86247c32f4f34e6f :: IO (Ptr CInt)
+{-# NOINLINE i18_ptr #-}
+i18_ptr :: Ptr CInt
+i18_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_86247c32f4f34e6f
+foreign import ccall safe "hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1" hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1 :: IO (Ptr CInt)
+{-# NOINLINE i19_ptr #-}
+i19_ptr :: Ptr CInt
+i19_ptr = unsafePerformIO hs_bindgen_test_visibility_attributes_3d3a0ab3e093d4b1


### PR DESCRIPTION
... and make all these foreign imports `unsafe` too. The `IO` change is required for subtle reasons. We plan to use address stubs for function declarations in the future as well, but without the `IO` `GHC` will complain about "dodgy foreign imports".

These dodgy import warnings were found in #1008. The current PR fixes this so that #1008 can be merged after.