### PR TITLE
Fix translation of String macros

### DIFF
--- a/hs-bindgen/fixtures/adios.pp.hs
+++ b/hs-bindgen/fixtures/adios.pp.hs
@@ -12,6 +12,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 

--- a/hs-bindgen/fixtures/anonymous.pp.hs
+++ b/hs-bindgen/fixtures/anonymous.pp.hs
@@ -5,6 +5,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 data S1_c = S1_c

--- a/hs-bindgen/fixtures/array.pp.hs
+++ b/hs-bindgen/fixtures/array.pp.hs
@@ -10,6 +10,7 @@ module Example where
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.IncompleteArray

--- a/hs-bindgen/fixtures/asm.pp.hs
+++ b/hs-bindgen/fixtures/asm.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/attributes.pp.hs
+++ b/hs-bindgen/fixtures/attributes.pp.hs
@@ -6,6 +6,7 @@ module Example where
 import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, IO, Int, Show, pure)
 
 data Foo = Foo

--- a/hs-bindgen/fixtures/bool_c23.pp.hs
+++ b/hs-bindgen/fixtures/bool_c23.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/decls_in_signature.pp.hs
+++ b/hs-bindgen/fixtures/decls_in_signature.pp.hs
@@ -13,6 +13,7 @@ import qualified Data.Array.Byte
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.SizedByteArray

--- a/hs-bindgen/fixtures/definitions.pp.hs
+++ b/hs-bindgen/fixtures/definitions.pp.hs
@@ -12,6 +12,7 @@ import qualified Data.Array.Byte
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.SizedByteArray

--- a/hs-bindgen/fixtures/distilled_lib_1.pp.hs
+++ b/hs-bindgen/fixtures/distilled_lib_1.pp.hs
@@ -18,6 +18,7 @@ import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.CEnum
 import qualified HsBindgen.Runtime.ConstantArray

--- a/hs-bindgen/fixtures/fun_attributes.pp.hs
+++ b/hs-bindgen/fixtures/fun_attributes.pp.hs
@@ -13,6 +13,7 @@ import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 

--- a/hs-bindgen/fixtures/fun_attributes_conflict.pp.hs
+++ b/hs-bindgen/fixtures/fun_attributes_conflict.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/globals.pp.hs
+++ b/hs-bindgen/fixtures/globals.pp.hs
@@ -13,6 +13,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.IncompleteArray

--- a/hs-bindgen/fixtures/iterator.pp.hs
+++ b/hs-bindgen/fixtures/iterator.pp.hs
@@ -5,9 +5,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.Block
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)

--- a/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl.pp.hs
@@ -13,6 +13,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)

--- a/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
+++ b/hs-bindgen/fixtures/macro_in_fundecl_vs_typedef.pp.hs
@@ -12,6 +12,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude ((<*>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/macro_strings.exts.txt
+++ b/hs-bindgen/fixtures/macro_strings.exts.txt
@@ -1,1 +1,2 @@
+MagicHash
 ExplicitForAll

--- a/hs-bindgen/fixtures/macro_strings.pp.hs
+++ b/hs-bindgen/fixtures/macro_strings.pp.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Example where
 
 import qualified C.Char
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified Foreign.C.String as FC
+import qualified GHC.Ptr as F
 import Prelude (Int)
 
 c1 :: C.Char.CharValue

--- a/hs-bindgen/fixtures/macro_types.pp.hs
+++ b/hs-bindgen/fixtures/macro_types.pp.hs
@@ -9,6 +9,7 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ConstantArray
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 

--- a/hs-bindgen/fixtures/names.pp.hs
+++ b/hs-bindgen/fixtures/names.pp.hs
@@ -4,8 +4,8 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/nested_types.pp.hs
+++ b/hs-bindgen/fixtures/nested_types.pp.hs
@@ -5,6 +5,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 data Foo = Foo

--- a/hs-bindgen/fixtures/opaque_declaration.pp.hs
+++ b/hs-bindgen/fixtures/opaque_declaration.pp.hs
@@ -5,6 +5,7 @@
 module Example where
 
 import qualified Foreign as F
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Show, pure, return)
 
 data Foo

--- a/hs-bindgen/fixtures/program_slicing_selection.pp.hs
+++ b/hs-bindgen/fixtures/program_slicing_selection.pp.hs
@@ -12,6 +12,7 @@ import Data.Void (Void)
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.CEnum
 import qualified HsBindgen.Runtime.Prelude

--- a/hs-bindgen/fixtures/recursive_struct.pp.hs
+++ b/hs-bindgen/fixtures/recursive_struct.pp.hs
@@ -5,6 +5,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 data Linked_list_A_t = Linked_list_A_t

--- a/hs-bindgen/fixtures/redeclaration.pp.hs
+++ b/hs-bindgen/fixtures/redeclaration.pp.hs
@@ -17,6 +17,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.SizedByteArray

--- a/hs-bindgen/fixtures/simple_func.pp.hs
+++ b/hs-bindgen/fixtures/simple_func.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/simple_structs.pp.hs
+++ b/hs-bindgen/fixtures/simple_structs.pp.hs
@@ -6,6 +6,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 data S1 = S1

--- a/hs-bindgen/fixtures/skip_over_long_double.pp.hs
+++ b/hs-bindgen/fixtures/skip_over_long_double.pp.hs
@@ -8,6 +8,7 @@ module Example where
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude ((<*>), Eq, IO, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/spec_examples.pp.hs
+++ b/hs-bindgen/fixtures/spec_examples.pp.hs
@@ -14,6 +14,7 @@ import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, return)

--- a/hs-bindgen/fixtures/struct_arg.pp.hs
+++ b/hs-bindgen/fixtures/struct_arg.pp.hs
@@ -8,6 +8,7 @@ module Example where
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude ((<*>), Eq, IO, Int, Show, pure)

--- a/hs-bindgen/fixtures/tentative_definitions.pp.hs
+++ b/hs-bindgen/fixtures/tentative_definitions.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/type_attributes.pp.hs
+++ b/hs-bindgen/fixtures/type_attributes.pp.hs
@@ -14,6 +14,7 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.SizedByteArray

--- a/hs-bindgen/fixtures/type_qualifiers.pp.hs
+++ b/hs-bindgen/fixtures/type_qualifiers.pp.hs
@@ -7,6 +7,7 @@ module Example where
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)

--- a/hs-bindgen/fixtures/typedef_analysis.pp.hs
+++ b/hs-bindgen/fixtures/typedef_analysis.pp.hs
@@ -7,6 +7,7 @@ module Example where
 
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure, return)
 
 {-| Examples for the various cases in by `HsBindgen.Frontend.Analysis.Typedefs`

--- a/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
+++ b/hs-bindgen/fixtures/typedef_vs_macro.pp.hs
@@ -9,6 +9,7 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.ConstantArray
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/typedefs.pp.hs
+++ b/hs-bindgen/fixtures/typedefs.pp.hs
@@ -9,6 +9,7 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as F
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 newtype Myint = Myint

--- a/hs-bindgen/fixtures/varargs.pp.hs
+++ b/hs-bindgen/fixtures/varargs.pp.hs
@@ -4,8 +4,8 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/fixtures/vector.pp.hs
+++ b/hs-bindgen/fixtures/vector.pp.hs
@@ -8,6 +8,7 @@ module Example where
 import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude ((<*>), (>>), Eq, IO, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/visibility_attributes.pp.hs
+++ b/hs-bindgen/fixtures/visibility_attributes.pp.hs
@@ -4,9 +4,9 @@
 
 module Example where
 
-import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as F
 import qualified HsBindgen.Runtime.CAPI as CAPI
 import Prelude (IO)
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Names.hs
@@ -161,7 +161,10 @@ moduleOf ident m0 = case parts of
     ["GHC", "Ix"]                    -> HsImportModule "Data.Ix" (Just "Ix")
     ("GHC" : "Foreign" : "C" : _)    -> HsImportModule "Foreign.C" (Just "FC")
     ("Foreign" : "C" : _)            -> HsImportModule "Foreign.C" (Just "FC")
-    ["GHC", "Ptr"]                   -> HsImportModule "Foreign"   (Just "F")
+    -- We'd prefer to use `Foreign.Ptr` because it is a stable and
+    -- compiler-agnostic interface in contrast to `GHC.Ptr`. However,
+    -- `Foreign.Ptr` does not export the constructor of `Ptr`, which we need.
+    ["GHC", "Ptr"]                   -> HsImportModule "GHC.Ptr"   (Just "F")
     ("GHC" : "Foreign" : _)          -> HsImportModule "Foreign"   (Just "F")
     ("Foreign" : _)                  -> HsImportModule "Foreign"   (Just "F")
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -13,8 +13,9 @@ import HsBindgen.Imports
 -- | Which GHC language extensions this declarations needs.
 requiredExtensions :: SDecl -> Set TH.Extension
 requiredExtensions = \case
-    DVar Var {..} -> mconcat [
+    DVar Var {..} -> mconcat $ [
         typeExtensions varType
+      , Set.fromList [TH.MagicHash | isECString varExpr]
       ]
     DInst x -> mconcat . concat $ [
         [ext TH.MultiParamTypeClasses | length (instanceArgs x) >= 2]
@@ -57,6 +58,11 @@ requiredExtensions = \case
   where
     ext :: TH.Extension -> Set TH.Extension
     ext = Set.singleton
+
+    isECString :: SExpr ctx -> Bool
+    isECString = \case
+      (ECString _) -> True
+      _otherExpr   -> False
 
 -- | Extensions for deriving clauses that are part of the datatype declaration
 nestedDeriving :: [(Strategy ClosedType, [Global])] -> Set TH.Extension


### PR DESCRIPTION
- Use `GHC.Ptr.Ptr (Ptr)` instead of the the non-existing (not re-exported) `Foreign.Ptr.Ptr (Ptr)`.
- Add the `MagicHash` extension.