### PR TITLE
Avoid "Ambiguous occurrence" errors by importing qualified

### DIFF
--- a/hs-bindgen/fixtures/macro_functions.pp.hs
+++ b/hs-bindgen/fixtures/macro_functions.pp.hs
@@ -4,15 +4,14 @@
 
 module Example where
 
-import C.Expr.HostPlatform ((*), (+), (.&.), (.|.), (/), (<), (<<), (>>))
 import qualified C.Expr.HostPlatform as C
 import qualified Foreign.C as FC
 
 iNCR :: forall a0. (C.Add a0) FC.CInt => a0 -> (C.AddRes a0) FC.CInt
-iNCR = \x0 -> (+) x0 (1 :: FC.CInt)
+iNCR = \x0 -> (C.+) x0 (1 :: FC.CInt)
 
 aDD :: forall a0 b1. (C.Add a0) b1 => a0 -> b1 -> (C.AddRes a0) b1
-aDD = \x0 -> \y1 -> (+) x0 y1
+aDD = \x0 -> \y1 -> (C.+) x0 y1
 
 iD :: forall a0. a0 -> a0
 iD = \x0 -> x0
@@ -21,34 +20,35 @@ cONST :: forall a0 b1. a0 -> b1 -> a0
 cONST = \x0 -> \y1 -> x0
 
 cMP :: forall a0 b1. (C.RelOrd a0) b1 => a0 -> b1 -> FC.CInt
-cMP = \x0 -> \y1 -> (<) x0 y1
+cMP = \x0 -> \y1 -> (C.<) x0 y1
 
 fUN1 :: forall a0 b1. (C.Add a0) ((C.MultRes FC.CULLong) b1) => (C.Mult FC.CULLong) b1 => a0 -> b1 -> (C.AddRes a0) ((C.MultRes FC.CULLong) b1)
 fUN1 =
-  \x0 -> \y1 -> (+) x0 ((*) (12 :: FC.CULLong) y1)
+  \x0 -> \y1 -> (C.+) x0 ((C.*) (12 :: FC.CULLong) y1)
 
 fUN2 :: forall a0 b1. (C.Mult FC.CULLong) b1 => (C.Shift a0) ((C.MultRes FC.CULLong) b1) => a0 -> b1 -> C.ShiftRes a0
 fUN2 =
-  \x0 -> \y1 -> (<<) x0 ((*) (3 :: FC.CULLong) y1)
+  \x0 -> \y1 -> (C.<<) x0 ((C.*) (3 :: FC.CULLong) y1)
 
 g :: forall a0 b1. (C.Add a0) FC.CInt => b1 -> a0 -> (C.AddRes a0) FC.CInt
 g = \x0 -> \y1 -> cONST (iNCR y1) (iD x0)
 
 dIV1 :: forall a0 b1. (C.Add b1) FC.CUInt => (C.Div a0) ((C.AddRes b1) FC.CUInt) => a0 -> b1 -> (C.DivRes a0) ((C.AddRes b1) FC.CUInt)
-dIV1 = \x0 -> \y1 -> (/) x0 ((+) y1 (12 :: FC.CUInt))
+dIV1 =
+  \x0 -> \y1 -> (C./) x0 ((C.+) y1 (12 :: FC.CUInt))
 
 dIV2 :: forall a0 b1. (C.Mult FC.CFloat) a0 => (C.Div ((C.MultRes FC.CFloat) a0)) b1 => a0 -> b1 -> (C.DivRes ((C.MultRes FC.CFloat) a0)) b1
 dIV2 =
-  \x0 -> \y1 -> (/) ((*) (10.0 :: FC.CFloat) x0) y1
+  \x0 -> \y1 -> (C./) ((C.*) (10.0 :: FC.CFloat) x0) y1
 
 sWAP32 :: forall a0. (C.Bitwise ((C.BitsRes (C.ShiftRes a0)) FC.CInt)) ((C.BitsRes (C.ShiftRes a0)) FC.CInt) => (C.Bitwise (C.ShiftRes a0)) FC.CInt => (C.Shift a0) FC.CInt => a0 -> (C.BitsRes ((C.BitsRes (C.ShiftRes a0)) FC.CInt)) ((C.BitsRes (C.ShiftRes a0)) FC.CInt)
 sWAP32 =
   \w0 ->
-    (.|.) ((.&.) ((>>) w0 (24 :: FC.CInt)) (255 :: FC.CInt)) ((.&.) ((<<) w0 (8 :: FC.CInt)) (16711680 :: FC.CInt))
+    (C..|.) ((C..&.) ((C.>>) w0 (24 :: FC.CInt)) (255 :: FC.CInt)) ((C..&.) ((C.<<) w0 (8 :: FC.CInt)) (16711680 :: FC.CInt))
 
 aV_VERSION_INT :: forall a0 b1 c2. (C.Bitwise (C.ShiftRes a0)) (C.ShiftRes b1) => (C.Bitwise ((C.BitsRes (C.ShiftRes a0)) (C.ShiftRes b1))) c2 => (C.Shift b1) FC.CInt => (C.Shift a0) FC.CInt => a0 -> b1 -> c2 -> (C.BitsRes ((C.BitsRes (C.ShiftRes a0)) (C.ShiftRes b1))) c2
 aV_VERSION_INT =
   \a0 ->
     \b1 ->
       \c2 ->
-        (.|.) ((.|.) ((<<) a0 (16 :: FC.CInt)) ((<<) b1 (8 :: FC.CInt))) c2
+        (C..|.) ((C..|.) ((C.<<) a0 (16 :: FC.CInt)) ((C.<<) b1 (8 :: FC.CInt))) c2

--- a/hs-bindgen/fixtures/macros.pp.hs
+++ b/hs-bindgen/fixtures/macros.pp.hs
@@ -3,7 +3,7 @@
 
 module Example where
 
-import C.Expr.HostPlatform ((*), (+))
+import qualified C.Expr.HostPlatform as C
 import qualified Foreign.C as FC
 
 oBJECTLIKE1 :: FC.CInt
@@ -13,10 +13,10 @@ oBJECTLIKE2 :: FC.CInt
 oBJECTLIKE2 = (2 :: FC.CInt)
 
 oBJECTLIKE3 :: FC.CInt
-oBJECTLIKE3 = (+) (3 :: FC.CInt) (3 :: FC.CInt)
+oBJECTLIKE3 = (C.+) (3 :: FC.CInt) (3 :: FC.CInt)
 
 oBJECTLIKE4 :: FC.CInt
-oBJECTLIKE4 = (+) (4 :: FC.CInt) (4 :: FC.CInt)
+oBJECTLIKE4 = (C.+) (4 :: FC.CInt) (4 :: FC.CInt)
 
 mEANING_OF_LIFE1 :: FC.CInt
 mEANING_OF_LIFE1 = (42 :: FC.CInt)
@@ -113,7 +113,7 @@ fLT6_3 :: FC.CFloat
 fLT6_3 = (9.9e-3 :: FC.CFloat)
 
 bAD1 :: FC.CDouble
-bAD1 = (+) (0.1 :: FC.CDouble) (1 :: FC.CInt)
+bAD1 = (C.+) (0.1 :: FC.CDouble) (1 :: FC.CInt)
 
 bAD2 :: FC.CULong
-bAD2 = (*) (2 :: FC.CLong) (2 :: FC.CULong)
+bAD2 = (C.*) (2 :: FC.CLong) (2 :: FC.CULong)

--- a/hs-bindgen/fixtures/type_naturals.pp.hs
+++ b/hs-bindgen/fixtures/type_naturals.pp.hs
@@ -6,7 +6,6 @@
 
 module Example where
 
-import C.Expr.HostPlatform ((*), (+), (-))
 import qualified C.Expr.HostPlatform as C
 import qualified Foreign as F
 import qualified Foreign.C as FC
@@ -17,20 +16,20 @@ n :: FC.CInt
 n = (3 :: FC.CInt)
 
 m :: FC.CInt
-m = (+) (1 :: FC.CInt) n
+m = (C.+) (1 :: FC.CInt) n
 
 f :: forall a0 b1. (C.Add a0) ((C.MultRes FC.CInt) b1) => (C.Sub ((C.AddRes a0) ((C.MultRes FC.CInt) b1))) FC.CInt => (C.Mult FC.CInt) b1 => a0 -> b1 -> (C.SubRes ((C.AddRes a0) ((C.MultRes FC.CInt) b1))) FC.CInt
 f =
   \a0 ->
     \b1 ->
-      (-) ((+) a0 ((*) (2 :: FC.CInt) b1)) (1 :: FC.CInt)
+      (C.-) ((C.+) a0 ((C.*) (2 :: FC.CInt) b1)) (1 :: FC.CInt)
 
 g :: forall a0 b1 c2. (C.Add ((C.MultRes FC.CInt) a0)) ((C.MultRes FC.CInt) b1) => (C.Mult FC.CInt) b1 => (C.Mult FC.CInt) a0 => c2 -> a0 -> b1 -> (C.AddRes ((C.MultRes FC.CInt) a0)) ((C.MultRes FC.CInt) b1)
 g =
   \u0 ->
     \x1 ->
       \y2 ->
-        (+) ((*) (10 :: FC.CInt) x1) ((*) (16 :: FC.CInt) y2)
+        (C.+) ((C.*) (10 :: FC.CInt) x1) ((C.*) (16 :: FC.CInt) y2)
 
 k :: forall a0. (C.Add FC.CInt) ((C.MultRes FC.CInt) a0) => (C.Mult FC.CInt) a0 => a0 -> (C.AddRes FC.CInt) ((C.MultRes FC.CInt) a0)
 k =

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Names.hs
@@ -158,7 +158,7 @@ moduleOf ident m0 = case parts of
     ["GHC", "Float"]                 -> iPrelude
     ["GHC", "Num"]                   -> iPrelude
     ["GHC", "Maybe"]                 -> iPrelude
-    ["GHC", "Ix"]                    -> HsImportModule "Data.Ix" (Just "Ix")
+    ["GHC", "Ix"]                    -> HsImportModule "Data.Ix"   (Just "Ix")
     ("GHC" : "Foreign" : "C" : _)    -> HsImportModule "Foreign.C" (Just "FC")
     ("Foreign" : "C" : _)            -> HsImportModule "Foreign.C" (Just "FC")
     ["GHC", "Ptr"]                   -> HsImportModule "Foreign"   (Just "F")
@@ -266,16 +266,16 @@ resolveGlobal = \case
     Not_class             -> importQ ''C.Expr.HostPlatform.Not
     Not_not               -> importQ 'C.Expr.HostPlatform.not
     Logical_class         -> importQ ''C.Expr.HostPlatform.Logical
-    Logical_and           -> importU '(C.Expr.HostPlatform.&&)
-    Logical_or            -> importU '(C.Expr.HostPlatform.||)
+    Logical_and           -> importQ '(C.Expr.HostPlatform.&&)
+    Logical_or            -> importQ '(C.Expr.HostPlatform.||)
     RelEq_class           -> importQ ''C.Expr.HostPlatform.RelEq
-    RelEq_eq              -> importU '(C.Expr.HostPlatform.==)
-    RelEq_uneq            -> importU '(C.Expr.HostPlatform.!=)
+    RelEq_eq              -> importQ '(C.Expr.HostPlatform.==)
+    RelEq_uneq            -> importQ '(C.Expr.HostPlatform.!=)
     RelOrd_class          -> importQ ''C.Expr.HostPlatform.RelOrd
-    RelOrd_lt             -> importU '(C.Expr.HostPlatform.<)
-    RelOrd_le             -> importU '(C.Expr.HostPlatform.<=)
-    RelOrd_gt             -> importU '(C.Expr.HostPlatform.>)
-    RelOrd_ge             -> importU '(C.Expr.HostPlatform.>=)
+    RelOrd_lt             -> importQ '(C.Expr.HostPlatform.<)
+    RelOrd_le             -> importQ '(C.Expr.HostPlatform.<=)
+    RelOrd_gt             -> importQ '(C.Expr.HostPlatform.>)
+    RelOrd_ge             -> importQ '(C.Expr.HostPlatform.>=)
     Plus_class            -> importQ ''C.Expr.HostPlatform.Plus
     Plus_resTyCon         -> importQ ''C.Expr.HostPlatform.PlusRes
     Plus_plus             -> importQ 'C.Expr.HostPlatform.plus
@@ -284,31 +284,31 @@ resolveGlobal = \case
     Minus_negate          -> importQ 'C.Expr.HostPlatform.negate
     Add_class             -> importQ ''C.Expr.HostPlatform.Add
     Add_resTyCon          -> importQ ''C.Expr.HostPlatform.AddRes
-    Add_add               -> importU '(C.Expr.HostPlatform.+)
+    Add_add               -> importQ '(C.Expr.HostPlatform.+)
     Sub_class             -> importQ ''C.Expr.HostPlatform.Sub
     Sub_resTyCon          -> importQ ''C.Expr.HostPlatform.SubRes
-    Sub_minus             -> importU '(C.Expr.HostPlatform.-)
+    Sub_minus             -> importQ '(C.Expr.HostPlatform.-)
     Mult_class            -> importQ ''C.Expr.HostPlatform.Mult
     Mult_resTyCon         -> importQ ''C.Expr.HostPlatform.MultRes
-    Mult_mult             -> importU '(C.Expr.HostPlatform.*)
+    Mult_mult             -> importQ '(C.Expr.HostPlatform.*)
     Div_class             -> importQ ''C.Expr.HostPlatform.Div
     Div_resTyCon          -> importQ ''C.Expr.HostPlatform.DivRes
-    Div_div               -> importU '(C.Expr.HostPlatform./)
+    Div_div               -> importQ '(C.Expr.HostPlatform./)
     Rem_class             -> importQ ''C.Expr.HostPlatform.Rem
     Rem_resTyCon          -> importQ ''C.Expr.HostPlatform.RemRes
-    Rem_rem               -> importU '(C.Expr.HostPlatform.%)
+    Rem_rem               -> importQ '(C.Expr.HostPlatform.%)
     Complement_class      -> importQ ''C.Expr.HostPlatform.Complement
     Complement_resTyCon   -> importQ ''C.Expr.HostPlatform.ComplementRes
     Complement_complement -> importQ '(C.Expr.HostPlatform..~)
     Bitwise_class         -> importQ ''C.Expr.HostPlatform.Bitwise
     Bitwise_resTyCon      -> importQ ''C.Expr.HostPlatform.BitsRes
-    Bitwise_and           -> importU '(C.Expr.HostPlatform..&.)
-    Bitwise_or            -> importU '(C.Expr.HostPlatform..|.)
-    Bitwise_xor           -> importU '(C.Expr.HostPlatform..^.)
+    Bitwise_and           -> importQ '(C.Expr.HostPlatform..&.)
+    Bitwise_or            -> importQ '(C.Expr.HostPlatform..|.)
+    Bitwise_xor           -> importQ '(C.Expr.HostPlatform..^.)
     Shift_class           -> importQ ''C.Expr.HostPlatform.Shift
     Shift_resTyCon        -> importQ ''C.Expr.HostPlatform.ShiftRes
-    Shift_shiftL          -> importU '(C.Expr.HostPlatform.<<)
-    Shift_shiftR          -> importU '(C.Expr.HostPlatform.>>)
+    Shift_shiftL          -> importQ '(C.Expr.HostPlatform.<<)
+    Shift_shiftR          -> importQ '(C.Expr.HostPlatform.>>)
 
     GHC_Float_castWord32ToFloat -> importQ 'GHC.Float.castWord32ToFloat
     GHC_Float_castWord64ToDouble -> importQ 'GHC.Float.castWord64ToDouble


### PR DESCRIPTION
This only affects C.Expr.HostPlatform.
All other imports are already qualified (excluding some imports from `base`).
Closes #1055.