### PR TITLE
Add `bool` to `stdlib` external binding spec

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
@@ -46,7 +46,8 @@ bindingSpec = BindingSpec.BindingSpec{..}
     bindingSpecCTypes  :: CTypeMap
     bindingSpecHsTypes :: HsTypeMap
     (bindingSpecCTypes, bindingSpecHsTypes) = mkMaps $
-         integralTypes
+         boolTypes
+      ++ integralTypes
       ++ floatingTypes
       ++ mathTypes
       ++ stdTypes
@@ -55,6 +56,11 @@ bindingSpec = BindingSpec.BindingSpec{..}
       ++ timeTypes
       ++ fileTypes
       ++ signalTypes
+
+    boolTypes :: [(CTypeKV, HsTypeKV)]
+    boolTypes = [
+        mkTypeN "bool" "CBool" cD intI (Just $ BindingSpec.Builtin BFT.CBool) ["stdbool.h"]
+      ]
 
     integralTypes :: [(CTypeKV, HsTypeKV)]
     integralTypes =


### PR DESCRIPTION
I ran into this while looking into #1240.  When I worked on `stdlib`, the `bool` type was already being translated to `CBool`.  This has apparently changed.