### PR TITLE
Revert "Added stylish haskell scripts and CI"

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Expr.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Expr.hs
@@ -7,7 +7,6 @@ import Text.Parsec
 import Text.Parsec.Expr
 
 import Clang.LowLevel.Core
-
 import HsBindgen.Frontend.Macro.Parse.Infra
 import HsBindgen.Frontend.Macro.Parse.Literal
 import HsBindgen.Frontend.Macro.Parse.Name

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Infra.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Infra.hs
@@ -17,10 +17,9 @@ module HsBindgen.Frontend.Macro.Parse.Infra (
   ) where
 
 import Data.Text qualified as Text
-import Text.Parsec hiding (runParser, token, tokens)
+import Text.Parsec hiding (token, tokens, runParser)
 import Text.Parsec qualified as Parsec
 import Text.Parsec.Pos
-import Text.SimplePrettyPrint (hsep, textToCtxDoc, vcat, (><))
 
 import Clang.Enum.Simple
 import Clang.HighLevel.Types
@@ -30,6 +29,7 @@ import Clang.Paths
 import HsBindgen.Errors
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer (PrettyForTrace (..))
+import Text.SimplePrettyPrint (hsep, textToCtxDoc, vcat, (><))
 
 {-------------------------------------------------------------------------------
   Parser type

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Name.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Parse/Name.hs
@@ -9,7 +9,7 @@ import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 
 import HsBindgen.Frontend.Macro.Parse.Infra
-import HsBindgen.Frontend.Naming (Name (..))
+import HsBindgen.Frontend.Naming (Name(..))
 import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Tc/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Macro/Tc/Type.hs
@@ -90,22 +90,33 @@ module HsBindgen.Frontend.Macro.Tc.Type (
   ) where
 
 -- base
-import Data.GADT.Compare (GEq (..), defaultEq)
 import Data.Kind qualified as Hs
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromJust)
-import Data.Text qualified as Text
 import Data.Type.Equality (type (:~:) (..))
-import Data.Type.Nat qualified as Nat (SNatI, eqNat, reflectToNum)
-import Data.Vec.Lazy qualified as Vec
 import Foreign.C.Types
 import Foreign.Ptr qualified as Foreign
 import GHC.Show (showSpace)
 
+-- fin
+import Data.Type.Nat qualified as Nat (SNatI, eqNat, reflectToNum,)
+
+-- some
+import Data.GADT.Compare (GEq (..), defaultEq)
+
+-- text
+import Data.Text qualified as Text
+
+-- vec
+import Data.Vec.Lazy qualified as Vec
+
+-- c-expr
 import C.Type qualified
 
+-- hs-bindgen
+
 import HsBindgen.Frontend.Macro.Pass
-import HsBindgen.Frontend.Naming (Name (..))
+import HsBindgen.Frontend.Naming (Name(..))
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Util.TestEquality (equals2)


### PR DESCRIPTION
Reverts well-typed/hs-bindgen#1079, in particular the stylish changes to @sheaf modules that were wrongly made due to a typo