### PR TITLE
Loosen bounds to enable building with Nixpkgs

### DIFF
--- a/ansi-diff/ansi-diff.cabal
+++ b/ansi-diff/ansi-diff.cabal
@@ -42,7 +42,7 @@ library
   build-depends:
     , ansi-terminal
     , base
-    , Diff           ^>=1.0.1.1
+    , Diff           >=0.5 &&  < 2.0
     , primitive
     , transformers
     , edit-distance ^>=0.2.2.1
@@ -56,7 +56,7 @@ benchmark ansi-diff-bench
     , ansi-diff
     , bytestring
     , deepseq
-    , Diff           ^>=1.0.1.1
+    , Diff
     , directory
     , edit-distance
     , filepath

--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -86,4 +86,4 @@ test-suite test-runtime
     , tasty             ^>=1.5
     , tasty-expected-failure ^>= 0.12.3
     , tasty-hunit       ^>=0.10.2
-    , tasty-quickcheck  ^>=0.11.1
+    , tasty-quickcheck  ^>=0.11

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -200,7 +200,7 @@ library internal
     , containers         >= 0.6.5.1    && < 0.8
     , contra-tracer      >= 0.2        && < 0.3
     , cryptohash-sha256  >= 0.11.102.1 && < 0.12
-    , data-default       >= 0.8        && < 0.9
+    , data-default       >= 0.7        && < 0.9
     , debruijn           ^>=0.3.1
     , directory          >= 1.3.6.2    && < 1.4
     , filepath           >= 1.4        && < 1.6
@@ -394,7 +394,7 @@ test-suite test-hs-bindgen
   build-depends:
       -- External dependencies
     , syb              >= 0.7.2.4 && < 0.8
-    , tasty-quickcheck >= 0.11.1  && < 0.12
+    , tasty-quickcheck >= 0.11    && < 0.12
     , temporary        >= 1.3     && < 1.4
 
 test-suite test-th

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Config.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Config.hs
@@ -1,7 +1,6 @@
 module HsBindgen.Backend.Hs.Haddock.Config where
 
-import Data.Default (Default)
-import GHC.Generics (Generic)
+import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------
   Haddock configuration
@@ -16,4 +15,6 @@ data HaddockConfig = HaddockConfig {
 data PathStyle = Short
                | Full
   deriving stock (Show, Eq, Generic)
-  deriving anyclass Default
+
+instance Default PathStyle where
+  def = Short


### PR DESCRIPTION
Required to build `hs-bindgen` with Stackage LTS 23 (which is the basis of Nix).