### PR TITLE
Deselect declarations transitively depending on omitted declarations

### DIFF
--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_external.yaml
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_external.yaml
@@ -1,0 +1,9 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: any
+hsmodule: Example
+ctypes:
+- omit:
+    headers: program-analysis/selection_omit_external_root.h
+    cname: struct Omitted

--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_external_a.h
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_external_a.h
@@ -1,0 +1,6 @@
+// Includes the root header, but does not use the omitted declaration.
+#include "selection_omit_external_root.h"
+
+struct UnrelatedDeclaration {
+  int m;
+};

--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_external_b.h
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_external_b.h
@@ -1,0 +1,10 @@
+// Includes the root header, and uses the omitted declaration.
+#include "selection_omit_external_root.h"
+
+struct DirectlyDependsOnOmitted {
+  struct Omitted o;
+};
+
+struct IndirectlyDependsOnOmitted {
+  struct DirectlyDependsOnOmitted d;
+};

--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_external_root.h
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_external_root.h
@@ -1,0 +1,3 @@
+struct Omitted {
+  int n;
+};

--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_prescriptive.h
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_prescriptive.h
@@ -1,0 +1,11 @@
+struct Omitted {
+  int n;
+};
+
+struct DirectlyDependsOnOmitted {
+  struct Omitted o;
+};
+
+struct IndirectlyDependsOnOmitted {
+  struct DirectlyDependsOnOmitted d;
+};

--- a/hs-bindgen/examples/golden/program-analysis/selection_omit_prescriptive.yaml
+++ b/hs-bindgen/examples/golden/program-analysis/selection_omit_prescriptive.yaml
@@ -1,0 +1,9 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: any
+hsmodule: Example
+ctypes:
+- omit:
+    headers: program-analysis/selection_omit_prescriptive.h
+    cname: struct Omitted

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example where
+
+import qualified Data.Proxy
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified GHC.Ptr as Ptr
+import qualified GHC.Records
+import qualified HsBindgen.Runtime.HasCField
+import HsBindgen.Runtime.TypeEquality (TyEq)
+import Prelude ((<*>), Eq, Int, Show, pure)
+
+{-| __C declaration:__ @UnrelatedDeclaration@
+
+    __defined at:__ @program-analysis\/selection_omit_external_a.h:4:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_a.h@
+-}
+data UnrelatedDeclaration = UnrelatedDeclaration
+  { unrelatedDeclaration_m :: FC.CInt
+    {- ^ __C declaration:__ @m@
+
+         __defined at:__ @program-analysis\/selection_omit_external_a.h:5:7@
+
+         __exported by:__ @program-analysis\/selection_omit_external_a.h@
+    -}
+  }
+  deriving stock (Eq, Show)
+
+instance F.Storable UnrelatedDeclaration where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure UnrelatedDeclaration
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"unrelatedDeclaration_m") ptr0
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          UnrelatedDeclaration unrelatedDeclaration_m2 ->
+            HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"unrelatedDeclaration_m") ptr0 unrelatedDeclaration_m2
+
+instance HsBindgen.Runtime.HasCField.HasCField UnrelatedDeclaration "unrelatedDeclaration_m" where
+
+  type CFieldType UnrelatedDeclaration "unrelatedDeclaration_m" =
+    FC.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UnrelatedDeclaration) "unrelatedDeclaration_m")
+         ) => GHC.Records.HasField "unrelatedDeclaration_m" (Ptr.Ptr UnrelatedDeclaration) (Ptr.Ptr ty) where
+
+  getField =
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/FunPtr.hs
@@ -1,0 +1,1 @@
+module Example.FunPtr () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Global.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Global.hs
@@ -1,0 +1,1 @@
+module Example.Global () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Safe.hs
@@ -1,0 +1,1 @@
+module Example.Safe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example/Unsafe.hs
@@ -1,0 +1,1 @@
+module Example.Unsafe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
@@ -1,0 +1,15 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example
+ctypes:
+- headers: program-analysis/selection_omit_external_a.h
+  cname: struct UnrelatedDeclaration
+  hsname: UnrelatedDeclaration
+hstypes:
+- hsname: UnrelatedDeclaration
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -1,0 +1,39 @@
+-- addDependentFile examples/golden/program-analysis/selection_omit_external_root.h
+-- addDependentFile examples/golden/program-analysis/selection_omit_external_a.h
+{-| __C declaration:__ @UnrelatedDeclaration@
+
+    __defined at:__ @program-analysis\/selection_omit_external_a.h:4:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_a.h@
+-}
+data UnrelatedDeclaration
+    = UnrelatedDeclaration {unrelatedDeclaration_m :: CInt
+                            {- ^ __C declaration:__ @m@
+
+                                 __defined at:__ @program-analysis\/selection_omit_external_a.h:5:7@
+
+                                 __exported by:__ @program-analysis\/selection_omit_external_a.h@
+                            -}}
+      {- ^ __C declaration:__ @UnrelatedDeclaration@
+
+           __defined at:__ @program-analysis\/selection_omit_external_a.h:4:8@
+
+           __exported by:__ @program-analysis\/selection_omit_external_a.h@
+      -}
+    deriving stock (Eq, Show)
+instance Storable UnrelatedDeclaration
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure UnrelatedDeclaration <*> peekCField (Proxy @"unrelatedDeclaration_m") ptr_0
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   UnrelatedDeclaration unrelatedDeclaration_m_3 -> pokeCField (Proxy @"unrelatedDeclaration_m") ptr_1 unrelatedDeclaration_m_3
+instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
+    where type CFieldType UnrelatedDeclaration
+                          "unrelatedDeclaration_m" = CInt
+          offset# = \_ -> \_ -> 0
+instance TyEq ty
+              (CFieldType UnrelatedDeclaration "unrelatedDeclaration_m") =>
+         HasField "unrelatedDeclaration_m"
+                  (Ptr UnrelatedDeclaration)
+                  (Ptr ty)
+    where getField = ptrToCField (Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example where
+
+import qualified Data.Proxy
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified GHC.Ptr as Ptr
+import qualified GHC.Records
+import qualified HsBindgen.Runtime.HasCField
+import HsBindgen.Runtime.TypeEquality (TyEq)
+import Prelude ((<*>), Eq, Int, Show, pure)
+
+{-| __C declaration:__ @Omitted@
+
+    __defined at:__ @selection_omit_external_root.h:1:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data Omitted = Omitted
+  { omitted_n :: FC.CInt
+    {- ^ __C declaration:__ @n@
+
+         __defined at:__ @selection_omit_external_root.h:2:7@
+
+         __exported by:__ @program-analysis\/selection_omit_external_b.h@
+    -}
+  }
+  deriving stock (Eq, Show)
+
+instance F.Storable Omitted where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure Omitted
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"omitted_n") ptr0
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Omitted omitted_n2 ->
+            HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"omitted_n") ptr0 omitted_n2
+
+instance HsBindgen.Runtime.HasCField.HasCField Omitted "omitted_n" where
+
+  type CFieldType Omitted "omitted_n" = FC.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Omitted) "omitted_n")
+         ) => GHC.Records.HasField "omitted_n" (Ptr.Ptr Omitted) (Ptr.Ptr ty) where
+
+  getField =
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"omitted_n")
+
+{-| __C declaration:__ @DirectlyDependsOnOmitted@
+
+    __defined at:__ @program-analysis\/selection_omit_external_b.h:4:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data DirectlyDependsOnOmitted = DirectlyDependsOnOmitted
+  { directlyDependsOnOmitted_o :: Omitted
+    {- ^ __C declaration:__ @o@
+
+         __defined at:__ @program-analysis\/selection_omit_external_b.h:5:18@
+
+         __exported by:__ @program-analysis\/selection_omit_external_b.h@
+    -}
+  }
+  deriving stock (Eq, Show)
+
+instance F.Storable DirectlyDependsOnOmitted where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure DirectlyDependsOnOmitted
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"directlyDependsOnOmitted_o") ptr0
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          DirectlyDependsOnOmitted directlyDependsOnOmitted_o2 ->
+            HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"directlyDependsOnOmitted_o") ptr0 directlyDependsOnOmitted_o2
+
+instance HsBindgen.Runtime.HasCField.HasCField DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" where
+
+  type CFieldType DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" =
+    Omitted
+
+  offset# = \_ -> \_ -> 0
+
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DirectlyDependsOnOmitted) "directlyDependsOnOmitted_o")
+         ) => GHC.Records.HasField "directlyDependsOnOmitted_o" (Ptr.Ptr DirectlyDependsOnOmitted) (Ptr.Ptr ty) where
+
+  getField =
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"directlyDependsOnOmitted_o")
+
+{-| __C declaration:__ @IndirectlyDependsOnOmitted@
+
+    __defined at:__ @program-analysis\/selection_omit_external_b.h:8:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data IndirectlyDependsOnOmitted = IndirectlyDependsOnOmitted
+  { indirectlyDependsOnOmitted_d :: DirectlyDependsOnOmitted
+    {- ^ __C declaration:__ @d@
+
+         __defined at:__ @program-analysis\/selection_omit_external_b.h:9:35@
+
+         __exported by:__ @program-analysis\/selection_omit_external_b.h@
+    -}
+  }
+  deriving stock (Eq, Show)
+
+instance F.Storable IndirectlyDependsOnOmitted where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure IndirectlyDependsOnOmitted
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"indirectlyDependsOnOmitted_d") ptr0
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          IndirectlyDependsOnOmitted indirectlyDependsOnOmitted_d2 ->
+            HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"indirectlyDependsOnOmitted_d") ptr0 indirectlyDependsOnOmitted_d2
+
+instance HsBindgen.Runtime.HasCField.HasCField IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" where
+
+  type CFieldType IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" =
+    DirectlyDependsOnOmitted
+
+  offset# = \_ -> \_ -> 0
+
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType IndirectlyDependsOnOmitted) "indirectlyDependsOnOmitted_d")
+         ) => GHC.Records.HasField "indirectlyDependsOnOmitted_d" (Ptr.Ptr IndirectlyDependsOnOmitted) (Ptr.Ptr ty) where
+
+  getField =
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/FunPtr.hs
@@ -1,0 +1,1 @@
+module Example.FunPtr () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Global.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Global.hs
@@ -1,0 +1,1 @@
+module Example.Global () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Safe.hs
@@ -1,0 +1,1 @@
+module Example.Safe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example/Unsafe.hs
@@ -1,0 +1,1 @@
+module Example.Unsafe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
@@ -1,0 +1,31 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example
+ctypes:
+- headers: program-analysis/selection_omit_external_b.h
+  cname: struct DirectlyDependsOnOmitted
+  hsname: DirectlyDependsOnOmitted
+- headers: program-analysis/selection_omit_external_b.h
+  cname: struct IndirectlyDependsOnOmitted
+  hsname: IndirectlyDependsOnOmitted
+- headers: program-analysis/selection_omit_external_b.h
+  cname: struct Omitted
+  hsname: Omitted
+hstypes:
+- hsname: DirectlyDependsOnOmitted
+  instances:
+  - Eq
+  - Show
+  - Storable
+- hsname: IndirectlyDependsOnOmitted
+  instances:
+  - Eq
+  - Show
+  - Storable
+- hsname: Omitted
+  instances:
+  - Eq
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -1,0 +1,113 @@
+-- addDependentFile examples/golden/program-analysis/selection_omit_external_root.h
+-- addDependentFile examples/golden/program-analysis/selection_omit_external_b.h
+{-| __C declaration:__ @Omitted@
+
+    __defined at:__ @selection_omit_external_root.h:1:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data Omitted
+    = Omitted {omitted_n :: CInt
+               {- ^ __C declaration:__ @n@
+
+                    __defined at:__ @selection_omit_external_root.h:2:7@
+
+                    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+               -}}
+      {- ^ __C declaration:__ @Omitted@
+
+           __defined at:__ @selection_omit_external_root.h:1:8@
+
+           __exported by:__ @program-analysis\/selection_omit_external_b.h@
+      -}
+    deriving stock (Eq, Show)
+instance Storable Omitted
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure Omitted <*> peekCField (Proxy @"omitted_n") ptr_0
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   Omitted omitted_n_3 -> pokeCField (Proxy @"omitted_n") ptr_1 omitted_n_3
+instance HasCField Omitted "omitted_n"
+    where type CFieldType Omitted "omitted_n" = CInt
+          offset# = \_ -> \_ -> 0
+instance TyEq ty (CFieldType Omitted "omitted_n") =>
+         HasField "omitted_n" (Ptr Omitted) (Ptr ty)
+    where getField = ptrToCField (Proxy @"omitted_n")
+{-| __C declaration:__ @DirectlyDependsOnOmitted@
+
+    __defined at:__ @program-analysis\/selection_omit_external_b.h:4:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data DirectlyDependsOnOmitted
+    = DirectlyDependsOnOmitted {directlyDependsOnOmitted_o :: Omitted
+                                {- ^ __C declaration:__ @o@
+
+                                     __defined at:__ @program-analysis\/selection_omit_external_b.h:5:18@
+
+                                     __exported by:__ @program-analysis\/selection_omit_external_b.h@
+                                -}}
+      {- ^ __C declaration:__ @DirectlyDependsOnOmitted@
+
+           __defined at:__ @program-analysis\/selection_omit_external_b.h:4:8@
+
+           __exported by:__ @program-analysis\/selection_omit_external_b.h@
+      -}
+    deriving stock (Eq, Show)
+instance Storable DirectlyDependsOnOmitted
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure DirectlyDependsOnOmitted <*> peekCField (Proxy @"directlyDependsOnOmitted_o") ptr_0
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   DirectlyDependsOnOmitted directlyDependsOnOmitted_o_3 -> pokeCField (Proxy @"directlyDependsOnOmitted_o") ptr_1 directlyDependsOnOmitted_o_3
+instance HasCField DirectlyDependsOnOmitted
+                   "directlyDependsOnOmitted_o"
+    where type CFieldType DirectlyDependsOnOmitted
+                          "directlyDependsOnOmitted_o" = Omitted
+          offset# = \_ -> \_ -> 0
+instance TyEq ty
+              (CFieldType DirectlyDependsOnOmitted
+                          "directlyDependsOnOmitted_o") =>
+         HasField "directlyDependsOnOmitted_o"
+                  (Ptr DirectlyDependsOnOmitted)
+                  (Ptr ty)
+    where getField = ptrToCField (Proxy @"directlyDependsOnOmitted_o")
+{-| __C declaration:__ @IndirectlyDependsOnOmitted@
+
+    __defined at:__ @program-analysis\/selection_omit_external_b.h:8:8@
+
+    __exported by:__ @program-analysis\/selection_omit_external_b.h@
+-}
+data IndirectlyDependsOnOmitted
+    = IndirectlyDependsOnOmitted {indirectlyDependsOnOmitted_d :: DirectlyDependsOnOmitted
+                                  {- ^ __C declaration:__ @d@
+
+                                       __defined at:__ @program-analysis\/selection_omit_external_b.h:9:35@
+
+                                       __exported by:__ @program-analysis\/selection_omit_external_b.h@
+                                  -}}
+      {- ^ __C declaration:__ @IndirectlyDependsOnOmitted@
+
+           __defined at:__ @program-analysis\/selection_omit_external_b.h:8:8@
+
+           __exported by:__ @program-analysis\/selection_omit_external_b.h@
+      -}
+    deriving stock (Eq, Show)
+instance Storable IndirectlyDependsOnOmitted
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure IndirectlyDependsOnOmitted <*> peekCField (Proxy @"indirectlyDependsOnOmitted_d") ptr_0
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   IndirectlyDependsOnOmitted indirectlyDependsOnOmitted_d_3 -> pokeCField (Proxy @"indirectlyDependsOnOmitted_d") ptr_1 indirectlyDependsOnOmitted_d_3
+instance HasCField IndirectlyDependsOnOmitted
+                   "indirectlyDependsOnOmitted_d"
+    where type CFieldType IndirectlyDependsOnOmitted
+                          "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
+          offset# = \_ -> \_ -> 0
+instance TyEq ty
+              (CFieldType IndirectlyDependsOnOmitted
+                          "indirectlyDependsOnOmitted_d") =>
+         HasField "indirectlyDependsOnOmitted_d"
+                  (Ptr IndirectlyDependsOnOmitted)
+                  (Ptr ty)
+    where getField = ptrToCField (Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example.hs
@@ -1,0 +1,1 @@
+module Example () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/FunPtr.hs
@@ -1,0 +1,1 @@
+module Example.FunPtr () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Global.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Global.hs
@@ -1,0 +1,1 @@
+module Example.Global () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Safe.hs
@@ -1,0 +1,1 @@
+module Example.Safe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/Example/Unsafe.hs
@@ -1,0 +1,1 @@
+module Example.Unsafe () where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/bindingspec.yaml
@@ -1,0 +1,9 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example
+ctypes:
+- omit:
+    headers: program-analysis/selection_omit_prescriptive.h
+    cname: struct Omitted

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_prescriptive/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile examples/golden/program-analysis/selection_omit_prescriptive.h

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -73,7 +73,7 @@ data ResolvedExtBinding = ResolvedExtBinding{
 data ResolveBindingSpecsMsg =
     ResolveBindingSpecsModuleMismatch       Hs.ModuleName Hs.ModuleName
   | ResolveBindingSpecsExtHsRefNoIdentifier C.QualName
-  | ResolveBindingSpecsOmittedTypeUse       C.QualName
+  | ResolveBindingSpecsOmittedType          C.QualName
   | ResolveBindingSpecsTypeNotUsed          C.QualName
   | ResolveBindingSpecsExtDecl              C.QualName
   | ResolveBindingSpecsExtType              C.QualName C.QualName
@@ -84,39 +84,39 @@ data ResolveBindingSpecsMsg =
 instance PrettyForTrace ResolveBindingSpecsMsg where
   prettyForTrace = \case
       ResolveBindingSpecsModuleMismatch hsModuleName pSpecHsModuleName ->
-        "prescriptive binding specification for module"
+        "Prescriptive binding specification for module"
           <+> prettyForTrace pSpecHsModuleName
           <+> "cannot be used to generate"
           <+> prettyForTrace hsModuleName
       ResolveBindingSpecsExtHsRefNoIdentifier cQualName ->
         "Haskell identifier not specified in binding specification:"
           <+> prettyForTrace cQualName
-      ResolveBindingSpecsOmittedTypeUse cQualName ->
-        "type omitted by binding specification used:"
+      ResolveBindingSpecsOmittedType cQualName ->
+        "Type omitted by binding specification used:"
           <+> prettyForTrace cQualName
       ResolveBindingSpecsTypeNotUsed cQualName ->
-        "binding specification for type not used:"
+        "Binding specification for type not used:"
           <+> prettyForTrace cQualName
       ResolveBindingSpecsExtDecl cQualName ->
-        "declaration with external binding dropped:"
+        "Declaration with external binding dropped:"
           <+> prettyForTrace cQualName
       ResolveBindingSpecsExtType ctx cQualName ->
-        "within declaration"
+        "Within declaration"
           <+> prettyForTrace ctx
           <+> "type replaced with external binding:"
           <+> prettyForTrace cQualName
       ResolveBindingSpecsPrescriptiveRequire cQualName ->
-        "prescriptive binding specification found:"
+        "Prescriptive binding specification found:"
           <+> prettyForTrace cQualName
       ResolveBindingSpecsPrescriptiveOmit cQualName ->
-        "declaration omitted by prescriptive binding specification:"
+        "Declaration omitted by prescriptive binding specification:"
           <+> prettyForTrace cQualName
 
 instance IsTrace Level ResolveBindingSpecsMsg where
   getDefaultLogLevel = \case
     ResolveBindingSpecsModuleMismatch{}       -> Error
     ResolveBindingSpecsExtHsRefNoIdentifier{} -> Error
-    ResolveBindingSpecsOmittedTypeUse{}       -> Error
+    ResolveBindingSpecsOmittedType{}          -> Info
     ResolveBindingSpecsTypeNotUsed{}          -> Error
     ResolveBindingSpecsExtDecl{}              -> Info
     ResolveBindingSpecsExtType{}              -> Info

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -144,10 +144,12 @@ selectDecls
               (TransitiveDependencyNotSelected, UnselectableBecauseUnusable u  ) ->
                 case u of
                   UnusableParseNotAttempted _ -> r
+                  UnusableOmitted _           -> r
                   _otherReason                -> l
               (UnselectableBecauseUnusable u  , TransitiveDependencyNotSelected) ->
                 case u of
                   UnusableParseNotAttempted _ -> l
+                  UnusableOmitted _           -> l
                   _otherReason                -> r
               (_, _) -> l
 

--- a/scripts/ci/compile-fixtures.sh
+++ b/scripts/ci/compile-fixtures.sh
@@ -31,7 +31,7 @@ KNOWN_FAILURES=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=83
+KNOWN_FIXTURES_COUNT=86
 
 # Default options
 JOBS=4
@@ -40,20 +40,20 @@ FORCE_ALL=false
 # Parse options
 while getopts "j:fh" opt; do
     case "$opt" in
-        j)
-            JOBS="$OPTARG"
-            ;;
-        f)
-            FORCE_ALL=true
-            ;;
-        h)
-            usage
-            exit 0
-            ;;
-        *)
-            usage >&2
-            exit 1
-            ;;
+    j)
+        JOBS="$OPTARG"
+        ;;
+    f)
+        FORCE_ALL=true
+        ;;
+    h)
+        usage
+        exit 0
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
     esac
 done
 shift $((OPTIND - 1))
@@ -83,7 +83,7 @@ get_fixture_name() {
     local fixture_name
     fixture_name="${fixture_dir#"$FIXTURES_DIR/"}"
     fixture_name="${fixture_name%/}"
-    echo "$fixture_name" > /dev/stdout
+    echo "$fixture_name" >/dev/stdout
 }
 
 # Function to check if a file is in the known failures list
@@ -111,10 +111,10 @@ compile_fixture() {
     # alphabetically. This ensures Example.hs is compiled before Example/*.hs,
     # which is necessary since the submodules import the main Example module.
     local files
-    files=$(find "$FIXTURES_DIR/$fixture_name/" -type f -name "*.hs" -print0 | \
-        xargs -0 -I {} sh -c 'echo $(echo "{}" | tr -cd "/" | wc -c) "{}"' | \
-        sort -n | \
-        cut -d' ' -f2- | \
+    files=$(find "$FIXTURES_DIR/$fixture_name/" -type f -name "*.hs" -print0 |
+        xargs -0 -I {} sh -c 'echo $(echo "{}" | tr -cd "/" | wc -c) "{}"' |
+        sort -n |
+        cut -d' ' -f2- |
         tr '\n' ' ')
 
     # Use a temporary output file to avoid polluting the fixtures directory
@@ -191,7 +191,7 @@ while IFS= read -r -d '' file; do
     fi
 done < <(find "$FIXTURES_DIR" -type f -name "Example.hs" -print0 | sort -z)
 
-FIXTURES_FOUND_COUNT=$(( ${#FIXTURES_TO_COMPILE[@]} + ${#FIXTURES_SKIPPED[@]} ))
+FIXTURES_FOUND_COUNT=$((${#FIXTURES_TO_COMPILE[@]} + ${#FIXTURES_SKIPPED[@]}))
 
 echo ""
 echo "========================================="

--- a/scripts/run-golden-test.sh
+++ b/scripts/run-golden-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Run a golden test on the command line. Useful for debugging and designing
+# tests.
+
+set -e
+
+usage() {
+    echo "Usage: $(basename "$0") TEST [OTHER_ARGUMENTS]"
+    echo
+    echo "For example,"
+    echo "    $(basename "$0") program-analysis/selection_omit_prescriptive.h"
+    echo
+    echo "OTHER_ARGUMENTS are passed on to 'hs-bindgen-cli preprocess'."
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+echo "Temporary output directory: ${TMP}"
+
+cabal run -- \
+    hs-bindgen-cli preprocess \
+    -I ./hs-bindgen/examples/golden \
+    -I ./hs-bindgen/musl-include/x86_64 \
+    --module Example \
+    --hs-output-dir "${TMP}" \
+    "$@"


### PR DESCRIPTION
Warn user in such cases.

Based on #1314 which should be merged first.

Travis and I agreed that trace messages should start with captial letters.