### PR TITLE
Add `ResolveBindingSpecs` info traces

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -221,11 +221,14 @@ resolveTop decl = RWS.ask >>= \MEnv{..} -> do
         return Nothing
       else case BindingSpec.lookupCTypeSpec cQualName declPaths envPSpec of
         Just (_hsModuleName, BindingSpec.Require cTypeSpec) -> do
-          RWS.modify' $ deleteNoPType cQualName sourcePath
+          RWS.modify' $
+              insertTrace (ResolveBindingSpecsPrescriptiveRequire cQualName)
+            . deleteNoPType cQualName sourcePath
           return $ Just (decl, Just cTypeSpec)
         Just (_hsModuleName, BindingSpec.Omit) -> do
           RWS.modify' $
-              deleteNoPType cQualName sourcePath
+              insertTrace (ResolveBindingSpecsPrescriptiveOmit cQualName)
+            . deleteNoPType cQualName sourcePath
             . insertOmittedType cQualName sourcePath
           return Nothing
         Nothing -> return $ Just (decl, Nothing)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -71,6 +71,8 @@ data ResolveBindingSpecsMsg =
   | ResolveBindingSpecsTypeNotUsed          C.QualName
   | ResolveBindingSpecsExtDecl              C.QualName
   | ResolveBindingSpecsExtType              C.QualName C.QualName
+  | ResolveBindingSpecsPrescriptiveRequire  C.QualName
+  | ResolveBindingSpecsPrescriptiveOmit     C.QualName
   deriving stock (Show)
 
 instance PrettyForTrace ResolveBindingSpecsMsg where
@@ -97,6 +99,12 @@ instance PrettyForTrace ResolveBindingSpecsMsg where
           <+> prettyForTrace ctx
           <+> "type replaced with external binding:"
           <+> prettyForTrace cQualName
+      ResolveBindingSpecsPrescriptiveRequire cQualName ->
+        "prescriptive binding specification found:"
+          <+> prettyForTrace cQualName
+      ResolveBindingSpecsPrescriptiveOmit cQualName ->
+        "declaration omitted by prescriptive binding specification:"
+          <+> prettyForTrace cQualName
 
 instance IsTrace Level ResolveBindingSpecsMsg where
   getDefaultLogLevel = \case
@@ -106,5 +114,7 @@ instance IsTrace Level ResolveBindingSpecsMsg where
     ResolveBindingSpecsTypeNotUsed{}          -> Error
     ResolveBindingSpecsExtDecl{}              -> Info
     ResolveBindingSpecsExtType{}              -> Info
+    ResolveBindingSpecsPrescriptiveRequire{}  -> Info
+    ResolveBindingSpecsPrescriptiveOmit{}     -> Info
   getSource          = const HsBindgen
   getTraceId         = const "resolve-binding-specs"


### PR DESCRIPTION
I wanted more information while looking at #1240.  This PR adds four trace messages, currently all `Info`.  The following pretty instance code is a good description:

```haskell
      ResolveBindingSpecsExtDecl cQualName ->
        "declaration with external binding dropped:"
          <+> prettyForTrace cQualName
      ResolveBindingSpecsExtType ctx cQualName ->
        "within declaration"               
          <+> prettyForTrace ctx
          <+> "type replaced with external binding:"
          <+> prettyForTrace cQualName
      ResolveBindingSpecsPrescriptiveRequire cQualName ->
        "prescriptive binding specification found:"
          <+> prettyForTrace cQualName
      ResolveBindingSpecsPrescriptiveOmit cQualName ->
        "declaration omitted by prescriptive binding specification:"
          <+> prettyForTrace cQualName
```