### PR TITLE
Fuse macro translation

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -255,6 +255,8 @@ data MacroExpr =
   deriving stock (Generic, Show)
 
 -- | RHS of a variable or function declaration.
+--
+-- TODO: Do we need this, or could we just use SExpr instead?
 type VarDeclRHS :: Ctx -> Star
 data VarDeclRHS ctx
   = VarDeclIntegral Integer HsPrimType

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST/Type.hs
@@ -3,11 +3,7 @@ module HsBindgen.Backend.Hs.AST.Type (
   HsType (..),
   ResultType(..),
   extractResultType,
-  hsPrimIntTy,
-  hsPrimFloatTy
 ) where
-
-import C.Type qualified as CExpr.Runtime
 
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Imports
@@ -89,36 +85,3 @@ extractResultType :: ResultType a -> a
 extractResultType (NormalResultType t) = t
 extractResultType (HeapResultType t)   = t
 
-hsPrimIntTy :: CExpr.Runtime.IntegralType -> HsPrimType
-hsPrimIntTy = \case
-  CExpr.Runtime.Bool -> HsPrimCBool
-  CExpr.Runtime.CharLike c ->
-    case c of
-      CExpr.Runtime.Char  -> HsPrimCChar
-      CExpr.Runtime.SChar -> HsPrimCSChar
-      CExpr.Runtime.UChar -> HsPrimCUChar
-  CExpr.Runtime.IntLike i ->
-    case i of
-      CExpr.Runtime.Short    s ->
-        case s of
-          CExpr.Runtime.Signed   -> HsPrimCShort
-          CExpr.Runtime.Unsigned -> HsPrimCUShort
-      CExpr.Runtime.Int      s ->
-        case s of
-          CExpr.Runtime.Signed   -> HsPrimCInt
-          CExpr.Runtime.Unsigned -> HsPrimCUInt
-      CExpr.Runtime.Long     s ->
-        case s of
-          CExpr.Runtime.Signed   -> HsPrimCLong
-          CExpr.Runtime.Unsigned -> HsPrimCULong
-      CExpr.Runtime.LongLong s ->
-        case s of
-          CExpr.Runtime.Signed   -> HsPrimCLLong
-          CExpr.Runtime.Unsigned -> HsPrimCULLong
-      CExpr.Runtime.PtrDiff    -> HsPrimCPtrDiff
-      CExpr.Runtime.Size       -> HsPrimCSize
-
-hsPrimFloatTy :: CExpr.Runtime.FloatingType -> HsPrimType
-hsPrimFloatTy = \case
-  CExpr.Runtime.FloatType  -> HsPrimCFloat
-  CExpr.Runtime.DoubleType -> HsPrimCDouble


### PR DESCRIPTION
Previously we were translating

* `DSL.MExpr Ps -> Hs.VarDeclRHS EmptyCtx -> SDecl`
* `DSL.Quant (DSL.Type Ty) -> SigmaType -> ClosedType`

Now these translations happen in one step, with the intermediate type eliminated. Indeed, `SigmaType` and associated types are now gone entirely. This also significantly cleans up the translation itself, hopefully the new code is easier to understand and maintain.