### PR TITLE
Introduce `BaseModuleName`

### DIFF
--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -16,7 +16,7 @@ module HsBindgen.App (
     -- ** Translation option
   , parseUniqueId
     -- ** Module option
-  , parseHsModuleName
+  , parseBaseModuleName
     -- ** Output options
   , parseHsOutputDir
   , parseOutputDirPolicy
@@ -45,7 +45,6 @@ import HsBindgen.Config.ClangArgs
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Frontend.RootHeader (UncheckedHashIncludeArg)
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
 
@@ -460,12 +459,12 @@ parseUniqueId = fmap UniqueId . strOption $ mconcat [
   Module option
 -------------------------------------------------------------------------------}
 
-parseHsModuleName :: Parser Hs.ModuleName
-parseHsModuleName = strOption $ mconcat [
+parseBaseModuleName :: Parser BaseModuleName
+parseBaseModuleName = strOption $ mconcat [
       long "module"
     , metavar "NAME"
     , showDefault
-    , value defBaseModuleName
+    , value def
     , help "Base name of the generated Haskell modules"
     ]
 

--- a/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
@@ -14,13 +14,13 @@ module HsBindgen.Cli.GenTests (
   ) where
 
 import Control.Monad (void)
+import Data.Default
 import Options.Applicative hiding (info)
 
 import HsBindgen
 import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -34,11 +34,11 @@ info = progDesc "Generate tests for generated Haskell code"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config       :: Config
-    , uniqueId     :: UniqueId
-    , hsModuleName :: Hs.ModuleName
-    , output       :: FilePath
-    , inputs       :: [UncheckedHashIncludeArg]
+      config         :: Config
+    , uniqueId       :: UniqueId
+    , baseModuleName :: BaseModuleName
+    , output         :: FilePath
+    , inputs         :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -46,7 +46,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseUniqueId
-      <*> parseHsModuleName
+      <*> parseBaseModuleName
       <*> parseGenTestsOutput
       <*> parseInputs
 
@@ -57,5 +57,5 @@ parseOpts =
 exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefact = writeTests output
-        bindgenConfig = toBindgenConfig config uniqueId defBaseModuleName
+        bindgenConfig = toBindgenConfig config uniqueId def
     void $ hsBindgen tracerConfig bindgenConfig inputs artefact

--- a/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
@@ -20,7 +20,6 @@ import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -34,11 +33,11 @@ info = progDesc "Output the include graph"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config       :: Config
-    , uniqueId     :: UniqueId
-    , hsModuleName :: Hs.ModuleName
-    , output       :: Maybe FilePath
-    , inputs       :: [UncheckedHashIncludeArg]
+      config         :: Config
+    , uniqueId       :: UniqueId
+    , baseModuleName :: BaseModuleName
+    , output         :: Maybe FilePath
+    , inputs         :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -46,7 +45,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseUniqueId
-      <*> parseHsModuleName
+      <*> parseBaseModuleName
       <*> optional parseOutput'
       <*> parseInputs
 
@@ -65,5 +64,5 @@ parseOutput' = strOption $ mconcat [
 exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefact = writeIncludeGraph output
-        bindgenConfig = toBindgenConfig config uniqueId hsModuleName
+        bindgenConfig = toBindgenConfig config uniqueId baseModuleName
     void $ hsBindgen tracerConfig bindgenConfig inputs artefact

--- a/hs-bindgen/app/HsBindgen/Cli/Info/UseDeclGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/UseDeclGraph.hs
@@ -20,7 +20,6 @@ import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -34,11 +33,11 @@ info = progDesc "Output the use-decl graph"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config       :: Config
-    , uniqueId     :: UniqueId
-    , hsModuleName :: Hs.ModuleName
-    , output       :: Maybe FilePath
-    , inputs       :: [UncheckedHashIncludeArg]
+      config         :: Config
+    , uniqueId       :: UniqueId
+    , baseModuleName :: BaseModuleName
+    , output         :: Maybe FilePath
+    , inputs         :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -46,7 +45,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseUniqueId
-      <*> parseHsModuleName
+      <*> parseBaseModuleName
       <*> optional parseOutput'
       <*> parseInputs
 
@@ -65,5 +64,5 @@ parseOutput' = strOption $ mconcat [
 exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefact = writeUseDeclGraph output
-        bindgenConfig = toBindgenConfig config uniqueId hsModuleName
+        bindgenConfig = toBindgenConfig config uniqueId baseModuleName
     void $ hsBindgen tracerConfig bindgenConfig inputs artefact

--- a/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
@@ -20,7 +20,6 @@ import HsBindgen
 import HsBindgen.App
 import HsBindgen.Config
 import HsBindgen.Frontend.RootHeader
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -34,10 +33,10 @@ info = progDesc "Parse C headers (all Frontend passes)"
 -------------------------------------------------------------------------------}
 
 data Opts = Opts {
-      config       :: Config
-    , uniqueId     :: UniqueId
-    , hsModuleName :: Hs.ModuleName
-    , inputs       :: [UncheckedHashIncludeArg]
+      config         :: Config
+    , uniqueId       :: UniqueId
+    , baseModuleName :: BaseModuleName
+    , inputs         :: [UncheckedHashIncludeArg]
     }
 
 parseOpts :: Parser Opts
@@ -45,7 +44,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseUniqueId
-      <*> parseHsModuleName
+      <*> parseBaseModuleName
       <*> parseInputs
 
 {-------------------------------------------------------------------------------
@@ -55,5 +54,5 @@ parseOpts =
 exec :: GlobalOpts -> Opts -> IO ()
 exec GlobalOpts{..} Opts{..} = do
     let artefact = ReifiedC >>= liftIO . print
-        bindgenConfig = toBindgenConfig config uniqueId hsModuleName
+        bindgenConfig = toBindgenConfig config uniqueId baseModuleName
     hsBindgen tracerConfig bindgenConfig inputs artefact

--- a/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
@@ -24,7 +24,6 @@ import HsBindgen.Config.Internal
 import HsBindgen.Errors
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -40,7 +39,7 @@ info = progDesc "Generate Haskell module from C headers"
 data Opts = Opts {
       config            :: Config
     , uniqueId          :: UniqueId
-    , hsModuleName      :: Hs.ModuleName
+    , baseModuleName    :: BaseModuleName
     , hsOutputDir       :: FilePath
     , outputDirPolicy   :: OutputDirPolicy
     , outputBindingSpec :: Maybe FilePath
@@ -54,7 +53,7 @@ parseOpts =
     Opts
       <$> parseConfig
       <*> parseUniqueId
-      <*> parseHsModuleName
+      <*> parseBaseModuleName
       <*> parseHsOutputDir
       <*> parseOutputDirPolicy
       <*> optional parseGenBindingSpec
@@ -78,7 +77,7 @@ exec GlobalOpts{..} Opts{..} = do
     void $ run $ artefacts
   where
     bindgenConfig :: BindgenConfig
-    bindgenConfig = toBindgenConfig config uniqueId hsModuleName
+    bindgenConfig = toBindgenConfig config uniqueId baseModuleName
 
     run :: Artefact a -> IO a
     run = hsBindgen tracerConfig bindgenConfig inputs

--- a/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
@@ -28,7 +28,6 @@ import HsBindgen.Backend.SHs.AST
 import HsBindgen.Config
 import HsBindgen.Errors
 import HsBindgen.Frontend.RootHeader
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   CLI help
@@ -70,12 +69,12 @@ parseOpts = do
 -------------------------------------------------------------------------------}
 
 data Lit = Lit {
-      globalOpts   :: GlobalOpts
-    , config       :: Config
-    , uniqueId     :: UniqueId
-    , hsModuleName :: Hs.ModuleName
-    , safety       :: Safety
-    , inputs       :: [UncheckedHashIncludeArg]
+      globalOpts     :: GlobalOpts
+    , config         :: Config
+    , uniqueId       :: UniqueId
+    , baseModuleName :: BaseModuleName
+    , safety         :: Safety
+    , inputs         :: [UncheckedHashIncludeArg]
     }
 
 parseLit :: Parser Lit
@@ -83,7 +82,7 @@ parseLit = Lit
   <$> parseGlobalOpts
   <*> parseConfig
   <*> parseUniqueId
-  <*> parseHsModuleName
+  <*> parseBaseModuleName
   <*> parseSafety
   <*> parseInputs
 
@@ -111,7 +110,7 @@ exec literateOpts = do
     Lit{..} <- maybe (throwIO' "cannot parse arguments in literate file") return $
       pureParseLit args
     let GlobalOpts{..} = globalOpts
-        bindgenConfig = toBindgenConfig config uniqueId hsModuleName
+        bindgenConfig = toBindgenConfig config uniqueId baseModuleName
     void $ hsBindgen tracerConfig bindgenConfig inputs $
       writeBindings safety (Just literateOpts.output)
   where

--- a/hs-bindgen/src-internal/HsBindgen/Artefact.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Artefact.hs
@@ -24,6 +24,7 @@ import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Backend.SHs.AST qualified as SHs
 import HsBindgen.Boot
+import HsBindgen.Config
 import HsBindgen.Config.ClangArgs qualified as ClangArgs
 import HsBindgen.Frontend
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
@@ -34,7 +35,6 @@ import HsBindgen.Frontend.AST.External qualified as C
 import HsBindgen.Frontend.ProcessIncludes qualified as ProcessIncludes
 import HsBindgen.Frontend.RootHeader (HashIncludeArg)
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -58,7 +58,7 @@ data Artefact (a :: Star) where
   -- * Backend
   HsDecls             :: Artefact (ByCategory [Hs.Decl])
   FinalDecls          :: Artefact (ByCategory ([UserlandCapiWrapper], [SHs.SDecl]))
-  FinalModuleBaseName :: Artefact Hs.ModuleName
+  FinalModuleBaseName :: Artefact BaseModuleName
   FinalModuleSafe     :: Artefact HsModule
   FinalModuleUnsafe   :: Artefact HsModule
   FinalModules        :: Artefact (ByCategory HsModule)

--- a/hs-bindgen/src-internal/HsBindgen/Backend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend.hs
@@ -16,7 +16,6 @@ import HsBindgen.Cache
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 -- | The backend translates the parsed C declarations in to Haskell
@@ -56,7 +55,7 @@ backend tracer BackendConfig{..} BootArtefact{..} FrontendArtefact{..} = do
     , ..
     }
   where
-    moduleBaseName = bootModule
+    moduleBaseName = bootBaseModule
 
     cache :: IO a -> IO (IO a)
     cache = cacheWith (contramap BackendCache tracer) Nothing
@@ -68,7 +67,7 @@ backend tracer BackendConfig{..} BootArtefact{..} FrontendArtefact{..} = do
 data BackendArtefact = BackendArtefact {
     backendHsDecls             :: IO (SHs.ByCategory [Hs.Decl])
   , backendFinalDecls          :: IO (SHs.ByCategory ([UserlandCapiWrapper], [SHs.SDecl]))
-  , backendFinalModuleBaseName :: Hs.ModuleName
+  , backendFinalModuleBaseName :: BaseModuleName
   , backendFinalModuleSafe     :: IO HsModule
   , backendFinalModuleUnsafe   :: IO HsModule
   , backendFinalModules        :: IO (SHs.ByCategory HsModule)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -54,7 +54,7 @@ import DeBruijn (Add (..), Env (..), Idx (..), pattern I1, pattern I2, sizeEnv,
 generateDeclarations ::
      TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> DeclIndex
   -> [C.Decl]
   -> ByCategory [Hs.Decl]
@@ -81,7 +81,7 @@ data WithCategory a = WithCategory {
 generateDeclarations' ::
      TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> DeclIndex
   -> [C.Decl]
   -> [WithCategory Hs.Decl]
@@ -332,7 +332,7 @@ generateDecs ::
      State.MonadState InstanceMap m
   => TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> C.Decl
   -> m [WithCategory Hs.Decl]
 generateDecs opts haddockConfig moduleName (C.Decl info kind spec) =
@@ -1588,7 +1588,7 @@ functionDecs ::
   => SHs.Safety
   -> TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> C.DeclInfo
   -> C.Function
   -> C.DeclSpec
@@ -1850,7 +1850,7 @@ getMainHashIncludeArg declInfo = case C.declHeaderInfo declInfo of
 global ::
      TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> InstanceMap
   -> C.DeclInfo
   -> C.Type
@@ -1937,7 +1937,7 @@ constGetter ty instsMap info pureStubName = concat [
 addressStubDecs ::
      TranslationConfig
   -> HaddockConfig
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> C.DeclInfo -- ^ The given declaration
   -> C.Type -- ^ The type of the given declaration
   -> C.DeclSpec
@@ -2073,7 +2073,7 @@ newtype UniqueSymbolId = UniqueSymbolId { unUniqueSymbolId :: String }
 
 getUniqueSymbolId ::
      UniqueId
-  -> Hs.ModuleName
+  -> BaseModuleName
   -> Maybe Safety
   -> String
   -> UniqueSymbolId
@@ -2096,11 +2096,11 @@ getUniqueSymbolId (UniqueId uniqueId) moduleName msafety symbolName =
 
     -- We use `cryptohash-sha256` to avoid potential dynamic linker problems
     -- (https://github.com/haskell-haskey/xxhash-ffi/issues/4).
-    getHash :: Hs.ModuleName -> Maybe Safety -> String -> String
+    getHash :: BaseModuleName -> Maybe Safety -> String -> String
     getHash x y z = B.unpack $ B.take 16 $ B16.encode $
       hash $ getString x y z
 
     -- We use ByteString to avoid hash changes induced by a change of how Text
     -- is encoded in GHC 9.2.
-    getString :: Hs.ModuleName -> Maybe Safety -> String -> ByteString
-    getString x y z = B.pack $ Hs.moduleNameToString x <> show y <> z
+    getString :: BaseModuleName -> Maybe Safety -> String -> ByteString
+    getString x y z = B.pack $ baseModuleNameToString x <> show y <> z

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
@@ -11,9 +11,7 @@ module HsBindgen.Backend.SHs.AST (
     PatExpr (..),
     SDecl (..),
     ByCategory(..),
-    BindingCategory(..),
     mapByCategory,
-    displayBindingCategory,
     Pragma (..),
     ClosedType,
     SType (..),
@@ -41,6 +39,7 @@ import HsBindgen.Backend.Hs.CallConv
 import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Origin qualified as Origin
 import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Config.Prelims
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.NameHint
@@ -305,28 +304,6 @@ newtype ByCategory a = ByCategory { unByCategory :: Map BindingCategory a }
 
 mapByCategory :: (BindingCategory -> a -> b) -> ByCategory a -> ByCategory b
 mapByCategory f = ByCategory . Map.mapWithKey f . unByCategory
-
--- | Foreign import category.
-data BindingCategory =
-    -- | Types (top-level bindings).
-    BType
-    -- | Foreign import bindings with a @safe@ foreign import modifier.
-  | BSafe
-    -- | Foreign import bindings with an @unsafe@ foreign import modifier.
-  | BUnsafe
-    -- | Pointers to functions; generally @unsafe@.
-  | BFunPtr
-    -- | Temporary category for bindings to global variables or constants.
-  | BGlobal
-  deriving stock (Show, Eq, Ord, Enum, Bounded)
-
-displayBindingCategory :: BindingCategory -> String
-displayBindingCategory = \case
-  BType   -> "Type"
-  BSafe   -> "Safe"
-  BUnsafe -> "Unsafe"
-  BFunPtr -> "FunPtr"
-  BGlobal -> "Global"
 
 type ClosedType = SType EmptyCtx
 

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -27,7 +27,6 @@ import HsBindgen.Config.ClangArgs qualified as ClangArgs
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 -- | Boot phase.
@@ -71,7 +70,7 @@ boot
         (contramap BootBindingSpec tracer)
         clangArgs
         target
-        hsModuleName
+        (fromBaseModuleName baseModuleName (Just BType))
         (bootBindingSpecConfig bindgenBootConfig)
 
     getExternalBindingSpecs <- cache "getExternalBindingSpecs" $ do
@@ -81,7 +80,7 @@ boot
       withTrace BootStatusPrescriptiveBindingSpec $ fmap snd getBindingSpecs
 
     pure BootArtefact {
-          bootModule                  = hsModuleName
+          bootBaseModule              = baseModuleName
         , bootCStandard               = clangArgsConfig.cStandard
         , bootClangArgs               = getClangArgs
         , bootTarget                  = getTarget
@@ -93,8 +92,8 @@ boot
     clangArgsConfig :: ClangArgsConfig FilePath
     clangArgsConfig = bindgenBootConfig.bootClangArgsConfig
 
-    hsModuleName :: Hs.ModuleName
-    hsModuleName = bindgenBootConfig.bootHsModuleName
+    baseModuleName :: BaseModuleName
+    baseModuleName = bindgenBootConfig.bootBaseModuleName
 
     tracerBootStatus :: Tracer BootStatusMsg
     tracerBootStatus = contramap BootStatus tracer
@@ -186,7 +185,7 @@ getClangTarget tracer clangArgs = do
 -------------------------------------------------------------------------------}
 
 data BootArtefact = BootArtefact {
-    bootModule                  :: Hs.ModuleName
+    bootBaseModule              :: BaseModuleName
   , bootCStandard               :: CStandard
   , bootClangArgs               :: IO ClangArgs
   , bootTarget                  :: IO ClangArgs.Target

--- a/hs-bindgen/src-internal/HsBindgen/Config.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config.hs
@@ -4,8 +4,8 @@
 module HsBindgen.Config (
     Config_(..)
   , UniqueId(..)
+  , BaseModuleName(..)
   , toBindgenConfig
-  , defBaseModuleName
 
     -- * Client
   , OutputDirPolicy(..)
@@ -24,7 +24,6 @@ import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
 
@@ -53,13 +52,13 @@ data Config_ path = Config {
   deriving stock (Functor, Foldable, Traversable)
   deriving anyclass (Default)
 
-toBindgenConfig :: Config_ FilePath -> UniqueId -> Hs.ModuleName -> BindgenConfig
-toBindgenConfig Config{..} uniqueId hsModuleName =
+toBindgenConfig :: Config_ FilePath -> UniqueId -> BaseModuleName -> BindgenConfig
+toBindgenConfig Config{..} uniqueId baseModuleName =
     BindgenConfig bootConfig frontendConfig backendConfig
   where
     bootConfig = BootConfig {
         bootClangArgsConfig   = clang
-      , bootHsModuleName      = hsModuleName
+      , bootBaseModuleName    = baseModuleName
       , bootBindingSpecConfig = bindingSpec
       }
     frontendConfig = FrontendConfig {

--- a/hs-bindgen/src-internal/HsBindgen/Config/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config/Internal.hs
@@ -21,7 +21,6 @@ import HsBindgen.Config.Prelims
 import HsBindgen.Frontend.Pass.Select.IsPass (ProgramSlicing)
 import HsBindgen.Frontend.Predicate (Boolean, ParsePredicate, SelectPredicate)
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Tracer
 
 -- | Configuration of @hs-bindgen@.
@@ -49,7 +48,7 @@ data BindgenConfig = BindgenConfig {
 
 data BootConfig = BootConfig {
       bootClangArgsConfig     :: ClangArgsConfig FilePath
-    , bootHsModuleName        :: Hs.ModuleName
+    , bootBaseModuleName      :: BaseModuleName
     , bootBindingSpecConfig   :: BindingSpecConfig
     }
   deriving stock (Show, Eq, Generic)
@@ -57,7 +56,7 @@ data BootConfig = BootConfig {
 instance Default BootConfig where
   def = BootConfig {
         bootClangArgsConfig   = def
-      , bootHsModuleName      = defBaseModuleName
+      , bootBaseModuleName    = def
       , bootBindingSpecConfig = def
       }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -153,7 +153,7 @@ frontend tracer FrontendConfig{..} BootArtefact{..} = do
       let (afterResolveBindingSpecs, msgsResolveBindingSpecs) =
             resolveBindingSpecs
               target
-              bootModule
+              (fromBaseModuleName bootBaseModule (Just BType))
               extSpecs
               pSpec
               afterNameAnon

--- a/hs-bindgen/src-internal/HsBindgen/Language/Haskell.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/Haskell.hs
@@ -10,6 +10,7 @@ module HsBindgen.Language.Haskell (
   , moduleNameToText
   , moduleNameFromString
   , moduleNameToString
+  , moduleNamePath
     -- * References
   , Identifier(..)
   , ExtRef(..)
@@ -26,8 +27,10 @@ module HsBindgen.Language.Haskell (
 
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
+import Data.Foldable qualified as Foldable
 import Data.Ord qualified as Ord
 import Data.Text qualified as Text
+import System.FilePath
 import Text.Read (readMaybe)
 import Text.SimplePrettyPrint qualified as PP
 
@@ -54,6 +57,14 @@ moduleNameFromString = moduleNameFromText . Text.pack
 
 moduleNameToString :: ModuleName -> String
 moduleNameToString = Text.unpack . moduleNameToText
+
+moduleNamePath :: ModuleName -> FilePath
+moduleNamePath moduleName = withoutExt <.> "hs"
+  where
+    withoutExt :: FilePath
+    withoutExt =
+        Foldable.foldl' (</>) "" $
+          map Text.unpack (Text.splitOn "." $ moduleNameToText moduleName)
 
 instance PrettyForTrace ModuleName where
   prettyForTrace = PP.textToCtxDoc . moduleNameToText

--- a/hs-bindgen/src-internal/HsBindgen/Test.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Test.hs
@@ -9,9 +9,10 @@ import System.FilePath qualified as FilePath
 
 import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.SHs.AST (ByCategory)
+import HsBindgen.Config
+import HsBindgen.Config.Prelims
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
-import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Test.C (genTestsC)
 import HsBindgen.Test.Hs (genTestsHs)
 import HsBindgen.Test.Readme (genTestsReadme)
@@ -24,16 +25,16 @@ import HsBindgen.Test.Readme (genTestsReadme)
 genTests ::
      [HashIncludeArg]
   -> ByCategory [Hs.Decl]
-  -> Hs.ModuleName -- ^ Generated Haskell module name
-  -> FilePath      -- ^ Test suite directory path
+  -> BaseModuleName -- ^ Generated Haskell module name
+  -> FilePath       -- ^ Test suite directory path
   -> IO ()
-genTests hashIncludeArgs decls hsModuleName testSuitePath = do
+genTests hashIncludeArgs decls baseModule testSuitePath = do
     -- fails when testSuitePath already exists
     mapM_ Dir.createDirectory $
       testSuitePath : cbitsPath : srcPath : modulePaths
     genTestsReadme
       readmePath
-      hsModuleName
+      baseModule
       testSuitePath
       cTestHeaderPath
       cTestSourcePath
@@ -46,7 +47,7 @@ genTests hashIncludeArgs decls hsModuleName testSuitePath = do
       hsTestPath
       hsSpecPath
       hsMainPath
-      hsModuleName
+      baseModule
       cTestHeaderPath
       decls
   where
@@ -68,7 +69,7 @@ genTests hashIncludeArgs decls hsModuleName testSuitePath = do
     hsMainPath                = FilePath.combine srcPath "Main.hs"
 
     moduleName :: String
-    moduleName = Hs.moduleNameToString hsModuleName
+    moduleName = baseModuleNameToString baseModule
 
 {-------------------------------------------------------------------------------
   Auxiliary functions

--- a/hs-bindgen/src-internal/HsBindgen/Test/Hs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Test/Hs.hs
@@ -4,8 +4,8 @@ module HsBindgen.Test.Hs (
 
 import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.SHs.AST
+import HsBindgen.Config
 import HsBindgen.Errors
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   Generation
@@ -13,11 +13,11 @@ import HsBindgen.Language.Haskell qualified as Hs
 
 -- | Generate Haskell test modules
 genTestsHs ::
-     FilePath      -- ^ Test module path
-  -> FilePath      -- ^ Spec module path
-  -> FilePath      -- ^ Main module path
-  -> Hs.ModuleName -- ^ Generated Haskell module name
-  -> FilePath      -- ^ C test header file path
+     FilePath       -- ^ Test module path
+  -> FilePath       -- ^ Spec module path
+  -> FilePath       -- ^ Main module path
+  -> BaseModuleName -- ^ Generated Haskell module name
+  -> FilePath       -- ^ C test header file path
   -> ByCategory [Hs.Decl]    -- ^ Declarations
   -> IO ()
 genTestsHs = throwPure_TODO 22 "generate test suite"

--- a/hs-bindgen/src-internal/HsBindgen/Test/Readme.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Test/Readme.hs
@@ -4,20 +4,20 @@ module HsBindgen.Test.Readme (
 
 import System.FilePath qualified as FilePath
 
-import HsBindgen.Language.Haskell qualified as Hs
+import HsBindgen.Config.Prelims
 
 {-------------------------------------------------------------------------------
   Generation
 -------------------------------------------------------------------------------}
 
 genTestsReadme ::
-     FilePath      -- ^ README path
-  -> Hs.ModuleName -- ^ Module name (example: @Acme.Foo@)
-  -> FilePath      -- ^ Test suite directory path
-  -> FilePath      -- ^ C header path
-  -> FilePath      -- ^ C source path
+     FilePath       -- ^ README path
+  -> BaseModuleName -- ^ Module name (example: @Acme.Foo@)
+  -> FilePath       -- ^ Test suite directory path
+  -> FilePath       -- ^ C header path
+  -> FilePath       -- ^ C source path
   -> IO ()
-genTestsReadme readmePath moduleName testSuitePath cHeaderPath cSourcePath =
+genTestsReadme readmePath baseModule testSuitePath cHeaderPath cSourcePath =
     writeFile readmePath $ unlines
       [ "# " ++ moduleNameStr ++ " hs-bindgen Test Suite"
       , ""
@@ -60,4 +60,4 @@ genTestsReadme readmePath moduleName testSuitePath cHeaderPath cSourcePath =
     testSuite = FilePath.takeFileName testSuitePath
 
     moduleNameStr :: String
-    moduleNameStr = Hs.moduleNameToString moduleName
+    moduleNameStr = baseModuleNameToString baseModule

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/TestCase.hs
@@ -211,7 +211,7 @@ getTestBootConfig testResources TestCase{..} = do
         bootClangArgsConfig = clangArgsConfig {
             builtinIncDir = BuiltinIncDirDisable
           }
-      , bootHsModuleName = "Example"
+      , bootBaseModuleName = "Example"
       , bootBindingSpecConfig = BindingSpecConfig {
             stdlibSpec              = testStdlibSpec
           , compatibility           = BindingSpecStrict


### PR DESCRIPTION
While I was working on improving the hashing situation (https://github.com/well-typed/hs-bindgen/issues/1342), @dschrempf quite rightly worried that I was confusing the "base" module name with the "actual" module name. This PR makes this distinction a lot more obvious by introducing a type level distinction between these two concepts. 

This makes a type-level distinction between the _base_ module name (`"Generated`") and "proper" (derived) module names (`"Generated.Safe"` etc, though also `"Generated"` itself).

This also centralizes the translation from base module name to module names, which helps to address
https://github.com/well-typed/hs-bindgen/issues/1339#issuecomment-3589665896 .

