### PR TITLE
Make binding spec `ctypes` and `hstypes` optional

### DIFF
--- a/hs-bindgen/fixtures/attributes/asm/bindingspec.yaml
+++ b/hs-bindgen/fixtures/attributes/asm/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/bindingspec.yaml
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/declarations/redeclaration_identical/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/redeclaration_identical/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/declarations/tentative_definitions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/tentative_definitions/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/edge-cases/headers/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/headers/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/edge-cases/names/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/names/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/functions/simple_func/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/simple_func/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/functions/varargs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/varargs/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/macros/macro_functions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_functions/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/macros/macro_strings/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_strings/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/macros/macros/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macros/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/program-analysis/delay_traces/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/delay_traces/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/program-analysis/selection_foo/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_foo/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/types/complex/complex_non_float_test/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/complex/complex_non_float_test/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/types/primitives/bool_c23/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/primitives/bool_c23/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/fixtures/types/structs/unnamed-struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/unnamed-struct/bindingspec.yaml
@@ -2,5 +2,3 @@ version:
   hs_bindgen: 0.1.0
   binding_specification: '1.0'
 hsmodule: Example
-ctypes: []
-hstypes: []

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/V1.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/V1.hs
@@ -542,18 +542,18 @@ data ABindingSpec = ABindingSpec {
 
 instance Aeson.FromJSON ABindingSpec where
   parseJSON = Aeson.withObject "ABindingSpec" $ \o -> do
-    aBindingSpecVersion  <- o .: "version"
-    aBindingSpecHsModule <- o .: "hsmodule"
-    aBindingSpecCTypes   <- o .: "ctypes"
-    aBindingSpecHsTypes  <- o .: "hstypes"
+    aBindingSpecVersion  <- o .:  "version"
+    aBindingSpecHsModule <- o .:  "hsmodule"
+    aBindingSpecCTypes   <- o .:? "ctypes"  .!= []
+    aBindingSpecHsTypes  <- o .:? "hstypes" .!= []
     return ABindingSpec{..}
 
 instance Aeson.ToJSON ABindingSpec where
-  toJSON ABindingSpec{..} = Aeson.object [
-      "version"  .= aBindingSpecVersion
-    , "hsmodule" .= aBindingSpecHsModule
-    , "ctypes"   .= aBindingSpecCTypes
-    , "hstypes"  .= aBindingSpecHsTypes
+  toJSON ABindingSpec{..} = Aeson.Object . KM.fromList $ catMaybes [
+      Just ("version"  .= aBindingSpecVersion)
+    , Just ("hsmodule" .= aBindingSpecHsModule)
+    , ("ctypes"  .=) <$> omitWhenNull aBindingSpecCTypes
+    , ("hstypes" .=) <$> omitWhenNull aBindingSpecHsTypes
     ]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The following can be left out completely:

```yaml
ctypes: []
hstypes: []
```