### PR TITLE
Fix associated type indentation (PP)

### DIFF
--- a/hs-bindgen/fixtures/enum_cpp_syntax.pp.hs
+++ b/hs-bindgen/fixtures/enum_cpp_syntax.pp.hs
@@ -44,7 +44,7 @@ instance F.Storable Foo_enum where
 instance HsBindgen.Runtime.CEnum.CEnum Foo_enum where
 
   type CEnumZ Foo_enum =
-  HsBindgen.Runtime.Prelude.Word32
+    HsBindgen.Runtime.Prelude.Word32
 
   toCEnum = Foo_enum
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Artefact/HsModule/Render.hs
@@ -254,7 +254,7 @@ instance Pretty SDecl where
           typs = flip map instanceTypes $ \(g, typArg, typSyn) -> nest 2 $ fsep
             [ "type" <+> ppUnqualBackendName (resolve g) <+> prettyPrec 1 typArg
                 <+> char '='
-            , pretty typSyn
+            , nest 2 (pretty typSyn)
             ]
           decs = flip map instanceDecs $ \(name, expr) -> nest 2 $ fsep
             [ ppUnqualBackendName (resolve name) <+> char '='


### PR DESCRIPTION
The pretty-printer for associated types was missing a `nest`, resulting in incorrect indentation when the type name is long.