### PR TITLE
Add `haskellId` to `DeclId`

### DIFF
--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -8,8 +9,10 @@ import qualified Data.Bits as Bits
 import qualified Data.Ix as Ix
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.FunPtr
 import Data.Bits (FiniteBits)
-import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
+import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @I@
 
@@ -70,3 +73,43 @@ newtype S = S
   }
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype (F.Storable, Bits.Bits, Bounded, Enum, FiniteBits, Integral, Ix.Ix, Num, Real)
+
+{-| __unique:__ @instance ToFunPtr (FC.CShort -> IO I)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_074b9de694d8f359 ::
+     (FC.CShort -> IO I)
+  -> IO (Ptr.FunPtr (FC.CShort -> IO I))
+
+{-| __unique:__ @instance FromFunPtr (FC.CShort -> IO I)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_c7a8adce35e64925 ::
+     Ptr.FunPtr (FC.CShort -> IO I)
+  -> FC.CShort -> IO I
+
+instance HsBindgen.Runtime.FunPtr.ToFunPtr (FC.CShort -> IO I) where
+
+  toFunPtr = hs_bindgen_074b9de694d8f359
+
+instance HsBindgen.Runtime.FunPtr.FromFunPtr (FC.CShort -> IO I) where
+
+  fromFunPtr = hs_bindgen_c7a8adce35e64925
+
+{-| __unique:__ @instance ToFunPtr (S -> IO FC.CInt)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_ffdbafa239adf14e ::
+     (S -> IO FC.CInt)
+  -> IO (Ptr.FunPtr (S -> IO FC.CInt))
+
+{-| __unique:__ @instance FromFunPtr (S -> IO FC.CInt)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_9c8a77fe3560cebd ::
+     Ptr.FunPtr (S -> IO FC.CInt)
+  -> S -> IO FC.CInt
+
+instance HsBindgen.Runtime.FunPtr.ToFunPtr (S -> IO FC.CInt) where
+
+  toFunPtr = hs_bindgen_ffdbafa239adf14e
+
+instance HsBindgen.Runtime.FunPtr.FromFunPtr (S -> IO FC.CInt) where
+
+  fromFunPtr = hs_bindgen_9c8a77fe3560cebd

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -430,6 +430,34 @@ newtype S
                       Ix,
                       Num,
                       Real)
+{-| __unique:__ @instance ToFunPtr (FC.CShort -> IO I)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_074b9de694d8f359 :: (CShort ->
+                                                                    IO I) ->
+                                                                   IO (FunPtr (CShort -> IO I))
+{-| __unique:__ @instance FromFunPtr (FC.CShort -> IO I)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_c7a8adce35e64925 :: FunPtr (CShort ->
+                                                                           IO I) ->
+                                                                   CShort -> IO I
+instance ToFunPtr (CShort -> IO I)
+    where toFunPtr = hs_bindgen_074b9de694d8f359
+instance FromFunPtr (CShort -> IO I)
+    where fromFunPtr = hs_bindgen_c7a8adce35e64925
+{-| __unique:__ @instance ToFunPtr (S -> IO FC.CInt)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_ffdbafa239adf14e :: (S ->
+                                                                    IO CInt) ->
+                                                                   IO (FunPtr (S -> IO CInt))
+{-| __unique:__ @instance FromFunPtr (S -> IO FC.CInt)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_9c8a77fe3560cebd :: FunPtr (S ->
+                                                                           IO CInt) ->
+                                                                   S -> IO CInt
+instance ToFunPtr (S -> IO CInt)
+    where toFunPtr = hs_bindgen_ffdbafa239adf14e
+instance FromFunPtr (S -> IO CInt)
+    where fromFunPtr = hs_bindgen_9c8a77fe3560cebd
 {-| __C declaration:__ @quux@
 
     __defined at:__ @macros\/macro_in_fundecl.h:12:6@

--- a/hs-bindgen/fixtures/manual/function_pointers/Example.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example.hs
@@ -169,3 +169,23 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Apply1Union) "apply1
 
   getField =
     HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"apply1Union_apply1_nopointer_union_field")
+
+{-| __unique:__ @instance ToFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_fe02c1e534fc52ea ::
+     ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)
+  -> IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))
+
+{-| __unique:__ @instance FromFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_fc27363846cb6139 ::
+     Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)
+  -> (Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt
+
+instance HsBindgen.Runtime.FunPtr.ToFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt) where
+
+  toFunPtr = hs_bindgen_fe02c1e534fc52ea
+
+instance HsBindgen.Runtime.FunPtr.FromFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt) where
+
+  fromFunPtr = hs_bindgen_fc27363846cb6139

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -339,6 +339,21 @@ instance TyEq ty
                   (Ptr Apply1Union)
                   (Ptr ty)
     where getField = ptrToCField (Proxy @"apply1Union_apply1_nopointer_union_field")
+{-| __unique:__ @instance ToFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)@
+-}
+foreign import ccall safe "wrapper" hs_bindgen_fe02c1e534fc52ea :: (FunPtr Int2int ->
+                                                                    CInt -> IO CInt) ->
+                                                                   IO (FunPtr (FunPtr Int2int ->
+                                                                               CInt -> IO CInt))
+{-| __unique:__ @instance FromFunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)@
+-}
+foreign import ccall safe "dynamic" hs_bindgen_fc27363846cb6139 :: FunPtr (FunPtr Int2int ->
+                                                                           CInt -> IO CInt) ->
+                                                                   FunPtr Int2int -> CInt -> IO CInt
+instance ToFunPtr (FunPtr Int2int -> CInt -> IO CInt)
+    where toFunPtr = hs_bindgen_fe02c1e534fc52ea
+instance FromFunPtr (FunPtr Int2int -> CInt -> IO CInt)
+    where fromFunPtr = hs_bindgen_fc27363846cb6139
 {-| __C declaration:__ @square@
 
     __defined at:__ @manual\/function_pointers.h:5:12@

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -35,8 +35,8 @@ generateHaddocksWithInfo config declInfo =
     fst $ generateHaddocksWithParams config declInfo Args{
         isField     = False
       , loc         = declInfo.declLoc
-      , nameC       = declInfo.declId.nameC
-      , nameHsIdent = declInfo.declId.nameHsIdent
+      , nameC       = C.declIdName      declInfo.declId
+      , nameHsIdent = C.declIdHaskellId declInfo.declId
       , comment     = declInfo.declComment
       , params      = []
       }
@@ -65,8 +65,8 @@ generateHaddocksWithInfoParams config declInfo params =
     generateHaddocksWithParams config declInfo Args{
         isField     = False
       , loc         = declInfo.declLoc
-      , nameC       = declInfo.declId.nameC
-      , nameHsIdent = declInfo.declId.nameHsIdent
+      , nameC       = C.declIdName      declInfo.declId
+      , nameHsIdent = C.declIdHaskellId declInfo.declId
       , comment     = declInfo.declComment
       , params
       }
@@ -96,8 +96,8 @@ data Args = Args{
 generateHaddocksWithParams :: HaddockConfig -> DeclInfo -> Args -> (Maybe HsDoc.Comment, [Hs.FunctionParameter])
 generateHaddocksWithParams HaddockConfig{..} declInfo Args{comment = Nothing, ..} =
   let (commentCName, commentLocation) =
-        case declInfo.declOrigin of
-          NameOriginGenerated (AnonId _)
+        case C.declIdIsGenerated declInfo.declId of
+          Just _
             | not isField                -> ( Nothing
                                             , Just (updateSingleLoc pathStyle loc)
                                             )
@@ -116,8 +116,8 @@ generateHaddocksWithParams HaddockConfig{..} declInfo Args{comment = Nothing, ..
       , map addFunctionParameterComment params)
 generateHaddocksWithParams HaddockConfig{..} declInfo Args{comment = Just CDoc.Comment{..}, ..} =
   let (commentCName, commentLocation) =
-        case declInfo.declOrigin of
-          NameOriginGenerated (AnonId _)
+        case C.declIdIsGenerated declInfo.declId of
+          Just _
             | not isField                -> ( Nothing
                                             , Just (updateSingleLoc pathStyle loc)
                                             )
@@ -399,7 +399,11 @@ convertInlineContent = \case
         CDoc.CXCommentInlineCommandRenderKind_Emphasized -> HsDoc.Emph args
         CDoc.CXCommentInlineCommandRenderKind_Anchor     -> HsDoc.Anchor (Text.unwords (map Text.strip inlineCommandArgs))
 
-  CDoc.InlineRefCommand (CommentRef arg) -> [HsDoc.Identifier (Hs.getIdentifier arg.nameHsIdent)]
+  CDoc.InlineRefCommand (CommentRef c mHsIdent) -> [
+      case mHsIdent of
+        Just hs -> HsDoc.Identifier (Hs.getIdentifier hs)
+        Nothing -> HsDoc.Monospace [HsDoc.TextContent $ C.getName c]
+    ]
 
   -- HTML is not currently supported
   --

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
@@ -15,6 +15,7 @@ import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.Hs.AST.Type
 import HsBindgen.Errors
 import HsBindgen.Frontend.AST.External qualified as C
+import HsBindgen.Frontend.Naming qualified as C
 import HsBindgen.Language.C qualified as C
 
 {-------------------------------------------------------------------------------
@@ -35,18 +36,18 @@ inContext :: HasCallStack => TypeContext -> C.Type -> Hs.HsType
 inContext ctx = go ctx
   where
     go :: TypeContext -> C.Type -> Hs.HsType
-    go _ (C.TypeTypedef (C.TypedefRegular name _)) =
-        Hs.HsTypRef (C.nameHs name)
+    go _ (C.TypeTypedef (C.TypedefRegular declId _)) =
+        Hs.HsTypRef (C.unsafeDeclIdHaskellName declId)
     go c (C.TypeTypedef (C.TypedefSquashed _name ty)) =
         go c ty
-    go _ (C.TypeStruct name _origin) =
-        Hs.HsTypRef (C.nameHs name)
-    go _ (C.TypeUnion name _origin) =
-        Hs.HsTypRef (C.nameHs name)
-    go _ (C.TypeEnum name _origin) =
-        Hs.HsTypRef (C.nameHs name)
-    go _ (C.TypeMacroTypedef name _origin) =
-        Hs.HsTypRef (C.nameHs name)
+    go _ (C.TypeStruct declId) =
+        Hs.HsTypRef (C.unsafeDeclIdHaskellName declId)
+    go _ (C.TypeUnion declId) =
+        Hs.HsTypRef (C.unsafeDeclIdHaskellName declId)
+    go _ (C.TypeEnum declId) =
+        Hs.HsTypRef (C.unsafeDeclIdHaskellName declId)
+    go _ (C.TypeMacroTypedef declId) =
+        Hs.HsTypRef (C.unsafeDeclIdHaskellName declId)
     go c C.TypeVoid =
         Hs.HsPrimType (void c)
     go _ (C.TypePrim p) =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -1,6 +1,7 @@
 module HsBindgen.Frontend.AST.Coerce (
     CoercePass(..)
   , CoercePassId(..)
+  , CoercePassHaskellId(..)
   , CoercePassTypedefRef(..)
   ) where
 
@@ -20,6 +21,9 @@ import HsBindgen.Imports
 class CoercePassId (p :: Pass) (p' :: Pass) where
   coercePassId :: Proxy '(p, p') -> Id p -> Id p'
 
+class CoercePassHaskellId (p :: Pass) (p' :: Pass) where
+  coercePassHaskellId :: Proxy '(p, p') -> HaskellId p -> HaskellId p'
+
 class CoercePassTypedefRef (p :: Pass) (p' :: Pass) where
   coercePassTypedefRef :: Proxy '(p, p') -> TypedefRef p -> TypedefRef p'
 
@@ -30,20 +34,28 @@ class CoercePassTypedefRef (p :: Pass) (p' :: Pass) where
 class CoercePass a p p' where
   coercePass :: a p -> a p'
 
-instance CoercePass DeclId p p' where
+instance (
+      CoercePassHaskellId p p'
+    ) => CoercePass DeclId p p' where
   coercePass = \case
       DeclIdNamed   named   -> DeclIdNamed   (coercePass named)
       DeclIdBuiltin builtin -> DeclIdBuiltin (coercePass builtin)
 
-instance CoercePass NamedDeclId p p' where
+instance (
+      CoercePassHaskellId p p'
+    ) => CoercePass NamedDeclId p p' where
   coercePass named = NamedDeclId{
-        name   = named.name
-      , origin = named.origin
+        name      = named.name
+      , origin    = named.origin
+      , haskellId = coercePassHaskellId (Proxy @'(p, p')) named.haskellId
       }
 
-instance CoercePass BuiltinDeclId p p' where
+instance (
+      CoercePassHaskellId p p'
+    ) => CoercePass BuiltinDeclId p p' where
   coercePass builtin = BuiltinDeclId{
-        name = builtin.name
+        name      = builtin.name
+      , haskellId = coercePassHaskellId (Proxy @'(p, p')) builtin.haskellId
       }
 
 instance (
@@ -57,12 +69,13 @@ instance (
       }
 
 instance (
-      CoercePassId p p'
+      CoercePassHaskellId p p'
     ) => CoercePass CommentRef p p' where
-  coercePass (CommentRef t) = CommentRef (coercePassId (Proxy @'(p, p')) t)
+  coercePass (CommentRef c hs) =
+      CommentRef c (coercePassHaskellId (Proxy @'(p, p')) <$> hs)
 
 instance (
-      CoercePassId p p'
+      CoercePassHaskellId p p'
     ) => CoercePass CDoc.Comment (CommentRef p) (CommentRef p') where
   coercePass comment = fmap coercePass comment
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
@@ -12,6 +12,7 @@ module HsBindgen.Frontend.AST.External (
   , Decl(..)
   , Int.Availability(..)
   , DeclInfo(..)
+  , FinalDeclId
   , Int.HeaderInfo(..)
   , FieldInfo(..)
   , DeclKind(..)
@@ -52,6 +53,7 @@ module HsBindgen.Frontend.AST.External (
   , ArrayClassification(..)
   , getArrayElementType
   , isCanonicalTypeArray
+  , typeDeclIds
     -- ** Erasure
   , FullType
   , Full
@@ -89,9 +91,11 @@ import Clang.Paths
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.AST.Internal qualified as Int
 import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass qualified as ResolveBindingSpecs
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
+import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -120,13 +124,17 @@ data Decl = Decl {
 
 data DeclInfo = DeclInfo {
       declLoc        :: SingleLoc
-    , declId         :: Int.NamePair
-    , declOrigin     :: C.NameOrigin
+    , declId         :: FinalDeclId
     , declAliases    :: [C.Name]
     , declHeaderInfo :: Maybe Int.HeaderInfo
     , declComment    :: Maybe (CDoc.Comment CommentRef)
     }
   deriving stock (Show, Eq, Generic)
+
+-- TODO <https://github.com/well-typed/hs-bindgen/issues/1267>
+-- It would probably make sense to move 'DeclId' into "AST.Internal", and then
+-- have a "finalized" version of it here.
+type FinalDeclId = C.DeclId MangleNames
 
 data FieldInfo = FieldInfo {
       fieldLoc     :: SingleLoc
@@ -262,7 +270,10 @@ data Function = Function {
 -------------------------------------------------------------------------------}
 
 -- | Cross-reference in a Doxygen comment
-newtype CommentRef = CommentRef Int.NamePair
+--
+-- The Haskell identifier might not be known (if the reference is to a
+-- declaration not in the current translation unit).
+data CommentRef = CommentRef C.Name (Maybe Hs.Identifier)
   deriving stock (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------
@@ -292,9 +303,9 @@ type Type = FullType
 -- | C types in Trees That Shrink style
 data TypeF tag =
     TypePrim C.PrimType
-  | TypeStruct Int.NamePair C.NameOrigin
-  | TypeUnion Int.NamePair C.NameOrigin
-  | TypeEnum Int.NamePair C.NameOrigin
+  | TypeStruct FinalDeclId
+  | TypeUnion FinalDeclId
+  | TypeEnum FinalDeclId
   | TypeTypedef
     -- | NOTE: has a strictness annotation, which allows GHC to infer that
     -- pattern matches are redundant when @TypedefRefF tag ~ Void@.
@@ -302,7 +313,7 @@ data TypeF tag =
     -- TODO: macros should get annotations with underlying types just like
     -- typedefs, so that we can erase the macro types and replace them with
     -- their underlying type. See issue #1200.
-  | TypeMacroTypedef Int.NamePair C.NameOrigin
+  | TypeMacroTypedef FinalDeclId
   | TypePointer (TypeF tag)
   | TypeConstArray Natural (TypeF tag)
   | TypeFun [TypeF tag] (TypeF tag)
@@ -328,7 +339,7 @@ data TypeQualifier = TypeQualifierConst
 data TypedefRef =
     TypedefRegular
       -- | Name of the referenced typedef declaration
-      Int.NamePair
+      FinalDeclId
       -- | The underlying type of the referenced typedef declaration
       --
       -- NOTE: the underlying type can arbitrarily reference other types,
@@ -399,22 +410,62 @@ getArrayElementType (IncompleteArrayClassification ty) = ty
 -- | Is the canonical type an array type? If so, is it an array of known size or
 -- unknown size? And what is the /full type/ of the array elements?
 isCanonicalTypeArray :: FullType -> Maybe (ArrayClassification FullType)
-isCanonicalTypeArray ty = case ty of
-    TypePrim _pt -> Nothing
-    TypeStruct _np _no -> Nothing
-    TypeUnion _np _no -> Nothing
-    TypeEnum _np _no -> Nothing
-    TypeTypedef ref -> isCanonicalTypeArray (eraseTypedef ref)
-    TypeMacroTypedef _np _no -> Nothing
-    TypePointer _t -> Nothing
-    TypeConstArray n t -> Just (ConstantArrayClassification n t)
-    TypeFun _args _res -> Nothing
-    TypeVoid -> Nothing
-    TypeIncompleteArray t -> Just (IncompleteArrayClassification t)
-    TypeBlock _t -> Nothing
-    TypeQualified _q t -> isCanonicalTypeArray t
-    TypeExtBinding _reb -> Nothing
-    TypeComplex _pt -> Nothing
+isCanonicalTypeArray ty =
+    case ty of
+      TypePrim _pt             -> Nothing
+      TypeStruct _declId       -> Nothing
+      TypeUnion _declId        -> Nothing
+      TypeEnum _declId         -> Nothing
+      TypeTypedef ref          -> isCanonicalTypeArray (eraseTypedef ref)
+      TypeMacroTypedef _declId -> Nothing
+      TypePointer _t           -> Nothing
+      TypeConstArray n t       -> Just (ConstantArrayClassification n t)
+      TypeFun _args _res       -> Nothing
+      TypeVoid                 -> Nothing
+      TypeIncompleteArray t    -> Just (IncompleteArrayClassification t)
+      TypeBlock _t             -> Nothing
+      TypeQualified _q t       -> isCanonicalTypeArray t
+      TypeExtBinding _reb      -> Nothing
+      TypeComplex _pt          -> Nothing
+
+-- | (Non-external) declarations referred to in this type
+--
+-- These are declarations that would appear in the generated Haskell type
+-- whenever this type is used.
+--
+-- This does /not/ include any external declarations.
+typeDeclIds :: Type -> [C.QualDeclId MangleNames]
+typeDeclIds = \case
+    -- Primitive types
+    TypePrim _    -> []
+    TypeVoid      -> []
+    TypeComplex _ -> []
+
+    -- Interesting cases
+    --
+    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1267>
+    -- Once 'DeclId' always has the 'NameKind' this can be simplified.
+    TypeStruct       declId -> [C.QualDeclId declId (C.NameKindTagged C.TagKindStruct)]
+    TypeUnion        declId -> [C.QualDeclId declId (C.NameKindTagged C.TagKindUnion)]
+    TypeEnum         declId -> [C.QualDeclId declId (C.NameKindTagged C.TagKindEnum)]
+    TypeMacroTypedef declId -> [C.QualDeclId declId  C.NameKindOrdinary]
+    TypeTypedef      ref    -> auxTypedef    ref
+    TypeExtBinding   _ext   -> []
+
+    -- Recurse
+    TypePointer         t -> typeDeclIds t
+    TypeConstArray _    t -> typeDeclIds t
+    TypeIncompleteArray t -> typeDeclIds t
+    TypeBlock           t -> typeDeclIds t
+    TypeQualified _     t -> typeDeclIds t
+    TypeFun args res      -> concatMap typeDeclIds (args ++ [res])
+  where
+    auxTypedef :: TypedefRef -> [C.QualDeclId MangleNames]
+    auxTypedef = \case
+        TypedefRegular declId _underlying ->
+          [C.QualDeclId declId C.NameKindOrdinary]
+        TypedefSquashed _origName underlying  ->
+          typeDeclIds underlying
 
 {-------------------------------------------------------------------------------
   Types: Trees That Shrink
@@ -508,18 +559,18 @@ mapTypeF fRef fQual = go
   where
     go :: TypeF tag -> TypeF tag'
     go ty = case ty of
-      TypePrim pt -> TypePrim pt
-      TypeStruct np no -> TypeStruct np no
-      TypeUnion np no -> TypeUnion np no
-      TypeEnum np no -> TypeEnum np no
-      TypeTypedef ref -> fRef ref
-      TypeMacroTypedef np no -> TypeMacroTypedef np no
-      TypePointer t -> TypePointer $ go t
-      TypeConstArray n t -> TypeConstArray n $ go t
-      TypeFun args res -> TypeFun (go <$> args) (go res)
-      TypeVoid -> TypeVoid
-      TypeIncompleteArray t -> TypeIncompleteArray (go t)
-      TypeBlock t -> TypeBlock (go t)
-      TypeQualified q t -> fQual q t
-      TypeExtBinding reb -> TypeExtBinding reb
-      TypeComplex pt -> TypeComplex pt
+      TypePrim pt             -> TypePrim pt
+      TypeStruct declId       -> TypeStruct declId
+      TypeUnion declId        -> TypeUnion declId
+      TypeEnum declId         -> TypeEnum declId
+      TypeTypedef ref         -> fRef ref
+      TypeMacroTypedef declId -> TypeMacroTypedef declId
+      TypePointer t           -> TypePointer $ go t
+      TypeConstArray n t      -> TypeConstArray n $ go t
+      TypeFun args res        -> TypeFun (go <$> args) (go res)
+      TypeVoid                -> TypeVoid
+      TypeIncompleteArray t   -> TypeIncompleteArray (go t)
+      TypeBlock t             -> TypeBlock (go t)
+      TypeQualified q t       -> fQual q t
+      TypeExtBinding reb      -> TypeExtBinding reb
+      TypeComplex pt          -> TypeComplex pt

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Finalize.hs
@@ -64,8 +64,7 @@ instance Finalize Int.DeclInfo where
 
   finalize info = Ext.DeclInfo{
         declLoc
-      , declId = namePair
-      , declOrigin = nameOrigin
+      , declId
       , declAliases
       , declHeaderInfo
       , declComment = fmap finalize declComment
@@ -73,7 +72,7 @@ instance Finalize Int.DeclInfo where
     where
       Int.DeclInfo{
           declLoc
-        , declId = (namePair, nameOrigin)
+        , declId
         , declAliases
         , declHeaderInfo
         , declComment
@@ -109,7 +108,7 @@ instance Finalize Int.DeclKind where
 instance Finalize Int.CommentRef where
   type Finalized Int.CommentRef = Ext.CommentRef
 
-  finalize (Int.CommentRef (x, _)) = Ext.CommentRef x
+  finalize (Int.CommentRef c hs) = Ext.CommentRef c hs
 
 instance Finalize Int.Comment where
   type Finalized Int.Comment = CDoc.Comment Ext.CommentRef
@@ -268,27 +267,27 @@ instance Finalize Int.CheckedMacroType where
 instance Finalize Int.Type where
   type Finalized Int.Type = Ext.Type
 
-  finalize (Int.TypePrim prim)                 = Ext.TypePrim prim
-  finalize (Int.TypeStruct (np, origin))       = Ext.TypeStruct np origin
-  finalize (Int.TypeUnion (np, origin))        = Ext.TypeUnion np origin
-  finalize (Int.TypeEnum (np, origin))         = Ext.TypeEnum np origin
-  finalize (Int.TypeTypedef ref)               = Ext.TypeTypedef (finalize ref)
-  finalize (Int.TypePointer typ)               = Ext.TypePointer (finalize typ)
-  finalize (Int.TypeFun args res)              = Ext.TypeFun (map finalize args) (finalize res)
-  finalize (Int.TypeVoid)                      = Ext.TypeVoid
-  finalize (Int.TypeConstArray n typ)          = Ext.TypeConstArray n (finalize typ)
-  finalize (Int.TypeIncompleteArray typ)       = Ext.TypeIncompleteArray (finalize typ)
-  finalize (Int.TypeExtBinding ext)            = Ext.TypeExtBinding ext
-  finalize (Int.TypeBlock typ)                 = Ext.TypeBlock (finalize typ)
-  finalize (Int.TypeConst typ)                 = Ext.TypeQualified Ext.TypeQualifierConst (finalize typ)
-  finalize (Int.TypeMacroTypedef (np, origin)) = Ext.TypeMacroTypedef np origin
-  finalize (Int.TypeComplex prim)              = Ext.TypeComplex prim
+  finalize (Int.TypePrim prim)           = Ext.TypePrim prim
+  finalize (Int.TypeStruct declId)       = Ext.TypeStruct declId
+  finalize (Int.TypeUnion declId)        = Ext.TypeUnion declId
+  finalize (Int.TypeEnum declId)         = Ext.TypeEnum declId
+  finalize (Int.TypeTypedef ref)         = Ext.TypeTypedef (finalize ref)
+  finalize (Int.TypePointer typ)         = Ext.TypePointer (finalize typ)
+  finalize (Int.TypeFun args res)        = Ext.TypeFun (map finalize args) (finalize res)
+  finalize (Int.TypeVoid)                = Ext.TypeVoid
+  finalize (Int.TypeConstArray n typ)    = Ext.TypeConstArray n (finalize typ)
+  finalize (Int.TypeIncompleteArray typ) = Ext.TypeIncompleteArray (finalize typ)
+  finalize (Int.TypeExtBinding ext)      = Ext.TypeExtBinding ext
+  finalize (Int.TypeBlock typ)           = Ext.TypeBlock (finalize typ)
+  finalize (Int.TypeConst typ)           = Ext.TypeQualified Ext.TypeQualifierConst (finalize typ)
+  finalize (Int.TypeMacroTypedef declId) = Ext.TypeMacroTypedef declId
+  finalize (Int.TypeComplex prim)        = Ext.TypeComplex prim
 
 instance Finalize Int.RenamedTypedefRef where
   type Finalized Int.RenamedTypedefRef = Ext.TypedefRef
 
-  finalize (Int.TypedefRegular (np, _origin) uTy) = Ext.TypedefRegular np (finalize uTy)
-  finalize (Int.TypedefSquashed nm ty) = Ext.TypedefSquashed nm (finalize ty)
+  finalize (Int.TypedefRegular declId uTy) = Ext.TypedefRegular declId (finalize uTy)
+  finalize (Int.TypedefSquashed nm ty)     = Ext.TypedefSquashed nm (finalize ty)
 
 {-------------------------------------------------------------------------------
   Internal: FLAMs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -333,9 +333,11 @@ newtype Comment p =
 
 -- | Cross-reference in a Doxygen comment
 --
--- We use @Id p@ here so that name mangling can do its job and we have
--- access to the right name to reference when generating Haddocks.
-newtype CommentRef p = CommentRef (Id p)
+-- Doxygen references are just strings; in particular, they do not distinguish
+-- between namespaces (i.e., @struct foo@ is simply referred to as @foo@). In
+-- 'MangleNames' we will /search/ for a matching name and set the @HaskellId@
+-- accordingly, so that we can generate an approprate reference in the Haddocks.
+data CommentRef p = CommentRef C.Name (Maybe (HaskellId p))
 
 {-------------------------------------------------------------------------------
   Macros
@@ -468,6 +470,7 @@ class ( IsPass p
       , Show (ArgumentName p)
       , Show (ExtBinding   p)
       , Show (FieldName    p)
+      , Show (HaskellId    p)
       , Show (Id           p)
       , Show (MacroBody    p)
       , Show (TypedefRef   p)
@@ -497,6 +500,7 @@ class ( IsPass p
 
       , Eq (ArgumentName p)
       , Eq (ExtBinding   p)
+      , Eq (HaskellId    p)
       , Eq (MacroBody    p)
       , Eq (TypedefRef   p)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
@@ -188,8 +188,9 @@ typedefOfTagged typedefName valOrRef taggedType@TaggedTypeId{..} useSites
     -- Struct and typedef same name, with intervening pointers
   | ByRef <- valOrRef, typedefName == taggedTypeIdName taggedType
   = let newDeclId = C.DeclIdNamed C.NamedDeclId{
-            name   = typedefName <> "_Deref"
-          , origin = updateOrigin taggedTypeDeclId
+            name      = typedefName <> "_Deref"
+          , origin    = updateOrigin taggedTypeDeclId
+          , haskellId = ()
           }
     in mempty{
            rename = Map.singleton (taggedTypeIdName taggedType) newDeclId
@@ -203,8 +204,9 @@ typedefOfTagged typedefName valOrRef taggedType@TaggedTypeId{..} useSites
     -- to be used throughout the code.
   | ByValue <- valOrRef, [_] <- useSites
   = let newDeclId = C.DeclIdNamed C.NamedDeclId{
-            name   = typedefName
-          , origin = updateOrigin taggedTypeDeclId
+            name      = typedefName
+          , origin    = updateOrigin taggedTypeDeclId
+          , haskellId = ()
           }
         newTagged = TaggedTypeId{
             taggedTypeDeclId = newDeclId

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -48,6 +48,15 @@ class IsPass (p :: Pass) where
   -- | Names of arguments (functions)
   type ArgumentName p :: Star
 
+  -- | Haskell identifier given to a declaration
+  --
+  -- This does not get instantiated until the 'MangleNames' pass.
+  --
+  -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1267>
+  -- This is part of a larger refactoring, and its usage will still change.
+  type HaskellId p :: Star
+  type HaskellId p = ()
+
   -- | Reference to a typedef
   --
   -- Initially this is just the name of the typedef, but after 'HandleTypedefs'

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -69,5 +69,8 @@ data ConstructTranslationUnitMsg =
 instance CoercePassId Parse ConstructTranslationUnit where
   coercePassId _ = id
 
+instance CoercePassHaskellId Parse ConstructTranslationUnit where
+  coercePassHaskellId _ = id
+
 instance CoercePassTypedefRef Parse ConstructTranslationUnit where
   coercePassTypedefRef _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -41,5 +41,8 @@ instance IsPass HandleMacros where
 instance CoercePassId ConstructTranslationUnit HandleMacros where
   coercePassId _ = id
 
+instance CoercePassHaskellId ConstructTranslationUnit HandleMacros where
+  coercePassHaskellId _ = id
+
 instance CoercePassTypedefRef ConstructTranslationUnit HandleMacros where
   coercePassTypedefRef _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs.hs
@@ -129,8 +129,9 @@ introduceAuxFunType td declInfo declAnn args res = [
     derefDecl = C.Decl {
           declInfo = declInfo {
               C.declId = C.DeclIdNamed C.NamedDeclId{
-                  name   = C.declIdName declInfo.declId <> "_Deref"
-                , origin = C.NameOriginGenerated (C.AnonId declInfo.declLoc)
+                  name      = C.declIdName declInfo.declId <> "_Deref"
+                , origin    = C.NameOriginGenerated (C.AnonId declInfo.declLoc)
+                , haskellId = ()
                 }
             , C.declComment = Just auxType
             }
@@ -160,7 +161,8 @@ introduceAuxFunType td declInfo declAnn args res = [
         Clang.Comment [
           Clang.Paragraph [
               Clang.TextContent "Auxiliary type used by "
-            , Clang.InlineRefCommand (C.CommentRef declInfo.declId)
+            , Clang.InlineRefCommand $
+                C.CommentRef (C.declIdName declInfo.declId) Nothing
             ]
         ]
 
@@ -190,7 +192,7 @@ instance HandleUseSites C.FieldInfo where
     }
 
 instance HandleUseSites C.CommentRef where
-  handleUseSites _ (C.CommentRef i) = C.CommentRef (coercePass i)
+  handleUseSites _ (C.CommentRef c hs) = C.CommentRef c hs
 
 instance HandleUseSites C.Comment where
   handleUseSites td (C.Comment comment) =
@@ -297,6 +299,7 @@ instance HandleUseSites C.Type where
             Just ty -> TypedefSquashed name (go ty)
             Nothing -> let named = C.NamedDeclId{
                                 name
-                              , origin = C.NameOriginInSource
+                              , origin    = C.NameOriginInSource
+                              , haskellId = ()
                               }
                        in TypedefRegular (C.DeclIdNamed named) (go uTy)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs/IsPass.hs
@@ -117,5 +117,8 @@ instance IsTrace Level HandleTypedefsMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
+instance CoercePassHaskellId Select HandleTypedefs where
+  coercePassHaskellId _ = id
+
 instance CoercePassId Select HandleTypedefs where
   coercePassId _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -6,6 +6,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bitraversable (bimapM)
 import Data.Map qualified as Map
+import Data.Maybe (listToMaybe)
 import Data.Proxy
 
 import HsBindgen.BindingSpec qualified as BindingSpec
@@ -144,49 +145,50 @@ class MangleDecl a where
 mangleDeclId ::
      C.DeclId HandleTypedefs
   -> [C.NameKind] -- ^ Possible name kinds
-  -> M (C.NamePair, C.NameOrigin)
+  -> M (C.DeclId MangleNames)
 mangleDeclId (C.DeclIdBuiltin _name) _kinds =
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1266>.
     -- Name mangling fails for built-ins: since they don't have a corresponding
     -- declaration, there will be no entry in the 'NameMap'.
     throwPure_TODO 1266 "Cannot mangle builtin name"
 mangleDeclId declId@(C.DeclIdNamed named) kinds = do
+    mHsIdent <- mangleName named.name kinds
+    case mHsIdent of
+      Nothing -> panicPure $ "Missing declaration: " <> show declId
+      Just hs -> return $ C.DeclIdNamed C.NamedDeclId{
+          name      = named.name
+        , origin    = named.origin
+        , haskellId = hs
+        }
+
+-- | Mangle C name, using previously constructed name map
+--
+-- Returns 'Nothing' if no match is found. This should not happen for any
+-- declarations we're processing, but can happen for names found in comment
+-- references, which could be anything at all.
+mangleName :: C.Name -> [C.NameKind] -> M (Maybe Hs.Identifier)
+mangleName name kinds = do
     nm <- asks envNameMap
     let lookupKind :: C.NameKind -> Maybe Hs.Identifier
-        lookupKind kind = Map.lookup (C.QualName named.name kind) nm
+        lookupKind kind = Map.lookup (C.QualName name kind) nm
+    return $ listToMaybe (mapMaybe lookupKind kinds)
 
-    case mapMaybe lookupKind kinds of
-      hs:_ -> return $ mkNamePair hs
-      []   ->
-        -- Name mangling failed
-        --
-        -- This can only happen if we did not register any declaration with the
-        -- given ID. This is most likely because the user did not select the
-        -- declaration. If the declaration was completely missing, Clang would
-        -- have complained already.
-        panicPure $ "Missing declaration: " <> show declId
-  where
-    mkNamePair :: Hs.Identifier -> (C.NamePair, C.NameOrigin)
-    mkNamePair hsName = (C.NamePair named.name hsName, named.origin)
-
-mangleQualDeclId :: C.QualDeclId HandleTypedefs -> M (C.NamePair, C.NameOrigin)
+mangleQualDeclId :: C.QualDeclId HandleTypedefs -> M (C.DeclId MangleNames)
 mangleQualDeclId (C.QualDeclId declId kind) = mangleDeclId declId [kind]
 
 {-------------------------------------------------------------------------------
   Additional name mangling functionality
-
-  TODO: Perhaps some (or all) of this should be configurable.
 -------------------------------------------------------------------------------}
 
 mangleFieldName :: C.DeclInfo MangleNames -> C.Name -> M C.NamePair
 mangleFieldName info fieldCName = do
     fc <- asks envFixCandidate
-    let candidate = declCName <> "_" <> fieldCName
+    let candidate = C.declIdName declId <> "_" <> fieldCName
     let (fieldHsName, mError) = fromCName fc (Proxy @Hs.NsVar) candidate
     forM_ mError $ modify . (:)
     return $ C.NamePair fieldCName fieldHsName
   where
-    C.DeclInfo{declId = (C.NamePair declCName _declHsName, _origin)} = info
+    C.DeclInfo{declId} = info
 
 -- | Mangle enum constant name
 --
@@ -203,20 +205,16 @@ mangleEnumConstant _info cName = do
 --
 -- Right now we reuse the name of the type also for the constructor.
 mkStructNames :: C.DeclInfo MangleNames -> C.RecordNames
-mkStructNames info = C.RecordNames{
-      recordConstr = C.nameHs namePair
+mkStructNames C.DeclInfo{declId} = C.RecordNames{
+      recordConstr = C.unsafeDeclIdHaskellName declId
     }
-  where
-    C.DeclInfo{declId = (namePair, _origin)} = info
 
 -- | Generic construction of newtype names, given only the type name
 mkNewtypeNames :: C.DeclInfo MangleNames -> C.NewtypeNames
-mkNewtypeNames info = C.NewtypeNames{
-      newtypeConstr = C.nameHs namePair
-    , newtypeField  = "un_" <> C.nameHs namePair
+mkNewtypeNames C.DeclInfo{declId} = C.NewtypeNames{
+      newtypeConstr = C.unsafeDeclIdHaskellName declId
+    , newtypeField  = "un_" <> C.unsafeDeclIdHaskellName declId
     }
-  where
-    C.DeclInfo{declId = (namePair, _origin)} = info
 
 -- | Union names
 --
@@ -305,11 +303,11 @@ instance MangleDecl C.DeclKind where
       C.DeclGlobal <$> mangle ty
 
 instance Mangle C.CommentRef where
-  mangle (C.CommentRef declId) =
+  mangle (C.CommentRef c _) = do
     -- NB: If this fails it means that we tried all possible name kinds and
     -- still didn't find any result. This might be because of a typo on the
     -- docs, or a missing reference.
-    C.CommentRef <$> mangleDeclId declId [minBound .. maxBound]
+    C.CommentRef c <$> mangleName c [minBound .. maxBound]
 
 instance Mangle C.Comment where
   mangle (C.Comment comment) =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -14,6 +14,7 @@ import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.HandleTypedefs.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -36,9 +37,10 @@ type family AnnMangleNames ix where
   AnnMangleNames _                  = NoAnn
 
 instance IsPass MangleNames where
-  type Id           MangleNames = (C.NamePair, C.NameOrigin)
+  type Id           MangleNames = C.DeclId MangleNames
   type FieldName    MangleNames = C.NamePair
   type ArgumentName MangleNames = Maybe C.NamePair
+  type HaskellId    MangleNames = Hs.Identifier
   type TypedefRef   MangleNames = RenamedTypedefRef MangleNames
   type MacroBody    MangleNames = C.CheckedMacro MangleNames
   type ExtBinding   MangleNames = ResolvedExtBinding

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
@@ -110,8 +110,9 @@ getDeclId env qualPrelimDeclId declId =
    case declId of
      C.PrelimDeclIdNamed n ->
        Right $ C.DeclIdNamed C.NamedDeclId{
-           name   = n
-         , origin = C.NameOriginInSource
+           name      = n
+         , origin    = C.NameOriginInSource
+         , haskellId = ()
          }
      C.PrelimDeclIdAnon anonId -> do
        let origin :: C.NameOrigin
@@ -120,14 +121,17 @@ getDeclId env qualPrelimDeclId declId =
          Just name -> Right $ C.DeclIdNamed C.NamedDeclId{
              name
            , origin
+           , haskellId = ()
            }
-         Nothing   -> Left $ C.DeclIdNamed C.NamedDeclId{
-             name = "unused_anonymous"
+         Nothing -> Left $ C.DeclIdNamed C.NamedDeclId{
+             name      = "unused_anonymous"
            , origin
+           , haskellId = ()
            }
      C.PrelimDeclIdBuiltin name ->
        Right $ C.DeclIdBuiltin C.BuiltinDeclId{
            name
+         , haskellId = ()
          }
 
 {-------------------------------------------------------------------------------
@@ -156,20 +160,7 @@ instance NameUseSites C.FieldInfo where
     }
 
 instance NameUseSites C.CommentRef where
-  nameUseSites _ (C.CommentRef t) = C.CommentRef (nameUseSite t)
-    where
-      nameUseSite :: C.PrelimDeclId -> C.DeclId NameAnon
-      nameUseSite qualPrelimDeclId =
-          case qualPrelimDeclId of
-            C.PrelimDeclIdNamed name -> C.DeclIdNamed C.NamedDeclId{
-                name
-              , origin = C.NameOriginInSource
-              }
-            C.PrelimDeclIdBuiltin name -> C.DeclIdBuiltin C.BuiltinDeclId{
-                name
-              }
-            C.PrelimDeclIdAnon _ ->
-              panicPure "Anonymous reference"
+  nameUseSites _ (C.CommentRef c hs) = C.CommentRef c hs
 
 instance NameUseSites C.Comment where
   nameUseSites env (C.Comment comment) =
@@ -276,17 +267,20 @@ instance NameUseSites C.Type where
             C.QualPrelimDeclIdNamed name _ns ->
               C.DeclIdNamed C.NamedDeclId{
                   name
-                , origin = C.NameOriginInSource
+                , origin    = C.NameOriginInSource
+                , haskellId = ()
                 }
             C.QualPrelimDeclIdBuiltin name  ->
               C.DeclIdBuiltin C.BuiltinDeclId{
                   name
+                , haskellId = ()
                 }
             C.QualPrelimDeclIdAnon anonId _tk ->
               case findNamedUseOf env qualPrelimDeclId of
                 Just useOfAnon -> C.DeclIdNamed C.NamedDeclId{
-                    name   = nameForAnon useOfAnon
-                  , origin = C.NameOriginGenerated anonId
+                    name      = nameForAnon useOfAnon
+                  , origin    = C.NameOriginGenerated anonId
+                  , haskellId = ()
                   }
                 Nothing ->
                   panicPure "unused anonymous declaration?"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -742,11 +742,10 @@ varDecl info = \curr -> do
 -------------------------------------------------------------------------------}
 
 parseCommentReferences :: CDoc.Comment Text -> C.Comment Parse
-parseCommentReferences = C.Comment
-                       . fmap ( C.CommentRef
-                              . C.PrelimDeclIdNamed
-                              . C.Name
-                              )
+parseCommentReferences comment = C.Comment (fmap auxRefs comment)
+  where
+    auxRefs :: Text -> C.CommentRef Parse
+    auxRefs ref = C.CommentRef (C.Name ref) Nothing
 
 -- | Partition declarations into anonymous and non-anonymous
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -455,8 +455,9 @@ instance Resolve C.Type where
         -> M (C.Type ResolveBindingSpecs)
       auxN mk cName cNameKind = aux mk C.QualDeclId {
           qualDeclId     = C.DeclIdNamed C.NamedDeclId{
-                               name   = cName
-                             , origin = C.NameOriginInSource
+                               name      = cName
+                             , origin    = C.NameOriginInSource
+                             , haskellId = ()
                              }
         , qualDeclIdKind = cNameKind
         }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -129,5 +129,8 @@ instance IsTrace Level ResolveBindingSpecsMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
+instance CoercePassHaskellId NameAnon ResolveBindingSpecs where
+  coercePassHaskellId _ = id
+
 instance CoercePassId NameAnon ResolveBindingSpecs where
   coercePassId _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -217,5 +217,8 @@ instance IsTrace Level SelectMsg where
 instance CoercePassId ResolveBindingSpecs Select where
   coercePassId _ = coercePass
 
+instance CoercePassHaskellId ResolveBindingSpecs Select where
+  coercePassHaskellId _ = id
+
 instance CoercePassTypedefRef ResolveBindingSpecs Select where
   coercePassTypedefRef _ = coercePass

--- a/manual/hs/manual/app/Manual/Functions/FirstOrder.hs
+++ b/manual/hs/manual/app/Manual/Functions/FirstOrder.hs
@@ -5,7 +5,6 @@ module Manual.Functions.FirstOrder (examples) where
 import Control.Monad ((<=<))
 import Foreign as F
 import Foreign.C (withCString)
-import Foreign.C qualified as FC
 import System.IO.Unsafe
 
 import HsBindgen.Runtime.FunPtr
@@ -24,19 +23,6 @@ import FunctionPointers.Safe qualified as FunPtr
 
 hashSafe :: String -> Int
 hashSafe s = fromIntegral $ unsafePerformIO $ withCString s hash
-
-{-------------------------------------------------------------------------------
-  Function pointer instances
--------------------------------------------------------------------------------}
-
-foreign import ccall "dynamic" mkApply1Fun ::
-     F.FunPtr (F.FunPtr FunPtr.Int2int -> FC.CInt -> IO FC.CInt)
-  -> F.FunPtr FunPtr.Int2int
-  -> FC.CInt
-  -> IO FC.CInt
-
-instance FromFunPtr (F.FunPtr FunPtr.Int2int -> FC.CInt -> IO FC.CInt) where
-  fromFunPtr = mkApply1Fun
 
 {-------------------------------------------------------------------------------
   Examples


### PR DESCRIPTION
Prior to this commit, we had

```hs
type Id Parse                    = C.PrelimDeclId
type Id ConstructTranslationUnit = C.PrelimDeclId
type Id HandleMacros             = C.PrelimDeclId
type Id NameAnon                 = C.DeclId NameAnon
type Id ResolveBindingSpecs      = C.DeclId ResolveBindingSpecs
type Id Select                   = C.DeclId Select
type Id HandleTypedefs           = C.DeclId HandleTypedefs
type Id MangleNames              = (C.NamePair, C.NameOrigin)
```

Now this is

```hs
type Id Parse                    = C.PrelimDeclId
type Id ConstructTranslationUnit = C.PrelimDeclId
type Id HandleMacros             = C.PrelimDeclId
type Id NameAnon                 = C.DeclId NameAnon
type Id ResolveBindingSpecs      = C.DeclId ResolveBindingSpecs
type Id Select                   = C.DeclId Select
type Id HandleTypedefs           = C.DeclId HandleTypedefs
type Id MangleNames              = C.DeclId MangleNames
```

The important change is that `DeclId` now has a `haskellId` field:

```hs
data DeclId (p :: Pass) =
    DeclIdNamed   (NamedDeclId   p)
  | DeclIdBuiltin (BuiltinDeclId p)

data NamedDeclId (p :: Pass) = NamedDeclId{
      name      :: Name
    , origin    :: NameOrigin
    , haskellId :: HaskellId p
    }

data BuiltinDeclId (p :: Pass) = BuiltinDeclId{
      name      :: Name
    , haskellId :: HaskellId p
    }
```

where `HaskellId` is a new type family in `IsPass`.

We use `HaskellId` also in `CommentRef`:

```hs
data CommentRef p = CommentRef C.Name (Maybe (HaskellId p))
```

We do not use `Id p` here anymore, in order to pave the way for _always_ including qualifiers (ordinary/struct/..) in `DeclId` (which we do not a priori know for cross-references in comments).

We no longer use `NamePair` at all for declartions. This gets us one step closer to the vision in https://github.com/well-typed/hs-bindgen/issues/1267.
