### PR TITLE
Remove all external binding dependency edges

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
@@ -127,11 +127,10 @@ getTransitiveDeps = DynGraph.reaches . unwrap
 
 -- | Delete dependencies
 deleteDeps ::
-     C.QualPrelimDeclId
-  -> [C.QualPrelimDeclId]
+     [C.QualPrelimDeclId]
   -> UseDeclGraph
   -> UseDeclGraph
-deleteDeps declId depIds = Wrap . DynGraph.deleteEdges declId depIds . unwrap
+deleteDeps depIds = Wrap . DynGraph.deleteEdgesTo depIds . unwrap
 
 {-------------------------------------------------------------------------------
   Construction auxiliary: sort key


### PR DESCRIPTION
The `ResolveBindingSpecs` pass removes dependency edges from the `UseDeclGraph` when a type is replaced by an external binding.  This needs to be done because the graph is used in the `Select` pass logic.

In the initial implementation, only the dependency edges for the declarations being processed were removed.  The code did not look at every declaration in the graph.

With this change, we now instead remove dependency edges for *all* declarations in the graph.  In the implementation, we already accumulated external binding details in the state.  The `C.QualPrelimDeclId` is added, and the updated `UseDeclGraph` is computed at the end of the pass.