### PR TITLE
Detect and reject function declarations where the type of the declaration is a typedef reference.

### DIFF
--- a/hs-bindgen/examples/golden/typedefs.h
+++ b/hs-bindgen/examples/golden/typedefs.h
@@ -1,2 +1,6 @@
 typedef int myint;
 typedef int * intptr;
+
+// Unsupported function with a typedef type. See issue #1034.
+typedef int int2int(int);
+extern int2int foo;

--- a/hs-bindgen/fixtures/typedefs.bindingspec.yaml
+++ b/hs-bindgen/fixtures/typedefs.bindingspec.yaml
@@ -3,6 +3,10 @@ version:
   binding_specification: '1.0'
 types:
 - headers: typedefs.h
+  cname: int2int
+  module: Example
+  identifier: Int2int
+- headers: typedefs.h
   cname: intptr
   module: Example
   identifier: Intptr

--- a/hs-bindgen/fixtures/typedefs.hs
+++ b/hs-bindgen/fixtures/typedefs.hs
@@ -307,4 +307,71 @@
         "@NsTypeConstr"
         "Intptr",
       deriveInstanceComment =
-      Nothing}]
+      Nothing},
+  DeclNewtype
+    Newtype {
+      newtypeName = Name
+        "@NsTypeConstr"
+        "Int2int",
+      newtypeConstr = Name
+        "@NsConstr"
+        "Int2int",
+      newtypeField = Field {
+        fieldName = Name
+          "@NsVar"
+          "un_Int2int",
+        fieldType = HsFun
+          (HsPrimType HsPrimCInt)
+          (HsIO (HsPrimType HsPrimCInt)),
+        fieldOrigin = GeneratedField,
+        fieldComment = Nothing},
+      newtypeOrigin = Decl {
+        declInfo = DeclInfo {
+          declLoc = "typedefs.h:5:13",
+          declId = NamePair {
+            nameC = Name "int2int",
+            nameHsIdent = Identifier
+              "Int2int"},
+          declOrigin = NameOriginInSource,
+          declAliases = [],
+          declHeaderInfo = Just
+            HeaderInfo {
+              headerMainHeaders = NE.fromList
+                ["typedefs.h"],
+              headerInclude = "typedefs.h"},
+          declComment = Nothing},
+        declKind = Typedef
+          Typedef {
+            typedefNames = NewtypeNames {
+              newtypeConstr = Name
+                "@NsConstr"
+                "Int2int",
+              newtypeField = Name
+                "@NsVar"
+                "un_Int2int"},
+            typedefType = TypeFun
+              [
+                TypePrim
+                  (PrimIntegral PrimInt Signed)]
+              (TypePrim
+                (PrimIntegral PrimInt Signed))},
+        declSpec = DeclSpec
+          TypeSpec {
+            typeSpecModule = Nothing,
+            typeSpecIdentifier = Nothing,
+            typeSpecInstances = Map.fromList
+              []}},
+      newtypeInstances = Set.fromList
+        [],
+      newtypeComment = Just
+        Comment {
+          commentTitle = Nothing,
+          commentOrigin = Just "int2int",
+          commentLocation = Just
+            "typedefs.h:5:13",
+          commentHeaderInfo = Just
+            HeaderInfo {
+              headerMainHeaders = NE.fromList
+                ["typedefs.h"],
+              headerInclude = "typedefs.h"},
+          commentChildren = []}}]

--- a/hs-bindgen/fixtures/typedefs.pp.hs
+++ b/hs-bindgen/fixtures/typedefs.pp.hs
@@ -10,7 +10,7 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import Data.Bits (FiniteBits)
-import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
+import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @myint@
 
@@ -35,3 +35,13 @@ newtype Intptr = Intptr
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable)
+
+{-| __C declaration:__ @int2int@
+
+    __defined at:__ @typedefs.h:5:13@
+
+    __exported by:__ @typedefs.h@
+-}
+newtype Int2int = Int2int
+  { un_Int2int :: FC.CInt -> IO FC.CInt
+  }

--- a/hs-bindgen/fixtures/typedefs.rs
+++ b/hs-bindgen/fixtures/typedefs.rs
@@ -2,3 +2,9 @@
 
 pub type myint = ::std::os::raw::c_int;
 pub type intptr = *mut ::std::os::raw::c_int;
+pub type int2int = ::std::option::Option<
+    unsafe extern "C" fn(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
+>;
+unsafe extern "C" {
+    pub fn foo(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}

--- a/hs-bindgen/fixtures/typedefs.th.txt
+++ b/hs-bindgen/fixtures/typedefs.th.txt
@@ -39,3 +39,17 @@ newtype Intptr
       -}
     deriving stock (Eq, Ord, Show)
     deriving newtype Storable
+{-| __C declaration:__ @int2int@
+
+    __defined at:__ @typedefs.h:5:13@
+
+    __exported by:__ @typedefs.h@
+-}
+newtype Int2int
+    = Int2int {un_Int2int :: (CInt -> IO CInt)}
+      {- ^ __C declaration:__ @int2int@
+
+           __defined at:__ @typedefs.h:5:13@
+
+           __exported by:__ @typedefs.h@
+      -}

--- a/hs-bindgen/fixtures/typedefs.tree-diff.txt
+++ b/hs-bindgen/fixtures/typedefs.tree-diff.txt
@@ -64,5 +64,41 @@ TranslationUnit {
           typeSpecModule = Nothing,
           typeSpecIdentifier = Nothing,
           typeSpecInstances = Map.fromList
+            []}},
+    Decl {
+      declInfo = DeclInfo {
+        declLoc = "typedefs.h:5:13",
+        declId = NamePair {
+          nameC = Name "int2int",
+          nameHsIdent = Identifier
+            "Int2int"},
+        declOrigin = NameOriginInSource,
+        declAliases = [],
+        declHeaderInfo = Just
+          HeaderInfo {
+            headerMainHeaders = NE.fromList
+              ["typedefs.h"],
+            headerInclude = "typedefs.h"},
+        declComment = Nothing},
+      declKind = DeclTypedef
+        Typedef {
+          typedefNames = NewtypeNames {
+            newtypeConstr = Name
+              "@NsConstr"
+              "Int2int",
+            newtypeField = Name
+              "@NsVar"
+              "un_Int2int"},
+          typedefType = TypeFun
+            [
+              TypePrim
+                (PrimIntegral PrimInt Signed)]
+            (TypePrim
+              (PrimIntegral PrimInt Signed))},
+      declSpec = DeclSpec
+        TypeSpec {
+          typeSpecModule = Nothing,
+          typeSpecIdentifier = Nothing,
+          typeSpecInstances = Map.fromList
             []}}],
   unitDeps = ["typedefs"]}

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -105,7 +105,6 @@ testCases = [
     , defaultTest "struct_arg"
     , defaultTest "type_qualifiers"
     , defaultTest "typedef_vs_macro"
-    , defaultTest "typedefs"
     , defaultTest "typenames"
     , defaultTest "unions"
     , defaultTest "uses_utf8"
@@ -202,6 +201,11 @@ testCases = [
           Just $ Expected $ Labelled "Squashed" $ C.declIdName (C.declId info)
         TraceFrontend (FrontendHandleTypedefs (HandleTypedefsRenamedTagged info _to)) ->
           Just $ Expected $ Labelled "Renamed"  $ C.declIdName (C.declId info)
+        _otherwise ->
+          Nothing
+    , testTraceCustom "typedefs" ["foo"] $ \case
+        TraceFrontend (FrontendSelect (SelectedButFailed (ParseFunctionOfTypeTypedef info))) ->
+          Just $ Expected $ C.declId info
         _otherwise ->
           Nothing
     , testTraceCustom "varargs" ["f", "g"] $ \case


### PR DESCRIPTION
Resolves #1134

These are currently unsupported. Before, `hs-bindgen` would panic if it found such declarations. Now it traces a warning.