### PR TITLE
Add parse predicate support to `info include-graph`

### DIFF
--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -12,6 +12,8 @@ module HsBindgen.App (
   , parseBindgenConfig
     -- ** Clang arguments
   , parseClangArgsConfig
+    -- ** Predicates and slicing
+  , parseParsePredicate
     -- ** Output options
   , parseOutput
   , parseGenBindingSpec
@@ -360,25 +362,25 @@ parseParsePredicate :: Parser ParsePredicate
 parseParsePredicate = fmap aux . many . asum $ [
       flag' (Right PTrue) $ mconcat [
           long "parse-all"
-        , help "Parse all declarations"
+        , help "Parse all headers"
         ]
     , flag' (Right (PIf FromMainHeaders)) $ mconcat [
           long "parse-from-main-headers"
-        , help "Parse declarations in main headers"
+        , help "Parse main headers"
         ]
     , flag' (Right (PIf FromMainHeaderDirs)) $ mconcat [
           long "parse-from-main-header-dirs"
-        , help "Parse declarations in main header directories (default)"
+        , help "Parse headers in main header directories (default)"
         ]
     , fmap (Right . PIf . HeaderPathMatches) $ strOption $ mconcat [
           long "parse-by-header-path"
         , metavar "PCRE"
-        , help "Parse declarations in headers with paths that match PCRE"
+        , help "Parse headers with paths that match PCRE"
         ]
     , fmap (Left . PIf . HeaderPathMatches) $ strOption $ mconcat [
           long "parse-except-by-header-path"
         , metavar "PCRE"
-        , help "Parse except declarations in headers with paths that match PCRE"
+        , help "Parse except headers with paths that match PCRE"
         ]
     ]
   where

--- a/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
@@ -13,47 +13,35 @@ module HsBindgen.Cli.Info.IncludeGraph (
   , exec
   ) where
 
-import Control.Monad ((<=<))
 import Options.Applicative hiding (info)
-import System.Exit (ExitCode (ExitFailure))
-
-import Clang.Enum.Bitfield
-import Clang.LowLevel.Core
-import Clang.Paths
 
 import HsBindgen.App
-import HsBindgen.Boot qualified as Boot
-import HsBindgen.Clang
-import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
-import HsBindgen.Frontend.Predicate qualified as Predicate
-import HsBindgen.Frontend.ProcessIncludes (processIncludes)
-import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Imports
 import HsBindgen.Lib
+
+import HsBindgen (writeIncludeGraph)
 
 {-------------------------------------------------------------------------------
   CLI help
 -------------------------------------------------------------------------------}
 
 info :: InfoMod a
-info = progDesc "Compute the include graph"
+info = progDesc "Output the include graph"
 
 {-------------------------------------------------------------------------------
   Options
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      clangArgsConfig :: ClangArgsConfig
-    , predicate       :: ParsePredicate
-    , output          :: Maybe FilePath
-    , inputs          :: [UncheckedHashIncludeArg]
+      bindgenConfig :: BindgenConfig
+    , output        :: Maybe FilePath
+    , inputs        :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
 parseOpts =
     Opts
-      <$> parseClangArgsConfig
-      <*> parseParsePredicate
+      <$> parseBindgenConfig
       <*> optional parseOutput'
       <*> parseInputs
 
@@ -70,36 +58,6 @@ parseOutput' = strOption $ mconcat [
 -------------------------------------------------------------------------------}
 
 exec :: GlobalOpts -> Opts -> IO ()
-exec GlobalOpts{..} opts =
-    either throwIO return =<< withTracer tracerConfig (execWithTracer opts)
-
-execWithTracer :: Opts -> Tracer IO TraceMsg -> IO ()
-execWithTracer Opts{..} tracer = do
-    hashIncludeArgs <- mapM (hashIncludeArgWithTrace hiaTracer) inputs
-    let rootHeader = RootHeader.fromMainFiles hashIncludeArgs
-    clangArgs <- Boot.getClangArgs (contramap TraceBoot tracer) clangArgsConfig
-    let clangInput =
-          ClangInputMemory
-            (getSourcePath RootHeader.name)
-            (RootHeader.content rootHeader)
-        clangSetup = (defaultClangSetup clangArgs clangInput) {
-            clangFlags = bitfieldEnum [
-                CXTranslationUnit_DetailedPreprocessingRecord
-              ]
-          }
-        exitOnClangError = maybe (throwIO $ ExitFailure 1) return
-    (includeGraph, isMainHeader, isInMainHeaderDir, _) <-
-      exitOnClangError <=< withClang clangTracer clangSetup $
-        fmap Just . processIncludes
-    let p path =
-             Predicate.matchParse isMainHeader isInMainHeaderDir path predicate
-          && path /= RootHeader.name
-    case output of
-      Just path -> writeFile path $ IncludeGraph.dumpMermaid p includeGraph
-      Nothing   -> putStr         $ IncludeGraph.dumpMermaid p includeGraph
-  where
-    hiaTracer :: Tracer IO HashIncludeArgMsg
-    hiaTracer = contramap (TraceBoot . BootHashIncludeArg) tracer
-
-    clangTracer :: Tracer IO ClangMsg
-    clangTracer = contramap (TraceFrontend . FrontendClang) tracer
+exec GlobalOpts{..} Opts{..} = do
+    let artefacts = writeIncludeGraph output :* Nil
+    void $ hsBindgen tracerConfig bindgenConfig inputs artefacts

--- a/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
@@ -92,7 +92,8 @@ execWithTracer Opts{..} tracer = do
       exitOnClangError <=< withClang clangTracer clangSetup $
         fmap Just . processIncludes
     let p path =
-          Predicate.matchParse isMainHeader isInMainHeaderDir path predicate
+             Predicate.matchParse isMainHeader isInMainHeaderDir path predicate
+          && path /= RootHeader.name
     case output of
       Just path -> writeFile path $ IncludeGraph.dumpMermaid p includeGraph
       Nothing   -> putStr         $ IncludeGraph.dumpMermaid p includeGraph

--- a/hs-bindgen/src-internal/Data/DynGraph.hs
+++ b/hs-bindgen/src-internal/Data/DynGraph.hs
@@ -92,5 +92,5 @@ dfFindMember = Labelled.dfFindMember
 -- | Render a Mermaid diagram
 --
 -- See https://mermaid.js.org/>
-dumpMermaid :: Bool -> (a -> String) -> DynGraph a -> String
-dumpMermaid isTranspose = Labelled.dumpMermaid isTranspose (const Nothing)
+dumpMermaid :: Bool -> (a -> Bool) -> (a -> String) -> DynGraph a -> String
+dumpMermaid isTranspose p = Labelled.dumpMermaid isTranspose p (const Nothing)

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -112,7 +112,7 @@ writeIncludeGraph file =
   Lift
     (IncludeGraph :* Nil)
     (\(I includeGraph :* Nil) ->
-       writeFile file (IncludeGraph.dumpMermaid includeGraph))
+       writeFile file (IncludeGraph.dumpMermaid (const True) includeGraph))
 
 -- | Write @use-decl@ graph to file.
 writeUseDeclGraph :: FilePath -> Artefact ()

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -38,7 +38,6 @@ import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.External qualified as C
 import HsBindgen.Frontend.RootHeader (HashIncludeArg, UncheckedHashIncludeArg)
-import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell (HsModuleName)
 import HsBindgen.TraceMsg
@@ -87,7 +86,7 @@ data Artefact (a :: Star) where
   -- * Boot
   HashIncludeArgs :: Artefact [HashIncludeArg]
   -- * Frontend
-  IncludeGraph    :: Artefact IncludeGraph.IncludeGraph
+  IncludeGraph    :: Artefact (IncludeGraph.Predicate, IncludeGraph.IncludeGraph)
   DeclIndex       :: Artefact DeclIndex.DeclIndex
   UseDeclGraph    :: Artefact UseDeclGraph.UseDeclGraph
   DeclUseGraph    :: Artefact DeclUseGraph.DeclUseGraph
@@ -107,15 +106,14 @@ instance Functor Artefact where
 -- | A list of 'Artefact's.
 type Artefacts as = NP Artefact as
 
--- | Write the include graph to file.
-writeIncludeGraph :: FilePath -> Artefact ()
-writeIncludeGraph file =
+-- | Write the include graph to `STDOUT` or a file.
+writeIncludeGraph :: Maybe FilePath -> Artefact ()
+writeIncludeGraph mPath =
   Lift
     (IncludeGraph :* Nil)
-    (\(I includeGraph :* Nil) ->
-       writeFile
-         file
-         (IncludeGraph.dumpMermaid (/= RootHeader.name) includeGraph))
+    (\(I (p, includeGraph) :* Nil) ->
+      write mPath $ IncludeGraph.dumpMermaid p includeGraph
+    )
 
 -- | Write @use-decl@ graph to file.
 writeUseDeclGraph :: FilePath -> Artefact ()

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -37,7 +37,8 @@ import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
 import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.External qualified as C
-import HsBindgen.Frontend.RootHeader
+import HsBindgen.Frontend.RootHeader (HashIncludeArg, UncheckedHashIncludeArg)
+import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell (HsModuleName)
 import HsBindgen.TraceMsg
@@ -112,7 +113,9 @@ writeIncludeGraph file =
   Lift
     (IncludeGraph :* Nil)
     (\(I includeGraph :* Nil) ->
-       writeFile file (IncludeGraph.dumpMermaid (const True) includeGraph))
+       writeFile
+         file
+         (IncludeGraph.dumpMermaid (/= RootHeader.name) includeGraph))
 
 -- | Write @use-decl@ graph to file.
 writeUseDeclGraph :: FilePath -> Artefact ()

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -145,9 +145,14 @@ frontend tracer FrontendConfig{..} BootArtefact{..} = do
     let -- Unit.
         cTranslationUnit :: C.TranslationUnit
         cTranslationUnit = finalize afterMangleNames
+        -- Include graph predicate
+        includeGraphP :: IncludeGraph.Predicate
+        includeGraphP path =
+             matchParse isMainHeader isInMainHeaderDir path frontendParsePredicate
+          && path /= name
         -- Graphs.
-        frontendIncludeGraph :: IncludeGraph.IncludeGraph
-        frontendIncludeGraph = unitIncludeGraph afterParse
+        frontendIncludeGraph :: (IncludeGraph.Predicate, IncludeGraph.IncludeGraph)
+        frontendIncludeGraph = (includeGraphP, unitIncludeGraph afterParse)
         frontendIndex        :: DeclIndex.DeclIndex
         frontendIndex        = declIndex $ unitAnn afterSort
         frontendUseDeclGraph :: UseDeclGraph.UseDeclGraph
@@ -201,12 +206,12 @@ frontend tracer FrontendConfig{..} BootArtefact{..} = do
 -------------------------------------------------------------------------------}
 
 data FrontendArtefact = FrontendArtefact {
-    frontendIncludeGraph    :: IncludeGraph.IncludeGraph
-  , frontendIndex           :: DeclIndex.DeclIndex
-  , frontendUseDeclGraph    :: UseDeclGraph.UseDeclGraph
-  , frontendDeclUseGraph    :: DeclUseGraph.DeclUseGraph
-  , frontendCDecls          :: [C.Decl]
-  , frontendDependencies    :: [SourcePath]
+    frontendIncludeGraph :: (IncludeGraph.Predicate, IncludeGraph.IncludeGraph)
+  , frontendIndex        :: DeclIndex.DeclIndex
+  , frontendUseDeclGraph :: UseDeclGraph.UseDeclGraph
+  , frontendDeclUseGraph :: DeclUseGraph.DeclUseGraph
+  , frontendCDecls       :: [C.Decl]
+  , frontendDependencies :: [SourcePath]
   }
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
@@ -17,6 +17,7 @@ module HsBindgen.Frontend.Analysis.IncludeGraph (
   , toSortedList
   , getIncludes
     -- * Debugging
+  , Predicate
   , dumpMermaid
   ) where
 
@@ -102,7 +103,13 @@ getIncludes mainPaths (IncludeGraph graph) =
   Debugging
 -------------------------------------------------------------------------------}
 
-dumpMermaid :: (SourcePath -> Bool) -> IncludeGraph -> String
+-- | Include graph predicate
+--
+-- An include graph predicate can be used to filter which indexes of an include
+-- graph are shown.
+type Predicate = SourcePath -> Bool
+
+dumpMermaid :: Predicate -> IncludeGraph -> String
 dumpMermaid p (IncludeGraph graph) =
     DynGraph.dumpMermaid True p (Just . renderInclude) getSourcePath graph
   where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
@@ -102,9 +102,9 @@ getIncludes mainPaths (IncludeGraph graph) =
   Debugging
 -------------------------------------------------------------------------------}
 
-dumpMermaid :: IncludeGraph -> String
-dumpMermaid (IncludeGraph graph) =
-    DynGraph.dumpMermaid True (Just . renderInclude) getSourcePath graph
+dumpMermaid :: (SourcePath -> Bool) -> IncludeGraph -> String
+dumpMermaid p (IncludeGraph graph) =
+    DynGraph.dumpMermaid True p (Just . renderInclude) getSourcePath graph
   where
     renderInclude :: Include -> String
     renderInclude = \case

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
@@ -161,6 +161,7 @@ dumpMermaid :: DeclIndex -> UseDeclGraph -> String
 dumpMermaid declIndex (Wrap graph) =
     DynGraph.dumpMermaid
       False
+      (const True)
       (Just . show)
       (\uid -> showDecl $ declIndex DeclIndex.! uid)
       graph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
@@ -112,7 +112,7 @@ evalPredicate info = wrapEff $ \ParseSupport{parseEnv} -> do
     let selected = Predicate.matchParse
                      (envIsMainHeader parseEnv)
                      (envIsInMainHeaderDir parseEnv)
-                     (C.declLoc info)
+                     (singleLocPath (C.declLoc info))
                      (envPredicate parseEnv)
     unless selected $ traceWith (envTracer parseEnv) (ParseExcluded info)
     return selected

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Monad.hs
@@ -113,7 +113,6 @@ evalPredicate info = wrapEff $ \ParseSupport{parseEnv} -> do
                      (envIsMainHeader parseEnv)
                      (envIsInMainHeaderDir parseEnv)
                      (C.declLoc info)
-                     (C.declId info)
                      (envPredicate parseEnv)
     unless selected $ traceWith (envTracer parseEnv) (ParseExcluded info)
     return selected

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -110,7 +110,7 @@ selectDecls isMainHeader isInMainHeaderDir SelectConfig{..} unitRBS =
       Predicate.matchSelect
         isMainHeader
         isInMainHeaderDir
-        loc
+        (singleLocPath loc)
         qualDeclId
         selectConfigPredicate
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Predicate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Predicate.hs
@@ -33,7 +33,6 @@ import Clang.HighLevel.Types
 import Clang.Paths
 
 import HsBindgen.Frontend.AST.External qualified as C
-import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------
@@ -150,17 +149,10 @@ matchParse ::
      IsMainHeader
   -> IsInMainHeaderDir
   -> SingleLoc
-  -> PrelimDeclId
   -> ParsePredicate
   -> Bool
-matchParse isMainHeader isInMainHeaderDir loc prelimDeclId
-    | isBuiltin = const False
-    | otherwise = eval (matchHeaderPath isMainHeader isInMainHeaderDir loc)
-  where
-    isBuiltin :: Bool
-    isBuiltin = case prelimDeclId of
-      PrelimDeclIdBuiltin{} -> True
-      _otherwise            -> False
+matchParse isMainHeader isInMainHeaderDir loc = eval $
+    matchHeaderPath isMainHeader isInMainHeaderDir loc
 
 -- | Match 'SelectPredicate' predicates
 matchSelect ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Predicate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Predicate.hs
@@ -29,7 +29,6 @@ import System.FilePath qualified as FilePath
 import Text.Regex.PCRE qualified as PCRE
 import Text.Regex.PCRE.Text ()
 
-import Clang.HighLevel.Types
 import Clang.Paths
 
 import HsBindgen.Frontend.AST.External qualified as C
@@ -111,25 +110,25 @@ instance Default SelectPredicate where
 --
 -- Dealing with main headers is somewhat subtle.  See
 -- "HsBindgen.Frontend.ProcessIncludes" for discussion.
-type IsMainHeader = SingleLoc -> Bool
+type IsMainHeader = SourcePath -> Bool
 
 -- | Construct an 'IsMainHeader' function for the given main header paths
 mkIsMainHeader ::
      Set SourcePath -- ^ Main header paths
   -> IsMainHeader
-mkIsMainHeader paths loc = singleLocPath loc `Set.member` paths
+mkIsMainHeader paths path = path `Set.member` paths
 
 -- | Check if a declaration is in a main header directory, including
 -- subdirectories
-type IsInMainHeaderDir = SingleLoc -> Bool
+type IsInMainHeaderDir = SourcePath -> Bool
 
 -- | Construct an 'IsInMainHeaderDir' function for the given main header paths
 mkIsInMainHeaderDir ::
      Set SourcePath -- ^ Main header paths
   -> IsInMainHeaderDir
-mkIsInMainHeaderDir paths loc =
+mkIsInMainHeaderDir paths path =
     let dir = FilePath.splitDirectories . FilePath.takeDirectory $
-          getSourcePath (singleLocPath loc)
+          getSourcePath path
     in  any (`List.isPrefixOf` dir) mainDirs
   where
     mainDirs :: [[FilePath]]
@@ -148,22 +147,22 @@ mkIsInMainHeaderDir paths loc =
 matchParse ::
      IsMainHeader
   -> IsInMainHeaderDir
-  -> SingleLoc
+  -> SourcePath
   -> ParsePredicate
   -> Bool
-matchParse isMainHeader isInMainHeaderDir loc = eval $
-    matchHeaderPath isMainHeader isInMainHeaderDir loc
+matchParse isMainHeader isInMainHeaderDir path = eval $
+    matchHeaderPath isMainHeader isInMainHeaderDir path
 
 -- | Match 'SelectPredicate' predicates
 matchSelect ::
      IsMainHeader
   -> IsInMainHeaderDir
-  -> SingleLoc
+  -> SourcePath
   -> C.QualDeclId
   -> SelectPredicate
   -> Bool
-matchSelect isMainHeader isInMainHeaderDir loc qid = eval $
-    either (matchHeaderPath isMainHeader isInMainHeaderDir loc) (matchDecl qid)
+matchSelect isMainHeader isInMainHeaderDir path qid = eval $
+    either (matchHeaderPath isMainHeader isInMainHeaderDir path) (matchDecl qid)
 
 {-------------------------------------------------------------------------------
   Merging
@@ -229,15 +228,13 @@ eval f = go
 matchHeaderPath ::
      IsMainHeader
   -> IsInMainHeaderDir
-  -> SingleLoc
+  -> SourcePath
   -> HeaderPathPredicate
   -> Bool
-matchHeaderPath isMainHeader isInMainHeaderDir loc = \case
-    FromMainHeaders      -> isMainHeader loc
-    FromMainHeaderDirs   -> isInMainHeaderDir loc
-    HeaderPathMatches re ->
-      let (SourcePath path) = singleLocPath loc
-       in matchTest re path
+matchHeaderPath isMainHeader isInMainHeaderDir path@(SourcePath pathT) = \case
+    FromMainHeaders      -> isMainHeader path
+    FromMainHeaderDirs   -> isInMainHeaderDir path
+    HeaderPathMatches re -> matchTest re pathT
 
 -- | Match 'DeclPredicate' predicates
 matchDecl :: C.QualDeclId -> DeclPredicate -> Bool


### PR DESCRIPTION
I needed to refactor parse predicates a bit to support this.

* We used to filter out builtin macros using `matchParse`, but now we want to also use a `ParsePredicate` to select which parts of an include graph to show, and declarations are not involved.  Handling of builtin macros needs to be handled specially anyway (#1087).  I removed the builtin check from `matchParse` and implemented it in `foldDecl`.  A `TODO` comment referring to #1087 is added.

* I refactored to define predicates on `SourcePath` instead of `SingleLoc`.  We do not have source locations when working on an include graph.  I doubt that we would want to write predicates on line number, column number, or offset anyway. :smile:

For CLI options, I tentatively implemented the following:

```
  --show-all               Show all headers (default)
  --show-main-headers      Show main headers only
  --show-main-header-dirs  Show headers in main header directories
  --show-by-header-path PCRE
                           Show headers with paths that match PCRE
  --show-except-by-header-path PCRE
                           Show headers with paths that do not match PCRE
```

First, a minimal test:

```c
#include <stdint.h>

typedef uint64_t identifier;
```

The full include graph shows standard library headers:

```
$ cabal run hs-bindgen-cli -- info include-graph -I . example.h
```

```mermaid
graph TD;
  v0["./example.h"]
  v4["/usr/include/bits/libc-header-start.h"]
  v11["/usr/include/bits/long-double.h"]
  v18["/usr/include/bits/stdint-intn.h"]
  v20["/usr/include/bits/stdint-least.h"]
  v19["/usr/include/bits/stdint-uintn.h"]
  v16["/usr/include/bits/time64.h"]
  v8["/usr/include/bits/timesize.h"]
  v14["/usr/include/bits/types.h"]
  v15["/usr/include/bits/typesizes.h"]
  v17["/usr/include/bits/wchar.h"]
  v7["/usr/include/bits/wordsize.h"]
  v6["/usr/include/features-time64.h"]
  v5["/usr/include/features.h"]
  v13["/usr/include/gnu/stubs-64.h"]
  v12["/usr/include/gnu/stubs.h"]
  v9["/usr/include/stdc-predef.h"]
  v3["/usr/include/stdint.h"]
  v10["/usr/include/sys/cdefs.h"]
  v2["/usr/lib/clang/20/include/stdint.h"]
  v1["hs-bindgen-root.h"]
  v1-->|"#include &lt;example.h&gt;"|v0
  v0-->|"#include &lt;stdint.h&gt;"|v2
  v2-->|"#include_next &lt;stdint.h&gt;"|v3
  v3-->|"#include &lt;bits/libc-header-start.h&gt;"|v4
  v4-->|"#include &lt;features.h&gt;"|v5
  v14-->|"#include &lt;features.h&gt;"|v5
  v5-->|"#include &lt;features-time64.h&gt;"|v6
  v3-->|"#include &lt;bits/wordsize.h&gt;"|v7
  v6-->|"#include &lt;bits/wordsize.h&gt;"|v7
  v8-->|"#include &lt;bits/wordsize.h&gt;"|v7
  v10-->|"#include &lt;bits/wordsize.h&gt;"|v7
  v14-->|"#include &lt;bits/wordsize.h&gt;"|v7
  v6-->|"#include &lt;bits/timesize.h&gt;"|v8
  v14-->|"#include &lt;bits/timesize.h&gt;"|v8
  v5-->|"#include &lt;stdc-predef.h&gt;"|v9
  v5-->|"#include &lt;sys/cdefs.h&gt;"|v10
  v10-->|"#include &lt;bits/long-double.h&gt;"|v11
  v5-->|"#include &lt;gnu/stubs.h&gt;"|v12
  v12-->|"#include &lt;gnu/stubs-64.h&gt;"|v13
  v3-->|"#include &lt;bits/types.h&gt;"|v14
  v18-->|"#include &lt;bits/types.h&gt;"|v14
  v19-->|"#include &lt;bits/types.h&gt;"|v14
  v20-->|"#include &lt;bits/types.h&gt;"|v14
  v14-->|"#include &lt;bits/typesizes.h&gt;"|v15
  v14-->|"#include &lt;bits/time64.h&gt;"|v16
  v3-->|"#include &lt;bits/wchar.h&gt;"|v17
  v3-->|"#include &lt;bits/stdint-intn.h&gt;"|v18
  v3-->|"#include &lt;bits/stdint-uintn.h&gt;"|v19
  v3-->|"#include &lt;bits/stdint-least.h&gt;"|v20
```

Only showing the main headers omits those:

```
$ cabal run hs-bindgen-cli -- info include-graph \
    -I . \
    --show-main-headers \
    example.h
```

```mermaid
graph TD;
  v0["./example.h"]
```

For a more complex example, I tried PCAP:

```
$ cabal run hs-bindgen-cli -- info include-graph \
    --gnu \
    pcap/pcap.h
```

```mermaid
graph TD;
  v74["/usr/include/arpa/inet.h"]
  v65["/usr/include/asm-generic/bitsperlong.h"]
  v63["/usr/include/asm-generic/posix_types.h"]
  v58["/usr/include/asm-generic/socket.h"]
  v67["/usr/include/asm-generic/sockios.h"]
  v64["/usr/include/asm/bitsperlong.h"]
  v61["/usr/include/asm/posix_types.h"]
  v62["/usr/include/asm/posix_types_64.h"]
  v57["/usr/include/asm/socket.h"]
  v66["/usr/include/asm/sockios.h"]
  v47["/usr/include/bits/atomic_wide_counter.h"]
  v36["/usr/include/bits/byteswap.h"]
  v34["/usr/include/bits/endian.h"]
  v35["/usr/include/bits/endianness.h"]
  v90["/usr/include/bits/floatn-common.h"]
  v89["/usr/include/bits/floatn.h"]
  v71["/usr/include/bits/in.h"]
  v18["/usr/include/bits/libc-header-start.h"]
  v13["/usr/include/bits/long-double.h"]
  v73["/usr/include/bits/netdb.h"]
  v46["/usr/include/bits/pthreadtypes-arch.h"]
  v44["/usr/include/bits/pthreadtypes.h"]
  v39["/usr/include/bits/select.h"]
  v56["/usr/include/bits/sockaddr.h"]
  v54["/usr/include/bits/socket.h"]
  v55["/usr/include/bits/socket_type.h"]
  v23["/usr/include/bits/stdint-intn.h"]
  v25["/usr/include/bits/stdint-least.h"]
  v24["/usr/include/bits/stdint-uintn.h"]
  v88["/usr/include/bits/stdio_lim.h"]
  v48["/usr/include/bits/struct_mutex.h"]
  v49["/usr/include/bits/struct_rwlock.h"]
  v45["/usr/include/bits/thread-shared-types.h"]
  v21["/usr/include/bits/time64.h"]
  v10["/usr/include/bits/timesize.h"]
  v19["/usr/include/bits/types.h"]
  v85["/usr/include/bits/types/FILE.h"]
  v84["/usr/include/bits/types/__FILE.h"]
  v83["/usr/include/bits/types/__fpos64_t.h"]
  v81["/usr/include/bits/types/__fpos_t.h"]
  v82["/usr/include/bits/types/__mbstate_t.h"]
  v41["/usr/include/bits/types/__sigset_t.h"]
  v27["/usr/include/bits/types/clock_t.h"]
  v28["/usr/include/bits/types/clockid_t.h"]
  v87["/usr/include/bits/types/cookie_io_functions_t.h"]
  v40["/usr/include/bits/types/sigset_t.h"]
  v86["/usr/include/bits/types/struct_FILE.h"]
  v53["/usr/include/bits/types/struct_iovec.h"]
  v68["/usr/include/bits/types/struct_osockaddr.h"]
  v43["/usr/include/bits/types/struct_timespec.h"]
  v42["/usr/include/bits/types/struct_timeval.h"]
  v29["/usr/include/bits/types/time_t.h"]
  v30["/usr/include/bits/types/timer_t.h"]
  v20["/usr/include/bits/typesizes.h"]
  v37["/usr/include/bits/uintn-identity.h"]
  v22["/usr/include/bits/wchar.h"]
  v9["/usr/include/bits/wordsize.h"]
  v33["/usr/include/endian.h"]
  v8["/usr/include/features-time64.h"]
  v7["/usr/include/features.h"]
  v15["/usr/include/gnu/stubs-64.h"]
  v14["/usr/include/gnu/stubs.h"]
  v6["/usr/include/inttypes.h"]
  v59["/usr/include/linux/posix_types.h"]
  v60["/usr/include/linux/stddef.h"]
  v69["/usr/include/netdb.h"]
  v70["/usr/include/netinet/in.h"]
  v75["/usr/include/pcap/bpf.h"]
  v3["/usr/include/pcap/compiler-tests.h"]
  v76["/usr/include/pcap/dlt.h"]
  v2["/usr/include/pcap/funcattrs.h"]
  v4["/usr/include/pcap/pcap-inttypes.h"]
  v0["/usr/include/pcap/pcap.h"]
  v51["/usr/include/pcap/socket.h"]
  v72["/usr/include/rpc/netdb.h"]
  v11["/usr/include/stdc-predef.h"]
  v17["/usr/include/stdint.h"]
  v77["/usr/include/stdio.h"]
  v12["/usr/include/sys/cdefs.h"]
  v38["/usr/include/sys/select.h"]
  v52["/usr/include/sys/socket.h"]
  v50["/usr/include/sys/time.h"]
  v26["/usr/include/sys/types.h"]
  v80["/usr/lib/clang/20/include/__stdarg___gnuc_va_list.h"]
  v78["/usr/lib/clang/20/include/__stddef_null.h"]
  v32["/usr/lib/clang/20/include/__stddef_size_t.h"]
  v5["/usr/lib/clang/20/include/inttypes.h"]
  v79["/usr/lib/clang/20/include/stdarg.h"]
  v31["/usr/lib/clang/20/include/stddef.h"]
  v16["/usr/lib/clang/20/include/stdint.h"]
  v1["hs-bindgen-root.h"]
  v1-->|"#include &lt;pcap/pcap.h&gt;"|v0
  v0-->|"#include &lt;pcap/funcattrs.h&gt;"|v2
  v75-->|"#include &lt;pcap/funcattrs.h&gt;"|v2
  v2-->|"#include &lt;pcap/compiler-tests.h&gt;"|v3
  v0-->|"#include &lt;pcap/pcap-inttypes.h&gt;"|v4
  v4-->|"#include &lt;inttypes.h&gt;"|v5
  v5-->|"#include_next &lt;inttypes.h&gt;"|v6
  v6-->|"#include &lt;features.h&gt;"|v7
  v18-->|"#include &lt;features.h&gt;"|v7
  v19-->|"#include &lt;features.h&gt;"|v7
  v26-->|"#include &lt;features.h&gt;"|v7
  v33-->|"#include &lt;features.h&gt;"|v7
  v36-->|"#include &lt;features.h&gt;"|v7
  v38-->|"#include &lt;features.h&gt;"|v7
  v50-->|"#include &lt;features.h&gt;"|v7
  v52-->|"#include &lt;features.h&gt;"|v7
  v69-->|"#include &lt;features.h&gt;"|v7
  v70-->|"#include &lt;features.h&gt;"|v7
  v72-->|"#include &lt;features.h&gt;"|v7
  v74-->|"#include &lt;features.h&gt;"|v7
  v89-->|"#include &lt;features.h&gt;"|v7
  v90-->|"#include &lt;features.h&gt;"|v7
  v7-->|"#include &lt;features-time64.h&gt;"|v8
  v8-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v10-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v12-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v17-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v19-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v46-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v86-->|"#include &lt;bits/wordsize.h&gt;"|v9
  v8-->|"#include &lt;bits/timesize.h&gt;"|v10
  v19-->|"#include &lt;bits/timesize.h&gt;"|v10
  v7-->|"#include &lt;stdc-predef.h&gt;"|v11
  v7-->|"#include &lt;sys/cdefs.h&gt;"|v12
  v12-->|"#include &lt;bits/long-double.h&gt;"|v13
  v90-->|"#include &lt;bits/long-double.h&gt;"|v13
  v7-->|"#include &lt;gnu/stubs.h&gt;"|v14
  v14-->|"#include &lt;gnu/stubs-64.h&gt;"|v15
  v6-->|"#include &lt;stdint.h&gt;"|v16
  v16-->|"#include_next &lt;stdint.h&gt;"|v17
  v17-->|"#include &lt;bits/libc-header-start.h&gt;"|v18
  v77-->|"#include &lt;bits/libc-header-start.h&gt;"|v18
  v17-->|"#include &lt;bits/types.h&gt;"|v19
  v23-->|"#include &lt;bits/types.h&gt;"|v19
  v24-->|"#include &lt;bits/types.h&gt;"|v19
  v25-->|"#include &lt;bits/types.h&gt;"|v19
  v26-->|"#include &lt;bits/types.h&gt;"|v19
  v27-->|"#include &lt;bits/types.h&gt;"|v19
  v28-->|"#include &lt;bits/types.h&gt;"|v19
  v29-->|"#include &lt;bits/types.h&gt;"|v19
  v30-->|"#include &lt;bits/types.h&gt;"|v19
  v36-->|"#include &lt;bits/types.h&gt;"|v19
  v37-->|"#include &lt;bits/types.h&gt;"|v19
  v38-->|"#include &lt;bits/types.h&gt;"|v19
  v42-->|"#include &lt;bits/types.h&gt;"|v19
  v43-->|"#include &lt;bits/types.h&gt;"|v19
  v50-->|"#include &lt;bits/types.h&gt;"|v19
  v70-->|"#include &lt;bits/types.h&gt;"|v19
  v77-->|"#include &lt;bits/types.h&gt;"|v19
  v81-->|"#include &lt;bits/types.h&gt;"|v19
  v83-->|"#include &lt;bits/types.h&gt;"|v19
  v86-->|"#include &lt;bits/types.h&gt;"|v19
  v87-->|"#include &lt;bits/types.h&gt;"|v19
  v19-->|"#include &lt;bits/typesizes.h&gt;"|v20
  v19-->|"#include &lt;bits/time64.h&gt;"|v21
  v17-->|"#include &lt;bits/wchar.h&gt;"|v22
  v17-->|"#include &lt;bits/stdint-intn.h&gt;"|v23
  v26-->|"#include &lt;bits/stdint-intn.h&gt;"|v23
  v17-->|"#include &lt;bits/stdint-uintn.h&gt;"|v24
  v69-->|"#include &lt;bits/stdint-uintn.h&gt;"|v24
  v70-->|"#include &lt;bits/stdint-uintn.h&gt;"|v24
  v17-->|"#include &lt;bits/stdint-least.h&gt;"|v25
  v0-->|"#include &lt;sys/types.h&gt;"|v26
  v51-->|"#include &lt;sys/types.h&gt;"|v26
  v54-->|"#include &lt;sys/types.h&gt;"|v26
  v26-->|"#include &lt;bits/types/clock_t.h&gt;"|v27
  v26-->|"#include &lt;bits/types/clockid_t.h&gt;"|v28
  v26-->|"#include &lt;bits/types/time_t.h&gt;"|v29
  v38-->|"#include &lt;bits/types/time_t.h&gt;"|v29
  v43-->|"#include &lt;bits/types/time_t.h&gt;"|v29
  v50-->|"#include &lt;bits/types/time_t.h&gt;"|v29
  v54-->|"#include &lt;bits/types/time_t.h&gt;"|v29
  v26-->|"#include &lt;bits/types/timer_t.h&gt;"|v30
  v26-->|"#include &lt;stddef.h&gt;"|v31
  v52-->|"#include &lt;stddef.h&gt;"|v31
  v53-->|"#include &lt;stddef.h&gt;"|v31
  v54-->|"#include &lt;stddef.h&gt;"|v31
  v72-->|"#include &lt;stddef.h&gt;"|v31
  v77-->|"#include &lt;stddef.h&gt;"|v31
  v31-->|"#include &lt;__stddef_size_t.h&gt;"|v32
  v26-->|"#include &lt;endian.h&gt;"|v33
  v70-->|"#include &lt;endian.h&gt;"|v33
  v33-->|"#include &lt;bits/endian.h&gt;"|v34
  v43-->|"#include &lt;bits/endian.h&gt;"|v34
  v34-->|"#include &lt;bits/endianness.h&gt;"|v35
  v33-->|"#include &lt;bits/byteswap.h&gt;"|v36
  v70-->|"#include &lt;bits/byteswap.h&gt;"|v36
  v33-->|"#include &lt;bits/uintn-identity.h&gt;"|v37
  v70-->|"#include &lt;bits/uintn-identity.h&gt;"|v37
  v26-->|"#include &lt;sys/select.h&gt;"|v38
  v50-->|"#include &lt;sys/select.h&gt;"|v38
  v38-->|"#include &lt;bits/select.h&gt;"|v39
  v38-->|"#include &lt;bits/types/sigset_t.h&gt;"|v40
  v40-->|"#include &lt;bits/types/__sigset_t.h&gt;"|v41
  v38-->|"#include &lt;bits/types/struct_timeval.h&gt;"|v42
  v50-->|"#include &lt;bits/types/struct_timeval.h&gt;"|v42
  v38-->|"#include &lt;bits/types/struct_timespec.h&gt;"|v43
  v26-->|"#include &lt;bits/pthreadtypes.h&gt;"|v44
  v44-->|"#include &lt;bits/thread-shared-types.h&gt;"|v45
  v45-->|"#include &lt;bits/pthreadtypes-arch.h&gt;"|v46
  v45-->|"#include &lt;bits/atomic_wide_counter.h&gt;"|v47
  v45-->|"#include &lt;bits/struct_mutex.h&gt;"|v48
  v45-->|"#include &lt;bits/struct_rwlock.h&gt;"|v49
  v0-->|"#include &lt;sys/time.h&gt;"|v50
  v0-->|"#include &lt;pcap/socket.h&gt;"|v51
  v51-->|"#include &lt;sys/socket.h&gt;"|v52
  v70-->|"#include &lt;sys/socket.h&gt;"|v52
  v52-->|"#include &lt;bits/types/struct_iovec.h&gt;"|v53
  v52-->|"#include &lt;bits/socket.h&gt;"|v54
  v54-->|"#include &lt;bits/socket_type.h&gt;"|v55
  v54-->|"#include &lt;bits/sockaddr.h&gt;"|v56
  v54-->|"#include &lt;asm/socket.h&gt;"|v57
  v57-->|"#include &lt;asm-generic/socket.h&gt;"|v58
  v58-->|"#include &lt;linux/posix_types.h&gt;"|v59
  v59-->|"#include &lt;linux/stddef.h&gt;"|v60
  v59-->|"#include &lt;asm/posix_types.h&gt;"|v61
  v61-->|"#include &lt;asm/posix_types_64.h&gt;"|v62
  v62-->|"#include &lt;asm-generic/posix_types.h&gt;"|v63
  v63-->|"#include &lt;asm/bitsperlong.h&gt;"|v64
  v64-->|"#include &lt;asm-generic/bitsperlong.h&gt;"|v65
  v58-->|"#include &lt;asm/sockios.h&gt;"|v66
  v66-->|"#include &lt;asm-generic/sockios.h&gt;"|v67
  v52-->|"#include &lt;bits/types/struct_osockaddr.h&gt;"|v68
  v51-->|"#include &lt;netdb.h&gt;"|v69
  v51-->|"#include &lt;netinet/in.h&gt;"|v70
  v69-->|"#include &lt;netinet/in.h&gt;"|v70
  v74-->|"#include &lt;netinet/in.h&gt;"|v70
  v70-->|"#include &lt;bits/in.h&gt;"|v71
  v69-->|"#include &lt;rpc/netdb.h&gt;"|v72
  v69-->|"#include &lt;bits/netdb.h&gt;"|v73
  v51-->|"#include &lt;arpa/inet.h&gt;"|v74
  v0-->|"#include &lt;pcap/bpf.h&gt;"|v75
  v75-->|"#include &lt;pcap/dlt.h&gt;"|v76
  v0-->|"#include &lt;stdio.h&gt;"|v77
  v31-->|"#include &lt;__stddef_null.h&gt;"|v78
  v77-->|"#include &lt;stdarg.h&gt;"|v79
  v79-->|"#include &lt;__stdarg___gnuc_va_list.h&gt;"|v80
  v77-->|"#include &lt;bits/types/__fpos_t.h&gt;"|v81
  v81-->|"#include &lt;bits/types/__mbstate_t.h&gt;"|v82
  v83-->|"#include &lt;bits/types/__mbstate_t.h&gt;"|v82
  v77-->|"#include &lt;bits/types/__fpos64_t.h&gt;"|v83
  v77-->|"#include &lt;bits/types/__FILE.h&gt;"|v84
  v77-->|"#include &lt;bits/types/FILE.h&gt;"|v85
  v77-->|"#include &lt;bits/types/struct_FILE.h&gt;"|v86
  v77-->|"#include &lt;bits/types/cookie_io_functions_t.h&gt;"|v87
  v77-->|"#include &lt;bits/stdio_lim.h&gt;"|v88
  v77-->|"#include &lt;bits/floatn.h&gt;"|v89
  v89-->|"#include &lt;bits/floatn-common.h&gt;"|v90
```

Users may want to use `--show-main-header-dirs` to only show the headers for the project being translated, not including dependencies or the standard library):

```
$ cabal run hs-bindgen-cli -- info include-graph \
    --gnu \
    --show-main-header-dirs \
    pcap/pcap.h
```

```mermaid
graph TD;
  v75["/usr/include/pcap/bpf.h"]
  v3["/usr/include/pcap/compiler-tests.h"]
  v76["/usr/include/pcap/dlt.h"]
  v2["/usr/include/pcap/funcattrs.h"]
  v4["/usr/include/pcap/pcap-inttypes.h"]
  v0["/usr/include/pcap/pcap.h"]
  v51["/usr/include/pcap/socket.h"]
  v0-->|"#include &lt;pcap/funcattrs.h&gt;"|v2
  v75-->|"#include &lt;pcap/funcattrs.h&gt;"|v2
  v2-->|"#include &lt;pcap/compiler-tests.h&gt;"|v3
  v0-->|"#include &lt;pcap/pcap-inttypes.h&gt;"|v4
  v0-->|"#include &lt;pcap/socket.h&gt;"|v51
  v0-->|"#include &lt;pcap/bpf.h&gt;"|v75
  v75-->|"#include &lt;pcap/dlt.h&gt;"|v76
```

Note that the resulting graph is not necessary (weakly) connected, especially when using `#include_next`.  I do not think that this is an issue, however.  Users can always use predicates to show headers needed to make a graph connected.