### PR TITLE
Nix: Resolve intricacies when overriding the version of LLVM used

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,9 @@
         "aarch64-darwin"
         "x86_64-darwin"
       ];
-      perSystem = import ./nix/hs-bindgen.nix { inherit nixpkgs overlays; };
+      perSystem = import ./nix/hs-bindgen.nix {
+        inherit nixpkgs libclang-bindings-src;
+      };
       flake.overlays = overlays;
     };
 }

--- a/nix/libclang-bindings.nix
+++ b/nix/libclang-bindings.nix
@@ -1,0 +1,21 @@
+{
+  haskellLib,
+  libclang-bindings-src,
+}:
+
+{
+  callCabal2nix,
+  llvmPackages,
+}:
+let
+  libclang-bindings-base = callCabal2nix "libclang-bindings" "${libclang-bindings-src}" {
+    # Truly override the LLVM version used. Use `cabal2nix` and drectly inspect
+    # the derivation created by `callCabal2nix`.
+    inherit (llvmPackages) clang;
+  };
+  libclang-bindings = haskellLib.compose.addBuildDepends [
+    llvmPackages.libclang
+    llvmPackages.llvm
+  ] libclang-bindings-base;
+in
+libclang-bindings

--- a/nix/overlay/default.nix
+++ b/nix/overlay/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
   libclang-bindings-src,
+  maybeLlvmPackages ? null,
 }:
 let
   libclangBindings = import ./libclang-bindings.nix {
-    inherit libclang-bindings-src;
+    inherit libclang-bindings-src maybeLlvmPackages;
   };
-  hsBindgen = import ./hs-bindgen.nix;
+  hsBindgen = import ./hs-bindgen.nix { inherit maybeLlvmPackages; };
   hsFixes = import ./overrides.nix;
-  rustBindgen = import ./rust-bindgen.nix;
+  rustBindgen = import ./rust-bindgen.nix { inherit maybeLlvmPackages; };
   default = lib.composeManyExtensions [
     libclangBindings
     hsBindgen

--- a/nix/overlay/libclang-bindings.nix
+++ b/nix/overlay/libclang-bindings.nix
@@ -1,25 +1,23 @@
 {
   libclang-bindings-src,
+  maybeLlvmPackages ? null,
 }:
 
 final: prev:
 let
-  hlib = final.haskell.lib.compose;
-  inherit (final.llvmPackages) libclang llvm;
+  llvmPackages = if maybeLlvmPackages == null then final.llvmPackages else maybeLlvmPackages;
+  libclang-bindings = import ../libclang-bindings.nix {
+    haskellLib = final.haskell.lib;
+    inherit libclang-bindings-src;
+  };
 in
 {
   haskell = prev.haskell // {
     packageOverrides =
       hfinal: hprev:
-      let
-        libclang-bindings = hfinal.callCabal2nix "libclang-bindings" "${libclang-bindings-src}" { };
-      in
       prev.haskell.packageOverrides hfinal hprev
       // {
-        libclang-bindings = hlib.addBuildDepends [
-          libclang
-          llvm
-        ] libclang-bindings;
+        libclang-bindings = hfinal.callPackage libclang-bindings { inherit llvmPackages; };
       };
   };
 }

--- a/nix/overlay/rust-bindgen.nix
+++ b/nix/overlay/rust-bindgen.nix
@@ -1,6 +1,16 @@
-# NOTE: May be used to overwrite the version of `rust-bindgen` which has
-# to align with the one used to create the fixtures.
-final: prev: {
+# NOTE: Override the LLVM version used by `rust-bindgen`, and the version of
+# `rust-bindgen` itself which has to align with the one used to create the
+# fixtures.
+{
+  maybeLlvmPackages ? null,
+}:
+
+final: prev:
+let
+  llvmPackages = if maybeLlvmPackages == null then final.llvmPackages else maybeLlvmPackages;
+  clang = llvmPackages.clang;
+in
+{
   rust-bindgen-unwrapped = prev.rust-bindgen-unwrapped.overrideAttrs (old: rec {
     version = "0.71.1";
     src = prev.fetchCrate {
@@ -12,6 +22,13 @@ final: prev: {
       pname = old.pname;
       inherit version src;
       hash = "sha256-4EyDjHreFFFSGf7UoftCh6eI/8nfIP1ANlYWq0K8a3I=";
+    };
+    preConfigure = ''
+      export LIBCLANG_PATH="${final.lib.getLib clang.cc}/lib"
+    '';
+    nativeCheckInputs = [ clang ];
+    passthru = {
+      clang = clang;
     };
   });
 }


### PR DESCRIPTION
The dependency graph involving LLVM versions is complex. We want to override the used version of LLVM in some places, but not all. (If we completely change the LLVM version, even the Rust compiler itself is recompiled).

This commit carefully overrides the version of LLVM used in places where we need the specific LLVM version, but not in places were the default LLVM version is alright, avoiding unnecessary rebuilds.

- Also update the Nix Flake lock file.
- I also tested and updated the tutorial. There have been quite some user-facing changes.