### PR TITLE
Add `HsBindgen.Runtime.CBoolSem`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -83,6 +83,7 @@
 # These cannot be used in hs-bindgen-runtime because they are defined in hs-bindgen.
 - ignore: {name: "Use panicIO",   within: "HsBindgen.Runtime.**" }
 - ignore: {name: "Use panicPure", within: "HsBindgen.Runtime.**" }
+- ignore: {name: "Use panicPure", within: "Test.HsBindgen.Runtime.**" }
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -45,6 +45,7 @@ library
     HsBindgen.Runtime.Block
     HsBindgen.Runtime.ByteArray
     HsBindgen.Runtime.CAPI
+    HsBindgen.Runtime.CBoolSem
     HsBindgen.Runtime.CEnum
     HsBindgen.Runtime.ConstantArray
     HsBindgen.Runtime.FlexibleArrayMember
@@ -84,6 +85,7 @@ test-suite test-runtime
   main-is:        test-runtime.hs
   other-modules:
     Test.HsBindgen.Runtime.Bitfield
+    Test.HsBindgen.Runtime.CBoolSem
     Test.HsBindgen.Runtime.CEnum
     Test.HsBindgen.Runtime.CEnumArbitrary
     Test.Internal.Tasty
@@ -98,3 +100,4 @@ test-suite test-runtime
     , tasty-expected-failure  ^>=0.12.3
     , tasty-hunit             ^>=0.10.2
     , tasty-quickcheck        ^>=0.11
+    , transformers            >=0.5     && <0.7

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/CBoolSem.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/CBoolSem.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | C boolean semantics
+--
+-- In C, boolean types are numeric, where value @0@ is considered false and any
+-- other value is considered true.  They are implemented differently across
+-- different C projects:
+--
+-- * Since C23, there is a @bool@ type and predefined constants @true@ and
+--   @false@.
+-- * Since C99, standard header @stdbool.h@ defines (implementation-dependent)
+--   type @_Bool@ and macros @true@ and @false@.  This header is deprecated
+--   since C23.
+-- * Before C99, users defined boolean types and values, following the common
+--   conventions.  Some projects still define their own boolean type, perhaps
+--   for compatibility with old C standards.  Common implementations include the
+--   following, where @bool@ may be spelled differently (such as @Bool@ or
+--   @BOOL@):
+--
+--     * An @enum@ type:
+--
+--         @
+--         typedef enum { false, true } bool;
+--         @
+--
+--     * A @typedef@ and /separate/ @enum@ values:
+--
+--         @
+--         typedef int bool;
+--         enum { false, true };
+--         @
+--
+--     * A @typedef@ and macro values:
+--
+--         @
+--         typedef int bool;
+--         #define true 1
+--         #define false 0
+--         @
+--
+--     * A macro alias and macro values:
+--
+--         @
+--         #define bool int
+--         #define true 1
+--         #define false 0
+--         @
+--
+-- This module provides an API that is compatible with bindings generated for
+-- any of these possible implementations.  Note that the implementation only
+-- requires 'Eq' and 'Num' instances.  Conversion follows C23 semantics: /only/
+-- value @0@ is considered false, and any other value is considered true.
+--
+-- Intended for qualified import.
+--
+-- > import HsBindgen.Runtime.CBoolSem qualified as CBoolSem
+module HsBindgen.Runtime.CBoolSem (
+    -- * Values
+    true
+  , false
+    -- * Predicates
+  , isTrue
+  , isFalse
+    -- * Conversion
+  , fromBool
+  , toBool
+    -- * Operations
+  , (&&)
+  , (||)
+  , not
+  , bool
+  , if_
+  , when
+  , unless
+  ) where
+
+import Prelude hiding (not, (&&), (||))
+import Prelude qualified
+
+{-------------------------------------------------------------------------------
+  Values
+-------------------------------------------------------------------------------}
+
+-- | Standard true value: @1@
+true :: Num b => b
+true = 1
+
+-- | Standard false value: @0@
+false :: Num b => b
+false = 0
+
+{-------------------------------------------------------------------------------
+  Predicates
+-------------------------------------------------------------------------------}
+
+-- | 'True' if the value is not @0@
+isTrue :: (Eq b, Num b) => b -> Bool
+isTrue = (/= false)
+
+-- | 'True' if the value is @0@
+isFalse :: (Eq b, Num b) => b -> Bool
+isFalse = (== false)
+
+{-------------------------------------------------------------------------------
+  Conversion
+-------------------------------------------------------------------------------}
+
+-- | Convert from 'Bool' to 'true' or 'false'
+fromBool :: Num b => Bool -> b
+fromBool True  = true
+fromBool False = false
+
+-- | Convert to 'Bool' using 'isTrue'
+toBool :: (Eq b, Num b) => b -> Bool
+toBool = isTrue
+
+{-------------------------------------------------------------------------------
+  Operations
+-------------------------------------------------------------------------------}
+
+-- | Boolean /and/, lazy in the second argument
+--
+-- This function returns one of the standard values.
+(&&) :: (Eq b, Num b) => b -> b -> b
+l && r = fromBool $ toBool l Prelude.&& toBool r
+
+-- | Boolean /or/, lazy in the second argument
+--
+-- This function returns one of the standard values.
+(||) :: (Eq b, Num b) => b -> b -> b
+l || r = fromBool $ toBool l Prelude.|| toBool r
+
+-- | Boolean /not/
+--
+-- This function returns one of the standard values.
+not :: (Eq b, Num b) => b -> b
+not = fromBool . Prelude.not . toBool
+
+-- | Boolean case analysis, implemented using 'isTrue'
+--
+-- See 'Data.Bool.bool' for details.
+bool :: (Eq b, Num b) => a -> a -> b -> a
+bool f t b = if isTrue b then t else f
+
+-- | Boolean case analysis, implemented using 'isTrue'
+if_ :: (Eq b, Num b) => b -> a -> a -> a
+if_ b t f = if isTrue b then t else f
+
+-- | Execute an applicative expression when the condition 'isTrue'
+when :: (Eq b, Num b, Applicative f) => b -> f () -> f ()
+when b e = if isTrue b then e else pure ()
+{-# ANN when ("HLint: ignore Use when" :: String) #-}
+
+-- | Execute an applicative expression when the condition 'ifFalse'
+unless :: (Eq b, Num b, Applicative f) => b -> f () -> f ()
+unless b e = if isFalse b then e else pure ()
+{-# ANN unless ("HLint: ignore Use when" :: String) #-}

--- a/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CBoolSem.hs
+++ b/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/CBoolSem.hs
@@ -1,0 +1,134 @@
+module Test.HsBindgen.Runtime.CBoolSem (tests) where
+
+import Control.Monad.Trans.Writer.Strict (Writer, execWriter, tell)
+import Data.Monoid (Sum (getSum))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
+
+import HsBindgen.Runtime.CBoolSem qualified as CBoolSem
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "HsBindgen.Runtime.CBoolSem" [
+      testTrue
+    , testFalse
+    , testIsTrue
+    , testIsFalse
+    , testFromBool
+    , testToBool
+    , testAnd
+    , testOr
+    , testNot
+    , testBool
+    , testIf_
+    , testWhen
+    , testUnless
+    ]
+
+newtype TestBool = TestBool Int
+  deriving newtype (Eq, Num, Show) -- do not add any more instances
+
+testTrue :: TestTree
+testTrue = testCase "true" $ TestBool 1 @=? CBoolSem.true
+
+testFalse :: TestTree
+testFalse = testCase "false" $ TestBool 0 @=? CBoolSem.false
+
+testIsTrue :: TestTree
+testIsTrue = testGroup "isTrue" [
+      testCase "0"   $ False @=? CBoolSem.isTrue @TestBool 0
+    , testCase "1"   $ True  @=? CBoolSem.isTrue @TestBool 1
+    , testCase "2"   $ True  @=? CBoolSem.isTrue @TestBool 2
+    , testCase "0.1" $ True  @=? CBoolSem.isTrue @Float    0.1
+    ]
+
+testIsFalse :: TestTree
+testIsFalse = testGroup "isFalse" [
+      testCase "0"   $ True  @=? CBoolSem.isFalse @TestBool 0
+    , testCase "1"   $ False @=? CBoolSem.isFalse @TestBool 1
+    , testCase "2"   $ False @=? CBoolSem.isFalse @TestBool 2
+    , testCase "0.1" $ False @=? CBoolSem.isFalse @Float    0.1
+    ]
+
+testFromBool :: TestTree
+testFromBool = testGroup "fromBool" [
+      testCase "True"  $ TestBool 1 @=? CBoolSem.fromBool True
+    , testCase "False" $ TestBool 0 @=? CBoolSem.fromBool False
+    ]
+
+testToBool :: TestTree
+testToBool = testGroup "toBool" [
+      testCase "0"   $ False @=? CBoolSem.toBool @TestBool 0
+    , testCase "1"   $ True  @=? CBoolSem.toBool @TestBool 1
+    , testCase "2"   $ True  @=? CBoolSem.toBool @TestBool 2
+    , testCase "0.1" $ True  @=? CBoolSem.toBool @Float    0.1
+    ]
+
+testAnd :: TestTree
+testAnd = testGroup "(&&)" [
+      testCase "bothT"  $ TestBool 1 @=? TestBool 2 CBoolSem.&& TestBool 3
+    , testCase "leftF"  $ TestBool 0 @=? TestBool 0 CBoolSem.&& undefined
+    , testCase "rightF" $ TestBool 0 @=? TestBool 1 CBoolSem.&& TestBool 0
+    ]
+
+testOr :: TestTree
+testOr = testGroup "(||)" [
+      testCase "bothF"  $ TestBool 0 @=? TestBool 0 CBoolSem.|| TestBool 0
+    , testCase "leftT"  $ TestBool 1 @=? TestBool 2 CBoolSem.|| undefined
+    , testCase "rightT" $ TestBool 1 @=? TestBool 0 CBoolSem.|| TestBool 2
+    ]
+
+testNot :: TestTree
+testNot = testGroup "not" [
+      testCase "0"   $ TestBool 1 @=? CBoolSem.not @TestBool 0
+    , testCase "1"   $ TestBool 0 @=? CBoolSem.not @TestBool 1
+    , testCase "2"   $ TestBool 0 @=? CBoolSem.not @TestBool 2
+    , testCase "0.1" $ 0.0        @=? CBoolSem.not @Float    0.1
+    ]
+
+testBool :: TestTree
+testBool = testGroup "bool" [
+      testCase "0"   $ 'f' @=? CBoolSem.bool @TestBool 'f' 't' 0
+    , testCase "1"   $ 't' @=? CBoolSem.bool @TestBool 'f' 't' 1
+    , testCase "2"   $ 't' @=? CBoolSem.bool @TestBool 'f' 't' 2
+    , testCase "0.1" $ 't' @=? CBoolSem.bool @Float    'f' 't' 0.1
+    ]
+
+testIf_ :: TestTree
+testIf_ = testGroup "if_" [
+      testCase "0"   $ 'f' @=? CBoolSem.if_ @TestBool 0   't' 'f'
+    , testCase "1"   $ 't' @=? CBoolSem.if_ @TestBool 1   't' 'f'
+    , testCase "2"   $ 't' @=? CBoolSem.if_ @TestBool 2   't' 'f'
+    , testCase "0.1" $ 't' @=? CBoolSem.if_ @Float    0.1 't' 'f'
+    ]
+
+testWhen :: TestTree
+testWhen = testGroup "when" [
+      testCase "0"   $ 0 @=? aux (CBoolSem.when @TestBool 0   act)
+    , testCase "1"   $ 1 @=? aux (CBoolSem.when @TestBool 1   act)
+    , testCase "2"   $ 1 @=? aux (CBoolSem.when @TestBool 1   act)
+    , testCase "0.1" $ 1 @=? aux (CBoolSem.when @Float    0.1 act)
+    ]
+  where
+    aux :: Writer (Sum Int) () -> Int
+    aux = getSum . execWriter
+
+    act :: Writer (Sum Int) ()
+    act = tell (pure 1)
+
+testUnless :: TestTree
+testUnless = testGroup "unless" [
+      testCase "0"   $ 1 @=? aux (CBoolSem.unless @TestBool 0   act)
+    , testCase "1"   $ 0 @=? aux (CBoolSem.unless @TestBool 1   act)
+    , testCase "2"   $ 0 @=? aux (CBoolSem.unless @TestBool 1   act)
+    , testCase "0.1" $ 0 @=? aux (CBoolSem.unless @Float    0.1 act)
+    ]
+  where
+    aux :: Writer (Sum Int) () -> Int
+    aux = getSum . execWriter
+
+    act :: Writer (Sum Int) ()
+    act = tell (pure 1)

--- a/hs-bindgen-runtime/test/test-runtime.hs
+++ b/hs-bindgen-runtime/test/test-runtime.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Test.HsBindgen.Runtime.Bitfield qualified
+import Test.HsBindgen.Runtime.CBoolSem qualified
 import Test.HsBindgen.Runtime.CEnum qualified
 import Test.Tasty (defaultMain, testGroup)
 
@@ -11,5 +12,6 @@ import Test.Tasty (defaultMain, testGroup)
 main :: IO ()
 main = defaultMain $ testGroup "test-runtime" [
       Test.HsBindgen.Runtime.Bitfield.tests
+    , Test.HsBindgen.Runtime.CBoolSem.tests
     , Test.HsBindgen.Runtime.CEnum.tests
     ]


### PR DESCRIPTION
Dealing with bindings for the various C boolean implementations is annoying.  I ran into it while working on `taglib` bindings, which defines a custom boolean type using a macro.  This runtime module should support *all* C boolean bindings, as long as they have `Eq` and `Num` instances.  This of course includes `CBool`.

Thoughts?