### PR TITLE
Use `git ls-files` in the `run-stylish-haskell.sh` script

### DIFF
--- a/scripts/ci/check-stylish-ignore
+++ b/scripts/ci/check-stylish-ignore
@@ -2,7 +2,6 @@
 # Add file paths (relative to project root) that should not be formatted
 # Examples:
 */Setup.hs
-dist-newstyle/**/*.hs
 alternatives/**/*.hs
 hs-bindgen/fixtures/*.hs
 hs-bindgen/src-internal/HsBindgen/Frontend/Macro/**/*

--- a/scripts/ci/run-stylish-haskell.sh
+++ b/scripts/ci/run-stylish-haskell.sh
@@ -86,13 +86,8 @@ command_exists() {
 # ==============================================================================
 
 # Find all Haskell files in the project
-# Uses 'fd' if available for better performance, falls back to 'find'
 find_all_haskell_files() {
-    if command_exists fd; then
-        fd -e "${HASKELL_EXTENSION}" --type f
-    else
-        find . -name "*.${HASKELL_EXTENSION}" -type f
-    fi
+    git ls-files --exclude-standard --no-deleted --deduplicate "*.${HASKELL_EXTENSION}"
 }
 
 # Get uncommitted Haskell files from git


### PR DESCRIPTION
This prevents the script from running `stylish-haskell` on files that are ignored by `git`, such as files in `dist-newstyle/`.`