### PR TITLE
Move to `hs-bindgen-cli internal frontend`

### DIFF
--- a/hs-bindgen/app/HsBindgen/Cli/Internal.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Internal.hs
@@ -16,7 +16,7 @@ module HsBindgen.Cli.Internal (
 import Options.Applicative hiding (info)
 
 import HsBindgen.App
-import HsBindgen.Cli.Internal.Parse qualified as Parse
+import HsBindgen.Cli.Internal.Frontend qualified as Frontend
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -31,11 +31,11 @@ info = progDesc "Internal commands, for hs-bindgen development"
 
 -- Ordered lexicographically
 newtype Cmd =
-    CmdParse Parse.Opts
+    CmdFrontend Frontend.Opts
 
 parseCmd :: Parser Cmd
 parseCmd = subparser $ mconcat [
-      cmd "parse" CmdParse Parse.parseOpts Parse.info
+      cmd "frontend" CmdFrontend Frontend.parseOpts Frontend.info
     ]
 
 {-------------------------------------------------------------------------------
@@ -44,4 +44,4 @@ parseCmd = subparser $ mconcat [
 
 exec :: GlobalOpts -> Cmd -> IO ()
 exec gopts = \case
-    CmdParse opts -> Parse.exec gopts opts
+    CmdFrontend opts -> Frontend.exec gopts opts

--- a/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
@@ -1,9 +1,9 @@
--- | @hs-bindgen-cli internal parse@ command
+-- | @hs-bindgen-cli internal frontend@ command
 --
 -- Intended for qualified import.
 --
--- > import HsBindgen.Cli.Internal.Parse qualified as Parse
-module HsBindgen.Cli.Internal.Parse (
+-- > import HsBindgen.Cli.Internal.Frontend qualified as Frontend
+module HsBindgen.Cli.Internal.Frontend (
     -- * CLI help
     info
     -- * Options
@@ -23,7 +23,7 @@ import HsBindgen.Lib
 -------------------------------------------------------------------------------}
 
 info :: InfoMod a
-info = progDesc "Parse C headers"
+info = progDesc "Parse C headers (all Frontend passes)"
 
 {-------------------------------------------------------------------------------
   Options

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -271,7 +271,7 @@ executable hs-bindgen-cli
       HsBindgen.Cli.Info.Libclang
       HsBindgen.Cli.Info.ResolveHeader
       HsBindgen.Cli.Internal
-      HsBindgen.Cli.Internal.Parse
+      HsBindgen.Cli.Internal.Frontend
       HsBindgen.Cli.Preprocess
       HsBindgen.Cli.ToolSupport
       HsBindgen.Cli.ToolSupport.Literate


### PR DESCRIPTION
The name `parse` is potentially confusing.  This command outputs the declarations after all of the `Frontend` passes, not just the `Parse` pass.