### PR TITLE
Move module from `BackendConfig` to `BootArtefact`

### DIFF
--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -14,6 +14,8 @@ module HsBindgen.App (
   , parseConfigPP
     -- ** Clang arguments
   , parseClangArgsConfig
+    -- ** Module option
+  , parseHsModuleName
     -- ** Output options
   , parseHsOutputDir
   , parseGenBindingSpec
@@ -159,9 +161,7 @@ parseConfig = Config
     <*> parsePathStyle
 
 parseConfigPP :: Parser ConfigPP
-parseConfigPP = ConfigPP
-    <$> optional parseUniqueId
-    <*> parseHsModuleName
+parseConfigPP = ConfigPP <$> optional parseUniqueId
 
 {-------------------------------------------------------------------------------
   Binding specifications
@@ -476,7 +476,7 @@ parseUniqueId = fmap UniqueId . strOption $ mconcat [
     ]
 
 {-------------------------------------------------------------------------------
-  Pretty printer options
+  Module option
 -------------------------------------------------------------------------------}
 
 parseHsModuleName :: Parser Hs.ModuleName
@@ -484,7 +484,7 @@ parseHsModuleName = strOption $ mconcat [
       long "module"
     , metavar "NAME"
     , showDefault
-    , value $ hsModuleOptsBaseName def
+    , value defModuleName
     , help "Base name of the generated Haskell modules"
     ]
 

--- a/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
@@ -20,6 +20,7 @@ import HsBindgen
 import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -33,10 +34,11 @@ info = progDesc "Generate tests for generated Haskell code"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config   :: Config
-    , configPP :: ConfigPP
-    , output   :: FilePath
-    , inputs   :: [UncheckedHashIncludeArg]
+      config       :: Config
+    , configPP     :: ConfigPP
+    , hsModuleName :: Hs.ModuleName
+    , output       :: FilePath
+    , inputs       :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -44,6 +46,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseConfigPP
+      <*> parseHsModuleName
       <*> parseGenTestsOutput
       <*> parseInputs
 
@@ -55,4 +58,4 @@ exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefacts = writeTests output :* Nil
         bindgenConfig = toBindgenConfigPP config configPP
-    void $ hsBindgen tracerConfig bindgenConfig inputs artefacts
+    void $ hsBindgen tracerConfig bindgenConfig hsModuleName inputs artefacts

--- a/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
@@ -20,6 +20,7 @@ import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -33,10 +34,11 @@ info = progDesc "Output the include graph"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config   :: Config
-    , configPP :: ConfigPP
-    , output   :: Maybe FilePath
-    , inputs   :: [UncheckedHashIncludeArg]
+      config       :: Config
+    , configPP     :: ConfigPP
+    , hsModuleName :: Hs.ModuleName
+    , output       :: Maybe FilePath
+    , inputs       :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -44,6 +46,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseConfigPP
+      <*> parseHsModuleName
       <*> optional parseOutput'
       <*> parseInputs
 
@@ -63,4 +66,4 @@ exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefacts = writeIncludeGraph output :* Nil
         bindgenConfig = toBindgenConfigPP config configPP
-    void $ hsBindgen tracerConfig bindgenConfig inputs artefacts
+    void $ hsBindgen tracerConfig bindgenConfig hsModuleName inputs artefacts

--- a/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
@@ -19,6 +19,7 @@ import HsBindgen
 import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -32,9 +33,10 @@ info = progDesc "Parse C headers (all Frontend passes)"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config   :: Config
-    , configPP :: ConfigPP
-    , inputs   :: [UncheckedHashIncludeArg]
+      config       :: Config
+    , configPP     :: ConfigPP
+    , hsModuleName :: Hs.ModuleName
+    , inputs       :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -42,6 +44,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseConfigPP
+      <*> parseHsModuleName
       <*> parseInputs
 
 {-------------------------------------------------------------------------------
@@ -53,5 +56,5 @@ exec GlobalOpts{..} Opts{..} = do
     let artefacts = ReifiedC :* Nil
         bindgenConfig = toBindgenConfigPP config configPP
     (I decls :* Nil) <-
-      hsBindgen tracerConfig bindgenConfig inputs artefacts
+      hsBindgen tracerConfig bindgenConfig hsModuleName inputs artefacts
     print decls

--- a/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
@@ -24,6 +24,7 @@ import HsBindgen.Artefact
 import HsBindgen.Config
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.RootHeader
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -39,6 +40,7 @@ info = progDesc "Generate Haskell module from C headers"
 data Opts = Opts {
       config            :: Config
     , configPP          :: ConfigPP
+    , hsModuleName      :: Hs.ModuleName
     , hsOutputDir       :: FilePath
     , outputBindingSpec :: Maybe FilePath
     , inputs            :: [UncheckedHashIncludeArg]
@@ -51,6 +53,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseConfigPP
+      <*> parseHsModuleName
       <*> parseHsOutputDir
       <*> optional parseGenBindingSpec
       <*> parseInputs
@@ -66,7 +69,7 @@ exec GlobalOpts{..} Opts{..} = void $ run $ (sequenceArtefacts artefacts) :* Nil
     bindgenConfig = toBindgenConfigPP config configPP
 
     run :: Artefacts as -> IO (NP I as)
-    run = hsBindgen tracerConfig bindgenConfig inputs
+    run = hsBindgen tracerConfig bindgenConfig hsModuleName inputs
 
     artefacts :: [Artefact ()]
     artefacts =

--- a/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
@@ -28,6 +28,7 @@ import HsBindgen.Backend.SHs.AST
 import HsBindgen.Config
 import HsBindgen.Errors
 import HsBindgen.Frontend.RootHeader
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -69,11 +70,12 @@ parseOpts = do
 -------------------------------------------------------------------------------}
 
 data Lit = Lit {
-      globalOpts :: GlobalOpts
-    , config     :: Config
-    , configPP   :: ConfigPP
-    , safety     :: Safety
-    , inputs     :: [UncheckedHashIncludeArg]
+      globalOpts   :: GlobalOpts
+    , config       :: Config
+    , configPP     :: ConfigPP
+    , hsModuleName :: Hs.ModuleName
+    , safety       :: Safety
+    , inputs       :: [UncheckedHashIncludeArg]
     }
 
 parseLit :: Parser Lit
@@ -81,6 +83,7 @@ parseLit = Lit
   <$> parseGlobalOpts
   <*> parseConfig
   <*> parseConfigPP
+  <*> parseHsModuleName
   <*> parseSafety
   <*> parseInputs
 
@@ -109,7 +112,7 @@ exec literateOpts = do
       pureParseLit args
     let GlobalOpts{..} = globalOpts
         bindgenConfig = toBindgenConfigPP config configPP
-    void $ hsBindgen tracerConfig bindgenConfig inputs $
+    void $ hsBindgen tracerConfig bindgenConfig hsModuleName inputs $
       writeBindings safety (Just literateOpts.output) :* Nil
   where
     throwIO' :: String -> IO a

--- a/hs-bindgen/src-internal/HsBindgen/Backend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend.hs
@@ -11,6 +11,7 @@ import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.SHs.AST qualified as SHs
 import HsBindgen.Backend.SHs.Simplify qualified as SHs
 import HsBindgen.Backend.SHs.Translation qualified as SHs
+import HsBindgen.Boot
 import HsBindgen.Cache
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend
@@ -22,8 +23,12 @@ import HsBindgen.Util.Tracer
 -- declarations.
 --
 -- The backend is pure and should not emit warnings or errors.
-backend :: Tracer IO BackendMsg -> BackendConfig -> FrontendArtefact -> IO BackendArtefact
-backend tracer BackendConfig{..} FrontendArtefact{..} = do
+backend :: Tracer IO BackendMsg
+  -> BackendConfig
+  -> BootArtefact
+  -> FrontendArtefact
+  -> IO BackendArtefact
+backend tracer BackendConfig{..} BootArtefact{..} FrontendArtefact{..} = do
     -- 1. Reified C declarations to @Hs@ declarations.
     backendHsDecls <- cache $
       Hs.generateDeclarations
@@ -51,7 +56,7 @@ backend tracer BackendConfig{..} FrontendArtefact{..} = do
     , ..
     }
   where
-    moduleBaseName = hsModuleOptsBaseName backendHsModuleOpts
+    moduleBaseName = bootModule
 
     cache :: IO a -> IO (IO a)
     cache = cacheWith (contramap BackendCache tracer) Nothing

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
@@ -8,7 +8,6 @@ module HsBindgen.Backend.HsModule.Translation (
     -- * HsModule
   , HsModule(..)
     -- * Translation
-  , HsModuleOpts(..)
   , defModuleName
   , translateModuleMultiple
   , translateModuleSingle
@@ -69,16 +68,6 @@ data HsModule = HsModule {
 {-------------------------------------------------------------------------------
   Translation
 -------------------------------------------------------------------------------}
-
-data HsModuleOpts = HsModuleOpts {
-      hsModuleOptsBaseName :: Hs.ModuleName
-    }
-  deriving stock (Show, Eq, Generic)
-
-instance Default HsModuleOpts where
-  def = HsModuleOpts {
-      hsModuleOptsBaseName = defModuleName
-    }
 
 defModuleName :: Hs.ModuleName
 defModuleName = "Generated"

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -19,6 +19,7 @@ import HsBindgen.Config.ClangArgs qualified as ClangArgs
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 -- | Boot phase.
@@ -31,9 +32,14 @@ import HsBindgen.Util.Tracer
 boot ::
      Tracer IO BootMsg
   -> BindgenConfig
+  -> Hs.ModuleName
   -> [UncheckedHashIncludeArg]
   -> IO BootArtefact
-boot tracer bindgenConfig@BindgenConfig{..} uncheckedHashIncludeArgs = do
+boot
+  tracer
+  bindgenConfig@BindgenConfig{..}
+  hsModuleName
+  uncheckedHashIncludeArgs = do
     traceStatus $ BootStatusStart bindgenConfig
 
     checkBackendConfig (contramap BootBackendConfig tracer) bindgenBackendConfig
@@ -61,7 +67,8 @@ boot tracer bindgenConfig@BindgenConfig{..} uncheckedHashIncludeArgs = do
       withTrace BootStatusExternalBindingSpec $ fmap snd getBindingSpecs
 
     pure BootArtefact {
-          bootClangArgs               = getClangArgs'
+          bootModule                  = hsModuleName
+        , bootClangArgs               = getClangArgs'
         , bootHashIncludeArgs         = getHashIncludeArgs
         , bootExternalBindingSpec     = getExternalBindingSpec
         , bootPrescriptiveBindingSpec = getPrescriptiveBindingSpec
@@ -100,7 +107,8 @@ getClangArgs tracer config = do
 -------------------------------------------------------------------------------}
 
 data BootArtefact = BootArtefact {
-    bootClangArgs               :: IO ClangArgs
+    bootModule                  :: Hs.ModuleName
+  , bootClangArgs               :: IO ClangArgs
   , bootHashIncludeArgs         :: IO [HashIncludeArg]
   , bootExternalBindingSpec     :: IO ExternalBindingSpec
   , bootPrescriptiveBindingSpec :: IO PrescriptiveBindingSpec

--- a/hs-bindgen/src-internal/HsBindgen/Config.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config.hs
@@ -18,7 +18,6 @@ import Optics.Core ((%), (&), (.~))
 
 import HsBindgen.Backend.Hs.Haddock.Config
 import HsBindgen.Backend.Hs.Translation
-import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Backend.UniqueId
 import HsBindgen.BindingSpec
@@ -27,7 +26,6 @@ import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   Common
@@ -81,28 +79,22 @@ toBindgenConfig Config{..} = BindgenConfig bootConfig frontendConfig backendConf
 
 -- | Configuration specific to preprocessor mode
 data ConfigPP = ConfigPP {
-    uniqueId   :: Maybe UniqueId
-  , moduleName :: Hs.ModuleName
+    uniqueId :: Maybe UniqueId
   }
   deriving stock (Show, Eq, Generic)
 
 instance Default ConfigPP where
   def = ConfigPP {
       uniqueId   = def
-    , moduleName = defModuleName
     }
 
 toBindgenConfigPP :: Config_ FilePath -> ConfigPP -> BindgenConfig
-toBindgenConfigPP config ConfigPP{..} =
-    bindgenConfig & setUniqueId & setModuleName
+toBindgenConfigPP config ConfigPP{..} = bindgenConfig & setUniqueId
   where
     bindgenConfig = toBindgenConfig config
     setUniqueId =
       #bindgenBackendConfig % #backendTranslationOpts % #translationUniqueId
         .~ (fromMaybe def uniqueId)
-    setModuleName =
-      #bindgenBackendConfig % #backendHsModuleOpts % #hsModuleOptsBaseName
-        .~ moduleName
 
 {-------------------------------------------------------------------------------
   Template Haskell

--- a/hs-bindgen/src-internal/HsBindgen/Config/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config/Internal.hs
@@ -13,7 +13,6 @@ module HsBindgen.Config.Internal
 
 import HsBindgen.Backend.Hs.Haddock.Config
 import HsBindgen.Backend.Hs.Translation
-import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.UniqueId
 import HsBindgen.BindingSpec
 import HsBindgen.Config.ClangArgs
@@ -78,7 +77,6 @@ data FrontendConfig = FrontendConfig {
 -- See also the notes at 'FrontendConfig'.
 data BackendConfig = BackendConfig {
       backendTranslationOpts :: TranslationOpts
-    , backendHsModuleOpts    :: HsModuleOpts
     , backendHaddockConfig   :: HaddockConfig
     }
   deriving stock (Show, Eq, Generic)

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -69,6 +69,8 @@ withHsBindgen config ConfigTH{..} hashIncludes = do
 
     bindgenConfig <- toBindgenConfigTH config
 
+    hsModuleName <- fromString . TH.loc_module <$> TH.location
+
     let -- Traverse #include directives.
         bindgenState :: BindgenState
         bindgenState = execState hashIncludes (BindgenState [])
@@ -84,6 +86,7 @@ withHsBindgen config ConfigTH{..} hashIncludes = do
       hsBindgen
         tracerConfigDefTH
         bindgenConfig
+        hsModuleName
         uncheckedHashIncludeArgs
         artefacts
     let decls = mergeDecls safety decls'

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
@@ -264,6 +264,7 @@ runTestHsBindgen' report testResources test artefacts = do
       hsBindgen
         traceConfig
         bindgenConfig
+        "Example"
         [testInputInclude test]
         artefacts
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Resources.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Resources.hs
@@ -24,7 +24,6 @@ import Clang.Args
 
 import HsBindgen.Backend.Hs.Haddock.Config
 import HsBindgen.Backend.Hs.Translation
-import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.UniqueId
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
@@ -112,9 +111,6 @@ getTestDefaultBackendConfig :: TestName -> PathStyle -> BackendConfig
 getTestDefaultBackendConfig testName pathStyle = def{
       backendTranslationOpts = def {
         translationUniqueId = UniqueId $ "test." ++ testName
-      }
-    , backendHsModuleOpts = HsModuleOpts{
-        hsModuleOptsBaseName  = "Example"
       }
     , backendHaddockConfig = HaddockConfig pathStyle
     }


### PR DESCRIPTION
We need the module name in the frontend as well as the backend.  Since the configuration should specify "how" and not "what," this commit removes it from the configuration altogether.  It is instead passed as an argument, like the input headers, and stored in the boot artifact.