### PR TITLE
Test LLVM 21 in CI

### DIFF
--- a/.github/actions/base/action.yml
+++ b/.github/actions/base/action.yml
@@ -42,7 +42,7 @@ runs:
         ghc --info
 
     - name: Install LLVM/Clang
-      uses: KyleMayes/install-llvm-action@v2
+      uses: KyleMayes/install-llvm-action@v2.0.8
       with:
         version: ${{ inputs.llvm }}
         directory: ${{ runner.temp }}/llvm

--- a/.github/workflows/haskell-simple-merge-queue.yml
+++ b/.github/workflows/haskell-simple-merge-queue.yml
@@ -41,6 +41,9 @@ jobs:
           - runner: 'ubuntu-latest'
             ghc:    '9.4.8'
             llvm:   '20'
+          - runner: 'ubuntu-latest'
+            ghc:    '9.4.8'
+            llvm:   '21'
           # Vary GHC version from 9.2 to 9.12.
           - runner: 'ubuntu-latest'
             ghc:    '9.2.8'
@@ -68,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run test
+      - name: Build and test `hs-bindgen` and manual
         uses: ./.github/actions/base
         # PRs can only be added to the MQ when all "required" checks pass.
         # PRs can only be merged into `main` when all "required" checks pass in the MQ.

--- a/cabal.project.base
+++ b/cabal.project.base
@@ -2,7 +2,7 @@
 source-repository-package
     type: git
     location: https://github.com/well-typed/libclang
-    tag: d4ae9a5fcca9ae71fcb4df2c0b0ea37c6b15c48c
+    tag: 41f70874b0f803366144059c0ed0f65809e8c385
 
 package clang
   flags: +dev

--- a/dev/dev-environment.md
+++ b/dev/dev-environment.md
@@ -5,10 +5,10 @@ Linux, NixOS, and macOS.
 
 ## General Prerequisites
 
-All platforms require:
+All platforms require (last updated October 9, 2025):
 - GHC 9.4.8 or greater (or compatible version)
 - Cabal (latest version)
-- LLVM/Clang (version 16 recommended)
+- LLVM/Clang (version 14 - 21)
 
 ## Linux (Ubuntu)
 


### PR DESCRIPTION
Manually tested:
- Compile and test `hs-bindgen` on Linux with GHC 9.12 and LLVM 21.

At the moment, `install-llvm-action` only supports LLVM up to version 20 :(.

I have created an issue: https://github.com/KyleMayes/install-llvm-action/issues/92

TODO before merge:
- [x] Merge upstream LLVM 21 PR into `libclang`: https://github.com/well-typed/libclang/pull/12
- [x] Adapt the reference to `libclang` in `project.cabal.base`.
- [x] Bump `install-llvm-action` so that it supports LLVM 21.
- [x] Run merge queue tests in PR view.
- [x] Add LLVM 21 to required checks in GitHub settings.
- [x] Deactivate merge queue tests in PR view (activate them in the merge queue).
- [ ] Merge.