### PR TITLE
Add a configure step to the `examples` workflow file

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -71,14 +71,25 @@ jobs:
     #
     # NOTE: the use of "cabal build all" is intentional.
 
+    - name: 🛠️ Configure (hs-bindgen-cli)
+      run: |
+        cabal configure --disable-test --disable-benchmark --disable-documentation --ghc-options="-Werror"
+        cat "cabal.project.local"
+
+    - name: 🛠️ Configure (${{ matrix.example }})
+      working-directory: ${{ env.hs-project-directory }}
+      run: |
+        cabal configure --disable-test --disable-benchmark --disable-documentation --ghc-options="-Werror"
+        cat "cabal.project.local"
+
     - name: 💾 Generate Cabal plan (hs-bindgen-cli)
       run: |
-        cabal build all --dry-run --disable-test --disable-benchmark
+        cabal build all --dry-run
 
     - name: 💾 Generate Cabal plan (${{ matrix.example }})
       working-directory: ${{ env.hs-project-directory }}
       run: |
-        cabal build all --dry-run --disable-test --disable-benchmark
+        cabal build all --dry-run
 
     # Here is where we hash the two build plan files together and include the
     # hash in the cache key. If either build plan changes, then the hash
@@ -103,12 +114,12 @@ jobs:
 
     - name: 🛠️ Build Cabal dependencies (hs-bindgen-cli)
       run: |
-        cabal build all --only-dependencies --disable-test --disable-benchmark
+        cabal build all --only-dependencies
 
     - name: 🛠️ Build Cabal dependencies (${{ matrix.example }})
       working-directory: ${{ env.hs-project-directory }}
       run: |
-        cabal build all --only-dependencies --disable-test --disable-benchmark
+        cabal build all --only-dependencies
 
     # Only save a new cache if it does not exist yet
     - name: 💾 Save Cabal dependencies
@@ -120,7 +131,7 @@ jobs:
 
     - name: 🏗️ Build (hs-bindgen-cli)
       run: |
-        cabal build hs-bindgen-cli --disable-test --disable-benchmark
+        cabal build hs-bindgen-cli
 
     - name: 🧪 Debug (hs-bindgen-cli)
       run: |

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,9 +73,9 @@ as the following requirements are met:
     the generated modules into the Haskell project
   * The script should make sure that the Haskell package can find the installed
     `libfoo` package. For locally installed packages, this probably means
-    setting `LD_LIBRARY_PATH` and adding a
-    `REPOSITORY_ROOT/examples/libfoo/hs-project/cabal.project.local` file that
-    includes:
+    setting `LD_LIBRARY_PATH` and updating the
+    `REPOSITORY_ROOT/examples/libfoo/hs-project/cabal.project.local` file so
+    that it includes:
     ```
     package libfoo
       extra-include-dirs:
@@ -83,6 +83,9 @@ as the following requirements are met:
       extra-lib-dirs:
         -- insert absolute path to installation directory for dll files here
     ```
+    If a `cabal.project.local` file already exists, then the file should be
+    updated to include the lines above. Otherwise, it should create the file
+    with the lines above.
   * The script should run the Haskell executable
 * Add a composite action by creating a new file at
    `REPOSITORY_ROOT/.github/actions/examples/libfoo.action.yml`

--- a/examples/botan/generate-and-run.sh
+++ b/examples/botan/generate-and-run.sh
@@ -34,16 +34,19 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     "botan/ffi.h"
 
 echo "# "
-echo "# Creating cabal.project.local"
+echo "# Updating cabal.project.local"
 echo "# "
 
-cat >"$SCRIPT_DIR/hs-project/cabal.project.local" <<EOF
+LINE=$(cat <<-EOF
 package botan
     extra-include-dirs:
         $BOTAN_DIR/build/include/public
     extra-lib-dirs:
         $BOTAN_DIR
 EOF
+)
+grep -qxF "$LINE" "$SCRIPT_DIR/hs-project/cabal.project.local" || echo "$LINE" >> "$SCRIPT_DIR/hs-project/cabal.project.local"
+cat "$SCRIPT_DIR/hs-project/cabal.project.local"
 
 echo "# "
 echo "# Done!"

--- a/examples/c-minisat/generate-and-run.sh
+++ b/examples/c-minisat/generate-and-run.sh
@@ -40,10 +40,10 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     "minisat.h"
 
 echo "# "
-echo "# Creating cabal.project.local"
+echo "# Updating cabal.project.local"
 echo "# "
 
-cat >"$SCRIPT_DIR/hs-project/cabal.project.local" <<EOF
+LINE=$(cat <<-EOF
 package c-minisat
     extra-include-dirs:
         $SCRIPT_DIR/minisat-c-bindings
@@ -52,6 +52,9 @@ package c-minisat
         $SCRIPT_DIR/minisat-c-bindings
       , $SCRIPT_DIR/minisat-c-bindings/build/dynamic/lib
 EOF
+)
+grep -qxF "$LINE" "$SCRIPT_DIR/hs-project/cabal.project.local" || echo "$LINE" >> "$SCRIPT_DIR/hs-project/cabal.project.local"
+cat "$SCRIPT_DIR/hs-project/cabal.project.local"
 
 echo "# "
 echo "# Done!"

--- a/examples/libpcap/generate-and-run.sh
+++ b/examples/libpcap/generate-and-run.sh
@@ -30,16 +30,19 @@ echo "# "
 ./generate.sh
 
 echo "# "
-echo "# Creating cabal.project.local"
+echo "# Updating cabal.project.local"
 echo "# "
 
-cat >hs-project/cabal.project.local <<EOF
+LINE=$(cat <<-EOF
 package libpcap
     extra-include-dirs:
         $LIBPCAP_DIR
     extra-lib-dirs:
         $LIBPCAP_DIR
 EOF
+)
+grep -qxF "$LINE" "$SCRIPT_DIR/hs-project/cabal.project.local" || echo "$LINE" >> "$SCRIPT_DIR/hs-project/cabal.project.local"
+cat "$SCRIPT_DIR/hs-project/cabal.project.local"
 
 echo "# "
 echo "# Done!"


### PR DESCRIPTION
This prevents having to pass `--disable-*` options to cabal everywhere in the
workflow file. As a result, I've also refactored the `generate-and-run.sh`
scripts for the examples to not just overwrite a `cabal.project.local` file with
paths to the C libraries and binaries, but instead append the paths to the file
if it already exists.