### PR TITLE
Insist on export lists

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -63,6 +63,7 @@ common lang
 library internal
   import:           lang
   hs-source-dirs:   src-internal
+  ghc-options:      -Wmissing-export-lists
 
   -- Modules containing public API.
   exposed-modules:  HsBindgen.Config

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Config.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Config.hs
@@ -1,4 +1,7 @@
-module HsBindgen.Backend.Hs.Haddock.Config where
+module HsBindgen.Backend.Hs.Haddock.Config (
+    HaddockConfig(..)
+  , PathStyle(..)
+  ) where
 
 import HsBindgen.Imports
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Documentation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Documentation.hs
@@ -3,7 +3,15 @@
 -- Intended for qualified import.
 --
 -- > import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
-module HsBindgen.Backend.Hs.Haddock.Documentation where
+module HsBindgen.Backend.Hs.Haddock.Documentation (
+    -- * Definition
+    Comment(..)
+  , CommentInlineContent(..)
+  , CommentMeta(..)
+  , CommentBlockContent(..)
+  , HeaderLevel(..)
+  , ListType(..)
+  ) where
 
 import Data.Semigroup (First (..))
 import Data.Text (Text)
@@ -14,6 +22,10 @@ import Clang.HighLevel.Types
 
 import HsBindgen.Backend.Hs.AST.Type (HsType)
 import HsBindgen.Frontend.AST.External qualified as C
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
 
 -- | Haddock documentation representation
 --

--- a/hs-bindgen/src-internal/HsBindgen/Clang/CompareVersions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/CompareVersions.hs
@@ -1,5 +1,7 @@
-
-module HsBindgen.Clang.CompareVersions where
+module HsBindgen.Clang.CompareVersions (
+    CompareVersionsMsg(..)
+  , compareClangVersions
+  ) where
 
 import Text.SimplePrettyPrint ((<+>))
 import Text.SimplePrettyPrint qualified as PP

--- a/hs-bindgen/src-internal/HsBindgen/NameHint.hs
+++ b/hs-bindgen/src-internal/HsBindgen/NameHint.hs
@@ -1,4 +1,6 @@
-module HsBindgen.NameHint where
+module HsBindgen.NameHint (
+    NameHint(..)
+  ) where
 
 import Data.Char (toLower)
 

--- a/hs-bindgen/src-internal/Text/SimplePrettyPrint.hs
+++ b/hs-bindgen/src-internal/Text/SimplePrettyPrint.hs
@@ -17,7 +17,57 @@
 -- The underlying @pretty@ library gives very little control over indentation.
 -- If we would like to have better indentation, we should either switch to a
 -- different underlying library or write our own.
-module Text.SimplePrettyPrint where
+module Text.SimplePrettyPrint (
+    CtxDoc -- opaque
+    -- * 'CtxDoc' features
+  , withFreshName
+  , ifFits
+    -- * Rendering
+  , runCtxDoc
+  , renderCtxDoc
+    -- ** Context
+  , Context -- opaque
+  , mkContext
+  , defaultContext
+  , debugContext
+    -- * Pretty class
+  , Pretty(..)
+  , renderPretty
+    -- * Construction
+    -- ** Primitives
+  , empty
+  , char
+  , string
+  , showToCtxDoc
+  , textToCtxDoc
+  , renderedLines
+    -- ** Horizontal and vertical composition
+  , (><)
+  , hcat
+  , (<+>)
+  , hsep
+  , ($$)
+  , vcat
+  , ($+$)
+  , vsep
+  , cat
+  , fcat
+  , sep
+  , fsep
+    -- ** Bracketing
+  , parens
+  , parensWhen
+  , vparensWhen
+  , singleQuotes
+    -- ** Lists
+  , hlist
+  , vlist
+    -- ** Indentation
+  , nest
+  , hang
+  , hangs
+  , hangs'
+  ) where
 
 import Data.List qualified as List
 import Data.String (IsString (fromString))


### PR DESCRIPTION
Doing this I discovered function `renderedLines` in the pretty-print module (which was amongst the modules without an export list), used that to fix the rendering of macro parse errors. Before:

```c
#define MyVoid void
```

would result in

```
[Warning] [HsBindgen] [select-handle-macros] Could not select declaration (macro parse failure):
  'MyVoid' at "./test.h:1:9":
    Could not parse macro as type: Unsupported:  type 'void'
    nor as expression: Reparse error:  "./test.h" (line 1, column 16):
unexpected "void" (simpleEnum CXToken_Keyword)
expecting expression
                       MyVoid void
```

which is quite bad (I knew it was bad but I didn't realize we had infrastructure in place to easily fix it). Now:

```
[Warning] [HsBindgen] [select-handle-macros] Could not select declaration (macro parse failure):
  'MyVoid' at "./test.h:1:9":
    Could not parse macro as type:
      Unsupported:  type 'void'
    nor as expression:
      "./test.h" (line 1, column 16):
      unexpected "void" (simpleEnum CXToken_Keyword)
      expecting expression
```

:relieved: 