### PR TITLE
Fix `preprocess --path-style` option

### DIFF
--- a/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
@@ -35,8 +35,9 @@ data Opts = Opts {
       bindgenConfig     :: BindgenConfig
     , output            :: Maybe FilePath
     , outputBindingSpec :: Maybe FilePath
-    , inputs            :: [UncheckedHashIncludeArg]
     , haddockConfig     :: HaddockConfig
+    , inputs            :: [UncheckedHashIncludeArg]
+    -- NOTE inputs (arguments) must be last, options must go before it
     }
 
 parseOpts :: Parser Opts
@@ -45,8 +46,8 @@ parseOpts =
       <$> parseBindgenConfig
       <*> optional parseOutput
       <*> optional parseGenBindingSpec
-      <*> parseInputs
       <*> parseHaddockConfig
+      <*> parseInputs
 
 {-------------------------------------------------------------------------------
   Execution


### PR DESCRIPTION
Options should be listed before arguments in the `--help` output.  I added a comment to help avoid making this mistake again.

This could alternatively be resolved by using `ApplicativeDo` and configuring the order in the `Parser` only, but there is no reason to do this here, as `Opts` is just used for CLI arguments and it is trivial to keep the order consistent.