### PR TITLE
Reorganize CLI commands

### DIFF
--- a/.github/actions/base/action.yml
+++ b/.github/actions/base/action.yml
@@ -103,7 +103,7 @@ runs:
         echo '### Version'
         cabal run hs-bindgen-cli -- --version
         echo '### libclang -v'
-        cabal run hs-bindgen-cli -- dev clang --clang-option=-v
+        cabal run hs-bindgen-cli -- info libclang --clang-option=-v
         echo '### Resolve (clang)'
         cabal run hs-bindgen-cli -- info resolve-header -v4 --builtin-include-dir=clang stdint.h
 

--- a/hs-bindgen/app/HsBindgen/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/Cli.hs
@@ -38,7 +38,7 @@ data Cmd =
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
       cmd  "preprocess"   CmdPreprocess  Preprocess.parseOpts Preprocess.info
-    , cmd  "gentests"     CmdGenTests    GenTests.parseOpts   GenTests.info
+    , cmd  "gen-tests"    CmdGenTests    GenTests.parseOpts   GenTests.info
     , cmd  "binding-spec" CmdBindingSpec BindingSpec.parseCmd BindingSpec.info
     , cmd  "info"         CmdInfo        Info.parseCmd        Info.info
     , cmd  "dev"          CmdDev         Dev.parseCmd         Dev.info

--- a/hs-bindgen/app/HsBindgen/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/Cli.hs
@@ -15,9 +15,9 @@ import Options.Applicative
 
 import HsBindgen.App
 import HsBindgen.Cli.BindingSpec qualified as BindingSpec
-import HsBindgen.Cli.Dev qualified as Dev
 import HsBindgen.Cli.GenTests qualified as GenTests
 import HsBindgen.Cli.Info qualified as Info
+import HsBindgen.Cli.Internal qualified as Internal
 import HsBindgen.Cli.Preprocess qualified as Preprocess
 import HsBindgen.Cli.ToolSupport qualified as ToolSupport
 import HsBindgen.Cli.ToolSupport.Literate qualified as Literate
@@ -32,7 +32,7 @@ data Cmd =
   | CmdGenTests    GenTests.Opts
   | CmdBindingSpec BindingSpec.Cmd
   | CmdInfo        Info.Cmd
-  | CmdDev         Dev.Cmd
+  | CmdInternal    Internal.Cmd
   | CmdToolSupport ToolSupport.Cmd
 
 parseCmd :: Parser Cmd
@@ -41,7 +41,7 @@ parseCmd = subparser $ mconcat [
     , cmd  "gen-tests"    CmdGenTests    GenTests.parseOpts   GenTests.info
     , cmd  "binding-spec" CmdBindingSpec BindingSpec.parseCmd BindingSpec.info
     , cmd  "info"         CmdInfo        Info.parseCmd        Info.info
-    , cmd  "dev"          CmdDev         Dev.parseCmd         Dev.info
+    , cmd  "internal"     CmdInternal    Internal.parseCmd    Internal.info
     , cmd_ "tool-support" CmdToolSupport ToolSupport.parseCmd ToolSupport.info
     ]
 
@@ -55,5 +55,5 @@ exec gopts = \case
     CmdGenTests    opts -> Nothing <$ GenTests.exec    gopts opts
     CmdBindingSpec cmd' -> Nothing <$ BindingSpec.exec gopts cmd'
     CmdInfo        cmd' -> Nothing <$ Info.exec        gopts cmd'
-    CmdDev         cmd' -> Nothing <$ Dev.exec         gopts cmd'
+    CmdInternal    cmd' -> Nothing <$ Internal.exec    gopts cmd'
     CmdToolSupport cmd' ->            ToolSupport.exec gopts cmd'

--- a/hs-bindgen/app/HsBindgen/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/Cli.hs
@@ -14,6 +14,7 @@ module HsBindgen.Cli (
 import Options.Applicative
 
 import HsBindgen.App
+import HsBindgen.Cli.BindingSpec qualified as BindingSpec
 import HsBindgen.Cli.Dev qualified as Dev
 import HsBindgen.Cli.GenTests qualified as GenTests
 import HsBindgen.Cli.Info qualified as Info
@@ -27,19 +28,21 @@ import HsBindgen.Cli.Preprocess qualified as Preprocess
 
 -- Ordered by usage
 data Cmd =
-    CmdPreprocess Preprocess.Opts
-  | CmdGenTests   GenTests.Opts
-  | CmdInfo       Info.Cmd
-  | CmdDev        Dev.Cmd
-  | CmdInternal   Internal.Cmd
+    CmdPreprocess  Preprocess.Opts
+  | CmdGenTests    GenTests.Opts
+  | CmdBindingSpec BindingSpec.Cmd
+  | CmdInfo        Info.Cmd
+  | CmdDev         Dev.Cmd
+  | CmdInternal    Internal.Cmd
 
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
-      cmd  "preprocess" CmdPreprocess Preprocess.parseOpts Preprocess.info
-    , cmd  "gentests"   CmdGenTests   GenTests.parseOpts   GenTests.info
-    , cmd  "info"       CmdInfo       Info.parseCmd        Info.info
-    , cmd  "dev"        CmdDev        Dev.parseCmd         Dev.info
-    , cmd_ "internal"   CmdInternal   Internal.parseCmd    Internal.info
+      cmd  "preprocess"   CmdPreprocess  Preprocess.parseOpts Preprocess.info
+    , cmd  "gentests"     CmdGenTests    GenTests.parseOpts   GenTests.info
+    , cmd  "binding-spec" CmdBindingSpec BindingSpec.parseCmd BindingSpec.info
+    , cmd  "info"         CmdInfo        Info.parseCmd        Info.info
+    , cmd  "dev"          CmdDev         Dev.parseCmd         Dev.info
+    , cmd_ "internal"     CmdInternal    Internal.parseCmd    Internal.info
     ]
 
 {-------------------------------------------------------------------------------
@@ -48,8 +51,9 @@ parseCmd = subparser $ mconcat [
 
 exec :: GlobalOpts -> Cmd -> IO (Maybe Literate.Opts)
 exec gopts = \case
-    CmdPreprocess opts -> Nothing <$ Preprocess.exec gopts opts
-    CmdGenTests   opts -> Nothing <$ GenTests.exec   gopts opts
-    CmdInfo       cmd' -> Nothing <$ Info.exec       gopts cmd'
-    CmdDev        cmd' -> Nothing <$ Dev.exec        gopts cmd'
-    CmdInternal   cmd' ->            Internal.exec   gopts cmd'
+    CmdPreprocess  opts -> Nothing <$ Preprocess.exec  gopts opts
+    CmdGenTests    opts -> Nothing <$ GenTests.exec    gopts opts
+    CmdBindingSpec cmd' -> Nothing <$ BindingSpec.exec gopts cmd'
+    CmdInfo        cmd' -> Nothing <$ Info.exec        gopts cmd'
+    CmdDev         cmd' -> Nothing <$ Dev.exec         gopts cmd'
+    CmdInternal    cmd' ->            Internal.exec    gopts cmd'

--- a/hs-bindgen/app/HsBindgen/Cli.hs
+++ b/hs-bindgen/app/HsBindgen/Cli.hs
@@ -18,9 +18,9 @@ import HsBindgen.Cli.BindingSpec qualified as BindingSpec
 import HsBindgen.Cli.Dev qualified as Dev
 import HsBindgen.Cli.GenTests qualified as GenTests
 import HsBindgen.Cli.Info qualified as Info
-import HsBindgen.Cli.Internal qualified as Internal
-import HsBindgen.Cli.Internal.Literate qualified as Literate
 import HsBindgen.Cli.Preprocess qualified as Preprocess
+import HsBindgen.Cli.ToolSupport qualified as ToolSupport
+import HsBindgen.Cli.ToolSupport.Literate qualified as Literate
 
 {-------------------------------------------------------------------------------
   Commands
@@ -33,7 +33,7 @@ data Cmd =
   | CmdBindingSpec BindingSpec.Cmd
   | CmdInfo        Info.Cmd
   | CmdDev         Dev.Cmd
-  | CmdInternal    Internal.Cmd
+  | CmdToolSupport ToolSupport.Cmd
 
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
@@ -42,7 +42,7 @@ parseCmd = subparser $ mconcat [
     , cmd  "binding-spec" CmdBindingSpec BindingSpec.parseCmd BindingSpec.info
     , cmd  "info"         CmdInfo        Info.parseCmd        Info.info
     , cmd  "dev"          CmdDev         Dev.parseCmd         Dev.info
-    , cmd_ "internal"     CmdInternal    Internal.parseCmd    Internal.info
+    , cmd_ "tool-support" CmdToolSupport ToolSupport.parseCmd ToolSupport.info
     ]
 
 {-------------------------------------------------------------------------------
@@ -56,4 +56,4 @@ exec gopts = \case
     CmdBindingSpec cmd' -> Nothing <$ BindingSpec.exec gopts cmd'
     CmdInfo        cmd' -> Nothing <$ Info.exec        gopts cmd'
     CmdDev         cmd' -> Nothing <$ Dev.exec         gopts cmd'
-    CmdInternal    cmd' ->            Internal.exec    gopts cmd'
+    CmdToolSupport cmd' ->            ToolSupport.exec gopts cmd'

--- a/hs-bindgen/app/HsBindgen/Cli/BindingSpec.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/BindingSpec.hs
@@ -1,9 +1,9 @@
--- | @hs-bindgen-cli dev binding-spec@ commands
+-- | @hs-bindgen-cli binding-spec@ commands
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Dev.BindingSpec qualified as BindingSpec
-module HsBindgen.Cli.Dev.BindingSpec (
+-- > import HsBindgen.Cli.BindingSpec qualified as BindingSpec
+module HsBindgen.Cli.BindingSpec (
     -- * CLI help
     info
     -- * Commands
@@ -16,7 +16,7 @@ module HsBindgen.Cli.Dev.BindingSpec (
 import Options.Applicative hiding (info)
 
 import HsBindgen.App
-import HsBindgen.Cli.Dev.BindingSpec.StdLib qualified as StdLib
+import HsBindgen.Cli.BindingSpec.StdLib qualified as StdLib
 
 {-------------------------------------------------------------------------------
   CLI help

--- a/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
@@ -33,12 +33,24 @@ info = progDesc "Write stdlib external binding specification"
   Options
 -------------------------------------------------------------------------------}
 
-newtype Opts = Opts {
+data Opts = Opts {
       clangArgsConfig :: ClangArgsConfig
+    , output          :: Maybe FilePath
     }
 
 parseOpts :: Parser Opts
-parseOpts = Opts <$> parseClangArgsConfig
+parseOpts =
+    Opts
+      <$> parseClangArgsConfig
+      <*> optional parseOutput'
+  where
+    parseOutput' :: Parser FilePath
+    parseOutput' = strOption $ mconcat [
+        short 'o'
+      , long "output"
+      , metavar "PATH"
+      , help "Output path for the binding specification"
+      ]
 
 {-------------------------------------------------------------------------------
   Execution
@@ -51,4 +63,6 @@ exec GlobalOpts{..} Opts{..} = do
       getStdlibBindingSpec
         (contramap (TraceBoot . BootBindingSpec) tracer)
         clangArgs
-    BS.putStr $ encodeBindingSpecYaml spec
+    case output of
+      Just path -> BS.writeFile path $ encodeBindingSpecYaml spec
+      Nothing   -> BS.putStr         $ encodeBindingSpecYaml spec

--- a/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
@@ -1,9 +1,9 @@
--- | @hs-bindgen-cli dev binding-spec stdlib@ command
+-- | @hs-bindgen-cli binding-spec stdlib@ command
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Dev.BindingSpec.StdLib qualified as StdLib
-module HsBindgen.Cli.Dev.BindingSpec.StdLib (
+-- > import HsBindgen.Cli.BindingSpec.StdLib qualified as StdLib
+module HsBindgen.Cli.BindingSpec.StdLib (
     -- * CLI help
     info
     -- * Options

--- a/hs-bindgen/app/HsBindgen/Cli/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Dev.hs
@@ -16,7 +16,6 @@ module HsBindgen.Cli.Dev (
 import Options.Applicative hiding (info)
 
 import HsBindgen.App
-import HsBindgen.Cli.Dev.Clang qualified as Clang
 import HsBindgen.Cli.Dev.Parse qualified as Parse
 
 {-------------------------------------------------------------------------------
@@ -31,14 +30,12 @@ info = progDesc "Development commands, used for debugging"
 -------------------------------------------------------------------------------}
 
 -- Ordered lexicographically
-data Cmd =
-    CmdClang Clang.Opts
-  | CmdParse Parse.Opts
+newtype Cmd =
+    CmdParse Parse.Opts
 
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
-      cmd "clang" CmdClang Clang.parseOpts Clang.info
-    , cmd "parse" CmdParse Parse.parseOpts Parse.info
+      cmd "parse" CmdParse Parse.parseOpts Parse.info
     ]
 
 {-------------------------------------------------------------------------------
@@ -47,5 +44,4 @@ parseCmd = subparser $ mconcat [
 
 exec :: GlobalOpts -> Cmd -> IO ()
 exec gopts = \case
-    CmdClang opts -> Clang.exec gopts opts
     CmdParse opts -> Parse.exec gopts opts

--- a/hs-bindgen/app/HsBindgen/Cli/Dev.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Dev.hs
@@ -16,7 +16,6 @@ module HsBindgen.Cli.Dev (
 import Options.Applicative hiding (info)
 
 import HsBindgen.App
-import HsBindgen.Cli.Dev.BindingSpec qualified as BindingSpec
 import HsBindgen.Cli.Dev.Clang qualified as Clang
 import HsBindgen.Cli.Dev.Parse qualified as Parse
 
@@ -33,15 +32,13 @@ info = progDesc "Development commands, used for debugging"
 
 -- Ordered lexicographically
 data Cmd =
-    CmdBindingSpec BindingSpec.Cmd
-  | CmdClang       Clang.Opts
-  | CmdParse       Parse.Opts
+    CmdClang Clang.Opts
+  | CmdParse Parse.Opts
 
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
-      cmd "binding-spec" CmdBindingSpec BindingSpec.parseCmd BindingSpec.info
-    , cmd "clang"        CmdClang       Clang.parseOpts      Clang.info
-    , cmd "parse"        CmdParse       Parse.parseOpts      Parse.info
+      cmd "clang" CmdClang Clang.parseOpts Clang.info
+    , cmd "parse" CmdParse Parse.parseOpts Parse.info
     ]
 
 {-------------------------------------------------------------------------------
@@ -50,6 +47,5 @@ parseCmd = subparser $ mconcat [
 
 exec :: GlobalOpts -> Cmd -> IO ()
 exec gopts = \case
-    CmdBindingSpec cmd' -> BindingSpec.exec gopts cmd'
-    CmdClang       opts -> Clang.exec       gopts opts
-    CmdParse       opts -> Parse.exec       gopts opts
+    CmdClang opts -> Clang.exec gopts opts
+    CmdParse opts -> Parse.exec gopts opts

--- a/hs-bindgen/app/HsBindgen/Cli/Info.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info.hs
@@ -17,6 +17,7 @@ import Options.Applicative hiding (info)
 
 import HsBindgen.App
 import HsBindgen.Cli.Info.IncludeGraph qualified as IncludeGraph
+import HsBindgen.Cli.Info.Libclang qualified as Libclang
 import HsBindgen.Cli.Info.ResolveHeader qualified as ResolveHeader
 
 {-------------------------------------------------------------------------------
@@ -33,6 +34,7 @@ info = progDesc "Informational commands, useful when creating bindings"
 -- Ordered lexicographically
 data Cmd =
     CmdIncludeGraph  IncludeGraph.Opts
+  | CmdLibclang      Libclang.Opts
   | CmdResolveHeader ResolveHeader.Opts
 
 parseCmd :: Parser Cmd
@@ -42,6 +44,11 @@ parseCmd = subparser $ mconcat [
         CmdIncludeGraph
         IncludeGraph.parseOpts
         IncludeGraph.info
+    , cmd
+        "libclang"
+        CmdLibclang
+        Libclang.parseOpts
+        Libclang.info
     , cmd
         "resolve-header"
         CmdResolveHeader
@@ -56,4 +63,5 @@ parseCmd = subparser $ mconcat [
 exec :: GlobalOpts -> Cmd -> IO ()
 exec gopts = \case
     CmdIncludeGraph  opts -> IncludeGraph.exec  gopts opts
+    CmdLibclang      opts -> Libclang.exec      gopts opts
     CmdResolveHeader opts -> ResolveHeader.exec gopts opts

--- a/hs-bindgen/app/HsBindgen/Cli/Info/Libclang.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/Libclang.hs
@@ -1,9 +1,9 @@
--- | @hs-bindgen-cli dev clang@ command
+-- | @hs-bindgen-cli info libclang@ command
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Dev.Clang qualified as Clang
-module HsBindgen.Cli.Dev.Clang (
+-- > import HsBindgen.Cli.Info.Libclang qualified as Libclang
+module HsBindgen.Cli.Info.Libclang (
     -- * CLI help
     info
     -- * Options
@@ -28,7 +28,7 @@ import HsBindgen.Lib
 
 info :: InfoMod a
 info = mconcat [
-      progDesc "Run Clang with empty input"
+      progDesc "Run libclang with empty input"
     , footerDoc . Just . PP.reflow $ mconcat [
           "This command provides a way to get output from libclang."
         , " For example, use --clang-option=-v to see version and include"

--- a/hs-bindgen/app/HsBindgen/Cli/ToolSupport.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/ToolSupport.hs
@@ -1,9 +1,9 @@
--- | @hs-bindgen-cli internal@ commands
+-- | @hs-bindgen-cli tool-support@ commands
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Internal qualified as Internal
-module HsBindgen.Cli.Internal (
+-- > import HsBindgen.Cli.ToolSupport qualified as ToolSupport
+module HsBindgen.Cli.ToolSupport (
     -- * CLI help
     info
     -- * Commands
@@ -16,14 +16,14 @@ module HsBindgen.Cli.Internal (
 import Options.Applicative hiding (info)
 
 import HsBindgen.App
-import HsBindgen.Cli.Internal.Literate qualified as Literate
+import HsBindgen.Cli.ToolSupport.Literate qualified as Literate
 
 {-------------------------------------------------------------------------------
   CLI help
 -------------------------------------------------------------------------------}
 
 info :: InfoMod a
-info = progDesc "Internal commands, not meant to be used directly"
+info = progDesc "Tool support commands, not meant to be used directly"
 
 {-------------------------------------------------------------------------------
   Commands

--- a/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE ApplicativeDo #-}
 
--- | @hs-bindgen-cli internal literate@ command
+-- | @hs-bindgen-cli tool-support literate@ command
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Internal.Literate qualified as Literate
-module HsBindgen.Cli.Internal.Literate (
+-- > import HsBindgen.Cli.ToolSupport.Literate qualified as Literate
+module HsBindgen.Cli.ToolSupport.Literate (
     -- * CLI help
     info
     -- * Options

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -16,8 +16,8 @@ import Clang.Version (clang_getClangVersion)
 
 import HsBindgen.App
 import HsBindgen.Cli qualified as Cli
-import HsBindgen.Cli.Internal.Literate qualified as Literate
 import HsBindgen.Cli.Preprocess qualified as Preprocess
+import HsBindgen.Cli.ToolSupport.Literate qualified as Literate
 import HsBindgen.Errors
 import HsBindgen.Imports
 import HsBindgen.Lib

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -263,9 +263,9 @@ executable hs-bindgen-cli
   other-modules:
       HsBindgen.App
       HsBindgen.Cli
+      HsBindgen.Cli.BindingSpec
+      HsBindgen.Cli.BindingSpec.StdLib
       HsBindgen.Cli.Dev
-      HsBindgen.Cli.Dev.BindingSpec
-      HsBindgen.Cli.Dev.BindingSpec.StdLib
       HsBindgen.Cli.Dev.Clang
       HsBindgen.Cli.Dev.Parse
       HsBindgen.Cli.Info

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -266,10 +266,10 @@ executable hs-bindgen-cli
       HsBindgen.Cli.BindingSpec
       HsBindgen.Cli.BindingSpec.StdLib
       HsBindgen.Cli.Dev
-      HsBindgen.Cli.Dev.Clang
       HsBindgen.Cli.Dev.Parse
       HsBindgen.Cli.Info
       HsBindgen.Cli.Info.IncludeGraph
+      HsBindgen.Cli.Info.Libclang
       HsBindgen.Cli.Info.ResolveHeader
       HsBindgen.Cli.Internal
       HsBindgen.Cli.Internal.Literate

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -265,13 +265,13 @@ executable hs-bindgen-cli
       HsBindgen.Cli
       HsBindgen.Cli.BindingSpec
       HsBindgen.Cli.BindingSpec.StdLib
-      HsBindgen.Cli.Dev
-      HsBindgen.Cli.Dev.Parse
+      HsBindgen.Cli.GenTests
       HsBindgen.Cli.Info
       HsBindgen.Cli.Info.IncludeGraph
       HsBindgen.Cli.Info.Libclang
       HsBindgen.Cli.Info.ResolveHeader
-      HsBindgen.Cli.GenTests
+      HsBindgen.Cli.Internal
+      HsBindgen.Cli.Internal.Parse
       HsBindgen.Cli.Preprocess
       HsBindgen.Cli.ToolSupport
       HsBindgen.Cli.ToolSupport.Literate

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -271,10 +271,10 @@ executable hs-bindgen-cli
       HsBindgen.Cli.Info.IncludeGraph
       HsBindgen.Cli.Info.Libclang
       HsBindgen.Cli.Info.ResolveHeader
-      HsBindgen.Cli.Internal
-      HsBindgen.Cli.Internal.Literate
       HsBindgen.Cli.GenTests
       HsBindgen.Cli.Preprocess
+      HsBindgen.Cli.ToolSupport
+      HsBindgen.Cli.ToolSupport.Literate
       Paths_hs_bindgen
   autogen-modules:
       Paths_hs_bindgen
@@ -443,7 +443,7 @@ test-suite test-pp
   -- (which would require either build-type: Custom or Hooks - both not a great options, at least yet).
   --
   -- The source files contains the actual options and arguments to be used with hs-bindgen
-  ghc-options: -pgmL hs-bindgen-cli -optL internal -optL literate
+  ghc-options: -pgmL hs-bindgen-cli -optL tool-support -optL literate
   cpp-options: -DTEST_PP
 
   build-tool-depends: hs-bindgen:hs-bindgen-cli

--- a/manual/LowLevel/Includes.md
+++ b/manual/LowLevel/Includes.md
@@ -351,9 +351,10 @@ include graph for one or more headers, in [Mermaid][] syntax.
 $ hs-bindgen-cli info include-graph stdint.h
 ```
 
-The `hs-bindgen-cli dev clang` command may be used to query Clang options such
-as `-v` using `libclang`, to confirm `libclang` C include search paths.
+The `hs-bindgen-cli info libclang` command may be used to run `libclang` with
+Clang options such as `-v`, to confirm the `libclang` version, C include search
+paths, etc.
 
 ```
-$ hs-bindgen-dev clang --clang-option=-v
+$ hs-bindgen-cli info libclang --clang-option=-v
 ```


### PR DESCRIPTION
This PR implements the changes discussed in #1088.

**New State**

```
hs-bindgen-cli
  preprocess               Generate Haskell module from C headers
  gen-tests                Generate tests for generated Haskell code
  binding-spec             Binding specification commands
    stdlib                   Write stdlib external binding specification
  info                     Informational commands, useful when creating bindings
    include-graph            Compute the include graph
    libclang                 Run libclang with empty input
    resolve-header           Resolve C headers to source paths
  internal                 Internal commands, for hs-bindgen development
    parse                    Parse C headers
  tool-support             Tool support commands, not meant to be used directly
    literate                 Generate Haskell module from C header, acting as
                             literate Haskell preprocessor
```