### PR TITLE
Include `UniqueId.source` as a comment

### DIFF
--- a/hs-bindgen/fixtures/arrays/array/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/FunPtr.hs
@@ -228,6 +228,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_fun_1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_3ced2f3b2af806f8" hs_bindgen_test_arraysarray_3ced2f3b2af806f8 ::
      IO (Ptr.FunPtr (FC.CInt -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt) -> IO FC.CInt))
 
@@ -245,6 +247,8 @@ fun_1_ptr :: Ptr.FunPtr (FC.CInt -> ((HsBindgen.Runtime.ConstantArray.ConstantAr
 fun_1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_3ced2f3b2af806f8
 
+{-| __unique:__ @ExampleNothingget_fun_2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_84966994a8d7df93" hs_bindgen_test_arraysarray_84966994a8d7df93 ::
      IO (Ptr.FunPtr (Triplet -> IO FC.CInt))
 
@@ -262,6 +266,8 @@ fun_2_ptr :: Ptr.FunPtr (Triplet -> IO FC.CInt)
 fun_2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_84966994a8d7df93
 
+{-| __unique:__ @ExampleNothingget_fun_3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_3e6c940dbd7e5492" hs_bindgen_test_arraysarray_3e6c940dbd7e5492 ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt) -> IO FC.CInt))
 
@@ -279,6 +285,8 @@ fun_3_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.C
 fun_3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_3e6c940dbd7e5492
 
+{-| __unique:__ @ExampleNothingget_fun_4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_d9f87d3e541b15e5" hs_bindgen_test_arraysarray_d9f87d3e541b15e5 ::
      IO (Ptr.FunPtr (List -> IO FC.CInt))
 
@@ -296,6 +304,8 @@ fun_4_ptr :: Ptr.FunPtr (List -> IO FC.CInt)
 fun_4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_d9f87d3e541b15e5
 
+{-| __unique:__ @ExampleNothingget_fun_5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_cd41e41992d89300" hs_bindgen_test_arraysarray_cd41e41992d89300 ::
      IO (Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> IO FC.CInt))
 
@@ -313,6 +323,8 @@ fun_5_ptr :: Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((Hs
 fun_5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_cd41e41992d89300
 
+{-| __unique:__ @ExampleNothingget_fun_6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_db0e2655437ab8bb" hs_bindgen_test_arraysarray_db0e2655437ab8bb ::
      IO (Ptr.FunPtr (Matrix -> IO FC.CInt))
 
@@ -330,6 +342,8 @@ fun_6_ptr :: Ptr.FunPtr (Matrix -> IO FC.CInt)
 fun_6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_db0e2655437ab8bb
 
+{-| __unique:__ @ExampleNothingget_fun_7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_9ec02aa16b020aa0" hs_bindgen_test_arraysarray_9ec02aa16b020aa0 ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> IO FC.CInt))
 
@@ -347,6 +361,8 @@ fun_7_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray ((Hs
 fun_7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_9ec02aa16b020aa0
 
+{-| __unique:__ @ExampleNothingget_fun_8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a41b8d1332b69b95" hs_bindgen_test_arraysarray_a41b8d1332b69b95 ::
      IO (Ptr.FunPtr (Tripletlist -> IO FC.CInt))
 
@@ -364,6 +380,8 @@ fun_8_ptr :: Ptr.FunPtr (Tripletlist -> IO FC.CInt)
 fun_8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_a41b8d1332b69b95
 
+{-| __unique:__ @ExampleNothingget_isSolved_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04" hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04 ::
      IO (Ptr.FunPtr (Sudoku -> IO FC.CInt))
 
@@ -381,6 +399,8 @@ isSolved_ptr :: Ptr.FunPtr (Sudoku -> IO FC.CInt)
 isSolved_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04
 
+{-| __unique:__ @ExampleNothingget_fun_1_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a3de5f7e233ad0e1" hs_bindgen_test_arraysarray_a3de5f7e233ad0e1 ::
      IO (Ptr.FunPtr (FC.CInt -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt) -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt) -> IO FC.CInt))
 
@@ -398,6 +418,8 @@ fun_1_const_ptr :: Ptr.FunPtr (FC.CInt -> ((HsBindgen.Runtime.ConstantArray.Cons
 fun_1_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_a3de5f7e233ad0e1
 
+{-| __unique:__ @ExampleNothingget_fun_2_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_3c09bbba7534ca1d" hs_bindgen_test_arraysarray_3c09bbba7534ca1d ::
      IO (Ptr.FunPtr (Triplet -> Triplet -> IO FC.CInt))
 
@@ -415,6 +437,8 @@ fun_2_const_ptr :: Ptr.FunPtr (Triplet -> Triplet -> IO FC.CInt)
 fun_2_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_3c09bbba7534ca1d
 
+{-| __unique:__ @ExampleNothingget_fun_3_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_0e53ed28ec1ca276" hs_bindgen_test_arraysarray_0e53ed28ec1ca276 ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt) -> (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt) -> IO FC.CInt))
 
@@ -432,6 +456,8 @@ fun_3_const_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArra
 fun_3_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_0e53ed28ec1ca276
 
+{-| __unique:__ @ExampleNothingget_fun_4_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_07d860d5e74c415b" hs_bindgen_test_arraysarray_07d860d5e74c415b ::
      IO (Ptr.FunPtr (List -> List -> IO FC.CInt))
 
@@ -449,6 +475,8 @@ fun_4_const_ptr :: Ptr.FunPtr (List -> List -> IO FC.CInt)
 fun_4_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_07d860d5e74c415b
 
+{-| __unique:__ @ExampleNothingget_fun_5_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_3c0a139c24d7202a" hs_bindgen_test_arraysarray_3c0a139c24d7202a ::
      IO (Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> IO FC.CInt))
 
@@ -466,6 +494,8 @@ fun_5_const_ptr :: Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 4
 fun_5_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_3c0a139c24d7202a
 
+{-| __unique:__ @ExampleNothingget_fun_6_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_62d236581cc18366" hs_bindgen_test_arraysarray_62d236581cc18366 ::
      IO (Ptr.FunPtr (Matrix -> Matrix -> IO FC.CInt))
 
@@ -483,6 +513,8 @@ fun_6_const_ptr :: Ptr.FunPtr (Matrix -> Matrix -> IO FC.CInt)
 fun_6_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_62d236581cc18366
 
+{-| __unique:__ @ExampleNothingget_fun_7_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_b4bf67c3cec12e54" hs_bindgen_test_arraysarray_b4bf67c3cec12e54 ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) -> IO FC.CInt))
 
@@ -500,6 +532,8 @@ fun_7_const_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArra
 fun_7_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_b4bf67c3cec12e54
 
+{-| __unique:__ @ExampleNothingget_fun_8_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_99dd6a6017eb0eec" hs_bindgen_test_arraysarray_99dd6a6017eb0eec ::
      IO (Ptr.FunPtr (Tripletlist -> Tripletlist -> IO FC.CInt))
 
@@ -517,6 +551,8 @@ fun_8_const_ptr :: Ptr.FunPtr (Tripletlist -> Tripletlist -> IO FC.CInt)
 fun_8_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_99dd6a6017eb0eec
 
+{-| __unique:__ @ExampleNothingget_isSolved_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_6deec046c95e4e0d" hs_bindgen_test_arraysarray_6deec046c95e4e0d ::
      IO (Ptr.FunPtr (Sudoku -> Sudoku -> IO FC.CInt))
 
@@ -534,6 +570,8 @@ isSolved_const_ptr :: Ptr.FunPtr (Sudoku -> Sudoku -> IO FC.CInt)
 isSolved_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_6deec046c95e4e0d
 
+{-| __unique:__ @ExampleNothingget_fun_9_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_76f53f330102e743" hs_bindgen_test_arraysarray_76f53f330102e743 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))))
 
@@ -551,6 +589,8 @@ fun_9_ptr :: Ptr.FunPtr (IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantA
 fun_9_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_76f53f330102e743
 
+{-| __unique:__ @ExampleNothingget_fun_10_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_abcc94f01de77b25" hs_bindgen_test_arraysarray_abcc94f01de77b25 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr Triplet)))
 
@@ -568,6 +608,8 @@ fun_10_ptr :: Ptr.FunPtr (IO (Ptr.Ptr Triplet))
 fun_10_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_abcc94f01de77b25
 
+{-| __unique:__ @ExampleNothingget_fun_11_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_6661b46e4a751a85" hs_bindgen_test_arraysarray_6661b46e4a751a85 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))))
 
@@ -585,6 +627,8 @@ fun_11_ptr :: Ptr.FunPtr (IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.Incompl
 fun_11_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_6661b46e4a751a85
 
+{-| __unique:__ @ExampleNothingget_fun_12_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_9c80a9e3300aad15" hs_bindgen_test_arraysarray_9c80a9e3300aad15 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr List)))
 
@@ -602,6 +646,8 @@ fun_12_ptr :: Ptr.FunPtr (IO (Ptr.Ptr List))
 fun_12_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_9c80a9e3300aad15
 
+{-| __unique:__ @ExampleNothingget_fun_13_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_bb741b7e8c029e7e" hs_bindgen_test_arraysarray_bb741b7e8c029e7e ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))))
 
@@ -619,6 +665,8 @@ fun_13_ptr :: Ptr.FunPtr (IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.Constant
 fun_13_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_bb741b7e8c029e7e
 
+{-| __unique:__ @ExampleNothingget_fun_14_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_75d83252a55a5c64" hs_bindgen_test_arraysarray_75d83252a55a5c64 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr Matrix)))
 
@@ -636,6 +684,8 @@ fun_14_ptr :: Ptr.FunPtr (IO (Ptr.Ptr Matrix))
 fun_14_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_75d83252a55a5c64
 
+{-| __unique:__ @ExampleNothingget_fun_15_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_069ac2d1873f3210" hs_bindgen_test_arraysarray_069ac2d1873f3210 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))))
 
@@ -653,6 +703,8 @@ fun_15_ptr :: Ptr.FunPtr (IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.Incompl
 fun_15_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_069ac2d1873f3210
 
+{-| __unique:__ @ExampleNothingget_fun_16_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_314971335aaa6db3" hs_bindgen_test_arraysarray_314971335aaa6db3 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr Tripletlist)))
 
@@ -670,6 +722,8 @@ fun_16_ptr :: Ptr.FunPtr (IO (Ptr.Ptr Tripletlist))
 fun_16_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_314971335aaa6db3
 
+{-| __unique:__ @ExampleNothingget_solve_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_9a62b5848be64bd4" hs_bindgen_test_arraysarray_9a62b5848be64bd4 ::
      IO (Ptr.FunPtr (IO (Ptr.Ptr Sudoku)))
 

--- a/hs-bindgen/fixtures/arrays/array/Example/Global.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Global.hs
@@ -152,6 +152,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_arr0_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a6413f4d2092265d" hs_bindgen_test_arraysarray_a6413f4d2092265d ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -169,6 +171,8 @@ arr0_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr0_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_a6413f4d2092265d
 
+{-| __unique:__ @ExampleNothingget_arr1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_1693226264ba4aeb" hs_bindgen_test_arraysarray_1693226264ba4aeb ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -186,6 +190,8 @@ arr1_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_1693226264ba4aeb
 
+{-| __unique:__ @ExampleNothingget_arr2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_dafcf99a73b93389" hs_bindgen_test_arraysarray_dafcf99a73b93389 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -203,6 +209,8 @@ arr2_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_dafcf99a73b93389
 
+{-| __unique:__ @ExampleNothingget_arr3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_ca1016acc3449dee" hs_bindgen_test_arraysarray_ca1016acc3449dee ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -220,6 +228,8 @@ arr3_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_ca1016acc3449dee
 
+{-| __unique:__ @ExampleNothingget_arr6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_1a8c921160bc99a6" hs_bindgen_test_arraysarray_1a8c921160bc99a6 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt))
 
@@ -237,6 +247,8 @@ arr6_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt)
 arr6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_1a8c921160bc99a6
 
+{-| __unique:__ @ExampleNothingget_arr7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_17cf970243739b65" hs_bindgen_test_arraysarray_17cf970243739b65 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
 
@@ -254,6 +266,8 @@ arr7_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
 arr7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_17cf970243739b65
 
+{-| __unique:__ @ExampleNothingget_arr_1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_85bc33b188037456" hs_bindgen_test_arraysarray_85bc33b188037456 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -271,6 +285,8 @@ arr_1_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr_1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_85bc33b188037456
 
+{-| __unique:__ @ExampleNothingget_arr_2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_87c784150cd3ff65" hs_bindgen_test_arraysarray_87c784150cd3ff65 ::
      IO (Ptr.Ptr Triplet)
 
@@ -288,6 +304,8 @@ arr_2_ptr :: Ptr.Ptr Triplet
 arr_2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_87c784150cd3ff65
 
+{-| __unique:__ @ExampleNothingget_arr_3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_e7b0de7633a7a62a" hs_bindgen_test_arraysarray_e7b0de7633a7a62a ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
 
@@ -305,6 +323,8 @@ arr_3_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
 arr_3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_e7b0de7633a7a62a
 
+{-| __unique:__ @ExampleNothingget_arr_4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73" hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73 ::
      IO (Ptr.Ptr List)
 
@@ -322,6 +342,8 @@ arr_4_ptr :: Ptr.Ptr List
 arr_4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73
 
+{-| __unique:__ @ExampleNothingget_arr_5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_7348a94e6adce96e" hs_bindgen_test_arraysarray_7348a94e6adce96e ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -339,6 +361,8 @@ arr_5_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBind
 arr_5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_7348a94e6adce96e
 
+{-| __unique:__ @ExampleNothingget_arr_6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_1308613140bb4b80" hs_bindgen_test_arraysarray_1308613140bb4b80 ::
      IO (Ptr.Ptr Matrix)
 
@@ -356,6 +380,8 @@ arr_6_ptr :: Ptr.Ptr Matrix
 arr_6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_1308613140bb4b80
 
+{-| __unique:__ @ExampleNothingget_arr_7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a060984b378ed676" hs_bindgen_test_arraysarray_a060984b378ed676 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -373,6 +399,8 @@ arr_7_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBind
 arr_7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_a060984b378ed676
 
+{-| __unique:__ @ExampleNothingget_arr_8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_d82706abb6d8ea04" hs_bindgen_test_arraysarray_d82706abb6d8ea04 ::
      IO (Ptr.Ptr Tripletlist)
 
@@ -390,6 +418,8 @@ arr_8_ptr :: Ptr.Ptr Tripletlist
 arr_8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_d82706abb6d8ea04
 
+{-| __unique:__ @ExampleNothingget_arr_1_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_7376d172f5729493" hs_bindgen_test_arraysarray_7376d172f5729493 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -413,6 +443,8 @@ arr_1_const :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
 arr_1_const =
   GHC.IO.Unsafe.unsafePerformIO (F.peek arr_1_const_ptr)
 
+{-| __unique:__ @ExampleNothingget_arr_2_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_f03586aa57dfce29" hs_bindgen_test_arraysarray_f03586aa57dfce29 ::
      IO (Ptr.Ptr Triplet)
 
@@ -436,6 +468,8 @@ arr_2_const :: Triplet
 arr_2_const =
   GHC.IO.Unsafe.unsafePerformIO (F.peek arr_2_const_ptr)
 
+{-| __unique:__ @ExampleNothingget_arr_3_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_54ffd4ffcd2dad61" hs_bindgen_test_arraysarray_54ffd4ffcd2dad61 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
 
@@ -453,6 +487,8 @@ arr_3_const_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC
 arr_3_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_54ffd4ffcd2dad61
 
+{-| __unique:__ @ExampleNothingget_arr_4_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9" hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9 ::
      IO (Ptr.Ptr List)
 
@@ -470,6 +506,8 @@ arr_4_const_ptr :: Ptr.Ptr List
 arr_4_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9
 
+{-| __unique:__ @ExampleNothingget_arr_5_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_46b406e096f6c9c1" hs_bindgen_test_arraysarray_46b406e096f6c9c1 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -493,6 +531,8 @@ arr_5_const :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Run
 arr_5_const =
   GHC.IO.Unsafe.unsafePerformIO (F.peek arr_5_const_ptr)
 
+{-| __unique:__ @ExampleNothingget_arr_6_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_ceb7f2027865ce12" hs_bindgen_test_arraysarray_ceb7f2027865ce12 ::
      IO (Ptr.Ptr Matrix)
 
@@ -516,6 +556,8 @@ arr_6_const :: Matrix
 arr_6_const =
   GHC.IO.Unsafe.unsafePerformIO (F.peek arr_6_const_ptr)
 
+{-| __unique:__ @ExampleNothingget_arr_7_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_2b565b2b97acdcb7" hs_bindgen_test_arraysarray_2b565b2b97acdcb7 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -533,6 +575,8 @@ arr_7_const_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((
 arr_7_const_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_arraysarray_2b565b2b97acdcb7
 
+{-| __unique:__ @ExampleNothingget_arr_8_const_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_03e2d9c4ef2ae993" hs_bindgen_test_arraysarray_03e2d9c4ef2ae993 ::
      IO (Ptr.Ptr Tripletlist)
 

--- a/hs-bindgen/fixtures/arrays/array/Example/Safe.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Safe.hs
@@ -180,6 +180,8 @@ __C declaration:__ @fun_1@
 __defined at:__ @arrays\/array.h:118:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_5d1be223fd040c3b" fun_1 ::
      FC.CInt
@@ -197,6 +199,8 @@ __C declaration:__ @fun_2@
 __defined at:__ @arrays\/array.h:121:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_cabe35537b18e986" fun_2 ::
      Ptr.Ptr FC.CInt
@@ -211,6 +215,8 @@ __C declaration:__ @fun_3@
 __defined at:__ @arrays\/array.h:124:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_3@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_4cdbf10236e78984" fun_3 ::
      Ptr.Ptr FC.CInt
@@ -225,6 +231,8 @@ __C declaration:__ @fun_4@
 __defined at:__ @arrays\/array.h:127:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_4@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_e356c5ddb2608063" fun_4 ::
      Ptr.Ptr FC.CInt
@@ -239,6 +247,8 @@ __C declaration:__ @fun_5@
 __defined at:__ @arrays\/array.h:130:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_5@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f5ccf2c8d2e60be5" fun_5 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -253,6 +263,8 @@ __C declaration:__ @fun_6@
 __defined at:__ @arrays\/array.h:133:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_6@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2b3a983697999524" fun_6 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -267,6 +279,8 @@ __C declaration:__ @fun_7@
 __defined at:__ @arrays\/array.h:136:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_7@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_72e9371a1b8b8907" fun_7 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -281,6 +295,8 @@ __C declaration:__ @fun_8@
 __defined at:__ @arrays\/array.h:139:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_8@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_62ad87463d9a75de" fun_8 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -295,6 +311,8 @@ __C declaration:__ @isSolved@
 __defined at:__ @arrays\/array.h:142:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust SafeisSolved@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2280ecc4c152a73f" isSolved ::
      Ptr.Ptr Triplet
@@ -304,6 +322,7 @@ foreign import ccall safe "hs_bindgen_test_arraysarray_2280ecc4c152a73f" isSolve
 
 {-| Pointer-based API for 'fun_1_const'
 
+__unique:__ @ExampleJust Safefun_1_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f1d120f83dc61db5" fun_1_const_wrapper ::
      FC.CInt
@@ -339,6 +358,7 @@ fun_1_const =
 
 {-| Pointer-based API for 'fun_2_const'
 
+__unique:__ @ExampleJust Safefun_2_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f15760e6f3596189" fun_2_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -369,6 +389,7 @@ fun_2_const =
 
 {-| Pointer-based API for 'fun_3_const'
 
+__unique:__ @ExampleJust Safefun_3_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_0ad99f041fc4f5ca" fun_3_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -399,6 +420,7 @@ fun_3_const =
 
 {-| Pointer-based API for 'fun_4_const'
 
+__unique:__ @ExampleJust Safefun_4_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d61f2b8777e6ca19" fun_4_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -429,6 +451,7 @@ fun_4_const =
 
 {-| Pointer-based API for 'fun_5_const'
 
+__unique:__ @ExampleJust Safefun_5_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9e1f66e6a0369c45" fun_5_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -459,6 +482,7 @@ fun_5_const =
 
 {-| Pointer-based API for 'fun_6_const'
 
+__unique:__ @ExampleJust Safefun_6_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_5b4bd3c6cee83e61" fun_6_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -489,6 +513,7 @@ fun_6_const =
 
 {-| Pointer-based API for 'fun_7_const'
 
+__unique:__ @ExampleJust Safefun_7_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_b551069ce9e1f12e" fun_7_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -519,6 +544,7 @@ fun_7_const =
 
 {-| Pointer-based API for 'fun_8_const'
 
+__unique:__ @ExampleJust Safefun_8_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_4ac495707a95aa13" fun_8_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -549,6 +575,7 @@ fun_8_const =
 
 {-| Pointer-based API for 'isSolved_const'
 
+__unique:__ @ExampleJust SafeisSolved_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_1bdcfcd7aca9a2f6" isSolved_const_wrapper ::
      Ptr.Ptr Triplet
@@ -584,6 +611,8 @@ __C declaration:__ @fun_9@
 __defined at:__ @arrays\/array.h:185:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_9@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d4c729a69c884fd4" fun_9 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
@@ -595,6 +624,8 @@ __C declaration:__ @fun_10@
 __defined at:__ @arrays\/array.h:188:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_10@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_bb92dfded907271e" fun_10 ::
      IO (Ptr.Ptr Triplet)
@@ -606,6 +637,8 @@ __C declaration:__ @fun_11@
 __defined at:__ @arrays\/array.h:191:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_11@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_489aaaa59e992ddf" fun_11 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
@@ -617,6 +650,8 @@ __C declaration:__ @fun_12@
 __defined at:__ @arrays\/array.h:194:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_12@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ee94c35f987d6c50" fun_12 ::
      IO (Ptr.Ptr List)
@@ -628,6 +663,8 @@ __C declaration:__ @fun_13@
 __defined at:__ @arrays\/array.h:197:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_13@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ca2c7b60ce85a964" fun_13 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
@@ -639,6 +676,8 @@ __C declaration:__ @fun_14@
 __defined at:__ @arrays\/array.h:200:9@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_14@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ab2c533efdae8e41" fun_14 ::
      IO (Ptr.Ptr Matrix)
@@ -650,6 +689,8 @@ __C declaration:__ @fun_15@
 __defined at:__ @arrays\/array.h:203:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_15@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_019bdeb5db79cee1" fun_15 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
@@ -661,6 +702,8 @@ __C declaration:__ @fun_16@
 __defined at:__ @arrays\/array.h:206:14@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safefun_16@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ca0e7c51654fef12" fun_16 ::
      IO (Ptr.Ptr Tripletlist)
@@ -672,6 +715,8 @@ __C declaration:__ @solve@
 __defined at:__ @arrays\/array.h:209:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Safesolve@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f6b66497ee1685b0" solve ::
      IO (Ptr.Ptr Sudoku)

--- a/hs-bindgen/fixtures/arrays/array/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Unsafe.hs
@@ -180,6 +180,8 @@ __C declaration:__ @fun_1@
 __defined at:__ @arrays\/array.h:118:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_38d1e706888c6509" fun_1 ::
      FC.CInt
@@ -197,6 +199,8 @@ __C declaration:__ @fun_2@
 __defined at:__ @arrays\/array.h:121:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_39ee469929b167e2" fun_2 ::
      Ptr.Ptr FC.CInt
@@ -211,6 +215,8 @@ __C declaration:__ @fun_3@
 __defined at:__ @arrays\/array.h:124:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_2aa49d73d177f65b" fun_3 ::
      Ptr.Ptr FC.CInt
@@ -225,6 +231,8 @@ __C declaration:__ @fun_4@
 __defined at:__ @arrays\/array.h:127:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_c3b2941d43616704" fun_4 ::
      Ptr.Ptr FC.CInt
@@ -239,6 +247,8 @@ __C declaration:__ @fun_5@
 __defined at:__ @arrays\/array.h:130:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_69ec2f59c3c40de4" fun_5 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -253,6 +263,8 @@ __C declaration:__ @fun_6@
 __defined at:__ @arrays\/array.h:133:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_6@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a4600c666e12a07a" fun_6 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -267,6 +279,8 @@ __C declaration:__ @fun_7@
 __defined at:__ @arrays\/array.h:136:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_7@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_b903c9d5ebf4f21f" fun_7 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -281,6 +295,8 @@ __C declaration:__ @fun_8@
 __defined at:__ @arrays\/array.h:139:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_8@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_88af789e5a205473" fun_8 ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -295,6 +311,8 @@ __C declaration:__ @isSolved@
 __defined at:__ @arrays\/array.h:142:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust UnsafeisSolved@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_617bd1cd5514ea45" isSolved ::
      Ptr.Ptr Triplet
@@ -304,6 +322,7 @@ foreign import ccall unsafe "hs_bindgen_test_arraysarray_617bd1cd5514ea45" isSol
 
 {-| Pointer-based API for 'fun_1_const'
 
+__unique:__ @ExampleJust Unsafefun_1_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_e4b00d6936127c9c" fun_1_const_wrapper ::
      FC.CInt
@@ -339,6 +358,7 @@ fun_1_const =
 
 {-| Pointer-based API for 'fun_2_const'
 
+__unique:__ @ExampleJust Unsafefun_2_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_5fe603fc3c41a066" fun_2_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -369,6 +389,7 @@ fun_2_const =
 
 {-| Pointer-based API for 'fun_3_const'
 
+__unique:__ @ExampleJust Unsafefun_3_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_d7b0d574cbe650f8" fun_3_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -399,6 +420,7 @@ fun_3_const =
 
 {-| Pointer-based API for 'fun_4_const'
 
+__unique:__ @ExampleJust Unsafefun_4_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_a7499ca2f044e9ce" fun_4_const_wrapper ::
      Ptr.Ptr FC.CInt
@@ -429,6 +451,7 @@ fun_4_const =
 
 {-| Pointer-based API for 'fun_5_const'
 
+__unique:__ @ExampleJust Unsafefun_5_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_24e12fc0372c2467" fun_5_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -459,6 +482,7 @@ fun_5_const =
 
 {-| Pointer-based API for 'fun_6_const'
 
+__unique:__ @ExampleJust Unsafefun_6_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_870ee33752c078df" fun_6_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -489,6 +513,7 @@ fun_6_const =
 
 {-| Pointer-based API for 'fun_7_const'
 
+__unique:__ @ExampleJust Unsafefun_7_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_18aa0941d0646906" fun_7_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -519,6 +544,7 @@ fun_7_const =
 
 {-| Pointer-based API for 'fun_8_const'
 
+__unique:__ @ExampleJust Unsafefun_8_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_94591138e958ffe1" fun_8_const_wrapper ::
      Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
@@ -549,6 +575,7 @@ fun_8_const =
 
 {-| Pointer-based API for 'isSolved_const'
 
+__unique:__ @ExampleJust UnsafeisSolved_const@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_ec99b7cbbed57b25" isSolved_const_wrapper ::
      Ptr.Ptr Triplet
@@ -584,6 +611,8 @@ __C declaration:__ @fun_9@
 __defined at:__ @arrays\/array.h:185:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_9@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_49d4508b43473bd2" fun_9 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
@@ -595,6 +624,8 @@ __C declaration:__ @fun_10@
 __defined at:__ @arrays\/array.h:188:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_10@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_d1763638472ee039" fun_10 ::
      IO (Ptr.Ptr Triplet)
@@ -606,6 +637,8 @@ __C declaration:__ @fun_11@
 __defined at:__ @arrays\/array.h:191:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_11@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_293d2be6d282321b" fun_11 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
@@ -617,6 +650,8 @@ __C declaration:__ @fun_12@
 __defined at:__ @arrays\/array.h:194:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_12@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_fe193d0e0c330960" fun_12 ::
      IO (Ptr.Ptr List)
@@ -628,6 +663,8 @@ __C declaration:__ @fun_13@
 __defined at:__ @arrays\/array.h:197:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_13@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_f3df0067620bd691" fun_13 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
@@ -639,6 +676,8 @@ __C declaration:__ @fun_14@
 __defined at:__ @arrays\/array.h:200:9@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_14@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_9d75a740147af339" fun_14 ::
      IO (Ptr.Ptr Matrix)
@@ -650,6 +689,8 @@ __C declaration:__ @fun_15@
 __defined at:__ @arrays\/array.h:203:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_15@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_d49e5e7f4ad3c830" fun_15 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
@@ -661,6 +702,8 @@ __C declaration:__ @fun_16@
 __defined at:__ @arrays\/array.h:206:14@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_16@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_900726612f7787e4" fun_16 ::
      IO (Ptr.Ptr Tripletlist)
@@ -672,6 +715,8 @@ __C declaration:__ @solve@
 __defined at:__ @arrays\/array.h:209:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafesolve@
 -}
 foreign import ccall unsafe "hs_bindgen_test_arraysarray_ede6133d23ed3248" solve ::
      IO (Ptr.Ptr Sudoku)

--- a/hs-bindgen/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/fixtures/arrays/array/th.txt
@@ -822,6 +822,8 @@ __C declaration:__ @fun_1@
 __defined at:__ @arrays\/array.h:118:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_5d1be223fd040c3b" fun_1 :: CInt ->
                                                                                   Ptr CInt ->
@@ -833,6 +835,8 @@ __C declaration:__ @fun_2@
 __defined at:__ @arrays\/array.h:121:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_cabe35537b18e986" fun_2 :: Ptr CInt ->
                                                                                   IO CInt
@@ -843,6 +847,8 @@ __C declaration:__ @fun_3@
 __defined at:__ @arrays\/array.h:124:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_3@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_4cdbf10236e78984" fun_3 :: Ptr CInt ->
                                                                                   IO CInt
@@ -853,6 +859,8 @@ __C declaration:__ @fun_4@
 __defined at:__ @arrays\/array.h:127:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_4@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_e356c5ddb2608063" fun_4 :: Ptr CInt ->
                                                                                   IO CInt
@@ -863,6 +871,8 @@ __C declaration:__ @fun_5@
 __defined at:__ @arrays\/array.h:130:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_5@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f5ccf2c8d2e60be5" fun_5 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -874,6 +884,8 @@ __C declaration:__ @fun_6@
 __defined at:__ @arrays\/array.h:133:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_6@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2b3a983697999524" fun_6 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -885,6 +897,8 @@ __C declaration:__ @fun_7@
 __defined at:__ @arrays\/array.h:136:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_7@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_72e9371a1b8b8907" fun_7 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -896,6 +910,8 @@ __C declaration:__ @fun_8@
 __defined at:__ @arrays\/array.h:139:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_8@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_62ad87463d9a75de" fun_8 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -907,11 +923,14 @@ __C declaration:__ @isSolved@
 __defined at:__ @arrays\/array.h:142:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust UnsafeisSolved@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2280ecc4c152a73f" isSolved :: Ptr Triplet ->
                                                                                      IO CInt
 {-| Pointer-based API for 'fun_1_const'
 
+__unique:__ @ExampleJust Unsafefun_1_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f1d120f83dc61db5" fun_1_const_wrapper :: CInt ->
                                                                                                 Ptr CInt ->
@@ -937,6 +956,7 @@ __exported by:__ @arrays\/array.h@
 fun_1_const = \x_0 -> \x_1 -> \x_2 -> withPtr x_2 (\ptr_3 -> fun_1_const_wrapper x_0 x_1 ptr_3)
 {-| Pointer-based API for 'fun_2_const'
 
+__unique:__ @ExampleJust Unsafefun_2_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f15760e6f3596189" fun_2_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -961,6 +981,7 @@ __exported by:__ @arrays\/array.h@
 fun_2_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_2_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_3_const'
 
+__unique:__ @ExampleJust Unsafefun_3_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_0ad99f041fc4f5ca" fun_3_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -985,6 +1006,7 @@ __exported by:__ @arrays\/array.h@
 fun_3_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_3_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_4_const'
 
+__unique:__ @ExampleJust Unsafefun_4_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d61f2b8777e6ca19" fun_4_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -1009,6 +1031,7 @@ __exported by:__ @arrays\/array.h@
 fun_4_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_4_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_5_const'
 
+__unique:__ @ExampleJust Unsafefun_5_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9e1f66e6a0369c45" fun_5_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1036,6 +1059,7 @@ __exported by:__ @arrays\/array.h@
 fun_5_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_5_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_6_const'
 
+__unique:__ @ExampleJust Unsafefun_6_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_5b4bd3c6cee83e61" fun_6_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1062,6 +1086,7 @@ __exported by:__ @arrays\/array.h@
 fun_6_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_6_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_7_const'
 
+__unique:__ @ExampleJust Unsafefun_7_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_b551069ce9e1f12e" fun_7_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1089,6 +1114,7 @@ __exported by:__ @arrays\/array.h@
 fun_7_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_7_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_8_const'
 
+__unique:__ @ExampleJust Unsafefun_8_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_4ac495707a95aa13" fun_8_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1115,6 +1141,7 @@ __exported by:__ @arrays\/array.h@
 fun_8_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_8_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'isSolved_const'
 
+__unique:__ @ExampleJust UnsafeisSolved_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_1bdcfcd7aca9a2f6" isSolved_const_wrapper :: Ptr Triplet ->
                                                                                                    Ptr Triplet ->
@@ -1144,6 +1171,8 @@ __C declaration:__ @fun_9@
 __defined at:__ @arrays\/array.h:185:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_9@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d4c729a69c884fd4" fun_9 :: IO (Ptr (ConstantArray 3
                                                                                                          CInt))
@@ -1154,6 +1183,8 @@ __C declaration:__ @fun_10@
 __defined at:__ @arrays\/array.h:188:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_10@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_bb92dfded907271e" fun_10 :: IO (Ptr Triplet)
 {-| Array of unknown size
@@ -1163,6 +1194,8 @@ __C declaration:__ @fun_11@
 __defined at:__ @arrays\/array.h:191:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_11@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_489aaaa59e992ddf" fun_11 :: IO (Ptr (IncompleteArray CInt))
 {-| Array of unknown size, typedef
@@ -1172,6 +1205,8 @@ __C declaration:__ @fun_12@
 __defined at:__ @arrays\/array.h:194:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_12@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ee94c35f987d6c50" fun_12 :: IO (Ptr List)
 {-| Multi-dimensional array of known size
@@ -1181,6 +1216,8 @@ __C declaration:__ @fun_13@
 __defined at:__ @arrays\/array.h:197:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_13@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ca2c7b60ce85a964" fun_13 :: IO (Ptr (ConstantArray 4
                                                                                                           (ConstantArray 3
@@ -1192,6 +1229,8 @@ __C declaration:__ @fun_14@
 __defined at:__ @arrays\/array.h:200:9@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_14@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ab2c533efdae8e41" fun_14 :: IO (Ptr Matrix)
 {-| Multi-dimensional array of unknown size
@@ -1201,6 +1240,8 @@ __C declaration:__ @fun_15@
 __defined at:__ @arrays\/array.h:203:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_15@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_019bdeb5db79cee1" fun_15 :: IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                            CInt)))
@@ -1211,6 +1252,8 @@ __C declaration:__ @fun_16@
 __defined at:__ @arrays\/array.h:206:14@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_16@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ca0e7c51654fef12" fun_16 :: IO (Ptr Tripletlist)
 {-| Typedef-in-typedef
@@ -1220,6 +1263,8 @@ __C declaration:__ @solve@
 __defined at:__ @arrays\/array.h:209:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafesolve@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f6b66497ee1685b0" solve :: IO (Ptr Sudoku)
 {-| Array of known size
@@ -1229,6 +1274,8 @@ __C declaration:__ @fun_1@
 __defined at:__ @arrays\/array.h:118:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_38d1e706888c6509" fun_1 :: CInt ->
                                                                                   Ptr CInt ->
@@ -1240,6 +1287,8 @@ __C declaration:__ @fun_2@
 __defined at:__ @arrays\/array.h:121:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_39ee469929b167e2" fun_2 :: Ptr CInt ->
                                                                                   IO CInt
@@ -1250,6 +1299,8 @@ __C declaration:__ @fun_3@
 __defined at:__ @arrays\/array.h:124:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_3@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2aa49d73d177f65b" fun_3 :: Ptr CInt ->
                                                                                   IO CInt
@@ -1260,6 +1311,8 @@ __C declaration:__ @fun_4@
 __defined at:__ @arrays\/array.h:127:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_4@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_c3b2941d43616704" fun_4 :: Ptr CInt ->
                                                                                   IO CInt
@@ -1270,6 +1323,8 @@ __C declaration:__ @fun_5@
 __defined at:__ @arrays\/array.h:130:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_5@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_69ec2f59c3c40de4" fun_5 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -1281,6 +1336,8 @@ __C declaration:__ @fun_6@
 __defined at:__ @arrays\/array.h:133:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_6@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a4600c666e12a07a" fun_6 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -1292,6 +1349,8 @@ __C declaration:__ @fun_7@
 __defined at:__ @arrays\/array.h:136:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_7@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_b903c9d5ebf4f21f" fun_7 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -1303,6 +1362,8 @@ __C declaration:__ @fun_8@
 __defined at:__ @arrays\/array.h:139:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_8@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_88af789e5a205473" fun_8 :: Ptr (ConstantArray 3
                                                                                                      CInt) ->
@@ -1314,11 +1375,14 @@ __C declaration:__ @isSolved@
 __defined at:__ @arrays\/array.h:142:5@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust UnsafeisSolved@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_617bd1cd5514ea45" isSolved :: Ptr Triplet ->
                                                                                      IO CInt
 {-| Pointer-based API for 'fun_1_const'
 
+__unique:__ @ExampleJust Unsafefun_1_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_e4b00d6936127c9c" fun_1_const_wrapper :: CInt ->
                                                                                                 Ptr CInt ->
@@ -1344,6 +1408,7 @@ __exported by:__ @arrays\/array.h@
 fun_1_const = \x_0 -> \x_1 -> \x_2 -> withPtr x_2 (\ptr_3 -> fun_1_const_wrapper x_0 x_1 ptr_3)
 {-| Pointer-based API for 'fun_2_const'
 
+__unique:__ @ExampleJust Unsafefun_2_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_5fe603fc3c41a066" fun_2_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -1368,6 +1433,7 @@ __exported by:__ @arrays\/array.h@
 fun_2_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_2_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_3_const'
 
+__unique:__ @ExampleJust Unsafefun_3_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d7b0d574cbe650f8" fun_3_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -1392,6 +1458,7 @@ __exported by:__ @arrays\/array.h@
 fun_3_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_3_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_4_const'
 
+__unique:__ @ExampleJust Unsafefun_4_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a7499ca2f044e9ce" fun_4_const_wrapper :: Ptr CInt ->
                                                                                                 Ptr CInt ->
@@ -1416,6 +1483,7 @@ __exported by:__ @arrays\/array.h@
 fun_4_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_4_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_5_const'
 
+__unique:__ @ExampleJust Unsafefun_5_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_24e12fc0372c2467" fun_5_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1443,6 +1511,7 @@ __exported by:__ @arrays\/array.h@
 fun_5_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_5_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_6_const'
 
+__unique:__ @ExampleJust Unsafefun_6_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_870ee33752c078df" fun_6_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1469,6 +1538,7 @@ __exported by:__ @arrays\/array.h@
 fun_6_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_6_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_7_const'
 
+__unique:__ @ExampleJust Unsafefun_7_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_18aa0941d0646906" fun_7_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1496,6 +1566,7 @@ __exported by:__ @arrays\/array.h@
 fun_7_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_7_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'fun_8_const'
 
+__unique:__ @ExampleJust Unsafefun_8_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_94591138e958ffe1" fun_8_const_wrapper :: Ptr (ConstantArray 3
                                                                                                                    CInt) ->
@@ -1522,6 +1593,7 @@ __exported by:__ @arrays\/array.h@
 fun_8_const = \x_0 -> \x_1 -> withPtr x_1 (\ptr_2 -> fun_8_const_wrapper x_0 ptr_2)
 {-| Pointer-based API for 'isSolved_const'
 
+__unique:__ @ExampleJust UnsafeisSolved_const@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ec99b7cbbed57b25" isSolved_const_wrapper :: Ptr Triplet ->
                                                                                                    Ptr Triplet ->
@@ -1551,6 +1623,8 @@ __C declaration:__ @fun_9@
 __defined at:__ @arrays\/array.h:185:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_9@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_49d4508b43473bd2" fun_9 :: IO (Ptr (ConstantArray 3
                                                                                                          CInt))
@@ -1561,6 +1635,8 @@ __C declaration:__ @fun_10@
 __defined at:__ @arrays\/array.h:188:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_10@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d1763638472ee039" fun_10 :: IO (Ptr Triplet)
 {-| Array of unknown size
@@ -1570,6 +1646,8 @@ __C declaration:__ @fun_11@
 __defined at:__ @arrays\/array.h:191:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_11@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_293d2be6d282321b" fun_11 :: IO (Ptr (IncompleteArray CInt))
 {-| Array of unknown size, typedef
@@ -1579,6 +1657,8 @@ __C declaration:__ @fun_12@
 __defined at:__ @arrays\/array.h:194:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_12@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_fe193d0e0c330960" fun_12 :: IO (Ptr List)
 {-| Multi-dimensional array of known size
@@ -1588,6 +1668,8 @@ __C declaration:__ @fun_13@
 __defined at:__ @arrays\/array.h:197:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_13@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f3df0067620bd691" fun_13 :: IO (Ptr (ConstantArray 4
                                                                                                           (ConstantArray 3
@@ -1599,6 +1681,8 @@ __C declaration:__ @fun_14@
 __defined at:__ @arrays\/array.h:200:9@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_14@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9d75a740147af339" fun_14 :: IO (Ptr Matrix)
 {-| Multi-dimensional array of unknown size
@@ -1608,6 +1692,8 @@ __C declaration:__ @fun_15@
 __defined at:__ @arrays\/array.h:203:7@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_15@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d49e5e7f4ad3c830" fun_15 :: IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                            CInt)))
@@ -1618,6 +1704,8 @@ __C declaration:__ @fun_16@
 __defined at:__ @arrays\/array.h:206:14@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafefun_16@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_900726612f7787e4" fun_16 :: IO (Ptr Tripletlist)
 {-| Typedef-in-typedef
@@ -1627,8 +1715,12 @@ __C declaration:__ @solve@
 __defined at:__ @arrays\/array.h:209:10@
 
 __exported by:__ @arrays\/array.h@
+
+__unique:__ @ExampleJust Unsafesolve@
 -}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ede6133d23ed3248" solve :: IO (Ptr Sudoku)
+{-| __unique:__ @ExampleNothingget_fun_1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_3ced2f3b2af806f8" hs_bindgen_test_arraysarray_3ced2f3b2af806f8 :: IO (FunPtr (CInt ->
                                                                                                                                      ConstantArray 3
                                                                                                                                                    CInt ->
@@ -1652,6 +1744,8 @@ __defined at:__ @arrays\/array.h:118:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_1_ptr = unsafePerformIO hs_bindgen_test_arraysarray_3ced2f3b2af806f8
+{-| __unique:__ @ExampleNothingget_fun_2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_84966994a8d7df93" hs_bindgen_test_arraysarray_84966994a8d7df93 :: IO (FunPtr (Triplet ->
                                                                                                                                      IO CInt))
 {-# NOINLINE fun_2_ptr #-}
@@ -1673,6 +1767,8 @@ __defined at:__ @arrays\/array.h:121:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_2_ptr = unsafePerformIO hs_bindgen_test_arraysarray_84966994a8d7df93
+{-| __unique:__ @ExampleNothingget_fun_3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_3e6c940dbd7e5492" hs_bindgen_test_arraysarray_3e6c940dbd7e5492 :: IO (FunPtr (IncompleteArray CInt ->
                                                                                                                                      IO CInt))
 {-# NOINLINE fun_3_ptr #-}
@@ -1694,6 +1790,8 @@ __defined at:__ @arrays\/array.h:124:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_3_ptr = unsafePerformIO hs_bindgen_test_arraysarray_3e6c940dbd7e5492
+{-| __unique:__ @ExampleNothingget_fun_4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d9f87d3e541b15e5" hs_bindgen_test_arraysarray_d9f87d3e541b15e5 :: IO (FunPtr (List ->
                                                                                                                                      IO CInt))
 {-# NOINLINE fun_4_ptr #-}
@@ -1715,6 +1813,8 @@ __defined at:__ @arrays\/array.h:127:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_4_ptr = unsafePerformIO hs_bindgen_test_arraysarray_d9f87d3e541b15e5
+{-| __unique:__ @ExampleNothingget_fun_5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_cd41e41992d89300" hs_bindgen_test_arraysarray_cd41e41992d89300 :: IO (FunPtr (ConstantArray 4
                                                                                                                                                    (ConstantArray 3
                                                                                                                                                                   CInt) ->
@@ -1739,6 +1839,8 @@ __defined at:__ @arrays\/array.h:130:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_5_ptr = unsafePerformIO hs_bindgen_test_arraysarray_cd41e41992d89300
+{-| __unique:__ @ExampleNothingget_fun_6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_db0e2655437ab8bb" hs_bindgen_test_arraysarray_db0e2655437ab8bb :: IO (FunPtr (Matrix ->
                                                                                                                                      IO CInt))
 {-# NOINLINE fun_6_ptr #-}
@@ -1760,6 +1862,8 @@ __defined at:__ @arrays\/array.h:133:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_6_ptr = unsafePerformIO hs_bindgen_test_arraysarray_db0e2655437ab8bb
+{-| __unique:__ @ExampleNothingget_fun_7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9ec02aa16b020aa0" hs_bindgen_test_arraysarray_9ec02aa16b020aa0 :: IO (FunPtr (IncompleteArray (ConstantArray 3
                                                                                                                                                                     CInt) ->
                                                                                                                                      IO CInt))
@@ -1783,6 +1887,8 @@ __defined at:__ @arrays\/array.h:136:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_7_ptr = unsafePerformIO hs_bindgen_test_arraysarray_9ec02aa16b020aa0
+{-| __unique:__ @ExampleNothingget_fun_8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a41b8d1332b69b95" hs_bindgen_test_arraysarray_a41b8d1332b69b95 :: IO (FunPtr (Tripletlist ->
                                                                                                                                      IO CInt))
 {-# NOINLINE fun_8_ptr #-}
@@ -1804,6 +1910,8 @@ __defined at:__ @arrays\/array.h:139:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_8_ptr = unsafePerformIO hs_bindgen_test_arraysarray_a41b8d1332b69b95
+{-| __unique:__ @ExampleNothingget_isSolved_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04" hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04 :: IO (FunPtr (Sudoku ->
                                                                                                                                      IO CInt))
 {-# NOINLINE isSolved_ptr #-}
@@ -1825,6 +1933,8 @@ __defined at:__ @arrays\/array.h:142:5@
 __exported by:__ @arrays\/array.h@
 -}
 isSolved_ptr = unsafePerformIO hs_bindgen_test_arraysarray_bdf2a6a8a3dd5b04
+{-| __unique:__ @ExampleNothingget_fun_1_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a3de5f7e233ad0e1" hs_bindgen_test_arraysarray_a3de5f7e233ad0e1 :: IO (FunPtr (CInt ->
                                                                                                                                      ConstantArray 3
                                                                                                                                                    CInt ->
@@ -1851,6 +1961,8 @@ __defined at:__ @arrays\/array.h:149:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_1_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_a3de5f7e233ad0e1
+{-| __unique:__ @ExampleNothingget_fun_2_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_3c09bbba7534ca1d" hs_bindgen_test_arraysarray_3c09bbba7534ca1d :: IO (FunPtr (Triplet ->
                                                                                                                                      Triplet ->
                                                                                                                                      IO CInt))
@@ -1873,6 +1985,8 @@ __defined at:__ @arrays\/array.h:152:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_2_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_3c09bbba7534ca1d
+{-| __unique:__ @ExampleNothingget_fun_3_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_0e53ed28ec1ca276" hs_bindgen_test_arraysarray_0e53ed28ec1ca276 :: IO (FunPtr (IncompleteArray CInt ->
                                                                                                                                      IncompleteArray CInt ->
                                                                                                                                      IO CInt))
@@ -1896,6 +2010,8 @@ __defined at:__ @arrays\/array.h:155:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_3_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_0e53ed28ec1ca276
+{-| __unique:__ @ExampleNothingget_fun_4_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_07d860d5e74c415b" hs_bindgen_test_arraysarray_07d860d5e74c415b :: IO (FunPtr (List ->
                                                                                                                                      List ->
                                                                                                                                      IO CInt))
@@ -1918,6 +2034,8 @@ __defined at:__ @arrays\/array.h:158:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_4_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_07d860d5e74c415b
+{-| __unique:__ @ExampleNothingget_fun_5_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_3c0a139c24d7202a" hs_bindgen_test_arraysarray_3c0a139c24d7202a :: IO (FunPtr (ConstantArray 4
                                                                                                                                                    (ConstantArray 3
                                                                                                                                                                   CInt) ->
@@ -1946,6 +2064,8 @@ __defined at:__ @arrays\/array.h:161:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_5_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_3c0a139c24d7202a
+{-| __unique:__ @ExampleNothingget_fun_6_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_62d236581cc18366" hs_bindgen_test_arraysarray_62d236581cc18366 :: IO (FunPtr (Matrix ->
                                                                                                                                      Matrix ->
                                                                                                                                      IO CInt))
@@ -1968,6 +2088,8 @@ __defined at:__ @arrays\/array.h:164:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_6_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_62d236581cc18366
+{-| __unique:__ @ExampleNothingget_fun_7_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_b4bf67c3cec12e54" hs_bindgen_test_arraysarray_b4bf67c3cec12e54 :: IO (FunPtr (IncompleteArray (ConstantArray 3
                                                                                                                                                                     CInt) ->
                                                                                                                                      IncompleteArray (ConstantArray 3
@@ -1994,6 +2116,8 @@ __defined at:__ @arrays\/array.h:167:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_7_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_b4bf67c3cec12e54
+{-| __unique:__ @ExampleNothingget_fun_8_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_99dd6a6017eb0eec" hs_bindgen_test_arraysarray_99dd6a6017eb0eec :: IO (FunPtr (Tripletlist ->
                                                                                                                                      Tripletlist ->
                                                                                                                                      IO CInt))
@@ -2016,6 +2140,8 @@ __defined at:__ @arrays\/array.h:170:5@
 __exported by:__ @arrays\/array.h@
 -}
 fun_8_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_99dd6a6017eb0eec
+{-| __unique:__ @ExampleNothingget_isSolved_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_6deec046c95e4e0d" hs_bindgen_test_arraysarray_6deec046c95e4e0d :: IO (FunPtr (Sudoku ->
                                                                                                                                      Sudoku ->
                                                                                                                                      IO CInt))
@@ -2038,6 +2164,8 @@ __defined at:__ @arrays\/array.h:173:5@
 __exported by:__ @arrays\/array.h@
 -}
 isSolved_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_6deec046c95e4e0d
+{-| __unique:__ @ExampleNothingget_fun_9_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_76f53f330102e743" hs_bindgen_test_arraysarray_76f53f330102e743 :: IO (FunPtr (IO (Ptr (ConstantArray 3
                                                                                                                                                             CInt))))
 {-# NOINLINE fun_9_ptr #-}
@@ -2059,6 +2187,8 @@ __defined at:__ @arrays\/array.h:185:7@
 __exported by:__ @arrays\/array.h@
 -}
 fun_9_ptr = unsafePerformIO hs_bindgen_test_arraysarray_76f53f330102e743
+{-| __unique:__ @ExampleNothingget_fun_10_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_abcc94f01de77b25" hs_bindgen_test_arraysarray_abcc94f01de77b25 :: IO (FunPtr (IO (Ptr Triplet)))
 {-# NOINLINE fun_10_ptr #-}
 {-| Array of known size, typedef
@@ -2079,6 +2209,8 @@ __defined at:__ @arrays\/array.h:188:10@
 __exported by:__ @arrays\/array.h@
 -}
 fun_10_ptr = unsafePerformIO hs_bindgen_test_arraysarray_abcc94f01de77b25
+{-| __unique:__ @ExampleNothingget_fun_11_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_6661b46e4a751a85" hs_bindgen_test_arraysarray_6661b46e4a751a85 :: IO (FunPtr (IO (Ptr (IncompleteArray CInt))))
 {-# NOINLINE fun_11_ptr #-}
 {-| Array of unknown size
@@ -2099,6 +2231,8 @@ __defined at:__ @arrays\/array.h:191:7@
 __exported by:__ @arrays\/array.h@
 -}
 fun_11_ptr = unsafePerformIO hs_bindgen_test_arraysarray_6661b46e4a751a85
+{-| __unique:__ @ExampleNothingget_fun_12_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9c80a9e3300aad15" hs_bindgen_test_arraysarray_9c80a9e3300aad15 :: IO (FunPtr (IO (Ptr List)))
 {-# NOINLINE fun_12_ptr #-}
 {-| Array of unknown size, typedef
@@ -2119,6 +2253,8 @@ __defined at:__ @arrays\/array.h:194:7@
 __exported by:__ @arrays\/array.h@
 -}
 fun_12_ptr = unsafePerformIO hs_bindgen_test_arraysarray_9c80a9e3300aad15
+{-| __unique:__ @ExampleNothingget_fun_13_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_bb741b7e8c029e7e" hs_bindgen_test_arraysarray_bb741b7e8c029e7e :: IO (FunPtr (IO (Ptr (ConstantArray 4
                                                                                                                                                             (ConstantArray 3
                                                                                                                                                                            CInt)))))
@@ -2142,6 +2278,8 @@ __defined at:__ @arrays\/array.h:197:7@
 __exported by:__ @arrays\/array.h@
 -}
 fun_13_ptr = unsafePerformIO hs_bindgen_test_arraysarray_bb741b7e8c029e7e
+{-| __unique:__ @ExampleNothingget_fun_14_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_75d83252a55a5c64" hs_bindgen_test_arraysarray_75d83252a55a5c64 :: IO (FunPtr (IO (Ptr Matrix)))
 {-# NOINLINE fun_14_ptr #-}
 {-| Multi-dimensional array of known size, typedef
@@ -2162,6 +2300,8 @@ __defined at:__ @arrays\/array.h:200:9@
 __exported by:__ @arrays\/array.h@
 -}
 fun_14_ptr = unsafePerformIO hs_bindgen_test_arraysarray_75d83252a55a5c64
+{-| __unique:__ @ExampleNothingget_fun_15_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_069ac2d1873f3210" hs_bindgen_test_arraysarray_069ac2d1873f3210 :: IO (FunPtr (IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                                                                              CInt)))))
 {-# NOINLINE fun_15_ptr #-}
@@ -2184,6 +2324,8 @@ __defined at:__ @arrays\/array.h:203:7@
 __exported by:__ @arrays\/array.h@
 -}
 fun_15_ptr = unsafePerformIO hs_bindgen_test_arraysarray_069ac2d1873f3210
+{-| __unique:__ @ExampleNothingget_fun_16_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_314971335aaa6db3" hs_bindgen_test_arraysarray_314971335aaa6db3 :: IO (FunPtr (IO (Ptr Tripletlist)))
 {-# NOINLINE fun_16_ptr #-}
 {-| Multi-dimensional array of unknown size, typedef
@@ -2204,6 +2346,8 @@ __defined at:__ @arrays\/array.h:206:14@
 __exported by:__ @arrays\/array.h@
 -}
 fun_16_ptr = unsafePerformIO hs_bindgen_test_arraysarray_314971335aaa6db3
+{-| __unique:__ @ExampleNothingget_solve_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_9a62b5848be64bd4" hs_bindgen_test_arraysarray_9a62b5848be64bd4 :: IO (FunPtr (IO (Ptr Sudoku)))
 {-# NOINLINE solve_ptr #-}
 {-| Typedef-in-typedef
@@ -2224,6 +2368,8 @@ __defined at:__ @arrays\/array.h:209:10@
 __exported by:__ @arrays\/array.h@
 -}
 solve_ptr = unsafePerformIO hs_bindgen_test_arraysarray_9a62b5848be64bd4
+{-| __unique:__ @ExampleNothingget_arr0_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a6413f4d2092265d" hs_bindgen_test_arraysarray_a6413f4d2092265d :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr0_ptr #-}
@@ -2245,6 +2391,8 @@ __defined at:__ @arrays\/array.h:11:5@
 __exported by:__ @arrays\/array.h@
 -}
 arr0_ptr = unsafePerformIO hs_bindgen_test_arraysarray_a6413f4d2092265d
+{-| __unique:__ @ExampleNothingget_arr1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_1693226264ba4aeb" hs_bindgen_test_arraysarray_1693226264ba4aeb :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr1_ptr #-}
@@ -2266,6 +2414,8 @@ __defined at:__ @arrays\/array.h:14:5@
 __exported by:__ @arrays\/array.h@
 -}
 arr1_ptr = unsafePerformIO hs_bindgen_test_arraysarray_1693226264ba4aeb
+{-| __unique:__ @ExampleNothingget_arr2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_dafcf99a73b93389" hs_bindgen_test_arraysarray_dafcf99a73b93389 :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr2_ptr #-}
@@ -2287,6 +2437,8 @@ __defined at:__ @arrays\/array.h:17:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr2_ptr = unsafePerformIO hs_bindgen_test_arraysarray_dafcf99a73b93389
+{-| __unique:__ @ExampleNothingget_arr3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ca1016acc3449dee" hs_bindgen_test_arraysarray_ca1016acc3449dee :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr3_ptr #-}
@@ -2308,6 +2460,8 @@ __defined at:__ @arrays\/array.h:20:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr3_ptr = unsafePerformIO hs_bindgen_test_arraysarray_ca1016acc3449dee
+{-| __unique:__ @ExampleNothingget_arr6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_1a8c921160bc99a6" hs_bindgen_test_arraysarray_1a8c921160bc99a6 :: IO (Ptr (ConstantArray 1
                                                                                                                                                 CInt))
 {-# NOINLINE arr6_ptr #-}
@@ -2329,6 +2483,8 @@ __defined at:__ @arrays\/array.h:29:5@
 __exported by:__ @arrays\/array.h@
 -}
 arr6_ptr = unsafePerformIO hs_bindgen_test_arraysarray_1a8c921160bc99a6
+{-| __unique:__ @ExampleNothingget_arr7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_17cf970243739b65" hs_bindgen_test_arraysarray_17cf970243739b65 :: IO (Ptr (IncompleteArray CInt))
 {-# NOINLINE arr7_ptr #-}
 {-| Global, extern, incomplete
@@ -2349,6 +2505,8 @@ __defined at:__ @arrays\/array.h:32:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr7_ptr = unsafePerformIO hs_bindgen_test_arraysarray_17cf970243739b65
+{-| __unique:__ @ExampleNothingget_arr_1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_85bc33b188037456" hs_bindgen_test_arraysarray_85bc33b188037456 :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr_1_ptr #-}
@@ -2370,6 +2528,8 @@ __defined at:__ @arrays\/array.h:62:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr_1_ptr = unsafePerformIO hs_bindgen_test_arraysarray_85bc33b188037456
+{-| __unique:__ @ExampleNothingget_arr_2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_87c784150cd3ff65" hs_bindgen_test_arraysarray_87c784150cd3ff65 :: IO (Ptr Triplet)
 {-# NOINLINE arr_2_ptr #-}
 {-| Array of known size, typedef
@@ -2390,6 +2550,8 @@ __defined at:__ @arrays\/array.h:65:16@
 __exported by:__ @arrays\/array.h@
 -}
 arr_2_ptr = unsafePerformIO hs_bindgen_test_arraysarray_87c784150cd3ff65
+{-| __unique:__ @ExampleNothingget_arr_3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_e7b0de7633a7a62a" hs_bindgen_test_arraysarray_e7b0de7633a7a62a :: IO (Ptr (IncompleteArray CInt))
 {-# NOINLINE arr_3_ptr #-}
 {-| Array of unknown size
@@ -2410,6 +2572,8 @@ __defined at:__ @arrays\/array.h:68:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr_3_ptr = unsafePerformIO hs_bindgen_test_arraysarray_e7b0de7633a7a62a
+{-| __unique:__ @ExampleNothingget_arr_4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73" hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73 :: IO (Ptr List)
 {-# NOINLINE arr_4_ptr #-}
 {-| Array of unknown size, typedef
@@ -2430,6 +2594,8 @@ __defined at:__ @arrays\/array.h:71:13@
 __exported by:__ @arrays\/array.h@
 -}
 arr_4_ptr = unsafePerformIO hs_bindgen_test_arraysarray_8fb64bc6c2bd4c73
+{-| __unique:__ @ExampleNothingget_arr_5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_7348a94e6adce96e" hs_bindgen_test_arraysarray_7348a94e6adce96e :: IO (Ptr (ConstantArray 4
                                                                                                                                                 (ConstantArray 3
                                                                                                                                                                CInt)))
@@ -2452,6 +2618,8 @@ __defined at:__ @arrays\/array.h:74:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr_5_ptr = unsafePerformIO hs_bindgen_test_arraysarray_7348a94e6adce96e
+{-| __unique:__ @ExampleNothingget_arr_6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_1308613140bb4b80" hs_bindgen_test_arraysarray_1308613140bb4b80 :: IO (Ptr Matrix)
 {-# NOINLINE arr_6_ptr #-}
 {-| Multi-dimensional array of known size, typedef
@@ -2472,6 +2640,8 @@ __defined at:__ @arrays\/array.h:77:15@
 __exported by:__ @arrays\/array.h@
 -}
 arr_6_ptr = unsafePerformIO hs_bindgen_test_arraysarray_1308613140bb4b80
+{-| __unique:__ @ExampleNothingget_arr_7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_a060984b378ed676" hs_bindgen_test_arraysarray_a060984b378ed676 :: IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                                                                  CInt)))
 {-# NOINLINE arr_7_ptr #-}
@@ -2493,6 +2663,8 @@ __defined at:__ @arrays\/array.h:80:12@
 __exported by:__ @arrays\/array.h@
 -}
 arr_7_ptr = unsafePerformIO hs_bindgen_test_arraysarray_a060984b378ed676
+{-| __unique:__ @ExampleNothingget_arr_8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_d82706abb6d8ea04" hs_bindgen_test_arraysarray_d82706abb6d8ea04 :: IO (Ptr Tripletlist)
 {-# NOINLINE arr_8_ptr #-}
 {-| Multi-dimensional array of unknown size, typedef
@@ -2513,6 +2685,8 @@ __defined at:__ @arrays\/array.h:83:20@
 __exported by:__ @arrays\/array.h@
 -}
 arr_8_ptr = unsafePerformIO hs_bindgen_test_arraysarray_d82706abb6d8ea04
+{-| __unique:__ @ExampleNothingget_arr_1_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_7376d172f5729493" hs_bindgen_test_arraysarray_7376d172f5729493 :: IO (Ptr (ConstantArray 3
                                                                                                                                                 CInt))
 {-# NOINLINE arr_1_const_ptr #-}
@@ -2537,6 +2711,8 @@ arr_1_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_7376d172f5729493
 {-# NOINLINE arr_1_const #-}
 arr_1_const :: ConstantArray 3 CInt
 arr_1_const = unsafePerformIO (peek arr_1_const_ptr)
+{-| __unique:__ @ExampleNothingget_arr_2_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_f03586aa57dfce29" hs_bindgen_test_arraysarray_f03586aa57dfce29 :: IO (Ptr Triplet)
 {-# NOINLINE arr_2_const_ptr #-}
 {-| Array of known size, typedef
@@ -2560,6 +2736,8 @@ arr_2_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_f03586aa57dfce29
 {-# NOINLINE arr_2_const #-}
 arr_2_const :: Triplet
 arr_2_const = unsafePerformIO (peek arr_2_const_ptr)
+{-| __unique:__ @ExampleNothingget_arr_3_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_54ffd4ffcd2dad61" hs_bindgen_test_arraysarray_54ffd4ffcd2dad61 :: IO (Ptr (IncompleteArray CInt))
 {-# NOINLINE arr_3_const_ptr #-}
 {-| Array of unknown size
@@ -2580,6 +2758,8 @@ __defined at:__ @arrays\/array.h:96:18@
 __exported by:__ @arrays\/array.h@
 -}
 arr_3_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_54ffd4ffcd2dad61
+{-| __unique:__ @ExampleNothingget_arr_4_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9" hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9 :: IO (Ptr List)
 {-# NOINLINE arr_4_const_ptr #-}
 {-| Array of unknown size, typedef
@@ -2600,6 +2780,8 @@ __defined at:__ @arrays\/array.h:99:19@
 __exported by:__ @arrays\/array.h@
 -}
 arr_4_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_8896c2ff5b9ce9c9
+{-| __unique:__ @ExampleNothingget_arr_5_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_46b406e096f6c9c1" hs_bindgen_test_arraysarray_46b406e096f6c9c1 :: IO (Ptr (ConstantArray 4
                                                                                                                                                 (ConstantArray 3
                                                                                                                                                                CInt)))
@@ -2625,6 +2807,8 @@ arr_5_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_46b406e096f6c9c1
 {-# NOINLINE arr_5_const #-}
 arr_5_const :: ConstantArray 4 (ConstantArray 3 CInt)
 arr_5_const = unsafePerformIO (peek arr_5_const_ptr)
+{-| __unique:__ @ExampleNothingget_arr_6_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_ceb7f2027865ce12" hs_bindgen_test_arraysarray_ceb7f2027865ce12 :: IO (Ptr Matrix)
 {-# NOINLINE arr_6_const_ptr #-}
 {-| Multi-dimensional array of known size, typedef
@@ -2648,6 +2832,8 @@ arr_6_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_ceb7f2027865ce12
 {-# NOINLINE arr_6_const #-}
 arr_6_const :: Matrix
 arr_6_const = unsafePerformIO (peek arr_6_const_ptr)
+{-| __unique:__ @ExampleNothingget_arr_7_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_2b565b2b97acdcb7" hs_bindgen_test_arraysarray_2b565b2b97acdcb7 :: IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                                                                  CInt)))
 {-# NOINLINE arr_7_const_ptr #-}
@@ -2669,6 +2855,8 @@ __defined at:__ @arrays\/array.h:108:18@
 __exported by:__ @arrays\/array.h@
 -}
 arr_7_const_ptr = unsafePerformIO hs_bindgen_test_arraysarray_2b565b2b97acdcb7
+{-| __unique:__ @ExampleNothingget_arr_8_const_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_arraysarray_03e2d9c4ef2ae993" hs_bindgen_test_arraysarray_03e2d9c4ef2ae993 :: IO (Ptr Tripletlist)
 {-# NOINLINE arr_8_const_ptr #-}
 {-| Multi-dimensional array of unknown size, typedef

--- a/hs-bindgen/fixtures/attributes/asm/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/FunPtr.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_asm_labeled_function_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesasm_b6d695e6a1f2622e" hs_bindgen_test_attributesasm_b6d695e6a1f2622e ::
      IO (Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt))
 

--- a/hs-bindgen/fixtures/attributes/asm/Example/Global.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_asm_labeled_variable_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesasm_f13c50d1f1661525" hs_bindgen_test_attributesasm_f13c50d1f1661525 ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/attributes/asm/Example/Safe.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Safe.hs
@@ -25,6 +25,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @attributes\/asm.h:4:5@
 
     __exported by:__ @attributes\/asm.h@
+
+    __unique:__ @ExampleJust Safeasm_labeled_function@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesasm_b15fc0d2b3d7c9a1" asm_labeled_function ::
      FC.CInt

--- a/hs-bindgen/fixtures/attributes/asm/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Unsafe.hs
@@ -25,6 +25,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @attributes\/asm.h:4:5@
 
     __exported by:__ @attributes\/asm.h@
+
+    __unique:__ @ExampleJust Unsafeasm_labeled_function@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesasm_289cb83358beadc0" asm_labeled_function ::
      FC.CInt

--- a/hs-bindgen/fixtures/attributes/asm/th.txt
+++ b/hs-bindgen/fixtures/attributes/asm/th.txt
@@ -34,6 +34,8 @@
     __defined at:__ @attributes\/asm.h:4:5@
 
     __exported by:__ @attributes\/asm.h@
+
+    __unique:__ @ExampleJust Unsafeasm_labeled_function@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesasm_b15fc0d2b3d7c9a1" asm_labeled_function :: CInt ->
                                                                                                    CInt ->
@@ -43,10 +45,14 @@ foreign import ccall safe "hs_bindgen_test_attributesasm_b15fc0d2b3d7c9a1" asm_l
     __defined at:__ @attributes\/asm.h:4:5@
 
     __exported by:__ @attributes\/asm.h@
+
+    __unique:__ @ExampleJust Unsafeasm_labeled_function@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesasm_289cb83358beadc0" asm_labeled_function :: CInt ->
                                                                                                    CInt ->
                                                                                                    IO CInt
+{-| __unique:__ @ExampleNothingget_asm_labeled_function_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesasm_b6d695e6a1f2622e" hs_bindgen_test_attributesasm_b6d695e6a1f2622e :: IO (FunPtr (CInt ->
                                                                                                                                          CInt ->
                                                                                                                                          IO CInt))
@@ -65,6 +71,8 @@ asm_labeled_function_ptr :: FunPtr (CInt -> CInt -> IO CInt)
     __exported by:__ @attributes\/asm.h@
 -}
 asm_labeled_function_ptr = unsafePerformIO hs_bindgen_test_attributesasm_b6d695e6a1f2622e
+{-| __unique:__ @ExampleNothingget_asm_labeled_variable_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesasm_f13c50d1f1661525" hs_bindgen_test_attributesasm_f13c50d1f1661525 :: IO (Ptr CInt)
 {-# NOINLINE asm_labeled_variable_ptr #-}
 {-| __C declaration:__ @asm_labeled_variable@

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/FunPtr.hs
@@ -194,6 +194,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_f0_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3" hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -209,6 +211,8 @@ f0_ptr :: Ptr.FunPtr (IO ())
 f0_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3
 
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1" hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -224,6 +228,8 @@ f1_ptr :: Ptr.FunPtr (IO ())
 f1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1
 
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69" hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -239,6 +245,8 @@ f2_ptr :: Ptr.FunPtr (IO ())
 f2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69
 
+{-| __unique:__ @ExampleNothingget_f3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2" hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -254,6 +262,8 @@ f3_ptr :: Ptr.FunPtr (IO ())
 f3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2
 
+{-| __unique:__ @ExampleNothingget_f4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b" hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -269,6 +279,8 @@ f4_ptr :: Ptr.FunPtr (IO ())
 f4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b
 
+{-| __unique:__ @ExampleNothingget_f5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b" hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -284,6 +296,8 @@ f5_ptr :: Ptr.FunPtr (IO ())
 f5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b
 
+{-| __unique:__ @ExampleNothingget_f6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd" hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -299,6 +313,8 @@ f6_ptr :: Ptr.FunPtr (IO ())
 f6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd
 
+{-| __unique:__ @ExampleNothingget_f7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5" hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -314,6 +330,8 @@ f7_ptr :: Ptr.FunPtr (IO ())
 f7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5
 
+{-| __unique:__ @ExampleNothingget_f8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b" hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -329,6 +347,8 @@ f8_ptr :: Ptr.FunPtr (IO ())
 f8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b
 
+{-| __unique:__ @ExampleNothingget_f9_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40" hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -344,6 +364,8 @@ f9_ptr :: Ptr.FunPtr (IO ())
 f9_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40
 
+{-| __unique:__ @ExampleNothingget_f10_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_45797238134784ac" hs_bindgen_test_attributesvisibility_attribut_45797238134784ac ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -359,6 +381,8 @@ f10_ptr :: Ptr.FunPtr (IO ())
 f10_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_45797238134784ac
 
+{-| __unique:__ @ExampleNothingget_f11_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039" hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -374,6 +398,8 @@ f11_ptr :: Ptr.FunPtr (IO ())
 f11_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039
 
+{-| __unique:__ @ExampleNothingget_f12_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da" hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -389,6 +415,8 @@ f12_ptr :: Ptr.FunPtr (IO ())
 f12_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da
 
+{-| __unique:__ @ExampleNothingget_f13_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037" hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -404,6 +432,8 @@ f13_ptr :: Ptr.FunPtr (IO ())
 f13_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037
 
+{-| __unique:__ @ExampleNothingget_f14_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70" hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -419,6 +449,8 @@ f14_ptr :: Ptr.FunPtr (IO ())
 f14_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70
 
+{-| __unique:__ @ExampleNothingget_f15_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef" hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -434,6 +466,8 @@ f15_ptr :: Ptr.FunPtr (IO ())
 f15_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef
 
+{-| __unique:__ @ExampleNothingget_f16_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15" hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -449,6 +483,8 @@ f16_ptr :: Ptr.FunPtr (IO ())
 f16_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15
 
+{-| __unique:__ @ExampleNothingget_f17_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2" hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -464,6 +500,8 @@ f17_ptr :: Ptr.FunPtr (IO ())
 f17_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2
 
+{-| __unique:__ @ExampleNothingget_f18_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c" hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -479,6 +517,8 @@ f18_ptr :: Ptr.FunPtr (IO ())
 f18_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c
 
+{-| __unique:__ @ExampleNothingget_f19_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909" hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -494,6 +534,8 @@ f19_ptr :: Ptr.FunPtr (IO ())
 f19_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909
 
+{-| __unique:__ @ExampleNothingget_f20_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753" hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -509,6 +551,8 @@ f20_ptr :: Ptr.FunPtr (IO ())
 f20_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753
 
+{-| __unique:__ @ExampleNothingget_f21_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc" hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -524,6 +568,8 @@ f21_ptr :: Ptr.FunPtr (IO ())
 f21_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc
 
+{-| __unique:__ @ExampleNothingget_f22_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d" hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -539,6 +585,8 @@ f22_ptr :: Ptr.FunPtr (IO ())
 f22_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d
 
+{-| __unique:__ @ExampleNothingget_f23_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9" hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -554,6 +602,8 @@ f23_ptr :: Ptr.FunPtr (IO ())
 f23_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9
 
+{-| __unique:__ @ExampleNothingget_f24_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370" hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -569,6 +619,8 @@ f24_ptr :: Ptr.FunPtr (IO ())
 f24_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370
 
+{-| __unique:__ @ExampleNothingget_f25_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc" hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -584,6 +636,8 @@ f25_ptr :: Ptr.FunPtr (IO ())
 f25_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc
 
+{-| __unique:__ @ExampleNothingget_f26_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552" hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -599,6 +653,8 @@ f26_ptr :: Ptr.FunPtr (IO ())
 f26_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552
 
+{-| __unique:__ @ExampleNothingget_f27_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df" hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -614,6 +670,8 @@ f27_ptr :: Ptr.FunPtr (IO ())
 f27_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df
 
+{-| __unique:__ @ExampleNothingget_f28_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0" hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -629,6 +687,8 @@ f28_ptr :: Ptr.FunPtr (IO ())
 f28_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0
 
+{-| __unique:__ @ExampleNothingget_f29_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1224b39f0e8e72cd" hs_bindgen_test_attributesvisibility_attribut_1224b39f0e8e72cd ::
      IO (Ptr.FunPtr (IO ()))
 

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Global.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Global.hs
@@ -135,6 +135,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_i0_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143" hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -150,6 +152,8 @@ i0_ptr :: Ptr.Ptr FC.CInt
 i0_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143
 
+{-| __unique:__ @ExampleNothingget_i1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983" hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -165,6 +169,8 @@ i1_ptr :: Ptr.Ptr FC.CInt
 i1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983
 
+{-| __unique:__ @ExampleNothingget_i2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159" hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -180,6 +186,8 @@ i2_ptr :: Ptr.Ptr FC.CInt
 i2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159
 
+{-| __unique:__ @ExampleNothingget_i3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5" hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -195,6 +203,8 @@ i3_ptr :: Ptr.Ptr FC.CInt
 i3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5
 
+{-| __unique:__ @ExampleNothingget_i4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2" hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -210,6 +220,8 @@ i4_ptr :: Ptr.Ptr FC.CInt
 i4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2
 
+{-| __unique:__ @ExampleNothingget_i5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa" hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -225,6 +237,8 @@ i5_ptr :: Ptr.Ptr FC.CInt
 i5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa
 
+{-| __unique:__ @ExampleNothingget_i6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78" hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -240,6 +254,8 @@ i6_ptr :: Ptr.Ptr FC.CInt
 i6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78
 
+{-| __unique:__ @ExampleNothingget_i7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e" hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -255,6 +271,8 @@ i7_ptr :: Ptr.Ptr FC.CInt
 i7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e
 
+{-| __unique:__ @ExampleNothingget_i8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce" hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -270,6 +288,8 @@ i8_ptr :: Ptr.Ptr FC.CInt
 i8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce
 
+{-| __unique:__ @ExampleNothingget_i9_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295" hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -285,6 +305,8 @@ i9_ptr :: Ptr.Ptr FC.CInt
 i9_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295
 
+{-| __unique:__ @ExampleNothingget_i10_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878" hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -300,6 +322,8 @@ i10_ptr :: Ptr.Ptr FC.CInt
 i10_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878
 
+{-| __unique:__ @ExampleNothingget_i11_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9" hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -315,6 +339,8 @@ i11_ptr :: Ptr.Ptr FC.CInt
 i11_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9
 
+{-| __unique:__ @ExampleNothingget_i12_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4" hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -330,6 +356,8 @@ i12_ptr :: Ptr.Ptr FC.CInt
 i12_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4
 
+{-| __unique:__ @ExampleNothingget_i13_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e" hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -345,6 +373,8 @@ i13_ptr :: Ptr.Ptr FC.CInt
 i13_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e
 
+{-| __unique:__ @ExampleNothingget_i14_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd" hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -360,6 +390,8 @@ i14_ptr :: Ptr.Ptr FC.CInt
 i14_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd
 
+{-| __unique:__ @ExampleNothingget_i15_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e" hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -375,6 +407,8 @@ i15_ptr :: Ptr.Ptr FC.CInt
 i15_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e
 
+{-| __unique:__ @ExampleNothingget_i16_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58" hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -390,6 +424,8 @@ i16_ptr :: Ptr.Ptr FC.CInt
 i16_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58
 
+{-| __unique:__ @ExampleNothingget_i17_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6" hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -405,6 +441,8 @@ i17_ptr :: Ptr.Ptr FC.CInt
 i17_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6
 
+{-| __unique:__ @ExampleNothingget_i18_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c" hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -420,6 +458,8 @@ i18_ptr :: Ptr.Ptr FC.CInt
 i18_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c
 
+{-| __unique:__ @ExampleNothingget_i19_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_df1c0751f896e6b8" hs_bindgen_test_attributesvisibility_attribut_df1c0751f896e6b8 ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Safe.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Safe.hs
@@ -137,6 +137,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @attributes\/visibility_attributes.h:17:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef0@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e8fda12159f2be9f" f0 ::
      IO ()
@@ -146,6 +148,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e8fda12
     __defined at:__ @attributes\/visibility_attributes.h:18:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef1@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a2f84d2570ef3892" f1 ::
      IO ()
@@ -155,6 +159,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a2f84d2
     __defined at:__ @attributes\/visibility_attributes.h:19:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef2@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1d043de05a457e90" f2 ::
      IO ()
@@ -164,6 +170,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1d043de
     __defined at:__ @attributes\/visibility_attributes.h:20:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef3@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e23eff1955ebb459" f3 ::
      IO ()
@@ -173,6 +181,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e23eff1
     __defined at:__ @attributes\/visibility_attributes.h:21:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef4@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ce219a1a5351d14e" f4 ::
      IO ()
@@ -182,6 +192,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ce219a1
     __defined at:__ @attributes\/visibility_attributes.h:24:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef5@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_caebbc1a0babf9c3" f5 ::
      IO ()
@@ -191,6 +203,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_caebbc1
     __defined at:__ @attributes\/visibility_attributes.h:25:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef6@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0e94ab16fe1245e4" f6 ::
      IO ()
@@ -200,6 +214,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0e94ab1
     __defined at:__ @attributes\/visibility_attributes.h:26:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef7@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_595393c65507c7b2" f7 ::
      IO ()
@@ -209,6 +225,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_595393c
     __defined at:__ @attributes\/visibility_attributes.h:27:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef8@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e6297cc5a3e79e0" f8 ::
      IO ()
@@ -218,6 +236,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e6297c
     __defined at:__ @attributes\/visibility_attributes.h:28:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef9@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d6b88eb048c2261" f9 ::
      IO ()
@@ -227,6 +247,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d6b88e
     __defined at:__ @attributes\/visibility_attributes.h:31:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef10@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ef53db381225865" f10 ::
      IO ()
@@ -236,6 +258,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ef53db
     __defined at:__ @attributes\/visibility_attributes.h:32:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef11@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c626c8c382be7e47" f11 ::
      IO ()
@@ -245,6 +269,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c626c8c
     __defined at:__ @attributes\/visibility_attributes.h:33:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef12@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_09bc3cf816a85839" f12 ::
      IO ()
@@ -254,6 +280,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_09bc3cf
     __defined at:__ @attributes\/visibility_attributes.h:34:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef13@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eadf3eb9d39365cf" f13 ::
      IO ()
@@ -263,6 +291,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eadf3eb
     __defined at:__ @attributes\/visibility_attributes.h:35:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef14@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_24313656b5162754" f14 ::
      IO ()
@@ -272,6 +302,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2431365
     __defined at:__ @attributes\/visibility_attributes.h:38:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef15@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_db09067813df28c1" f15 ::
      IO ()
@@ -281,6 +313,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_db09067
     __defined at:__ @attributes\/visibility_attributes.h:39:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef16@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ce3176c4406cf10" f16 ::
      IO ()
@@ -290,6 +324,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ce3176
     __defined at:__ @attributes\/visibility_attributes.h:40:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef17@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2354b7b245be3629" f17 ::
      IO ()
@@ -299,6 +335,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2354b7b
     __defined at:__ @attributes\/visibility_attributes.h:41:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef18@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a24f6e8ea1a74456" f18 ::
      IO ()
@@ -308,6 +346,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a24f6e8
     __defined at:__ @attributes\/visibility_attributes.h:42:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef19@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e14cdae313c9647d" f19 ::
      IO ()
@@ -317,6 +357,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e14cdae
     __defined at:__ @attributes\/visibility_attributes.h:45:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef20@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_d973493c824fdf05" f20 ::
      IO ()
@@ -326,6 +368,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_d973493
     __defined at:__ @attributes\/visibility_attributes.h:46:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef21@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cc1b3614f810260c" f21 ::
      IO ()
@@ -335,6 +379,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cc1b361
     __defined at:__ @attributes\/visibility_attributes.h:47:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef22@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cb764aa14ed3e34c" f22 ::
      IO ()
@@ -344,6 +390,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cb764aa
     __defined at:__ @attributes\/visibility_attributes.h:48:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef23@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_dc225cc74f4331bf" f23 ::
      IO ()
@@ -353,6 +401,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_dc225cc
     __defined at:__ @attributes\/visibility_attributes.h:49:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef24@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_88449e6c03902cdf" f24 ::
      IO ()
@@ -362,6 +412,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_88449e6
     __defined at:__ @attributes\/visibility_attributes.h:52:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef25@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7370ca6009a58826" f25 ::
      IO ()
@@ -371,6 +423,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7370ca6
     __defined at:__ @attributes\/visibility_attributes.h:53:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef26@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a67323b70e59146d" f26 ::
      IO ()
@@ -380,6 +434,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a67323b
     __defined at:__ @attributes\/visibility_attributes.h:54:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef27@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_968a7a3827f17839" f27 ::
      IO ()
@@ -389,6 +445,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_968a7a3
     __defined at:__ @attributes\/visibility_attributes.h:55:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef28@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fbb18ffa92c2c5be" f28 ::
      IO ()
@@ -398,6 +456,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fbb18ff
     __defined at:__ @attributes\/visibility_attributes.h:56:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Safef29@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_60afc98eb89b8a2d" f29 ::
      IO ()

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Unsafe.hs
@@ -137,6 +137,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @attributes\/visibility_attributes.h:17:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef0@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_3ff941535f1a906c" f0 ::
      IO ()
@@ -146,6 +148,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_3ff94
     __defined at:__ @attributes\/visibility_attributes.h:18:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_c1788128a5b1c813" f1 ::
      IO ()
@@ -155,6 +159,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_c1788
     __defined at:__ @attributes\/visibility_attributes.h:19:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_14361e995fb5684a" f2 ::
      IO ()
@@ -164,6 +170,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_14361
     __defined at:__ @attributes\/visibility_attributes.h:20:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_2bef032cbe15ffd0" f3 ::
      IO ()
@@ -173,6 +181,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_2bef0
     __defined at:__ @attributes\/visibility_attributes.h:21:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_cd0cf1428bcc9b38" f4 ::
      IO ()
@@ -182,6 +192,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_cd0cf
     __defined at:__ @attributes\/visibility_attributes.h:24:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8c6188a2eaf5d0d4" f5 ::
      IO ()
@@ -191,6 +203,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8c618
     __defined at:__ @attributes\/visibility_attributes.h:25:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef6@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b8eff0c55713150e" f6 ::
      IO ()
@@ -200,6 +214,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_b8eff
     __defined at:__ @attributes\/visibility_attributes.h:26:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef7@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_71135129c9373ee7" f7 ::
      IO ()
@@ -209,6 +225,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_71135
     __defined at:__ @attributes\/visibility_attributes.h:27:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef8@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_febb2843049709cd" f8 ::
      IO ()
@@ -218,6 +236,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_febb2
     __defined at:__ @attributes\/visibility_attributes.h:28:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef9@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f6882e1e65092791" f9 ::
      IO ()
@@ -227,6 +247,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f6882
     __defined at:__ @attributes\/visibility_attributes.h:31:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef10@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_7d21aeb39d51b64f" f10 ::
      IO ()
@@ -236,6 +258,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_7d21a
     __defined at:__ @attributes\/visibility_attributes.h:32:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef11@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_fe9b18a1d2845606" f11 ::
      IO ()
@@ -245,6 +269,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_fe9b1
     __defined at:__ @attributes\/visibility_attributes.h:33:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef12@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8b5aacef3fb80581" f12 ::
      IO ()
@@ -254,6 +280,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_8b5aa
     __defined at:__ @attributes\/visibility_attributes.h:34:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef13@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_9162af7e5d2b25bd" f13 ::
      IO ()
@@ -263,6 +291,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_9162a
     __defined at:__ @attributes\/visibility_attributes.h:35:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef14@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_92d022f6d12704a3" f14 ::
      IO ()
@@ -272,6 +302,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_92d02
     __defined at:__ @attributes\/visibility_attributes.h:38:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef15@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1ade4a16b9edc93f" f15 ::
      IO ()
@@ -281,6 +313,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1ade4
     __defined at:__ @attributes\/visibility_attributes.h:39:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef16@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_702e08cfa9d8f107" f16 ::
      IO ()
@@ -290,6 +324,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_702e0
     __defined at:__ @attributes\/visibility_attributes.h:40:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef17@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_6839cf744c467402" f17 ::
      IO ()
@@ -299,6 +335,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_6839c
     __defined at:__ @attributes\/visibility_attributes.h:41:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef18@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_bcbefba8cee060e9" f18 ::
      IO ()
@@ -308,6 +346,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_bcbef
     __defined at:__ @attributes\/visibility_attributes.h:42:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef19@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_6991c5868d8397b8" f19 ::
      IO ()
@@ -317,6 +357,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_6991c
     __defined at:__ @attributes\/visibility_attributes.h:45:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef20@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_168f1d96d48b3571" f20 ::
      IO ()
@@ -326,6 +368,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_168f1
     __defined at:__ @attributes\/visibility_attributes.h:46:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef21@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_05b34816425cdccc" f21 ::
      IO ()
@@ -335,6 +379,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_05b34
     __defined at:__ @attributes\/visibility_attributes.h:47:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef22@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1531783017d14d65" f22 ::
      IO ()
@@ -344,6 +390,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_15317
     __defined at:__ @attributes\/visibility_attributes.h:48:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef23@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_e086f69c4390fd7e" f23 ::
      IO ()
@@ -353,6 +401,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_e086f
     __defined at:__ @attributes\/visibility_attributes.h:49:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef24@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_eaa6acf5b4299e7c" f24 ::
      IO ()
@@ -362,6 +412,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_eaa6a
     __defined at:__ @attributes\/visibility_attributes.h:52:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef25@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_a82bd6ddcf01332d" f25 ::
      IO ()
@@ -371,6 +423,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_a82bd
     __defined at:__ @attributes\/visibility_attributes.h:53:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef26@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1ee51cc55408f9a7" f26 ::
      IO ()
@@ -380,6 +434,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_1ee51
     __defined at:__ @attributes\/visibility_attributes.h:54:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef27@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f6035b3578b5d5cd" f27 ::
      IO ()
@@ -389,6 +445,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_f6035
     __defined at:__ @attributes\/visibility_attributes.h:55:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef28@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_a827e3b8d932270f" f28 ::
      IO ()
@@ -398,6 +456,8 @@ foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_a827e
     __defined at:__ @attributes\/visibility_attributes.h:56:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef29@
 -}
 foreign import ccall unsafe "hs_bindgen_test_attributesvisibility_attribut_316dcf70a67165b5" f29 ::
      IO ()

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/th.txt
@@ -545,6 +545,8 @@
     __defined at:__ @attributes\/visibility_attributes.h:17:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef0@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e8fda12159f2be9f" f0 :: IO Unit
 {-| __C declaration:__ @f1@
@@ -552,6 +554,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e8fda12
     __defined at:__ @attributes\/visibility_attributes.h:18:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a2f84d2570ef3892" f1 :: IO Unit
 {-| __C declaration:__ @f2@
@@ -559,6 +563,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a2f84d2
     __defined at:__ @attributes\/visibility_attributes.h:19:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1d043de05a457e90" f2 :: IO Unit
 {-| __C declaration:__ @f3@
@@ -566,6 +572,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1d043de
     __defined at:__ @attributes\/visibility_attributes.h:20:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e23eff1955ebb459" f3 :: IO Unit
 {-| __C declaration:__ @f4@
@@ -573,6 +581,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e23eff1
     __defined at:__ @attributes\/visibility_attributes.h:21:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef4@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ce219a1a5351d14e" f4 :: IO Unit
 {-| __C declaration:__ @f5@
@@ -580,6 +590,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ce219a1
     __defined at:__ @attributes\/visibility_attributes.h:24:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef5@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_caebbc1a0babf9c3" f5 :: IO Unit
 {-| __C declaration:__ @f6@
@@ -587,6 +599,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_caebbc1
     __defined at:__ @attributes\/visibility_attributes.h:25:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef6@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0e94ab16fe1245e4" f6 :: IO Unit
 {-| __C declaration:__ @f7@
@@ -594,6 +608,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0e94ab1
     __defined at:__ @attributes\/visibility_attributes.h:26:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef7@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_595393c65507c7b2" f7 :: IO Unit
 {-| __C declaration:__ @f8@
@@ -601,6 +617,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_595393c
     __defined at:__ @attributes\/visibility_attributes.h:27:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef8@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e6297cc5a3e79e0" f8 :: IO Unit
 {-| __C declaration:__ @f9@
@@ -608,6 +626,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e6297c
     __defined at:__ @attributes\/visibility_attributes.h:28:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef9@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d6b88eb048c2261" f9 :: IO Unit
 {-| __C declaration:__ @f10@
@@ -615,6 +635,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d6b88e
     __defined at:__ @attributes\/visibility_attributes.h:31:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef10@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ef53db381225865" f10 :: IO Unit
 {-| __C declaration:__ @f11@
@@ -622,6 +644,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ef53db
     __defined at:__ @attributes\/visibility_attributes.h:32:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef11@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c626c8c382be7e47" f11 :: IO Unit
 {-| __C declaration:__ @f12@
@@ -629,6 +653,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c626c8c
     __defined at:__ @attributes\/visibility_attributes.h:33:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef12@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_09bc3cf816a85839" f12 :: IO Unit
 {-| __C declaration:__ @f13@
@@ -636,6 +662,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_09bc3cf
     __defined at:__ @attributes\/visibility_attributes.h:34:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef13@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eadf3eb9d39365cf" f13 :: IO Unit
 {-| __C declaration:__ @f14@
@@ -643,6 +671,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eadf3eb
     __defined at:__ @attributes\/visibility_attributes.h:35:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef14@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_24313656b5162754" f14 :: IO Unit
 {-| __C declaration:__ @f15@
@@ -650,6 +680,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2431365
     __defined at:__ @attributes\/visibility_attributes.h:38:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef15@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_db09067813df28c1" f15 :: IO Unit
 {-| __C declaration:__ @f16@
@@ -657,6 +689,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_db09067
     __defined at:__ @attributes\/visibility_attributes.h:39:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef16@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ce3176c4406cf10" f16 :: IO Unit
 {-| __C declaration:__ @f17@
@@ -664,6 +698,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4ce3176
     __defined at:__ @attributes\/visibility_attributes.h:40:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef17@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2354b7b245be3629" f17 :: IO Unit
 {-| __C declaration:__ @f18@
@@ -671,6 +707,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2354b7b
     __defined at:__ @attributes\/visibility_attributes.h:41:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef18@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a24f6e8ea1a74456" f18 :: IO Unit
 {-| __C declaration:__ @f19@
@@ -678,6 +716,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a24f6e8
     __defined at:__ @attributes\/visibility_attributes.h:42:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef19@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e14cdae313c9647d" f19 :: IO Unit
 {-| __C declaration:__ @f20@
@@ -685,6 +725,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e14cdae
     __defined at:__ @attributes\/visibility_attributes.h:45:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef20@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_d973493c824fdf05" f20 :: IO Unit
 {-| __C declaration:__ @f21@
@@ -692,6 +734,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_d973493
     __defined at:__ @attributes\/visibility_attributes.h:46:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef21@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cc1b3614f810260c" f21 :: IO Unit
 {-| __C declaration:__ @f22@
@@ -699,6 +743,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cc1b361
     __defined at:__ @attributes\/visibility_attributes.h:47:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef22@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cb764aa14ed3e34c" f22 :: IO Unit
 {-| __C declaration:__ @f23@
@@ -706,6 +752,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cb764aa
     __defined at:__ @attributes\/visibility_attributes.h:48:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef23@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_dc225cc74f4331bf" f23 :: IO Unit
 {-| __C declaration:__ @f24@
@@ -713,6 +761,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_dc225cc
     __defined at:__ @attributes\/visibility_attributes.h:49:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef24@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_88449e6c03902cdf" f24 :: IO Unit
 {-| __C declaration:__ @f25@
@@ -720,6 +770,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_88449e6
     __defined at:__ @attributes\/visibility_attributes.h:52:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef25@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7370ca6009a58826" f25 :: IO Unit
 {-| __C declaration:__ @f26@
@@ -727,6 +779,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7370ca6
     __defined at:__ @attributes\/visibility_attributes.h:53:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef26@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a67323b70e59146d" f26 :: IO Unit
 {-| __C declaration:__ @f27@
@@ -734,6 +788,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a67323b
     __defined at:__ @attributes\/visibility_attributes.h:54:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef27@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_968a7a3827f17839" f27 :: IO Unit
 {-| __C declaration:__ @f28@
@@ -741,6 +797,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_968a7a3
     __defined at:__ @attributes\/visibility_attributes.h:55:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef28@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fbb18ffa92c2c5be" f28 :: IO Unit
 {-| __C declaration:__ @f29@
@@ -748,6 +806,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fbb18ff
     __defined at:__ @attributes\/visibility_attributes.h:56:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef29@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_60afc98eb89b8a2d" f29 :: IO Unit
 {-| __C declaration:__ @f0@
@@ -755,6 +815,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_60afc98
     __defined at:__ @attributes\/visibility_attributes.h:17:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef0@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_3ff941535f1a906c" f0 :: IO Unit
 {-| __C declaration:__ @f1@
@@ -762,6 +824,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_3ff9415
     __defined at:__ @attributes\/visibility_attributes.h:18:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c1788128a5b1c813" f1 :: IO Unit
 {-| __C declaration:__ @f2@
@@ -769,6 +833,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_c178812
     __defined at:__ @attributes\/visibility_attributes.h:19:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_14361e995fb5684a" f2 :: IO Unit
 {-| __C declaration:__ @f3@
@@ -776,6 +842,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_14361e9
     __defined at:__ @attributes\/visibility_attributes.h:20:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2bef032cbe15ffd0" f3 :: IO Unit
 {-| __C declaration:__ @f4@
@@ -783,6 +851,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2bef032
     __defined at:__ @attributes\/visibility_attributes.h:21:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef4@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cd0cf1428bcc9b38" f4 :: IO Unit
 {-| __C declaration:__ @f5@
@@ -790,6 +860,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_cd0cf14
     __defined at:__ @attributes\/visibility_attributes.h:24:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef5@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8c6188a2eaf5d0d4" f5 :: IO Unit
 {-| __C declaration:__ @f6@
@@ -797,6 +869,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8c6188a
     __defined at:__ @attributes\/visibility_attributes.h:25:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef6@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b8eff0c55713150e" f6 :: IO Unit
 {-| __C declaration:__ @f7@
@@ -804,6 +878,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b8eff0c
     __defined at:__ @attributes\/visibility_attributes.h:26:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef7@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_71135129c9373ee7" f7 :: IO Unit
 {-| __C declaration:__ @f8@
@@ -811,6 +887,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7113512
     __defined at:__ @attributes\/visibility_attributes.h:27:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef8@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_febb2843049709cd" f8 :: IO Unit
 {-| __C declaration:__ @f9@
@@ -818,6 +896,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_febb284
     __defined at:__ @attributes\/visibility_attributes.h:28:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef9@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f6882e1e65092791" f9 :: IO Unit
 {-| __C declaration:__ @f10@
@@ -825,6 +905,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f6882e1
     __defined at:__ @attributes\/visibility_attributes.h:31:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef10@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d21aeb39d51b64f" f10 :: IO Unit
 {-| __C declaration:__ @f11@
@@ -832,6 +914,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7d21aeb
     __defined at:__ @attributes\/visibility_attributes.h:32:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef11@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fe9b18a1d2845606" f11 :: IO Unit
 {-| __C declaration:__ @f12@
@@ -839,6 +923,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_fe9b18a
     __defined at:__ @attributes\/visibility_attributes.h:33:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef12@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8b5aacef3fb80581" f12 :: IO Unit
 {-| __C declaration:__ @f13@
@@ -846,6 +932,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8b5aace
     __defined at:__ @attributes\/visibility_attributes.h:34:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef13@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_9162af7e5d2b25bd" f13 :: IO Unit
 {-| __C declaration:__ @f14@
@@ -853,6 +941,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_9162af7
     __defined at:__ @attributes\/visibility_attributes.h:35:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef14@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_92d022f6d12704a3" f14 :: IO Unit
 {-| __C declaration:__ @f15@
@@ -860,6 +950,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_92d022f
     __defined at:__ @attributes\/visibility_attributes.h:38:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef15@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1ade4a16b9edc93f" f15 :: IO Unit
 {-| __C declaration:__ @f16@
@@ -867,6 +959,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1ade4a1
     __defined at:__ @attributes\/visibility_attributes.h:39:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef16@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_702e08cfa9d8f107" f16 :: IO Unit
 {-| __C declaration:__ @f17@
@@ -874,6 +968,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_702e08c
     __defined at:__ @attributes\/visibility_attributes.h:40:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef17@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_6839cf744c467402" f17 :: IO Unit
 {-| __C declaration:__ @f18@
@@ -881,6 +977,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_6839cf7
     __defined at:__ @attributes\/visibility_attributes.h:41:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef18@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_bcbefba8cee060e9" f18 :: IO Unit
 {-| __C declaration:__ @f19@
@@ -888,6 +986,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_bcbefba
     __defined at:__ @attributes\/visibility_attributes.h:42:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef19@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_6991c5868d8397b8" f19 :: IO Unit
 {-| __C declaration:__ @f20@
@@ -895,6 +995,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_6991c58
     __defined at:__ @attributes\/visibility_attributes.h:45:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef20@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_168f1d96d48b3571" f20 :: IO Unit
 {-| __C declaration:__ @f21@
@@ -902,6 +1004,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_168f1d9
     __defined at:__ @attributes\/visibility_attributes.h:46:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef21@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_05b34816425cdccc" f21 :: IO Unit
 {-| __C declaration:__ @f22@
@@ -909,6 +1013,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_05b3481
     __defined at:__ @attributes\/visibility_attributes.h:47:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef22@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1531783017d14d65" f22 :: IO Unit
 {-| __C declaration:__ @f23@
@@ -916,6 +1022,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1531783
     __defined at:__ @attributes\/visibility_attributes.h:48:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef23@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e086f69c4390fd7e" f23 :: IO Unit
 {-| __C declaration:__ @f24@
@@ -923,6 +1031,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e086f69
     __defined at:__ @attributes\/visibility_attributes.h:49:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef24@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eaa6acf5b4299e7c" f24 :: IO Unit
 {-| __C declaration:__ @f25@
@@ -930,6 +1040,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_eaa6acf
     __defined at:__ @attributes\/visibility_attributes.h:52:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef25@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a82bd6ddcf01332d" f25 :: IO Unit
 {-| __C declaration:__ @f26@
@@ -937,6 +1049,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a82bd6d
     __defined at:__ @attributes\/visibility_attributes.h:53:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef26@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1ee51cc55408f9a7" f26 :: IO Unit
 {-| __C declaration:__ @f27@
@@ -944,6 +1058,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1ee51cc
     __defined at:__ @attributes\/visibility_attributes.h:54:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef27@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f6035b3578b5d5cd" f27 :: IO Unit
 {-| __C declaration:__ @f28@
@@ -951,6 +1067,8 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f6035b3
     __defined at:__ @attributes\/visibility_attributes.h:55:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef28@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a827e3b8d932270f" f28 :: IO Unit
 {-| __C declaration:__ @f29@
@@ -958,8 +1076,12 @@ foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a827e3b
     __defined at:__ @attributes\/visibility_attributes.h:56:56@
 
     __exported by:__ @attributes\/visibility_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef29@
 -}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_316dcf70a67165b5" f29 :: IO Unit
+{-| __unique:__ @ExampleNothingget_f0_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3" hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f0_ptr #-}
 {-| __C declaration:__ @f0@
@@ -976,6 +1098,8 @@ f0_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f0_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_a03f2cbeac50b3d3
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1" hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f1_ptr #-}
 {-| __C declaration:__ @f1@
@@ -992,6 +1116,8 @@ f1_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f1_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_5469bdc0395f86c1
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69" hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f2_ptr #-}
 {-| __C declaration:__ @f2@
@@ -1008,6 +1134,8 @@ f2_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f2_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_490ca7e8c8282a69
+{-| __unique:__ @ExampleNothingget_f3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2" hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f3_ptr #-}
 {-| __C declaration:__ @f3@
@@ -1024,6 +1152,8 @@ f3_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f3_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_38506a9ac5626bf2
+{-| __unique:__ @ExampleNothingget_f4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b" hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b :: IO (FunPtr (IO Unit))
 {-# NOINLINE f4_ptr #-}
 {-| __C declaration:__ @f4@
@@ -1040,6 +1170,8 @@ f4_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f4_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_10e5fac8fefa811b
+{-| __unique:__ @ExampleNothingget_f5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b" hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b :: IO (FunPtr (IO Unit))
 {-# NOINLINE f5_ptr #-}
 {-| __C declaration:__ @f5@
@@ -1056,6 +1188,8 @@ f5_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f5_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3f137e2ee71fd73b
+{-| __unique:__ @ExampleNothingget_f6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd" hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd :: IO (FunPtr (IO Unit))
 {-# NOINLINE f6_ptr #-}
 {-| __C declaration:__ @f6@
@@ -1072,6 +1206,8 @@ f6_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f6_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b69720e01b3b7ccd
+{-| __unique:__ @ExampleNothingget_f7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5" hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f7_ptr #-}
 {-| __C declaration:__ @f7@
@@ -1088,6 +1224,8 @@ f7_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f7_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_97be5f53b506f3b5
+{-| __unique:__ @ExampleNothingget_f8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b" hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b :: IO (FunPtr (IO Unit))
 {-# NOINLINE f8_ptr #-}
 {-| __C declaration:__ @f8@
@@ -1104,6 +1242,8 @@ f8_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f8_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_ae7ef3d579d77d0b
+{-| __unique:__ @ExampleNothingget_f9_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40" hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f9_ptr #-}
 {-| __C declaration:__ @f9@
@@ -1120,6 +1260,8 @@ f9_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f9_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_ef6d611329a20b40
+{-| __unique:__ @ExampleNothingget_f10_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_45797238134784ac" hs_bindgen_test_attributesvisibility_attribut_45797238134784ac :: IO (FunPtr (IO Unit))
 {-# NOINLINE f10_ptr #-}
 {-| __C declaration:__ @f10@
@@ -1136,6 +1278,8 @@ f10_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f10_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_45797238134784ac
+{-| __unique:__ @ExampleNothingget_f11_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039" hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f11_ptr #-}
 {-| __C declaration:__ @f11@
@@ -1152,6 +1296,8 @@ f11_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f11_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_f09c80553786e039
+{-| __unique:__ @ExampleNothingget_f12_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da" hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da :: IO (FunPtr (IO Unit))
 {-# NOINLINE f12_ptr #-}
 {-| __C declaration:__ @f12@
@@ -1168,6 +1314,8 @@ f12_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f12_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2e9999eac1cab3da
+{-| __unique:__ @ExampleNothingget_f13_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037" hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f13_ptr #-}
 {-| __C declaration:__ @f13@
@@ -1184,6 +1332,8 @@ f13_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f13_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_32e5be8a3f3ac037
+{-| __unique:__ @ExampleNothingget_f14_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70" hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f14_ptr #-}
 {-| __C declaration:__ @f14@
@@ -1200,6 +1350,8 @@ f14_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f14_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0b00a23924c6dc70
+{-| __unique:__ @ExampleNothingget_f15_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef" hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef :: IO (FunPtr (IO Unit))
 {-# NOINLINE f15_ptr #-}
 {-| __C declaration:__ @f15@
@@ -1216,6 +1368,8 @@ f15_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f15_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0d2891732562e5ef
+{-| __unique:__ @ExampleNothingget_f16_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15" hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f16_ptr #-}
 {-| __C declaration:__ @f16@
@@ -1232,6 +1386,8 @@ f16_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f16_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_f25227febbe8db15
+{-| __unique:__ @ExampleNothingget_f17_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2" hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f17_ptr #-}
 {-| __C declaration:__ @f17@
@@ -1248,6 +1404,8 @@ f17_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f17_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b90b1824c2839fd2
+{-| __unique:__ @ExampleNothingget_f18_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c" hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c :: IO (FunPtr (IO Unit))
 {-# NOINLINE f18_ptr #-}
 {-| __C declaration:__ @f18@
@@ -1264,6 +1422,8 @@ f18_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f18_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_24ba8b98fe453a5c
+{-| __unique:__ @ExampleNothingget_f19_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909" hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f19_ptr #-}
 {-| __C declaration:__ @f19@
@@ -1280,6 +1440,8 @@ f19_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f19_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b857c57c0cf79909
+{-| __unique:__ @ExampleNothingget_f20_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753" hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f20_ptr #-}
 {-| __C declaration:__ @f20@
@@ -1296,6 +1458,8 @@ f20_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f20_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_d695cc521dd39753
+{-| __unique:__ @ExampleNothingget_f21_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc" hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc :: IO (FunPtr (IO Unit))
 {-# NOINLINE f21_ptr #-}
 {-| __C declaration:__ @f21@
@@ -1312,6 +1476,8 @@ f21_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f21_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_7311dbbdd00abedc
+{-| __unique:__ @ExampleNothingget_f22_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d" hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d :: IO (FunPtr (IO Unit))
 {-# NOINLINE f22_ptr #-}
 {-| __C declaration:__ @f22@
@@ -1328,6 +1494,8 @@ f22_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f22_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_4246b9344ad4db0d
+{-| __unique:__ @ExampleNothingget_f23_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9" hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f23_ptr #-}
 {-| __C declaration:__ @f23@
@@ -1344,6 +1512,8 @@ f23_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f23_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_dcef056ccb5953f9
+{-| __unique:__ @ExampleNothingget_f24_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370" hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f24_ptr #-}
 {-| __C declaration:__ @f24@
@@ -1360,6 +1530,8 @@ f24_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f24_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_9ab6df359be6d370
+{-| __unique:__ @ExampleNothingget_f25_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc" hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc :: IO (FunPtr (IO Unit))
 {-# NOINLINE f25_ptr #-}
 {-| __C declaration:__ @f25@
@@ -1376,6 +1548,8 @@ f25_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f25_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_80cad6f0afd3f1fc
+{-| __unique:__ @ExampleNothingget_f26_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552" hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f26_ptr #-}
 {-| __C declaration:__ @f26@
@@ -1392,6 +1566,8 @@ f26_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f26_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b1580cdccf30f552
+{-| __unique:__ @ExampleNothingget_f27_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df" hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df :: IO (FunPtr (IO Unit))
 {-# NOINLINE f27_ptr #-}
 {-| __C declaration:__ @f27@
@@ -1408,6 +1584,8 @@ f27_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f27_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2e4891a5e2afe0df
+{-| __unique:__ @ExampleNothingget_f28_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0" hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f28_ptr #-}
 {-| __C declaration:__ @f28@
@@ -1424,6 +1602,8 @@ f28_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f28_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_e2949a9b7b7cbfc0
+{-| __unique:__ @ExampleNothingget_f29_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_1224b39f0e8e72cd" hs_bindgen_test_attributesvisibility_attribut_1224b39f0e8e72cd :: IO (FunPtr (IO Unit))
 {-# NOINLINE f29_ptr #-}
 {-| __C declaration:__ @f29@
@@ -1440,6 +1620,8 @@ f29_ptr :: FunPtr (IO Unit)
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 f29_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_1224b39f0e8e72cd
+{-| __unique:__ @ExampleNothingget_i0_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143" hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143 :: IO (Ptr CInt)
 {-# NOINLINE i0_ptr #-}
 {-| __C declaration:__ @i0@
@@ -1456,6 +1638,8 @@ i0_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i0_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_216496b15d8f3143
+{-| __unique:__ @ExampleNothingget_i1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983" hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983 :: IO (Ptr CInt)
 {-# NOINLINE i1_ptr #-}
 {-| __C declaration:__ @i1@
@@ -1472,6 +1656,8 @@ i1_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i1_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a4a155fb4b3e983
+{-| __unique:__ @ExampleNothingget_i2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159" hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159 :: IO (Ptr CInt)
 {-# NOINLINE i2_ptr #-}
 {-| __C declaration:__ @i2@
@@ -1488,6 +1674,8 @@ i2_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i2_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a341976b53c3159
+{-| __unique:__ @ExampleNothingget_i3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5" hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5 :: IO (Ptr CInt)
 {-# NOINLINE i3_ptr #-}
 {-| __C declaration:__ @i3@
@@ -1504,6 +1692,8 @@ i3_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i3_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a18e8a325536dc5
+{-| __unique:__ @ExampleNothingget_i4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2" hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2 :: IO (Ptr CInt)
 {-# NOINLINE i4_ptr #-}
 {-| __C declaration:__ @i4@
@@ -1520,6 +1710,8 @@ i4_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i4_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_8a083f6803595ed2
+{-| __unique:__ @ExampleNothingget_i5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa" hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa :: IO (Ptr CInt)
 {-# NOINLINE i5_ptr #-}
 {-| __C declaration:__ @i5@
@@ -1536,6 +1728,8 @@ i5_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i5_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9d322a4c171d6fa
+{-| __unique:__ @ExampleNothingget_i6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78" hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78 :: IO (Ptr CInt)
 {-# NOINLINE i6_ptr #-}
 {-| __C declaration:__ @i6@
@@ -1552,6 +1746,8 @@ i6_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i6_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_2c4836056a76ae78
+{-| __unique:__ @ExampleNothingget_i7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e" hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e :: IO (Ptr CInt)
 {-# NOINLINE i7_ptr #-}
 {-| __C declaration:__ @i7@
@@ -1568,6 +1764,8 @@ i7_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i7_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9d40a2f9eb7062e
+{-| __unique:__ @ExampleNothingget_i8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce" hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce :: IO (Ptr CInt)
 {-# NOINLINE i8_ptr #-}
 {-| __C declaration:__ @i8@
@@ -1584,6 +1782,8 @@ i8_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i8_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3fd4c67173dc11ce
+{-| __unique:__ @ExampleNothingget_i9_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295" hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295 :: IO (Ptr CInt)
 {-# NOINLINE i9_ptr #-}
 {-| __C declaration:__ @i9@
@@ -1600,6 +1800,8 @@ i9_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i9_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b9ff2784975e7295
+{-| __unique:__ @ExampleNothingget_i10_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878" hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878 :: IO (Ptr CInt)
 {-# NOINLINE i10_ptr #-}
 {-| __C declaration:__ @i10@
@@ -1616,6 +1818,8 @@ i10_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i10_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_17a29f1f8c101878
+{-| __unique:__ @ExampleNothingget_i11_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9" hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9 :: IO (Ptr CInt)
 {-# NOINLINE i11_ptr #-}
 {-| __C declaration:__ @i11@
@@ -1632,6 +1836,8 @@ i11_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i11_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_4e591df5ac4216c9
+{-| __unique:__ @ExampleNothingget_i12_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4" hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4 :: IO (Ptr CInt)
 {-# NOINLINE i12_ptr #-}
 {-| __C declaration:__ @i12@
@@ -1648,6 +1854,8 @@ i12_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i12_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_7a8621a15e9246c4
+{-| __unique:__ @ExampleNothingget_i13_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e" hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e :: IO (Ptr CInt)
 {-# NOINLINE i13_ptr #-}
 {-| __C declaration:__ @i13@
@@ -1664,6 +1872,8 @@ i13_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i13_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_96cb39c8a898775e
+{-| __unique:__ @ExampleNothingget_i14_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd" hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd :: IO (Ptr CInt)
 {-# NOINLINE i14_ptr #-}
 {-| __C declaration:__ @i14@
@@ -1680,6 +1890,8 @@ i14_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i14_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_9f817ee25723fbcd
+{-| __unique:__ @ExampleNothingget_i15_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e" hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e :: IO (Ptr CInt)
 {-# NOINLINE i15_ptr #-}
 {-| __C declaration:__ @i15@
@@ -1696,6 +1908,8 @@ i15_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i15_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_0f8755cf60822f2e
+{-| __unique:__ @ExampleNothingget_i16_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58" hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58 :: IO (Ptr CInt)
 {-# NOINLINE i16_ptr #-}
 {-| __C declaration:__ @i16@
@@ -1712,6 +1926,8 @@ i16_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i16_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_3023a5c63e753d58
+{-| __unique:__ @ExampleNothingget_i17_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6" hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6 :: IO (Ptr CInt)
 {-# NOINLINE i17_ptr #-}
 {-| __C declaration:__ @i17@
@@ -1728,6 +1944,8 @@ i17_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i17_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_b5610fa653ca61e6
+{-| __unique:__ @ExampleNothingget_i18_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c" hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c :: IO (Ptr CInt)
 {-# NOINLINE i18_ptr #-}
 {-| __C declaration:__ @i18@
@@ -1744,6 +1962,8 @@ i18_ptr :: Ptr CInt
     __exported by:__ @attributes\/visibility_attributes.h@
 -}
 i18_ptr = unsafePerformIO hs_bindgen_test_attributesvisibility_attribut_17edf053c36e012c
+{-| __unique:__ @ExampleNothingget_i19_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_attributesvisibility_attribut_df1c0751f896e6b8" hs_bindgen_test_attributesvisibility_attribut_df1c0751f896e6b8 :: IO (Ptr CInt)
 {-# NOINLINE i19_ptr #-}
 {-| __C declaration:__ @i19@

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/FunPtr.hs
@@ -23,6 +23,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_f_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationsdeclarations_requ_c34fd33eedc1490d" hs_bindgen_test_declarationsdeclarations_requ_c34fd33eedc1490d ::
      IO (Ptr.FunPtr (A -> IO ()))
 

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Safe.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Safe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @declarations\/declarations_required_for_scoping.h:7:6@
 
     __exported by:__ @declarations\/declarations_required_for_scoping.h@
+
+    __unique:__ @ExampleJust Safef@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdeclarations_requ_fcce70013c76ce8b" f ::
      A

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Unsafe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @declarations\/declarations_required_for_scoping.h:7:6@
 
     __exported by:__ @declarations\/declarations_required_for_scoping.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall unsafe "hs_bindgen_test_declarationsdeclarations_requ_b68b2cffacc97c1d" f ::
      A

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -51,6 +51,8 @@ newtype A
     __defined at:__ @declarations\/declarations_required_for_scoping.h:7:6@
 
     __exported by:__ @declarations\/declarations_required_for_scoping.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdeclarations_requ_fcce70013c76ce8b" f :: A ->
                                                                                                 IO Unit
@@ -59,9 +61,13 @@ foreign import ccall safe "hs_bindgen_test_declarationsdeclarations_requ_fcce700
     __defined at:__ @declarations\/declarations_required_for_scoping.h:7:6@
 
     __exported by:__ @declarations\/declarations_required_for_scoping.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdeclarations_requ_b68b2cffacc97c1d" f :: A ->
                                                                                                 IO Unit
+{-| __unique:__ @ExampleNothingget_f_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationsdeclarations_requ_c34fd33eedc1490d" hs_bindgen_test_declarationsdeclarations_requ_c34fd33eedc1490d :: IO (FunPtr (A ->
                                                                                                                                                                          IO Unit))
 {-# NOINLINE f_ptr #-}

--- a/hs-bindgen/fixtures/declarations/definitions/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/FunPtr.hs
@@ -23,6 +23,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_foo_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationsdefinitions_32925a42980e81cd" hs_bindgen_test_declarationsdefinitions_32925a42980e81cd ::
      IO (Ptr.FunPtr (FC.CDouble -> IO FC.CInt))
 

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_n_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationsdefinitions_cfec0f95f22bb37c" hs_bindgen_test_declarationsdefinitions_cfec0f95f22bb37c ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Safe.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Safe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @declarations\/definitions.h:13:5@
 
     __exported by:__ @declarations\/definitions.h@
+
+    __unique:__ @ExampleJust Safefoo@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_5a514c66396155ff" foo ::
      FC.CDouble

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Unsafe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @declarations\/definitions.h:13:5@
 
     __exported by:__ @declarations\/definitions.h@
+
+    __unique:__ @ExampleJust Unsafefoo@
 -}
 foreign import ccall unsafe "hs_bindgen_test_declarationsdefinitions_84e4eb047d6694cd" foo ::
      FC.CDouble

--- a/hs-bindgen/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/definitions/th.txt
@@ -159,6 +159,8 @@ instance TyEq ty (CFieldType Y "y_o") =>
     __defined at:__ @declarations\/definitions.h:13:5@
 
     __exported by:__ @declarations\/definitions.h@
+
+    __unique:__ @ExampleJust Unsafefoo@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_5a514c66396155ff" foo :: CDouble ->
                                                                                             IO CInt
@@ -167,9 +169,13 @@ foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_5a514c6639615
     __defined at:__ @declarations\/definitions.h:13:5@
 
     __exported by:__ @declarations\/definitions.h@
+
+    __unique:__ @ExampleJust Unsafefoo@
 -}
 foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_84e4eb047d6694cd" foo :: CDouble ->
                                                                                             IO CInt
+{-| __unique:__ @ExampleNothingget_foo_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_32925a42980e81cd" hs_bindgen_test_declarationsdefinitions_32925a42980e81cd :: IO (FunPtr (CDouble ->
                                                                                                                                                              IO CInt))
 {-# NOINLINE foo_ptr #-}
@@ -187,6 +193,8 @@ foo_ptr :: FunPtr (CDouble -> IO CInt)
     __exported by:__ @declarations\/definitions.h@
 -}
 foo_ptr = unsafePerformIO hs_bindgen_test_declarationsdefinitions_32925a42980e81cd
+{-| __unique:__ @ExampleNothingget_n_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationsdefinitions_cfec0f95f22bb37c" hs_bindgen_test_declarationsdefinitions_cfec0f95f22bb37c :: IO (Ptr CInt)
 {-# NOINLINE n_ptr #-}
 {-| __C declaration:__ @n@

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_x_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationsredeclaration_10b125673bf2041b" hs_bindgen_test_declarationsredeclaration_10b125673bf2041b ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/redeclaration/th.txt
@@ -171,6 +171,8 @@ instance HasCField Y "y_o"
 instance TyEq ty (CFieldType Y "y_o") =>
          HasField "y_o" (Ptr Y) (Ptr ty)
     where getField = ptrToCField (Proxy @"y_o")
+{-| __unique:__ @ExampleNothingget_x_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationsredeclaration_10b125673bf2041b" hs_bindgen_test_declarationsredeclaration_10b125673bf2041b :: IO (Ptr CInt)
 {-# NOINLINE x_ptr #-}
 {-| __C declaration:__ @x@

--- a/hs-bindgen/fixtures/declarations/tentative_definitions/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/tentative_definitions/Example/Global.hs
@@ -33,6 +33,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_i1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983" hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -48,6 +50,8 @@ i1_ptr :: Ptr.Ptr FC.CInt
 i1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983
 
+{-| __unique:__ @ExampleNothingget_i2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationstentative_definit_8a341976b53c3159" hs_bindgen_test_declarationstentative_definit_8a341976b53c3159 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -63,6 +67,8 @@ i2_ptr :: Ptr.Ptr FC.CInt
 i2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_declarationstentative_definit_8a341976b53c3159
 
+{-| __unique:__ @ExampleNothingget_i3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_declarationstentative_definit_8a18e8a325536dc5" hs_bindgen_test_declarationstentative_definit_8a18e8a325536dc5 ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/declarations/tentative_definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/tentative_definitions/th.txt
@@ -18,6 +18,8 @@
 -- {
 --   return &i3;
 -- }
+{-| __unique:__ @ExampleNothingget_i1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983" hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983 :: IO (Ptr CInt)
 {-# NOINLINE i1_ptr #-}
 {-| __C declaration:__ @i1@
@@ -34,6 +36,8 @@ i1_ptr :: Ptr CInt
     __exported by:__ @declarations\/tentative_definitions.h@
 -}
 i1_ptr = unsafePerformIO hs_bindgen_test_declarationstentative_definit_8a4a155fb4b3e983
+{-| __unique:__ @ExampleNothingget_i2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationstentative_definit_8a341976b53c3159" hs_bindgen_test_declarationstentative_definit_8a341976b53c3159 :: IO (Ptr CInt)
 {-# NOINLINE i2_ptr #-}
 {-| __C declaration:__ @i2@
@@ -50,6 +54,8 @@ i2_ptr :: Ptr CInt
     __exported by:__ @declarations\/tentative_definitions.h@
 -}
 i2_ptr = unsafePerformIO hs_bindgen_test_declarationstentative_definit_8a341976b53c3159
+{-| __unique:__ @ExampleNothingget_i3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_declarationstentative_definit_8a18e8a325536dc5" hs_bindgen_test_declarationstentative_definit_8a18e8a325536dc5 :: IO (Ptr CInt)
 {-# NOINLINE i3_ptr #-}
 {-| __C declaration:__ @i3@

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/FunPtr.hs
@@ -148,6 +148,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_process_data_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6" hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6 ::
      IO (Ptr.FunPtr ((Ptr.Ptr HsBindgen.Runtime.Prelude.Word8) -> (Ptr.Ptr HsBindgen.Runtime.Prelude.Word8) -> (Ptr.Ptr HsBindgen.Runtime.Prelude.CSize) -> IO FC.CInt))
 
@@ -177,6 +179,8 @@ process_data_ptr :: Ptr.FunPtr ((Ptr.Ptr HsBindgen.Runtime.Prelude.Word8) -> (Pt
 process_data_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6
 
+{-| __unique:__ @ExampleNothingget_process_file_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b" hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b ::
      IO (Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CBool))
 
@@ -202,6 +206,8 @@ process_file_ptr :: Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CBool)
 process_file_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b
 
+{-| __unique:__ @ExampleNothingget_calculate_value_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1" hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1 ::
      IO (Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt))
 
@@ -234,6 +240,8 @@ calculate_value_ptr :: Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)
 calculate_value_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1
 
+{-| __unique:__ @ExampleNothingget_html_example_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66" hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CBool))
 
@@ -261,6 +269,8 @@ html_example_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CBool)
 html_example_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66
 
+{-| __unique:__ @ExampleNothingget_list_example_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366" hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366 ::
      IO (Ptr.FunPtr ((Ptr.Ptr (Ptr.Ptr FC.CChar)) -> HsBindgen.Runtime.Prelude.CSize -> IO FC.CBool))
 
@@ -316,6 +326,8 @@ list_example_ptr :: Ptr.FunPtr ((Ptr.Ptr (Ptr.Ptr FC.CChar)) -> HsBindgen.Runtim
 list_example_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366
 
+{-| __unique:__ @ExampleNothingget_dangerous_function_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b" hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b ::
      IO (Ptr.FunPtr ((Ptr.Ptr Void) -> IO (Ptr.Ptr Void)))
 
@@ -345,6 +357,8 @@ dangerous_function_ptr :: Ptr.FunPtr ((Ptr.Ptr Void) -> IO (Ptr.Ptr Void))
 dangerous_function_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b
 
+{-| __unique:__ @ExampleNothingget_detailed_return_codes_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7" hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7 ::
      IO (Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt))
 
@@ -374,6 +388,8 @@ detailed_return_codes_ptr :: Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt)
 detailed_return_codes_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7
 
+{-| __unique:__ @ExampleNothingget_old_function_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b" hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -399,6 +415,8 @@ old_function_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 old_function_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b
 
+{-| __unique:__ @ExampleNothingget_versioned_function_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0" hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -424,6 +442,8 @@ versioned_function_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 versioned_function_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0
 
+{-| __unique:__ @ExampleNothingget_process_buffer_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175" hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175 ::
      IO (Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 64) FC.CChar) -> HsBindgen.Runtime.Prelude.CSize -> IO FC.CInt))
 
@@ -449,6 +469,8 @@ process_buffer_ptr :: Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArra
 process_buffer_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175
 
+{-| __unique:__ @ExampleNothingget_my_memcpy_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8" hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Void) -> (Ptr.Ptr Void) -> HsBindgen.Runtime.Prelude.CSize -> IO (Ptr.Ptr Void)))
 
@@ -476,6 +498,8 @@ my_memcpy_ptr :: Ptr.FunPtr ((Ptr.Ptr Void) -> (Ptr.Ptr Void) -> HsBindgen.Runti
 my_memcpy_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8
 
+{-| __unique:__ @ExampleNothingget_double_value_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa" hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -499,6 +523,8 @@ double_value_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 double_value_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa
 
+{-| __unique:__ @ExampleNothingget_complex_function_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75" hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Config_t) -> (Ptr.Ptr HsBindgen.Runtime.Prelude.Word8) -> HsBindgen.Runtime.Prelude.CSize -> IO Status_code_t))
 
@@ -579,6 +605,8 @@ complex_function_ptr :: Ptr.FunPtr ((Ptr.Ptr Config_t) -> (Ptr.Ptr HsBindgen.Run
 complex_function_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75
 
+{-| __unique:__ @ExampleNothingget_hash_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01" hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01 ::
      IO (Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt))
 
@@ -594,6 +622,8 @@ hash_ptr :: Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt)
 hash_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01
 
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_c41111f40a04cdc9" hs_bindgen_test_documentationdoxygen_docs_c41111f40a04cdc9 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Global.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Global.hs
@@ -27,6 +27,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_global_counter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660" hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -50,6 +52,8 @@ global_counter_ptr :: Ptr.Ptr FC.CInt
 global_counter_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660
 
+{-| __unique:__ @ExampleNothingget_version_string_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_0f1cef8c70bbdf2c" hs_bindgen_test_documentationdoxygen_docs_0f1cef8c70bbdf2c ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CChar))
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Safe.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Safe.hs
@@ -134,6 +134,8 @@ __C declaration:__ @process_data@
 __defined at:__ @documentation\/doxygen_docs.h:105:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safeprocess_data@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_508324ba72521a99" process_data ::
      Ptr.Ptr HsBindgen.Runtime.Prelude.Word8
@@ -174,6 +176,8 @@ __C declaration:__ @process_file@
 __defined at:__ @documentation\/doxygen_docs.h:116:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safeprocess_file@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_02a55804dd9edb28" process_file ::
      Ptr.Ptr FC.CChar
@@ -207,6 +211,8 @@ __C declaration:__ @calculate_value@
 __defined at:__ @documentation\/doxygen_docs.h:131:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safecalculate_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_7ce4f4a3b2997c64" calculate_value ::
      FC.CInt
@@ -242,6 +248,8 @@ __C declaration:__ @html_example@
 __defined at:__ @documentation\/doxygen_docs.h:148:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safehtml_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_b971c7e6099b9f35" html_example ::
      FC.CInt
@@ -298,6 +306,8 @@ __C declaration:__ @list_example@
 __defined at:__ @documentation\/doxygen_docs.h:174:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_b42fb41209c21d6e" list_example ::
      Ptr.Ptr (Ptr.Ptr FC.CChar)
@@ -335,6 +345,8 @@ __C declaration:__ @dangerous_function@
 __defined at:__ @documentation\/doxygen_docs.h:186:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safedangerous_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_344ca27a161ed698" dangerous_function ::
      Ptr.Ptr Void
@@ -365,6 +377,8 @@ __C declaration:__ @detailed_return_codes@
 __defined at:__ @documentation\/doxygen_docs.h:197:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safedetailed_return_codes@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4e897ea8e36e2189" detailed_return_codes ::
      Ptr.Ptr FC.CChar
@@ -391,6 +405,8 @@ __C declaration:__ @old_function@
 __defined at:__ @documentation\/doxygen_docs.h:206:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safeold_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_aee6bb852150141b" old_function ::
      FC.CInt
@@ -417,6 +433,8 @@ __C declaration:__ @versioned_function@
 __defined at:__ @documentation\/doxygen_docs.h:216:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safeversioned_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e655a7662e006c99" versioned_function ::
      FC.CInt
@@ -439,6 +457,8 @@ __C declaration:__ @process_buffer@
 __defined at:__ @documentation\/doxygen_docs.h:332:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safeprocess_buffer@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_d8a2703f133ce8c2" process_buffer ::
      Ptr.Ptr FC.CChar
@@ -474,6 +494,8 @@ __C declaration:__ @my_memcpy@
 __defined at:__ @documentation\/doxygen_docs.h:342:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4b3bfd2d72a2db5d" my_memcpy ::
      Ptr.Ptr Void
@@ -512,6 +534,8 @@ __C declaration:__ @double_value@
 __defined at:__ @documentation\/doxygen_docs.h:350:19@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safedouble_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4a61cf13840fa8c5" double_value ::
      FC.CInt
@@ -593,6 +617,8 @@ __C declaration:__ @complex_function@
 __defined at:__ @documentation\/doxygen_docs.h:423:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safecomplex_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_848ab7c74f34f667" complex_function ::
      Ptr.Ptr Config_t
@@ -623,6 +649,8 @@ __C declaration:__ @hash@
 __defined at:__ @documentation\/doxygen_docs.h:427:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Safehash@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e30754e2591f701a" hash ::
      Ptr.Ptr FC.CChar
@@ -635,6 +663,8 @@ foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e30754e2591
     __defined at:__ @documentation\/doxygen_docs.h:429:5@
 
     __exported by:__ @documentation\/doxygen_docs.h@
+
+    __unique:__ @ExampleJust Safesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_55e5eb89e54abf83" square ::
      FC.CInt

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Unsafe.hs
@@ -134,6 +134,8 @@ __C declaration:__ @process_data@
 __defined at:__ @documentation\/doxygen_docs.h:105:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_data@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_2d2b30c70759c0c4" process_data ::
      Ptr.Ptr HsBindgen.Runtime.Prelude.Word8
@@ -174,6 +176,8 @@ __C declaration:__ @process_file@
 __defined at:__ @documentation\/doxygen_docs.h:116:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_file@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_d6a9988889495ac1" process_file ::
      Ptr.Ptr FC.CChar
@@ -207,6 +211,8 @@ __C declaration:__ @calculate_value@
 __defined at:__ @documentation\/doxygen_docs.h:131:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecalculate_value@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_082e1bba4d72bc95" calculate_value ::
      FC.CInt
@@ -242,6 +248,8 @@ __C declaration:__ @html_example@
 __defined at:__ @documentation\/doxygen_docs.h:148:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehtml_example@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_fddff4284f0988ec" html_example ::
      FC.CInt
@@ -298,6 +306,8 @@ __C declaration:__ @list_example@
 __defined at:__ @documentation\/doxygen_docs.h:174:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_41af05ef1797fa6d" list_example ::
      Ptr.Ptr (Ptr.Ptr FC.CChar)
@@ -335,6 +345,8 @@ __C declaration:__ @dangerous_function@
 __defined at:__ @documentation\/doxygen_docs.h:186:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedangerous_function@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_3f6186f38de47df9" dangerous_function ::
      Ptr.Ptr Void
@@ -365,6 +377,8 @@ __C declaration:__ @detailed_return_codes@
 __defined at:__ @documentation\/doxygen_docs.h:197:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedetailed_return_codes@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_b5913ddf382b031a" detailed_return_codes ::
      Ptr.Ptr FC.CChar
@@ -391,6 +405,8 @@ __C declaration:__ @old_function@
 __defined at:__ @documentation\/doxygen_docs.h:206:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeold_function@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_2b7f6e5fbd1f46e1" old_function ::
      FC.CInt
@@ -417,6 +433,8 @@ __C declaration:__ @versioned_function@
 __defined at:__ @documentation\/doxygen_docs.h:216:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeversioned_function@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_7760ce72dbe3dbbb" versioned_function ::
      FC.CInt
@@ -439,6 +457,8 @@ __C declaration:__ @process_buffer@
 __defined at:__ @documentation\/doxygen_docs.h:332:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_buffer@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_75f51ea0caca0775" process_buffer ::
      Ptr.Ptr FC.CChar
@@ -474,6 +494,8 @@ __C declaration:__ @my_memcpy@
 __defined at:__ @documentation\/doxygen_docs.h:342:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_e8c4a96cefd6117e" my_memcpy ::
      Ptr.Ptr Void
@@ -512,6 +534,8 @@ __C declaration:__ @double_value@
 __defined at:__ @documentation\/doxygen_docs.h:350:19@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedouble_value@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_e73c6e96d9e7581d" double_value ::
      FC.CInt
@@ -593,6 +617,8 @@ __C declaration:__ @complex_function@
 __defined at:__ @documentation\/doxygen_docs.h:423:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecomplex_function@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_bc28ed88ec7705d4" complex_function ::
      Ptr.Ptr Config_t
@@ -623,6 +649,8 @@ __C declaration:__ @hash@
 __defined at:__ @documentation\/doxygen_docs.h:427:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_88887d4b5f42f079" hash ::
      Ptr.Ptr FC.CChar
@@ -635,6 +663,8 @@ foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_88887d4b5
     __defined at:__ @documentation\/doxygen_docs.h:429:5@
 
     __exported by:__ @documentation\/doxygen_docs.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall unsafe "hs_bindgen_test_documentationdoxygen_docs_cb3c687f16289bb3" square ::
      FC.CInt

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -1480,6 +1480,8 @@ __C declaration:__ @process_data@
 __defined at:__ @documentation\/doxygen_docs.h:105:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_data@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_508324ba72521a99" process_data :: Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                        Ptr HsBindgen.Runtime.Prelude.Word8 ->
@@ -1500,6 +1502,8 @@ __C declaration:__ @process_file@
 __defined at:__ @documentation\/doxygen_docs.h:116:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_file@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_02a55804dd9edb28" process_file :: Ptr CChar ->
                                                                                                        IO CBool
@@ -1525,6 +1529,8 @@ __C declaration:__ @calculate_value@
 __defined at:__ @documentation\/doxygen_docs.h:131:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecalculate_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_7ce4f4a3b2997c64" calculate_value :: CInt ->
                                                                                                           CInt ->
@@ -1546,6 +1552,8 @@ __C declaration:__ @html_example@
 __defined at:__ @documentation\/doxygen_docs.h:148:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehtml_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_b971c7e6099b9f35" html_example :: CInt ->
                                                                                                        IO CBool
@@ -1594,6 +1602,8 @@ __C declaration:__ @list_example@
 __defined at:__ @documentation\/doxygen_docs.h:174:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_b42fb41209c21d6e" list_example :: Ptr (Ptr CChar) ->
                                                                                                        HsBindgen.Runtime.Prelude.CSize ->
@@ -1617,6 +1627,8 @@ __C declaration:__ @dangerous_function@
 __defined at:__ @documentation\/doxygen_docs.h:186:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedangerous_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_344ca27a161ed698" dangerous_function :: Ptr Void ->
                                                                                                              IO (Ptr Void)
@@ -1639,6 +1651,8 @@ __C declaration:__ @detailed_return_codes@
 __defined at:__ @documentation\/doxygen_docs.h:197:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedetailed_return_codes@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4e897ea8e36e2189" detailed_return_codes :: Ptr CChar ->
                                                                                                                 IO CInt
@@ -1657,6 +1671,8 @@ __C declaration:__ @old_function@
 __defined at:__ @documentation\/doxygen_docs.h:206:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeold_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_aee6bb852150141b" old_function :: CInt ->
                                                                                                        IO CInt
@@ -1675,6 +1691,8 @@ __C declaration:__ @versioned_function@
 __defined at:__ @documentation\/doxygen_docs.h:216:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeversioned_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e655a7662e006c99" versioned_function :: CInt ->
                                                                                                              IO CInt
@@ -1693,6 +1711,8 @@ __C declaration:__ @process_buffer@
 __defined at:__ @documentation\/doxygen_docs.h:332:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_buffer@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_d8a2703f133ce8c2" process_buffer :: Ptr CChar ->
                                                                                                          HsBindgen.Runtime.Prelude.CSize ->
@@ -1714,6 +1734,8 @@ __C declaration:__ @my_memcpy@
 __defined at:__ @documentation\/doxygen_docs.h:342:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4b3bfd2d72a2db5d" my_memcpy :: Ptr Void ->
                                                                                                     Ptr Void ->
@@ -1732,6 +1754,8 @@ __C declaration:__ @double_value@
 __defined at:__ @documentation\/doxygen_docs.h:350:19@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedouble_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4a61cf13840fa8c5" double_value :: CInt ->
                                                                                                        IO CInt
@@ -1805,6 +1829,8 @@ __C declaration:__ @complex_function@
 __defined at:__ @documentation\/doxygen_docs.h:423:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecomplex_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_848ab7c74f34f667" complex_function :: Ptr Config_t ->
                                                                                                            Ptr HsBindgen.Runtime.Prelude.Word8 ->
@@ -1819,6 +1845,8 @@ __C declaration:__ @hash@
 __defined at:__ @documentation\/doxygen_docs.h:427:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e30754e2591f701a" hash :: Ptr CChar ->
                                                                                                IO CInt
@@ -1827,6 +1855,8 @@ foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e30754e2591
     __defined at:__ @documentation\/doxygen_docs.h:429:5@
 
     __exported by:__ @documentation\/doxygen_docs.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_55e5eb89e54abf83" square :: CInt ->
                                                                                                  CInt
@@ -1849,6 +1879,8 @@ __C declaration:__ @process_data@
 __defined at:__ @documentation\/doxygen_docs.h:105:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_data@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_2d2b30c70759c0c4" process_data :: Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                        Ptr HsBindgen.Runtime.Prelude.Word8 ->
@@ -1869,6 +1901,8 @@ __C declaration:__ @process_file@
 __defined at:__ @documentation\/doxygen_docs.h:116:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_file@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_d6a9988889495ac1" process_file :: Ptr CChar ->
                                                                                                        IO CBool
@@ -1894,6 +1928,8 @@ __C declaration:__ @calculate_value@
 __defined at:__ @documentation\/doxygen_docs.h:131:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecalculate_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_082e1bba4d72bc95" calculate_value :: CInt ->
                                                                                                           CInt ->
@@ -1915,6 +1951,8 @@ __C declaration:__ @html_example@
 __defined at:__ @documentation\/doxygen_docs.h:148:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehtml_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_fddff4284f0988ec" html_example :: CInt ->
                                                                                                        IO CBool
@@ -1963,6 +2001,8 @@ __C declaration:__ @list_example@
 __defined at:__ @documentation\/doxygen_docs.h:174:6@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_41af05ef1797fa6d" list_example :: Ptr (Ptr CChar) ->
                                                                                                        HsBindgen.Runtime.Prelude.CSize ->
@@ -1986,6 +2026,8 @@ __C declaration:__ @dangerous_function@
 __defined at:__ @documentation\/doxygen_docs.h:186:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedangerous_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_3f6186f38de47df9" dangerous_function :: Ptr Void ->
                                                                                                              IO (Ptr Void)
@@ -2008,6 +2050,8 @@ __C declaration:__ @detailed_return_codes@
 __defined at:__ @documentation\/doxygen_docs.h:197:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedetailed_return_codes@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_b5913ddf382b031a" detailed_return_codes :: Ptr CChar ->
                                                                                                                 IO CInt
@@ -2026,6 +2070,8 @@ __C declaration:__ @old_function@
 __defined at:__ @documentation\/doxygen_docs.h:206:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeold_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_2b7f6e5fbd1f46e1" old_function :: CInt ->
                                                                                                        IO CInt
@@ -2044,6 +2090,8 @@ __C declaration:__ @versioned_function@
 __defined at:__ @documentation\/doxygen_docs.h:216:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeversioned_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_7760ce72dbe3dbbb" versioned_function :: CInt ->
                                                                                                              IO CInt
@@ -2062,6 +2110,8 @@ __C declaration:__ @process_buffer@
 __defined at:__ @documentation\/doxygen_docs.h:332:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafeprocess_buffer@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_75f51ea0caca0775" process_buffer :: Ptr CChar ->
                                                                                                          HsBindgen.Runtime.Prelude.CSize ->
@@ -2083,6 +2133,8 @@ __C declaration:__ @my_memcpy@
 __defined at:__ @documentation\/doxygen_docs.h:342:7@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e8c4a96cefd6117e" my_memcpy :: Ptr Void ->
                                                                                                     Ptr Void ->
@@ -2101,6 +2153,8 @@ __C declaration:__ @double_value@
 __defined at:__ @documentation\/doxygen_docs.h:350:19@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafedouble_value@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e73c6e96d9e7581d" double_value :: CInt ->
                                                                                                        IO CInt
@@ -2174,6 +2228,8 @@ __C declaration:__ @complex_function@
 __defined at:__ @documentation\/doxygen_docs.h:423:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafecomplex_function@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_bc28ed88ec7705d4" complex_function :: Ptr Config_t ->
                                                                                                            Ptr HsBindgen.Runtime.Prelude.Word8 ->
@@ -2188,6 +2244,8 @@ __C declaration:__ @hash@
 __defined at:__ @documentation\/doxygen_docs.h:427:5@
 
 __exported by:__ @documentation\/doxygen_docs.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_88887d4b5f42f079" hash :: Ptr CChar ->
                                                                                                IO CInt
@@ -2196,9 +2254,13 @@ foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_88887d4b5f4
     __defined at:__ @documentation\/doxygen_docs.h:429:5@
 
     __exported by:__ @documentation\/doxygen_docs.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_cb3c687f16289bb3" square :: CInt ->
                                                                                                  CInt
+{-| __unique:__ @ExampleNothingget_process_data_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6" hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6 :: IO (FunPtr (Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                                                                                  Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                                                                                  Ptr HsBindgen.Runtime.Prelude.CSize ->
@@ -2248,6 +2310,8 @@ __defined at:__ @documentation\/doxygen_docs.h:105:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 process_data_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_d0e1f65bee5472f6
+{-| __unique:__ @ExampleNothingget_process_file_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b" hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b :: IO (FunPtr (Ptr CChar ->
                                                                                                                                                                  IO CBool))
 {-# NOINLINE process_file_ptr #-}
@@ -2285,6 +2349,8 @@ __defined at:__ @documentation\/doxygen_docs.h:116:6@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 process_file_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_3621ac21e0f7a16b
+{-| __unique:__ @ExampleNothingget_calculate_value_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1" hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1 :: IO (FunPtr (CInt ->
                                                                                                                                                                  CInt ->
                                                                                                                                                                  IO CInt))
@@ -2337,6 +2403,8 @@ __defined at:__ @documentation\/doxygen_docs.h:131:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 calculate_value_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_90c8694d918623e1
+{-| __unique:__ @ExampleNothingget_html_example_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66" hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66 :: IO (FunPtr (CInt ->
                                                                                                                                                                  IO CBool))
 {-# NOINLINE html_example_ptr #-}
@@ -2378,6 +2446,8 @@ __defined at:__ @documentation\/doxygen_docs.h:148:6@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 html_example_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_e113abb2b0034e66
+{-| __unique:__ @ExampleNothingget_list_example_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366" hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366 :: IO (FunPtr (Ptr (Ptr CChar) ->
                                                                                                                                                                  HsBindgen.Runtime.Prelude.CSize ->
                                                                                                                                                                  IO CBool))
@@ -2477,6 +2547,8 @@ __defined at:__ @documentation\/doxygen_docs.h:174:6@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 list_example_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_24b25f22222ce366
+{-| __unique:__ @ExampleNothingget_dangerous_function_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b" hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b :: IO (FunPtr (Ptr Void ->
                                                                                                                                                                  IO (Ptr Void)))
 {-# NOINLINE dangerous_function_ptr #-}
@@ -2522,6 +2594,8 @@ __defined at:__ @documentation\/doxygen_docs.h:186:7@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 dangerous_function_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_6017a8a05430a56b
+{-| __unique:__ @ExampleNothingget_detailed_return_codes_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7" hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7 :: IO (FunPtr (Ptr CChar ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE detailed_return_codes_ptr #-}
@@ -2567,6 +2641,8 @@ __defined at:__ @documentation\/doxygen_docs.h:197:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 detailed_return_codes_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_78d3a59b40cdc8e7
+{-| __unique:__ @ExampleNothingget_old_function_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b" hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b :: IO (FunPtr (CInt ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE old_function_ptr #-}
@@ -2604,6 +2680,8 @@ __defined at:__ @documentation\/doxygen_docs.h:206:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 old_function_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_885c5a5805adf39b
+{-| __unique:__ @ExampleNothingget_versioned_function_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0" hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0 :: IO (FunPtr (CInt ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE versioned_function_ptr #-}
@@ -2641,6 +2719,8 @@ __defined at:__ @documentation\/doxygen_docs.h:216:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 versioned_function_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_247ac59146595fd0
+{-| __unique:__ @ExampleNothingget_process_buffer_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175" hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175 :: IO (FunPtr (ConstantArray 64
                                                                                                                                                                                CChar ->
                                                                                                                                                                  HsBindgen.Runtime.Prelude.CSize ->
@@ -2681,6 +2761,8 @@ __defined at:__ @documentation\/doxygen_docs.h:332:5@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 process_buffer_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_7c3d7625a05c8175
+{-| __unique:__ @ExampleNothingget_my_memcpy_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8" hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8 :: IO (FunPtr (Ptr Void ->
                                                                                                                                                                  Ptr Void ->
                                                                                                                                                                  HsBindgen.Runtime.Prelude.CSize ->
@@ -2725,6 +2807,8 @@ __defined at:__ @documentation\/doxygen_docs.h:342:7@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 my_memcpy_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_e2e8b5d5ac435de8
+{-| __unique:__ @ExampleNothingget_double_value_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa" hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa :: IO (FunPtr (CInt ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE double_value_ptr #-}
@@ -2758,6 +2842,8 @@ __defined at:__ @documentation\/doxygen_docs.h:350:19@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 double_value_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_c819fda6b145aafa
+{-| __unique:__ @ExampleNothingget_complex_function_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75" hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75 :: IO (FunPtr (Ptr Config_t ->
                                                                                                                                                                  Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                                                                                  HsBindgen.Runtime.Prelude.CSize ->
@@ -2909,6 +2995,8 @@ __defined at:__ @documentation\/doxygen_docs.h:423:15@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 complex_function_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_76146a96271b3f75
+{-| __unique:__ @ExampleNothingget_hash_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01" hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01 :: IO (FunPtr (Ptr CChar ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE hash_ptr #-}
@@ -2926,6 +3014,8 @@ hash_ptr :: FunPtr (Ptr CChar -> IO CInt)
     __exported by:__ @documentation\/doxygen_docs.h@
 -}
 hash_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_4de9606eb9c5dd01
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_c41111f40a04cdc9" hs_bindgen_test_documentationdoxygen_docs_c41111f40a04cdc9 :: IO (FunPtr (CInt ->
                                                                                                                                                                  IO CInt))
 {-# NOINLINE square_ptr #-}
@@ -2943,6 +3033,8 @@ square_ptr :: FunPtr (CInt -> IO CInt)
     __exported by:__ @documentation\/doxygen_docs.h@
 -}
 square_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_c41111f40a04cdc9
+{-| __unique:__ @ExampleNothingget_global_counter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660" hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660 :: IO (Ptr CInt)
 {-# NOINLINE global_counter_ptr #-}
 {-|
@@ -2975,6 +3067,8 @@ __defined at:__ @documentation\/doxygen_docs.h:61:12@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 global_counter_ptr = unsafePerformIO hs_bindgen_test_documentationdoxygen_docs_1a40d1e5fbd04660
+{-| __unique:__ @ExampleNothingget_version_string_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_documentationdoxygen_docs_0f1cef8c70bbdf2c" hs_bindgen_test_documentationdoxygen_docs_0f1cef8c70bbdf2c :: IO (Ptr (Ptr CChar))
 {-# NOINLINE version_string_ptr #-}
 {-|

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/FunPtr.hs
@@ -32,6 +32,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_ϒ_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_857cc80028e9fd4d" hs_bindgen_test_edgecasesadios_857cc80028e9fd4d ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -47,6 +49,8 @@ cϒ_ptr :: Ptr.FunPtr (IO ())
 cϒ_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesadios_857cc80028e9fd4d
 
+{-| __unique:__ @ExampleNothingget_拜拜_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7" hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -62,6 +66,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7" hs
 拜拜_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7
 
+{-| __unique:__ @ExampleNothingget_Say拜拜_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_2879b42f75005d3b" hs_bindgen_test_edgecasesadios_2879b42f75005d3b ::
      IO (Ptr.FunPtr (IO ()))
 

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Global.hs
@@ -28,6 +28,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_ϒϒ_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_e4b974661ff038a0" hs_bindgen_test_edgecasesadios_e4b974661ff038a0 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -43,6 +45,8 @@ cϒϒ_ptr :: Ptr.Ptr FC.CInt
 cϒϒ_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesadios_e4b974661ff038a0
 
+{-| __unique:__ @ExampleNothingget_ϒϒϒ_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_c538a25ba7055dd4" hs_bindgen_test_edgecasesadios_c538a25ba7055dd4 ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Safe.hs
@@ -29,6 +29,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/adios.h:18:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Safeϒ@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_1f928c1e5a3ea8be" cϒ ::
      IO ()
@@ -38,6 +40,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_1f928c1e5a3ea8be" cϒ 
     __defined at:__ @edge-cases\/adios.h:27:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Safe拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_912e938ac6370f83" 拜拜 ::
      IO ()
@@ -47,6 +51,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_912e938ac6370f83" 拜�
     __defined at:__ @edge-cases\/adios.h:31:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust SafeSay拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_cc7cd7984d0bfaee" say拜拜 ::
      IO ()

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Unsafe.hs
@@ -29,6 +29,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/adios.h:18:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafeϒ@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_82fab26db9547005" cϒ ::
      IO ()
@@ -38,6 +40,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_82fab26db9547005" c�
     __defined at:__ @edge-cases\/adios.h:27:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafe拜拜@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_ad1afd0d0a11937f" 拜拜 ::
      IO ()
@@ -47,6 +51,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_ad1afd0d0a11937f" �
     __defined at:__ @edge-cases\/adios.h:31:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust UnsafeSay拜拜@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesadios_9a2b7b543a500f7d" say拜拜 ::
      IO ()

--- a/hs-bindgen/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/adios/th.txt
@@ -119,6 +119,8 @@ instance HasCField C数字 "un_C\25968\23383"
     __defined at:__ @edge-cases\/adios.h:18:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafeϒ@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_1f928c1e5a3ea8be" cϒ :: IO Unit
 {-| __C declaration:__ @拜拜@
@@ -126,6 +128,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_1f928c1e5a3ea8be" cϒ 
     __defined at:__ @edge-cases\/adios.h:27:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafe拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_912e938ac6370f83" 拜拜 :: IO Unit
 {-| __C declaration:__ @Say拜拜@
@@ -133,6 +137,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_912e938ac6370f83" 拜�
     __defined at:__ @edge-cases\/adios.h:31:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust UnsafeSay拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_cc7cd7984d0bfaee" say拜拜 :: IO Unit
 {-| __C declaration:__ @ϒ@
@@ -140,6 +146,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_cc7cd7984d0bfaee" say�
     __defined at:__ @edge-cases\/adios.h:18:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafeϒ@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_82fab26db9547005" cϒ :: IO Unit
 {-| __C declaration:__ @拜拜@
@@ -147,6 +155,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_82fab26db9547005" cϒ 
     __defined at:__ @edge-cases\/adios.h:27:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust Unsafe拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_ad1afd0d0a11937f" 拜拜 :: IO Unit
 {-| __C declaration:__ @Say拜拜@
@@ -154,8 +164,12 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_ad1afd0d0a11937f" 拜�
     __defined at:__ @edge-cases\/adios.h:31:6@
 
     __exported by:__ @edge-cases\/adios.h@
+
+    __unique:__ @ExampleJust UnsafeSay拜拜@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_9a2b7b543a500f7d" say拜拜 :: IO Unit
+{-| __unique:__ @ExampleNothingget_ϒ_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_857cc80028e9fd4d" hs_bindgen_test_edgecasesadios_857cc80028e9fd4d :: IO (FunPtr (IO Unit))
 {-# NOINLINE cϒ_ptr #-}
 {-| __C declaration:__ @ϒ@
@@ -172,6 +186,8 @@ cϒ_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/adios.h@
 -}
 cϒ_ptr = unsafePerformIO hs_bindgen_test_edgecasesadios_857cc80028e9fd4d
+{-| __unique:__ @ExampleNothingget_拜拜_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7" hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7 :: IO (FunPtr (IO Unit))
 {-# NOINLINE 拜拜_ptr #-}
 {-| __C declaration:__ @拜拜@
@@ -188,6 +204,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7" hs_b
     __exported by:__ @edge-cases\/adios.h@
 -}
 拜拜_ptr = unsafePerformIO hs_bindgen_test_edgecasesadios_8b289d4c7ae2c2a7
+{-| __unique:__ @ExampleNothingget_Say拜拜_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_2879b42f75005d3b" hs_bindgen_test_edgecasesadios_2879b42f75005d3b :: IO (FunPtr (IO Unit))
 {-# NOINLINE say拜拜_ptr #-}
 {-| __C declaration:__ @Say拜拜@
@@ -204,6 +222,8 @@ say拜拜_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/adios.h@
 -}
 say拜拜_ptr = unsafePerformIO hs_bindgen_test_edgecasesadios_2879b42f75005d3b
+{-| __unique:__ @ExampleNothingget_ϒϒ_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_e4b974661ff038a0" hs_bindgen_test_edgecasesadios_e4b974661ff038a0 :: IO (Ptr CInt)
 {-# NOINLINE cϒϒ_ptr #-}
 {-| __C declaration:__ @ϒϒ@
@@ -220,6 +240,8 @@ cϒϒ_ptr :: Ptr CInt
     __exported by:__ @edge-cases\/adios.h@
 -}
 cϒϒ_ptr = unsafePerformIO hs_bindgen_test_edgecasesadios_e4b974661ff038a0
+{-| __unique:__ @ExampleNothingget_ϒϒϒ_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesadios_c538a25ba7055dd4" hs_bindgen_test_edgecasesadios_c538a25ba7055dd4 :: IO (Ptr CInt)
 {-# NOINLINE cϒϒϒ_ptr #-}
 {-| __C declaration:__ @ϒϒϒ@

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/FunPtr.hs
@@ -26,6 +26,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_some_fun_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesdistilled_lib_1_969c7d0305e0614c" hs_bindgen_test_edgecasesdistilled_lib_1_969c7d0305e0614c ::
      IO (Ptr.FunPtr ((Ptr.Ptr A_type_t) -> HsBindgen.Runtime.Prelude.Word32 -> (HsBindgen.Runtime.IncompleteArray.IncompleteArray HsBindgen.Runtime.Prelude.Word8) -> IO HsBindgen.Runtime.Prelude.Int32))
 

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_v_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesdistilled_lib_1_b9e65c51f976c6f6" hs_bindgen_test_edgecasesdistilled_lib_1_b9e65c51f976c6f6 ::
      IO (Ptr.Ptr Var_t)
 

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Safe.hs
@@ -27,6 +27,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/distilled_lib_1.h:72:9@
 
     __exported by:__ @edge-cases\/distilled_lib_1.h@
+
+    __unique:__ @ExampleJust Safesome_fun@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_29c178c31334688f" some_fun ::
      Ptr.Ptr A_type_t

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Unsafe.hs
@@ -27,6 +27,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/distilled_lib_1.h:72:9@
 
     __exported by:__ @edge-cases\/distilled_lib_1.h@
+
+    __unique:__ @ExampleJust Unsafesome_fun@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesdistilled_lib_1_efd27157959bd4b3" some_fun ::
      Ptr.Ptr A_type_t

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -696,6 +696,8 @@ instance HasCField Callback_t "un_Callback_t"
     __defined at:__ @edge-cases\/distilled_lib_1.h:72:9@
 
     __exported by:__ @edge-cases\/distilled_lib_1.h@
+
+    __unique:__ @ExampleJust Unsafesome_fun@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_29c178c31334688f" some_fun :: Ptr A_type_t ->
                                                                                                   HsBindgen.Runtime.Prelude.Word32 ->
@@ -706,11 +708,15 @@ foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_29c178c31334
     __defined at:__ @edge-cases\/distilled_lib_1.h:72:9@
 
     __exported by:__ @edge-cases\/distilled_lib_1.h@
+
+    __unique:__ @ExampleJust Unsafesome_fun@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_efd27157959bd4b3" some_fun :: Ptr A_type_t ->
                                                                                                   HsBindgen.Runtime.Prelude.Word32 ->
                                                                                                   Ptr HsBindgen.Runtime.Prelude.Word8 ->
                                                                                                   IO HsBindgen.Runtime.Prelude.Int32
+{-| __unique:__ @ExampleNothingget_some_fun_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_969c7d0305e0614c" hs_bindgen_test_edgecasesdistilled_lib_1_969c7d0305e0614c :: IO (FunPtr (Ptr A_type_t ->
                                                                                                                                                                HsBindgen.Runtime.Prelude.Word32 ->
                                                                                                                                                                IncompleteArray HsBindgen.Runtime.Prelude.Word8 ->
@@ -733,6 +739,8 @@ some_fun_ptr :: FunPtr (Ptr A_type_t ->
     __exported by:__ @edge-cases\/distilled_lib_1.h@
 -}
 some_fun_ptr = unsafePerformIO hs_bindgen_test_edgecasesdistilled_lib_1_969c7d0305e0614c
+{-| __unique:__ @ExampleNothingget_v_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesdistilled_lib_1_b9e65c51f976c6f6" hs_bindgen_test_edgecasesdistilled_lib_1_b9e65c51f976c6f6 :: IO (Ptr Var_t)
 {-# NOINLINE v_ptr #-}
 {-| __C declaration:__ @v@

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/FunPtr.hs
@@ -90,6 +90,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_makeToggle_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_504a6a44ef649697" hs_bindgen_test_edgecasesiterator_504a6a44ef649697 ::
      IO (Ptr.FunPtr (FC.CBool -> IO Toggle))
 
@@ -105,6 +107,8 @@ makeToggle_ptr :: Ptr.FunPtr (FC.CBool -> IO Toggle)
 makeToggle_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_504a6a44ef649697
 
+{-| __unique:__ @ExampleNothingget_toggleNext_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_ee784d0363e34151" hs_bindgen_test_edgecasesiterator_ee784d0363e34151 ::
      IO (Ptr.FunPtr (Toggle -> IO FC.CBool))
 
@@ -120,6 +124,8 @@ toggleNext_ptr :: Ptr.FunPtr (Toggle -> IO FC.CBool)
 toggleNext_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_ee784d0363e34151
 
+{-| __unique:__ @ExampleNothingget_releaseToggle_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_864850832eaf96b9" hs_bindgen_test_edgecasesiterator_864850832eaf96b9 ::
      IO (Ptr.FunPtr (Toggle -> IO ()))
 
@@ -135,6 +141,8 @@ releaseToggle_ptr :: Ptr.FunPtr (Toggle -> IO ())
 releaseToggle_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_864850832eaf96b9
 
+{-| __unique:__ @ExampleNothingget_makeCounter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53" hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53 ::
      IO (Ptr.FunPtr (FC.CInt -> FC.CInt -> IO Counter))
 
@@ -150,6 +158,8 @@ makeCounter_ptr :: Ptr.FunPtr (FC.CInt -> FC.CInt -> IO Counter)
 makeCounter_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53
 
+{-| __unique:__ @ExampleNothingget_counterNext_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66" hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66 ::
      IO (Ptr.FunPtr (Counter -> IO FC.CInt))
 
@@ -165,6 +175,8 @@ counterNext_ptr :: Ptr.FunPtr (Counter -> IO FC.CInt)
 counterNext_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66
 
+{-| __unique:__ @ExampleNothingget_releaseCounter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_8e1661e238f6f451" hs_bindgen_test_edgecasesiterator_8e1661e238f6f451 ::
      IO (Ptr.FunPtr (Counter -> IO ()))
 
@@ -180,6 +192,8 @@ releaseCounter_ptr :: Ptr.FunPtr (Counter -> IO ())
 releaseCounter_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_8e1661e238f6f451
 
+{-| __unique:__ @ExampleNothingget_makeVarCounter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8" hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8 ::
      IO (Ptr.FunPtr (FC.CInt -> IO VarCounter))
 
@@ -195,6 +209,8 @@ makeVarCounter_ptr :: Ptr.FunPtr (FC.CInt -> IO VarCounter)
 makeVarCounter_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8
 
+{-| __unique:__ @ExampleNothingget_varCounterNext_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_4d10204c4166188d" hs_bindgen_test_edgecasesiterator_4d10204c4166188d ::
      IO (Ptr.FunPtr (VarCounter -> FC.CInt -> IO FC.CInt))
 
@@ -210,6 +226,8 @@ varCounterNext_ptr :: Ptr.FunPtr (VarCounter -> FC.CInt -> IO FC.CInt)
 varCounterNext_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesiterator_4d10204c4166188d
 
+{-| __unique:__ @ExampleNothingget_releaseVarCounter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_bde04ef01335be42" hs_bindgen_test_edgecasesiterator_bde04ef01335be42 ::
      IO (Ptr.FunPtr (VarCounter -> IO ()))
 

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/Safe.hs
@@ -75,6 +75,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/iterator.h:4:8@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafemakeToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_900530c0457bf5ee" makeToggle ::
      FC.CBool
@@ -87,6 +89,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_900530c0457bf5ee" m
     __defined at:__ @edge-cases\/iterator.h:5:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafetoggleNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_0584fdb88b39872d" toggleNext ::
      Toggle
@@ -99,6 +103,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_0584fdb88b39872d" t
     __defined at:__ @edge-cases\/iterator.h:6:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafereleaseToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_6d013ab8b38fc1d9" releaseToggle ::
      Toggle
@@ -111,6 +117,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_6d013ab8b38fc1d9" r
     __defined at:__ @edge-cases\/iterator.h:11:9@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafemakeCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_10d749b6b17037ba" makeCounter ::
      FC.CInt
@@ -126,6 +134,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_10d749b6b17037ba" m
     __defined at:__ @edge-cases\/iterator.h:12:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafecounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_9695aacc59a66573" counterNext ::
      Counter
@@ -138,6 +148,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_9695aacc59a66573" c
     __defined at:__ @edge-cases\/iterator.h:13:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafereleaseCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_49a436aa15c7ea70" releaseCounter ::
      Counter
@@ -150,6 +162,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_49a436aa15c7ea70" r
     __defined at:__ @edge-cases\/iterator.h:18:12@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafemakeVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_f12a50c4468834b5" makeVarCounter ::
      FC.CInt
@@ -162,6 +176,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_f12a50c4468834b5" m
     __defined at:__ @edge-cases\/iterator.h:19:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafevarCounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_2c8a2667de9b1ffb" varCounterNext ::
      VarCounter
@@ -177,6 +193,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_2c8a2667de9b1ffb" v
     __defined at:__ @edge-cases\/iterator.h:20:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust SafereleaseVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_023ae1f9abf46556" releaseVarCounter ::
      VarCounter

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/Unsafe.hs
@@ -75,6 +75,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/iterator.h:4:8@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeToggle@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_bd3974ddabfde9b8" makeToggle ::
      FC.CBool
@@ -87,6 +89,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_bd3974ddabfde9b8"
     __defined at:__ @edge-cases\/iterator.h:5:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafetoggleNext@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_055df53eaf199b0e" toggleNext ::
      Toggle
@@ -99,6 +103,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_055df53eaf199b0e"
     __defined at:__ @edge-cases\/iterator.h:6:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseToggle@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_07fb95f9614be94f" releaseToggle ::
      Toggle
@@ -111,6 +117,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_07fb95f9614be94f"
     __defined at:__ @edge-cases\/iterator.h:11:9@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeCounter@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_af5aabad780cc152" makeCounter ::
      FC.CInt
@@ -126,6 +134,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_af5aabad780cc152"
     __defined at:__ @edge-cases\/iterator.h:12:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafecounterNext@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_009eccead86c2acf" counterNext ::
      Counter
@@ -138,6 +148,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_009eccead86c2acf"
     __defined at:__ @edge-cases\/iterator.h:13:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseCounter@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_74f266597157c353" releaseCounter ::
      Counter
@@ -150,6 +162,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_74f266597157c353"
     __defined at:__ @edge-cases\/iterator.h:18:12@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeVarCounter@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_61a09dd9011981f5" makeVarCounter ::
      FC.CInt
@@ -162,6 +176,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_61a09dd9011981f5"
     __defined at:__ @edge-cases\/iterator.h:19:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafevarCounterNext@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_4d944ebb7dc53d23" varCounterNext ::
      VarCounter
@@ -177,6 +193,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_4d944ebb7dc53d23"
     __defined at:__ @edge-cases\/iterator.h:20:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseVarCounter@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesiterator_502ca8978fd91294" releaseVarCounter ::
      VarCounter

--- a/hs-bindgen/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/iterator/th.txt
@@ -252,6 +252,8 @@ instance HasCField VarCounter "un_VarCounter"
     __defined at:__ @edge-cases\/iterator.h:4:8@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_900530c0457bf5ee" makeToggle :: CBool ->
                                                                                              IO Toggle
@@ -260,6 +262,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_900530c0457bf5ee" m
     __defined at:__ @edge-cases\/iterator.h:5:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafetoggleNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_0584fdb88b39872d" toggleNext :: Toggle ->
                                                                                              IO CBool
@@ -268,6 +272,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_0584fdb88b39872d" t
     __defined at:__ @edge-cases\/iterator.h:6:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_6d013ab8b38fc1d9" releaseToggle :: Toggle ->
                                                                                                 IO Unit
@@ -276,6 +282,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_6d013ab8b38fc1d9" r
     __defined at:__ @edge-cases\/iterator.h:11:9@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_10d749b6b17037ba" makeCounter :: CInt ->
                                                                                               CInt ->
@@ -285,6 +293,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_10d749b6b17037ba" m
     __defined at:__ @edge-cases\/iterator.h:12:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafecounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_9695aacc59a66573" counterNext :: Counter ->
                                                                                               IO CInt
@@ -293,6 +303,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_9695aacc59a66573" c
     __defined at:__ @edge-cases\/iterator.h:13:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_49a436aa15c7ea70" releaseCounter :: Counter ->
                                                                                                  IO Unit
@@ -301,6 +313,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_49a436aa15c7ea70" r
     __defined at:__ @edge-cases\/iterator.h:18:12@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_f12a50c4468834b5" makeVarCounter :: CInt ->
                                                                                                  IO VarCounter
@@ -309,6 +323,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_f12a50c4468834b5" m
     __defined at:__ @edge-cases\/iterator.h:19:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafevarCounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_2c8a2667de9b1ffb" varCounterNext :: VarCounter ->
                                                                                                  CInt ->
@@ -318,6 +334,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_2c8a2667de9b1ffb" v
     __defined at:__ @edge-cases\/iterator.h:20:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_023ae1f9abf46556" releaseVarCounter :: VarCounter ->
                                                                                                     IO Unit
@@ -326,6 +344,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_023ae1f9abf46556" r
     __defined at:__ @edge-cases\/iterator.h:4:8@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_bd3974ddabfde9b8" makeToggle :: CBool ->
                                                                                              IO Toggle
@@ -334,6 +354,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_bd3974ddabfde9b8" m
     __defined at:__ @edge-cases\/iterator.h:5:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafetoggleNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_055df53eaf199b0e" toggleNext :: Toggle ->
                                                                                              IO CBool
@@ -342,6 +364,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_055df53eaf199b0e" t
     __defined at:__ @edge-cases\/iterator.h:6:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseToggle@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_07fb95f9614be94f" releaseToggle :: Toggle ->
                                                                                                 IO Unit
@@ -350,6 +374,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_07fb95f9614be94f" r
     __defined at:__ @edge-cases\/iterator.h:11:9@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_af5aabad780cc152" makeCounter :: CInt ->
                                                                                               CInt ->
@@ -359,6 +385,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_af5aabad780cc152" m
     __defined at:__ @edge-cases\/iterator.h:12:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafecounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_009eccead86c2acf" counterNext :: Counter ->
                                                                                               IO CInt
@@ -367,6 +395,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_009eccead86c2acf" c
     __defined at:__ @edge-cases\/iterator.h:13:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_74f266597157c353" releaseCounter :: Counter ->
                                                                                                  IO Unit
@@ -375,6 +405,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_74f266597157c353" r
     __defined at:__ @edge-cases\/iterator.h:18:12@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafemakeVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_61a09dd9011981f5" makeVarCounter :: CInt ->
                                                                                                  IO VarCounter
@@ -383,6 +415,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_61a09dd9011981f5" m
     __defined at:__ @edge-cases\/iterator.h:19:5@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafevarCounterNext@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_4d944ebb7dc53d23" varCounterNext :: VarCounter ->
                                                                                                  CInt ->
@@ -392,9 +426,13 @@ foreign import ccall safe "hs_bindgen_test_edgecasesiterator_4d944ebb7dc53d23" v
     __defined at:__ @edge-cases\/iterator.h:20:6@
 
     __exported by:__ @edge-cases\/iterator.h@
+
+    __unique:__ @ExampleJust UnsafereleaseVarCounter@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_502ca8978fd91294" releaseVarCounter :: VarCounter ->
                                                                                                     IO Unit
+{-| __unique:__ @ExampleNothingget_makeToggle_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_504a6a44ef649697" hs_bindgen_test_edgecasesiterator_504a6a44ef649697 :: IO (FunPtr (CBool ->
                                                                                                                                                  IO Toggle))
 {-# NOINLINE makeToggle_ptr #-}
@@ -412,6 +450,8 @@ makeToggle_ptr :: FunPtr (CBool -> IO Toggle)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 makeToggle_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_504a6a44ef649697
+{-| __unique:__ @ExampleNothingget_toggleNext_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_ee784d0363e34151" hs_bindgen_test_edgecasesiterator_ee784d0363e34151 :: IO (FunPtr (Toggle ->
                                                                                                                                                  IO CBool))
 {-# NOINLINE toggleNext_ptr #-}
@@ -429,6 +469,8 @@ toggleNext_ptr :: FunPtr (Toggle -> IO CBool)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 toggleNext_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_ee784d0363e34151
+{-| __unique:__ @ExampleNothingget_releaseToggle_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_864850832eaf96b9" hs_bindgen_test_edgecasesiterator_864850832eaf96b9 :: IO (FunPtr (Toggle ->
                                                                                                                                                  IO Unit))
 {-# NOINLINE releaseToggle_ptr #-}
@@ -446,6 +488,8 @@ releaseToggle_ptr :: FunPtr (Toggle -> IO Unit)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 releaseToggle_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_864850832eaf96b9
+{-| __unique:__ @ExampleNothingget_makeCounter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53" hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53 :: IO (FunPtr (CInt ->
                                                                                                                                                  CInt ->
                                                                                                                                                  IO Counter))
@@ -464,6 +508,8 @@ makeCounter_ptr :: FunPtr (CInt -> CInt -> IO Counter)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 makeCounter_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_48b98d306e2a8d53
+{-| __unique:__ @ExampleNothingget_counterNext_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66" hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66 :: IO (FunPtr (Counter ->
                                                                                                                                                  IO CInt))
 {-# NOINLINE counterNext_ptr #-}
@@ -481,6 +527,8 @@ counterNext_ptr :: FunPtr (Counter -> IO CInt)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 counterNext_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_aeb21db5034e4d66
+{-| __unique:__ @ExampleNothingget_releaseCounter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_8e1661e238f6f451" hs_bindgen_test_edgecasesiterator_8e1661e238f6f451 :: IO (FunPtr (Counter ->
                                                                                                                                                  IO Unit))
 {-# NOINLINE releaseCounter_ptr #-}
@@ -498,6 +546,8 @@ releaseCounter_ptr :: FunPtr (Counter -> IO Unit)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 releaseCounter_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_8e1661e238f6f451
+{-| __unique:__ @ExampleNothingget_makeVarCounter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8" hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8 :: IO (FunPtr (CInt ->
                                                                                                                                                  IO VarCounter))
 {-# NOINLINE makeVarCounter_ptr #-}
@@ -515,6 +565,8 @@ makeVarCounter_ptr :: FunPtr (CInt -> IO VarCounter)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 makeVarCounter_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_b14e88e9cf7a56b8
+{-| __unique:__ @ExampleNothingget_varCounterNext_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_4d10204c4166188d" hs_bindgen_test_edgecasesiterator_4d10204c4166188d :: IO (FunPtr (VarCounter ->
                                                                                                                                                  CInt ->
                                                                                                                                                  IO CInt))
@@ -533,6 +585,8 @@ varCounterNext_ptr :: FunPtr (VarCounter -> CInt -> IO CInt)
     __exported by:__ @edge-cases\/iterator.h@
 -}
 varCounterNext_ptr = unsafePerformIO hs_bindgen_test_edgecasesiterator_4d10204c4166188d
+{-| __unique:__ @ExampleNothingget_releaseVarCounter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesiterator_bde04ef01335be42" hs_bindgen_test_edgecasesiterator_bde04ef01335be42 :: IO (FunPtr (VarCounter ->
                                                                                                                                                  IO Unit))
 {-# NOINLINE releaseVarCounter_ptr #-}

--- a/hs-bindgen/fixtures/edge-cases/names/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/FunPtr.hs
@@ -164,6 +164,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_by_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8" hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -179,6 +181,8 @@ by'_ptr :: Ptr.FunPtr (IO ())
 by'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8
 
+{-| __unique:__ @ExampleNothingget_forall_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_a56841d4692515a9" hs_bindgen_test_edgecasesnames_a56841d4692515a9 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -194,6 +198,8 @@ forall'_ptr :: Ptr.FunPtr (IO ())
 forall'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_a56841d4692515a9
 
+{-| __unique:__ @ExampleNothingget_mdo_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378" hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -209,6 +215,8 @@ mdo'_ptr :: Ptr.FunPtr (IO ())
 mdo'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378
 
+{-| __unique:__ @ExampleNothingget_pattern_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_b393d3c39de80903" hs_bindgen_test_edgecasesnames_b393d3c39de80903 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -224,6 +232,8 @@ pattern'_ptr :: Ptr.FunPtr (IO ())
 pattern'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_b393d3c39de80903
 
+{-| __unique:__ @ExampleNothingget_proc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_f73545ae9224ff2d" hs_bindgen_test_edgecasesnames_f73545ae9224ff2d ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -239,6 +249,8 @@ proc'_ptr :: Ptr.FunPtr (IO ())
 proc'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_f73545ae9224ff2d
 
+{-| __unique:__ @ExampleNothingget_rec_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0dd0f0805657312b" hs_bindgen_test_edgecasesnames_0dd0f0805657312b ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -254,6 +266,8 @@ rec'_ptr :: Ptr.FunPtr (IO ())
 rec'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_0dd0f0805657312b
 
+{-| __unique:__ @ExampleNothingget_using_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037" hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -269,6 +283,8 @@ using'_ptr :: Ptr.FunPtr (IO ())
 using'_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037
 
+{-| __unique:__ @ExampleNothingget_anyclass_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4" hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -284,6 +300,8 @@ anyclass_ptr :: Ptr.FunPtr (IO ())
 anyclass_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4
 
+{-| __unique:__ @ExampleNothingget_capi_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_3513093206483c6f" hs_bindgen_test_edgecasesnames_3513093206483c6f ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -299,6 +317,8 @@ capi_ptr :: Ptr.FunPtr (IO ())
 capi_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_3513093206483c6f
 
+{-| __unique:__ @ExampleNothingget_cases_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9" hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -314,6 +334,8 @@ cases_ptr :: Ptr.FunPtr (IO ())
 cases_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9
 
+{-| __unique:__ @ExampleNothingget_ccall_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_79b6583362113331" hs_bindgen_test_edgecasesnames_79b6583362113331 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -329,6 +351,8 @@ ccall_ptr :: Ptr.FunPtr (IO ())
 ccall_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_79b6583362113331
 
+{-| __unique:__ @ExampleNothingget_dynamic_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45" hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -344,6 +368,8 @@ dynamic_ptr :: Ptr.FunPtr (IO ())
 dynamic_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45
 
+{-| __unique:__ @ExampleNothingget_export_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_98505ac7a8664e29" hs_bindgen_test_edgecasesnames_98505ac7a8664e29 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -359,6 +385,8 @@ export_ptr :: Ptr.FunPtr (IO ())
 export_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_98505ac7a8664e29
 
+{-| __unique:__ @ExampleNothingget_family_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_849e77496a12f443" hs_bindgen_test_edgecasesnames_849e77496a12f443 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -374,6 +402,8 @@ family_ptr :: Ptr.FunPtr (IO ())
 family_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_849e77496a12f443
 
+{-| __unique:__ @ExampleNothingget_group_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5" hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -389,6 +419,8 @@ group_ptr :: Ptr.FunPtr (IO ())
 group_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5
 
+{-| __unique:__ @ExampleNothingget_interruptible_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_d016728709223884" hs_bindgen_test_edgecasesnames_d016728709223884 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -404,6 +436,8 @@ interruptible_ptr :: Ptr.FunPtr (IO ())
 interruptible_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_d016728709223884
 
+{-| __unique:__ @ExampleNothingget_javascript_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_fa5819996081f2b8" hs_bindgen_test_edgecasesnames_fa5819996081f2b8 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -419,6 +453,8 @@ javascript_ptr :: Ptr.FunPtr (IO ())
 javascript_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_fa5819996081f2b8
 
+{-| __unique:__ @ExampleNothingget_label_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0004d966bf5f8027" hs_bindgen_test_edgecasesnames_0004d966bf5f8027 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -434,6 +470,8 @@ label_ptr :: Ptr.FunPtr (IO ())
 label_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_0004d966bf5f8027
 
+{-| __unique:__ @ExampleNothingget_prim_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea" hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -449,6 +487,8 @@ prim_ptr :: Ptr.FunPtr (IO ())
 prim_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea
 
+{-| __unique:__ @ExampleNothingget_role_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_89449e7f8f90fc97" hs_bindgen_test_edgecasesnames_89449e7f8f90fc97 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -464,6 +504,8 @@ role_ptr :: Ptr.FunPtr (IO ())
 role_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_89449e7f8f90fc97
 
+{-| __unique:__ @ExampleNothingget_safe_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_983c057a9645fd29" hs_bindgen_test_edgecasesnames_983c057a9645fd29 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -479,6 +521,8 @@ safe_ptr :: Ptr.FunPtr (IO ())
 safe_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_983c057a9645fd29
 
+{-| __unique:__ @ExampleNothingget_stdcall_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_8ea4a9581868a08c" hs_bindgen_test_edgecasesnames_8ea4a9581868a08c ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -494,6 +538,8 @@ stdcall_ptr :: Ptr.FunPtr (IO ())
 stdcall_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_8ea4a9581868a08c
 
+{-| __unique:__ @ExampleNothingget_stock_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_9d4197174428177d" hs_bindgen_test_edgecasesnames_9d4197174428177d ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -509,6 +555,8 @@ stock_ptr :: Ptr.FunPtr (IO ())
 stock_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_9d4197174428177d
 
+{-| __unique:__ @ExampleNothingget_unsafe_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_6eb48adc74567d6d" hs_bindgen_test_edgecasesnames_6eb48adc74567d6d ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -524,6 +572,8 @@ unsafe_ptr :: Ptr.FunPtr (IO ())
 unsafe_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_edgecasesnames_6eb48adc74567d6d
 
+{-| __unique:__ @ExampleNothingget_via_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_64eddb721da8c268" hs_bindgen_test_edgecasesnames_64eddb721da8c268 ::
      IO (Ptr.FunPtr (IO ()))
 

--- a/hs-bindgen/fixtures/edge-cases/names/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/Safe.hs
@@ -117,6 +117,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/names.h:3:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeby@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e7f535b7085fc20" by' ::
      IO ()
@@ -126,6 +128,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e7f535b7085fc20" by' 
     __defined at:__ @edge-cases\/names.h:4:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeforall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_fc72c248490e573d" forall' ::
      IO ()
@@ -135,6 +139,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_fc72c248490e573d" fora
     __defined at:__ @edge-cases\/names.h:5:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safemdo@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f21dd25a8b27374a" mdo' ::
      IO ()
@@ -144,6 +150,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_f21dd25a8b27374a" mdo'
     __defined at:__ @edge-cases\/names.h:6:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safepattern@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0ab5fb5a8105f789" pattern' ::
      IO ()
@@ -153,6 +161,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0ab5fb5a8105f789" patt
     __defined at:__ @edge-cases\/names.h:7:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeproc@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_c14da8252137427c" proc' ::
      IO ()
@@ -162,6 +172,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_c14da8252137427c" proc
     __defined at:__ @edge-cases\/names.h:8:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Saferec@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_1706dcb069f095bc" rec' ::
      IO ()
@@ -171,6 +183,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_1706dcb069f095bc" rec'
     __defined at:__ @edge-cases\/names.h:9:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeusing@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9cbe86d126f1d8ee" using' ::
      IO ()
@@ -180,6 +194,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_9cbe86d126f1d8ee" usin
     __defined at:__ @edge-cases\/names.h:12:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeanyclass@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_84e650893f3a92e0" anyclass ::
      IO ()
@@ -189,6 +205,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_84e650893f3a92e0" anyc
     __defined at:__ @edge-cases\/names.h:13:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safecapi@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a931e0b3ecf47315" capi ::
      IO ()
@@ -198,6 +216,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_a931e0b3ecf47315" capi
     __defined at:__ @edge-cases\/names.h:14:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safecases@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_8a21f58b60402b4c" cases ::
      IO ()
@@ -207,6 +227,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_8a21f58b60402b4c" case
     __defined at:__ @edge-cases\/names.h:15:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeccall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_e72f0a6b1520490f" ccall ::
      IO ()
@@ -216,6 +238,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_e72f0a6b1520490f" ccal
     __defined at:__ @edge-cases\/names.h:16:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safedynamic@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_87e085120fafde48" dynamic ::
      IO ()
@@ -225,6 +249,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_87e085120fafde48" dyna
     __defined at:__ @edge-cases\/names.h:17:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeexport@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e6d6a351c0f2d6b" export ::
      IO ()
@@ -234,6 +260,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e6d6a351c0f2d6b" expo
     __defined at:__ @edge-cases\/names.h:18:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safefamily@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_bd4d89d0e474ae7a" family ::
      IO ()
@@ -243,6 +271,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_bd4d89d0e474ae7a" fami
     __defined at:__ @edge-cases\/names.h:19:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safegroup@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_d33488d9cb279feb" group ::
      IO ()
@@ -252,6 +282,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_d33488d9cb279feb" grou
     __defined at:__ @edge-cases\/names.h:20:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeinterruptible@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a3851f5a39a9e5d" interruptible ::
      IO ()
@@ -261,6 +293,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a3851f5a39a9e5d" inte
     __defined at:__ @edge-cases\/names.h:21:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safejavascript@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_fa9100d6d4da2bd4" javascript ::
      IO ()
@@ -270,6 +304,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_fa9100d6d4da2bd4" java
     __defined at:__ @edge-cases\/names.h:22:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safelabel@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_264e9aa826f1d8fd" label ::
      IO ()
@@ -279,6 +315,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_264e9aa826f1d8fd" labe
     __defined at:__ @edge-cases\/names.h:23:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeprim@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_06aa327310da5120" prim ::
      IO ()
@@ -288,6 +326,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_06aa327310da5120" prim
     __defined at:__ @edge-cases\/names.h:24:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Saferole@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0c2d88e0ce229900" role ::
      IO ()
@@ -297,6 +337,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0c2d88e0ce229900" role
     __defined at:__ @edge-cases\/names.h:25:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safesafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a703e7f54db3712e" safe ::
      IO ()
@@ -306,6 +348,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_a703e7f54db3712e" safe
     __defined at:__ @edge-cases\/names.h:26:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safestdcall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_001ca64746b969f3" stdcall ::
      IO ()
@@ -315,6 +359,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_001ca64746b969f3" stdc
     __defined at:__ @edge-cases\/names.h:27:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safestock@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_44ab69657e70c20b" stock ::
      IO ()
@@ -324,6 +370,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_44ab69657e70c20b" stoc
     __defined at:__ @edge-cases\/names.h:28:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safeunsafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_cf74a7d7f3568406" unsafe ::
      IO ()
@@ -333,6 +381,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_cf74a7d7f3568406" unsa
     __defined at:__ @edge-cases\/names.h:29:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Safevia@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f24fb703d4751a60" via ::
      IO ()

--- a/hs-bindgen/fixtures/edge-cases/names/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/Unsafe.hs
@@ -117,6 +117,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/names.h:3:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeby@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_757d799fd708dfd3" by' ::
      IO ()
@@ -126,6 +128,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_757d799fd708dfd3" by
     __defined at:__ @edge-cases\/names.h:4:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeforall@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_56a86e542f270644" forall' ::
      IO ()
@@ -135,6 +139,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_56a86e542f270644" fo
     __defined at:__ @edge-cases\/names.h:5:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafemdo@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_66ccc318fc33f3db" mdo' ::
      IO ()
@@ -144,6 +150,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_66ccc318fc33f3db" md
     __defined at:__ @edge-cases\/names.h:6:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafepattern@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_59e8310c2fbfd7a5" pattern' ::
      IO ()
@@ -153,6 +161,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_59e8310c2fbfd7a5" pa
     __defined at:__ @edge-cases\/names.h:7:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeproc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0e3a2ce0789fb7e6" proc' ::
      IO ()
@@ -162,6 +172,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0e3a2ce0789fb7e6" pr
     __defined at:__ @edge-cases\/names.h:8:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferec@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_a8bd1db6a6708dae" rec' ::
      IO ()
@@ -171,6 +183,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_a8bd1db6a6708dae" re
     __defined at:__ @edge-cases\/names.h:9:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeusing@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_4f84a89a7d96b0e6" using' ::
      IO ()
@@ -180,6 +194,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_4f84a89a7d96b0e6" us
     __defined at:__ @edge-cases\/names.h:12:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeanyclass@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_e4c0e5d7430611d1" anyclass ::
      IO ()
@@ -189,6 +205,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_e4c0e5d7430611d1" an
     __defined at:__ @edge-cases\/names.h:13:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecapi@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0b2f0d5537de919f" capi ::
      IO ()
@@ -198,6 +216,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_0b2f0d5537de919f" ca
     __defined at:__ @edge-cases\/names.h:14:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecases@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_1ffa6d7a4b3beb7c" cases ::
      IO ()
@@ -207,6 +227,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_1ffa6d7a4b3beb7c" ca
     __defined at:__ @edge-cases\/names.h:15:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeccall@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ebc1b326e523e58f" ccall ::
      IO ()
@@ -216,6 +238,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ebc1b326e523e58f" cc
     __defined at:__ @edge-cases\/names.h:16:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafedynamic@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ab433e9e3ef36d2f" dynamic ::
      IO ()
@@ -225,6 +249,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ab433e9e3ef36d2f" dy
     __defined at:__ @edge-cases\/names.h:17:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeexport@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_df679baa272472fa" export ::
      IO ()
@@ -234,6 +260,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_df679baa272472fa" ex
     __defined at:__ @edge-cases\/names.h:18:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafefamily@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_9a60b7b7be9ca341" family ::
      IO ()
@@ -243,6 +271,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_9a60b7b7be9ca341" fa
     __defined at:__ @edge-cases\/names.h:19:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafegroup@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_3923700cc828a4dd" group ::
      IO ()
@@ -252,6 +282,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_3923700cc828a4dd" gr
     __defined at:__ @edge-cases\/names.h:20:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeinterruptible@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ba3f97d9b80e552c" interruptible ::
      IO ()
@@ -261,6 +293,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_ba3f97d9b80e552c" in
     __defined at:__ @edge-cases\/names.h:21:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafejavascript@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_f348c51860201a12" javascript ::
      IO ()
@@ -270,6 +304,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_f348c51860201a12" ja
     __defined at:__ @edge-cases\/names.h:22:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafelabel@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_464d035f44366a5b" label ::
      IO ()
@@ -279,6 +315,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_464d035f44366a5b" la
     __defined at:__ @edge-cases\/names.h:23:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeprim@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_1a1c4d5a866be872" prim ::
      IO ()
@@ -288,6 +326,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_1a1c4d5a866be872" pr
     __defined at:__ @edge-cases\/names.h:24:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferole@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_2b805a841a0f220d" role ::
      IO ()
@@ -297,6 +337,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_2b805a841a0f220d" ro
     __defined at:__ @edge-cases\/names.h:25:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafesafe@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_efbfe85dc9b68bc4" safe ::
      IO ()
@@ -306,6 +348,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_efbfe85dc9b68bc4" sa
     __defined at:__ @edge-cases\/names.h:26:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestdcall@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_27ef4256cbaf6815" stdcall ::
      IO ()
@@ -315,6 +359,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_27ef4256cbaf6815" st
     __defined at:__ @edge-cases\/names.h:27:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestock@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_6e4ae46773b9e016" stock ::
      IO ()
@@ -324,6 +370,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_6e4ae46773b9e016" st
     __defined at:__ @edge-cases\/names.h:28:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeunsafe@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_03cf69812528c410" unsafe ::
      IO ()
@@ -333,6 +381,8 @@ foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_03cf69812528c410" un
     __defined at:__ @edge-cases\/names.h:29:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafevia@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesnames_e611a3f38f7a3eb9" via ::
      IO ()

--- a/hs-bindgen/fixtures/edge-cases/names/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/names/th.txt
@@ -355,6 +355,8 @@
     __defined at:__ @edge-cases\/names.h:3:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeby@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e7f535b7085fc20" by' :: IO Unit
 {-| __C declaration:__ @forall@
@@ -362,6 +364,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e7f535b7085fc20" by' 
     __defined at:__ @edge-cases\/names.h:4:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeforall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_fc72c248490e573d" forall' :: IO Unit
 {-| __C declaration:__ @mdo@
@@ -369,6 +373,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_fc72c248490e573d" fora
     __defined at:__ @edge-cases\/names.h:5:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafemdo@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f21dd25a8b27374a" mdo' :: IO Unit
 {-| __C declaration:__ @pattern@
@@ -376,6 +382,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_f21dd25a8b27374a" mdo'
     __defined at:__ @edge-cases\/names.h:6:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafepattern@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0ab5fb5a8105f789" pattern' :: IO Unit
 {-| __C declaration:__ @proc@
@@ -383,6 +391,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0ab5fb5a8105f789" patt
     __defined at:__ @edge-cases\/names.h:7:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeproc@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_c14da8252137427c" proc' :: IO Unit
 {-| __C declaration:__ @rec@
@@ -390,6 +400,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_c14da8252137427c" proc
     __defined at:__ @edge-cases\/names.h:8:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferec@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_1706dcb069f095bc" rec' :: IO Unit
 {-| __C declaration:__ @using@
@@ -397,6 +409,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_1706dcb069f095bc" rec'
     __defined at:__ @edge-cases\/names.h:9:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeusing@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9cbe86d126f1d8ee" using' :: IO Unit
 {-| __C declaration:__ @anyclass@
@@ -404,6 +418,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_9cbe86d126f1d8ee" usin
     __defined at:__ @edge-cases\/names.h:12:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeanyclass@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_84e650893f3a92e0" anyclass :: IO Unit
 {-| __C declaration:__ @capi@
@@ -411,6 +427,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_84e650893f3a92e0" anyc
     __defined at:__ @edge-cases\/names.h:13:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecapi@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a931e0b3ecf47315" capi :: IO Unit
 {-| __C declaration:__ @cases@
@@ -418,6 +436,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_a931e0b3ecf47315" capi
     __defined at:__ @edge-cases\/names.h:14:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecases@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_8a21f58b60402b4c" cases :: IO Unit
 {-| __C declaration:__ @ccall@
@@ -425,6 +445,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_8a21f58b60402b4c" case
     __defined at:__ @edge-cases\/names.h:15:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeccall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_e72f0a6b1520490f" ccall :: IO Unit
 {-| __C declaration:__ @dynamic@
@@ -432,6 +454,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_e72f0a6b1520490f" ccal
     __defined at:__ @edge-cases\/names.h:16:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafedynamic@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_87e085120fafde48" dynamic :: IO Unit
 {-| __C declaration:__ @export@
@@ -439,6 +463,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_87e085120fafde48" dyna
     __defined at:__ @edge-cases\/names.h:17:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeexport@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e6d6a351c0f2d6b" export :: IO Unit
 {-| __C declaration:__ @family@
@@ -446,6 +472,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e6d6a351c0f2d6b" expo
     __defined at:__ @edge-cases\/names.h:18:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafefamily@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_bd4d89d0e474ae7a" family :: IO Unit
 {-| __C declaration:__ @group@
@@ -453,6 +481,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_bd4d89d0e474ae7a" fami
     __defined at:__ @edge-cases\/names.h:19:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafegroup@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_d33488d9cb279feb" group :: IO Unit
 {-| __C declaration:__ @interruptible@
@@ -460,6 +490,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_d33488d9cb279feb" grou
     __defined at:__ @edge-cases\/names.h:20:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeinterruptible@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a3851f5a39a9e5d" interruptible :: IO Unit
 {-| __C declaration:__ @javascript@
@@ -467,6 +499,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a3851f5a39a9e5d" inte
     __defined at:__ @edge-cases\/names.h:21:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafejavascript@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_fa9100d6d4da2bd4" javascript :: IO Unit
 {-| __C declaration:__ @label@
@@ -474,6 +508,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_fa9100d6d4da2bd4" java
     __defined at:__ @edge-cases\/names.h:22:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafelabel@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_264e9aa826f1d8fd" label :: IO Unit
 {-| __C declaration:__ @prim@
@@ -481,6 +517,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_264e9aa826f1d8fd" labe
     __defined at:__ @edge-cases\/names.h:23:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeprim@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_06aa327310da5120" prim :: IO Unit
 {-| __C declaration:__ @role@
@@ -488,6 +526,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_06aa327310da5120" prim
     __defined at:__ @edge-cases\/names.h:24:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferole@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0c2d88e0ce229900" role :: IO Unit
 {-| __C declaration:__ @safe@
@@ -495,6 +535,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0c2d88e0ce229900" role
     __defined at:__ @edge-cases\/names.h:25:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafesafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a703e7f54db3712e" safe :: IO Unit
 {-| __C declaration:__ @stdcall@
@@ -502,6 +544,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_a703e7f54db3712e" safe
     __defined at:__ @edge-cases\/names.h:26:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestdcall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_001ca64746b969f3" stdcall :: IO Unit
 {-| __C declaration:__ @stock@
@@ -509,6 +553,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_001ca64746b969f3" stdc
     __defined at:__ @edge-cases\/names.h:27:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestock@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_44ab69657e70c20b" stock :: IO Unit
 {-| __C declaration:__ @unsafe@
@@ -516,6 +562,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_44ab69657e70c20b" stoc
     __defined at:__ @edge-cases\/names.h:28:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeunsafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_cf74a7d7f3568406" unsafe :: IO Unit
 {-| __C declaration:__ @via@
@@ -523,6 +571,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_cf74a7d7f3568406" unsa
     __defined at:__ @edge-cases\/names.h:29:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafevia@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f24fb703d4751a60" via :: IO Unit
 {-| __C declaration:__ @by@
@@ -530,6 +580,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_f24fb703d4751a60" via 
     __defined at:__ @edge-cases\/names.h:3:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeby@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_757d799fd708dfd3" by' :: IO Unit
 {-| __C declaration:__ @forall@
@@ -537,6 +589,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_757d799fd708dfd3" by' 
     __defined at:__ @edge-cases\/names.h:4:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeforall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_56a86e542f270644" forall' :: IO Unit
 {-| __C declaration:__ @mdo@
@@ -544,6 +598,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_56a86e542f270644" fora
     __defined at:__ @edge-cases\/names.h:5:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafemdo@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_66ccc318fc33f3db" mdo' :: IO Unit
 {-| __C declaration:__ @pattern@
@@ -551,6 +607,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_66ccc318fc33f3db" mdo'
     __defined at:__ @edge-cases\/names.h:6:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafepattern@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_59e8310c2fbfd7a5" pattern' :: IO Unit
 {-| __C declaration:__ @proc@
@@ -558,6 +616,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_59e8310c2fbfd7a5" patt
     __defined at:__ @edge-cases\/names.h:7:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeproc@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e3a2ce0789fb7e6" proc' :: IO Unit
 {-| __C declaration:__ @rec@
@@ -565,6 +625,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0e3a2ce0789fb7e6" proc
     __defined at:__ @edge-cases\/names.h:8:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferec@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a8bd1db6a6708dae" rec' :: IO Unit
 {-| __C declaration:__ @using@
@@ -572,6 +634,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_a8bd1db6a6708dae" rec'
     __defined at:__ @edge-cases\/names.h:9:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeusing@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_4f84a89a7d96b0e6" using' :: IO Unit
 {-| __C declaration:__ @anyclass@
@@ -579,6 +643,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_4f84a89a7d96b0e6" usin
     __defined at:__ @edge-cases\/names.h:12:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeanyclass@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_e4c0e5d7430611d1" anyclass :: IO Unit
 {-| __C declaration:__ @capi@
@@ -586,6 +652,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_e4c0e5d7430611d1" anyc
     __defined at:__ @edge-cases\/names.h:13:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecapi@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0b2f0d5537de919f" capi :: IO Unit
 {-| __C declaration:__ @cases@
@@ -593,6 +661,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_0b2f0d5537de919f" capi
     __defined at:__ @edge-cases\/names.h:14:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafecases@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_1ffa6d7a4b3beb7c" cases :: IO Unit
 {-| __C declaration:__ @ccall@
@@ -600,6 +670,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_1ffa6d7a4b3beb7c" case
     __defined at:__ @edge-cases\/names.h:15:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeccall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_ebc1b326e523e58f" ccall :: IO Unit
 {-| __C declaration:__ @dynamic@
@@ -607,6 +679,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_ebc1b326e523e58f" ccal
     __defined at:__ @edge-cases\/names.h:16:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafedynamic@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_ab433e9e3ef36d2f" dynamic :: IO Unit
 {-| __C declaration:__ @export@
@@ -614,6 +688,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_ab433e9e3ef36d2f" dyna
     __defined at:__ @edge-cases\/names.h:17:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeexport@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_df679baa272472fa" export :: IO Unit
 {-| __C declaration:__ @family@
@@ -621,6 +697,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_df679baa272472fa" expo
     __defined at:__ @edge-cases\/names.h:18:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafefamily@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a60b7b7be9ca341" family :: IO Unit
 {-| __C declaration:__ @group@
@@ -628,6 +706,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_9a60b7b7be9ca341" fami
     __defined at:__ @edge-cases\/names.h:19:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafegroup@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_3923700cc828a4dd" group :: IO Unit
 {-| __C declaration:__ @interruptible@
@@ -635,6 +715,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_3923700cc828a4dd" grou
     __defined at:__ @edge-cases\/names.h:20:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeinterruptible@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_ba3f97d9b80e552c" interruptible :: IO Unit
 {-| __C declaration:__ @javascript@
@@ -642,6 +724,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_ba3f97d9b80e552c" inte
     __defined at:__ @edge-cases\/names.h:21:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafejavascript@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f348c51860201a12" javascript :: IO Unit
 {-| __C declaration:__ @label@
@@ -649,6 +733,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_f348c51860201a12" java
     __defined at:__ @edge-cases\/names.h:22:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafelabel@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_464d035f44366a5b" label :: IO Unit
 {-| __C declaration:__ @prim@
@@ -656,6 +742,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_464d035f44366a5b" labe
     __defined at:__ @edge-cases\/names.h:23:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeprim@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_1a1c4d5a866be872" prim :: IO Unit
 {-| __C declaration:__ @role@
@@ -663,6 +751,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_1a1c4d5a866be872" prim
     __defined at:__ @edge-cases\/names.h:24:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsaferole@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_2b805a841a0f220d" role :: IO Unit
 {-| __C declaration:__ @safe@
@@ -670,6 +760,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_2b805a841a0f220d" role
     __defined at:__ @edge-cases\/names.h:25:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafesafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_efbfe85dc9b68bc4" safe :: IO Unit
 {-| __C declaration:__ @stdcall@
@@ -677,6 +769,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_efbfe85dc9b68bc4" safe
     __defined at:__ @edge-cases\/names.h:26:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestdcall@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_27ef4256cbaf6815" stdcall :: IO Unit
 {-| __C declaration:__ @stock@
@@ -684,6 +778,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_27ef4256cbaf6815" stdc
     __defined at:__ @edge-cases\/names.h:27:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafestock@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_6e4ae46773b9e016" stock :: IO Unit
 {-| __C declaration:__ @unsafe@
@@ -691,6 +787,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_6e4ae46773b9e016" stoc
     __defined at:__ @edge-cases\/names.h:28:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafeunsafe@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_03cf69812528c410" unsafe :: IO Unit
 {-| __C declaration:__ @via@
@@ -698,8 +796,12 @@ foreign import ccall safe "hs_bindgen_test_edgecasesnames_03cf69812528c410" unsa
     __defined at:__ @edge-cases\/names.h:29:6@
 
     __exported by:__ @edge-cases\/names.h@
+
+    __unique:__ @ExampleJust Unsafevia@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_e611a3f38f7a3eb9" via :: IO Unit
+{-| __unique:__ @ExampleNothingget_by_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8" hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8 :: IO (FunPtr (IO Unit))
 {-# NOINLINE by'_ptr #-}
 {-| __C declaration:__ @by@
@@ -716,6 +818,8 @@ by'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 by'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_3e566432e1b7bdd8
+{-| __unique:__ @ExampleNothingget_forall_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_a56841d4692515a9" hs_bindgen_test_edgecasesnames_a56841d4692515a9 :: IO (FunPtr (IO Unit))
 {-# NOINLINE forall'_ptr #-}
 {-| __C declaration:__ @forall@
@@ -732,6 +836,8 @@ forall'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 forall'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_a56841d4692515a9
+{-| __unique:__ @ExampleNothingget_mdo_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378" hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378 :: IO (FunPtr (IO Unit))
 {-# NOINLINE mdo'_ptr #-}
 {-| __C declaration:__ @mdo@
@@ -748,6 +854,8 @@ mdo'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 mdo'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_4b14baa1fbc8f378
+{-| __unique:__ @ExampleNothingget_pattern_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_b393d3c39de80903" hs_bindgen_test_edgecasesnames_b393d3c39de80903 :: IO (FunPtr (IO Unit))
 {-# NOINLINE pattern'_ptr #-}
 {-| __C declaration:__ @pattern@
@@ -764,6 +872,8 @@ pattern'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 pattern'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_b393d3c39de80903
+{-| __unique:__ @ExampleNothingget_proc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_f73545ae9224ff2d" hs_bindgen_test_edgecasesnames_f73545ae9224ff2d :: IO (FunPtr (IO Unit))
 {-# NOINLINE proc'_ptr #-}
 {-| __C declaration:__ @proc@
@@ -780,6 +890,8 @@ proc'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 proc'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_f73545ae9224ff2d
+{-| __unique:__ @ExampleNothingget_rec_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0dd0f0805657312b" hs_bindgen_test_edgecasesnames_0dd0f0805657312b :: IO (FunPtr (IO Unit))
 {-# NOINLINE rec'_ptr #-}
 {-| __C declaration:__ @rec@
@@ -796,6 +908,8 @@ rec'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 rec'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_0dd0f0805657312b
+{-| __unique:__ @ExampleNothingget_using_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037" hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037 :: IO (FunPtr (IO Unit))
 {-# NOINLINE using'_ptr #-}
 {-| __C declaration:__ @using@
@@ -812,6 +926,8 @@ using'_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 using'_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_aa3ce68f2bc5f037
+{-| __unique:__ @ExampleNothingget_anyclass_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4" hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4 :: IO (FunPtr (IO Unit))
 {-# NOINLINE anyclass_ptr #-}
 {-| __C declaration:__ @anyclass@
@@ -828,6 +944,8 @@ anyclass_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 anyclass_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_9f90f5dd46a351a4
+{-| __unique:__ @ExampleNothingget_capi_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_3513093206483c6f" hs_bindgen_test_edgecasesnames_3513093206483c6f :: IO (FunPtr (IO Unit))
 {-# NOINLINE capi_ptr #-}
 {-| __C declaration:__ @capi@
@@ -844,6 +962,8 @@ capi_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 capi_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_3513093206483c6f
+{-| __unique:__ @ExampleNothingget_cases_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9" hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9 :: IO (FunPtr (IO Unit))
 {-# NOINLINE cases_ptr #-}
 {-| __C declaration:__ @cases@
@@ -860,6 +980,8 @@ cases_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 cases_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_af7d0bdd6562f7d9
+{-| __unique:__ @ExampleNothingget_ccall_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_79b6583362113331" hs_bindgen_test_edgecasesnames_79b6583362113331 :: IO (FunPtr (IO Unit))
 {-# NOINLINE ccall_ptr #-}
 {-| __C declaration:__ @ccall@
@@ -876,6 +998,8 @@ ccall_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 ccall_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_79b6583362113331
+{-| __unique:__ @ExampleNothingget_dynamic_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45" hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45 :: IO (FunPtr (IO Unit))
 {-# NOINLINE dynamic_ptr #-}
 {-| __C declaration:__ @dynamic@
@@ -892,6 +1016,8 @@ dynamic_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 dynamic_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_5c19071f2f4eaf45
+{-| __unique:__ @ExampleNothingget_export_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_98505ac7a8664e29" hs_bindgen_test_edgecasesnames_98505ac7a8664e29 :: IO (FunPtr (IO Unit))
 {-# NOINLINE export_ptr #-}
 {-| __C declaration:__ @export@
@@ -908,6 +1034,8 @@ export_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 export_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_98505ac7a8664e29
+{-| __unique:__ @ExampleNothingget_family_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_849e77496a12f443" hs_bindgen_test_edgecasesnames_849e77496a12f443 :: IO (FunPtr (IO Unit))
 {-# NOINLINE family_ptr #-}
 {-| __C declaration:__ @family@
@@ -924,6 +1052,8 @@ family_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 family_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_849e77496a12f443
+{-| __unique:__ @ExampleNothingget_group_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5" hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5 :: IO (FunPtr (IO Unit))
 {-# NOINLINE group_ptr #-}
 {-| __C declaration:__ @group@
@@ -940,6 +1070,8 @@ group_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 group_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_41e72434cbcfa0d5
+{-| __unique:__ @ExampleNothingget_interruptible_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_d016728709223884" hs_bindgen_test_edgecasesnames_d016728709223884 :: IO (FunPtr (IO Unit))
 {-# NOINLINE interruptible_ptr #-}
 {-| __C declaration:__ @interruptible@
@@ -956,6 +1088,8 @@ interruptible_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 interruptible_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_d016728709223884
+{-| __unique:__ @ExampleNothingget_javascript_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_fa5819996081f2b8" hs_bindgen_test_edgecasesnames_fa5819996081f2b8 :: IO (FunPtr (IO Unit))
 {-# NOINLINE javascript_ptr #-}
 {-| __C declaration:__ @javascript@
@@ -972,6 +1106,8 @@ javascript_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 javascript_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_fa5819996081f2b8
+{-| __unique:__ @ExampleNothingget_label_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_0004d966bf5f8027" hs_bindgen_test_edgecasesnames_0004d966bf5f8027 :: IO (FunPtr (IO Unit))
 {-# NOINLINE label_ptr #-}
 {-| __C declaration:__ @label@
@@ -988,6 +1124,8 @@ label_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 label_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_0004d966bf5f8027
+{-| __unique:__ @ExampleNothingget_prim_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea" hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea :: IO (FunPtr (IO Unit))
 {-# NOINLINE prim_ptr #-}
 {-| __C declaration:__ @prim@
@@ -1004,6 +1142,8 @@ prim_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 prim_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_d9ec78c543d7f0ea
+{-| __unique:__ @ExampleNothingget_role_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_89449e7f8f90fc97" hs_bindgen_test_edgecasesnames_89449e7f8f90fc97 :: IO (FunPtr (IO Unit))
 {-# NOINLINE role_ptr #-}
 {-| __C declaration:__ @role@
@@ -1020,6 +1160,8 @@ role_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 role_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_89449e7f8f90fc97
+{-| __unique:__ @ExampleNothingget_safe_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_983c057a9645fd29" hs_bindgen_test_edgecasesnames_983c057a9645fd29 :: IO (FunPtr (IO Unit))
 {-# NOINLINE safe_ptr #-}
 {-| __C declaration:__ @safe@
@@ -1036,6 +1178,8 @@ safe_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 safe_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_983c057a9645fd29
+{-| __unique:__ @ExampleNothingget_stdcall_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_8ea4a9581868a08c" hs_bindgen_test_edgecasesnames_8ea4a9581868a08c :: IO (FunPtr (IO Unit))
 {-# NOINLINE stdcall_ptr #-}
 {-| __C declaration:__ @stdcall@
@@ -1052,6 +1196,8 @@ stdcall_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 stdcall_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_8ea4a9581868a08c
+{-| __unique:__ @ExampleNothingget_stock_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_9d4197174428177d" hs_bindgen_test_edgecasesnames_9d4197174428177d :: IO (FunPtr (IO Unit))
 {-# NOINLINE stock_ptr #-}
 {-| __C declaration:__ @stock@
@@ -1068,6 +1214,8 @@ stock_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 stock_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_9d4197174428177d
+{-| __unique:__ @ExampleNothingget_unsafe_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_6eb48adc74567d6d" hs_bindgen_test_edgecasesnames_6eb48adc74567d6d :: IO (FunPtr (IO Unit))
 {-# NOINLINE unsafe_ptr #-}
 {-| __C declaration:__ @unsafe@
@@ -1084,6 +1232,8 @@ unsafe_ptr :: FunPtr (IO Unit)
     __exported by:__ @edge-cases\/names.h@
 -}
 unsafe_ptr = unsafePerformIO hs_bindgen_test_edgecasesnames_6eb48adc74567d6d
+{-| __unique:__ @ExampleNothingget_via_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesnames_64eddb721da8c268" hs_bindgen_test_edgecasesnames_64eddb721da8c268 :: IO (FunPtr (IO Unit))
 {-# NOINLINE via_ptr #-}
 {-| __C declaration:__ @via@

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/FunPtr.hs
@@ -29,6 +29,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_resample_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesspec_examples_46b04422dcd0bbd5" hs_bindgen_test_edgecasesspec_examples_46b04422dcd0bbd5 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Int32_T) -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 30720000) Cint16_T) -> Int64_T -> Int64_T -> ((HsBindgen.Runtime.ConstantArray.ConstantArray 30720000) Cint16_T) -> IO ()))
 

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Safe.hs
@@ -29,6 +29,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/spec_examples.h:31:6@
 
     __exported by:__ @edge-cases\/spec_examples.h@
+
+    __unique:__ @ExampleJust Saferesample@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_7d4128962cfce15d" resample ::
      Ptr.Ptr Int32_T

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Unsafe.hs
@@ -29,6 +29,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @edge-cases\/spec_examples.h:31:6@
 
     __exported by:__ @edge-cases\/spec_examples.h@
+
+    __unique:__ @ExampleJust Unsaferesample@
 -}
 foreign import ccall unsafe "hs_bindgen_test_edgecasesspec_examples_f31d4400b3244637" resample ::
      Ptr.Ptr Int32_T

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
@@ -291,6 +291,8 @@ data C
     __defined at:__ @edge-cases\/spec_examples.h:31:6@
 
     __exported by:__ @edge-cases\/spec_examples.h@
+
+    __unique:__ @ExampleJust Unsaferesample@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_7d4128962cfce15d" resample :: Ptr Int32_T ->
                                                                                                 Ptr Cint16_T ->
@@ -303,6 +305,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_7d4128962cfce1
     __defined at:__ @edge-cases\/spec_examples.h:31:6@
 
     __exported by:__ @edge-cases\/spec_examples.h@
+
+    __unique:__ @ExampleJust Unsaferesample@
 -}
 foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_f31d4400b3244637" resample :: Ptr Int32_T ->
                                                                                                 Ptr Cint16_T ->
@@ -310,6 +314,8 @@ foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_f31d4400b32446
                                                                                                 Int64_T ->
                                                                                                 Ptr Cint16_T ->
                                                                                                 IO Unit
+{-| __unique:__ @ExampleNothingget_resample_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_edgecasesspec_examples_46b04422dcd0bbd5" hs_bindgen_test_edgecasesspec_examples_46b04422dcd0bbd5 :: IO (FunPtr (Ptr Int32_T ->
                                                                                                                                                            ConstantArray 30720000
                                                                                                                                                                          Cint16_T ->

--- a/hs-bindgen/fixtures/functions/callbacks/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/FunPtr.hs
@@ -178,6 +178,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_readFileWithProcessor_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_c4b06d89a94616dd" hs_bindgen_test_functionscallbacks_c4b06d89a94616dd ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO ())) -> FC.CInt -> IO FC.CInt))
 
@@ -193,6 +195,8 @@ readFileWithProcessor_ptr :: Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO ())) -> FC.C
 readFileWithProcessor_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_c4b06d89a94616dd
 
+{-| __unique:__ @ExampleNothingget_watchTemperature_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_22c54726df44b640" hs_bindgen_test_functionscallbacks_22c54726df44b640 ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO ())) -> FC.CInt -> IO ()))
 
@@ -208,6 +212,8 @@ watchTemperature_ptr :: Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO ())) -> FC.CInt -
 watchTemperature_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_22c54726df44b640
 
+{-| __unique:__ @ExampleNothingget_onFileOpened_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_8167a5b82d621c9d" hs_bindgen_test_functionscallbacks_8167a5b82d621c9d ::
      IO (Ptr.FunPtr (FileOpenedNotification -> IO ()))
 
@@ -223,6 +229,8 @@ onFileOpened_ptr :: Ptr.FunPtr (FileOpenedNotification -> IO ())
 onFileOpened_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_8167a5b82d621c9d
 
+{-| __unique:__ @ExampleNothingget_onProgressChanged_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3" hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3 ::
      IO (Ptr.FunPtr (ProgressUpdate -> IO ()))
 
@@ -238,6 +246,8 @@ onProgressChanged_ptr :: Ptr.FunPtr (ProgressUpdate -> IO ())
 onProgressChanged_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3
 
+{-| __unique:__ @ExampleNothingget_validateInput_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb" hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb ::
      IO (Ptr.FunPtr (DataValidator -> FC.CInt -> IO FC.CInt))
 
@@ -253,6 +263,8 @@ validateInput_ptr :: Ptr.FunPtr (DataValidator -> FC.CInt -> IO FC.CInt)
 validateInput_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb
 
+{-| __unique:__ @ExampleNothingget_onNewMeasurement_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431" hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431 ::
      IO (Ptr.FunPtr (MeasurementReceived -> IO ()))
 
@@ -268,6 +280,8 @@ onNewMeasurement_ptr :: Ptr.FunPtr (MeasurementReceived -> IO ())
 onNewMeasurement_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431
 
+{-| __unique:__ @ExampleNothingget_onNewMeasurement2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce" hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce ::
      IO (Ptr.FunPtr (MeasurementReceived2 -> IO ()))
 
@@ -283,6 +297,8 @@ onNewMeasurement2_ptr :: Ptr.FunPtr (MeasurementReceived2 -> IO ())
 onNewMeasurement2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce
 
+{-| __unique:__ @ExampleNothingget_onBufferReady_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_8091188123328aa8" hs_bindgen_test_functionscallbacks_8091188123328aa8 ::
      IO (Ptr.FunPtr (SampleBufferFull -> IO ()))
 
@@ -298,6 +314,8 @@ onBufferReady_ptr :: Ptr.FunPtr (SampleBufferFull -> IO ())
 onBufferReady_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_8091188123328aa8
 
+{-| __unique:__ @ExampleNothingget_transformMeasurement_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa" hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa ::
      IO (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.FunPtr (FC.CDouble -> FC.CInt -> IO FC.CDouble)) -> FC.CInt -> IO ())) -> IO ()))
 
@@ -313,6 +331,8 @@ transformMeasurement_ptr :: Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.FunPtr ((P
 transformMeasurement_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa
 
+{-| __unique:__ @ExampleNothingget_processWithCallbacks_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7" hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7 ::
      IO (Ptr.FunPtr ((Ptr.FunPtr ((Ptr.Ptr Measurement) -> FileOpenedNotification -> FC.CInt -> IO ())) -> IO ()))
 
@@ -328,6 +348,8 @@ processWithCallbacks_ptr :: Ptr.FunPtr ((Ptr.FunPtr ((Ptr.Ptr Measurement) -> Fi
 processWithCallbacks_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7
 
+{-| __unique:__ @ExampleNothingget_registerHandler_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_5a70e34ecc71835b" hs_bindgen_test_functionscallbacks_5a70e34ecc71835b ::
      IO (Ptr.FunPtr ((Ptr.Ptr MeasurementHandler) -> IO ()))
 
@@ -343,6 +365,8 @@ registerHandler_ptr :: Ptr.FunPtr ((Ptr.Ptr MeasurementHandler) -> IO ())
 registerHandler_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_5a70e34ecc71835b
 
+{-| __unique:__ @ExampleNothingget_executePipeline_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_1a0881ba01e93710" hs_bindgen_test_functionscallbacks_1a0881ba01e93710 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.Ptr DataPipeline) -> IO ()))
 
@@ -358,6 +382,8 @@ executePipeline_ptr :: Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.Ptr DataPipelin
 executePipeline_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_1a0881ba01e93710
 
+{-| __unique:__ @ExampleNothingget_runProcessor_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f" hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f ::
      IO (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.Ptr Processor) -> IO ()))
 
@@ -373,6 +399,8 @@ runProcessor_ptr :: Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.Ptr Processor) -> 
 runProcessor_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f
 
+{-| __unique:__ @ExampleNothingget_processMeasurementWithValidation_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b" hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b ::
      IO (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> FC.CInt -> IO ())) -> DataValidator -> IO ())) -> IO ()))
 
@@ -388,6 +416,8 @@ processMeasurementWithValidation_ptr :: Ptr.FunPtr ((Ptr.Ptr Measurement) -> (Pt
 processMeasurementWithValidation_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b
 
+{-| __unique:__ @ExampleNothingget_f_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_c34fd33eedc1490d" hs_bindgen_test_functionscallbacks_c34fd33eedc1490d ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (Foo -> IO ())) -> IO ()))
 
@@ -403,6 +433,8 @@ f_ptr :: Ptr.FunPtr ((Ptr.FunPtr (Foo -> IO ())) -> IO ())
 f_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionscallbacks_c34fd33eedc1490d
 
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_490ca7e8c8282a69" hs_bindgen_test_functionscallbacks_490ca7e8c8282a69 ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (Foo2 -> IO ())) -> IO ()))
 

--- a/hs-bindgen/fixtures/functions/callbacks/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/Safe.hs
@@ -150,6 +150,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/callbacks.h:4:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafereadFileWithProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_a0a59181c714c131" readFileWithProcessor ::
      Ptr.FunPtr (FC.CInt -> IO ())
@@ -165,6 +167,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_a0a59181c714c131" 
     __defined at:__ @functions\/callbacks.h:5:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafewatchTemperature@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_d59e6698796971ea" watchTemperature ::
      Ptr.FunPtr (FC.CInt -> IO ())
@@ -180,6 +184,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_d59e6698796971ea" 
     __defined at:__ @functions\/callbacks.h:14:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeonFileOpened@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c9fb8fdc3d0d3978" onFileOpened ::
      FileOpenedNotification
@@ -192,6 +198,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_c9fb8fdc3d0d3978" 
     __defined at:__ @functions\/callbacks.h:15:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeonProgressChanged@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_7921ad1b219190e4" onProgressChanged ::
      ProgressUpdate
@@ -204,6 +212,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_7921ad1b219190e4" 
     __defined at:__ @functions\/callbacks.h:16:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafevalidateInput@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_ae19d658f098584a" validateInput ::
      DataValidator
@@ -219,6 +229,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_ae19d658f098584a" 
     __defined at:__ @functions\/callbacks.h:27:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeonNewMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_d2fdffe85523b3ef" onNewMeasurement ::
      MeasurementReceived
@@ -231,6 +243,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_d2fdffe85523b3ef" 
     __defined at:__ @functions\/callbacks.h:30:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeonNewMeasurement2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c5b555bbc07b808d" onNewMeasurement2 ::
      MeasurementReceived2
@@ -243,6 +257,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_c5b555bbc07b808d" 
     __defined at:__ @functions\/callbacks.h:33:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeonBufferReady@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_65927c77229ad893" onBufferReady ::
      SampleBufferFull
@@ -255,6 +271,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_65927c77229ad893" 
     __defined at:__ @functions\/callbacks.h:38:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafetransformMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b6a9249f49b986f" transformMeasurement ::
      Ptr.Ptr Measurement
@@ -270,6 +288,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b6a9249f49b986f" 
     __defined at:__ @functions\/callbacks.h:43:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeprocessWithCallbacks@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_2c3e0e84ae9cde51" processWithCallbacks ::
      Ptr.FunPtr ((Ptr.Ptr Measurement) -> FileOpenedNotification -> FC.CInt -> IO ())
@@ -282,6 +302,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_2c3e0e84ae9cde51" 
     __defined at:__ @functions\/callbacks.h:56:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SaferegisterHandler@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b172585709f9d48" registerHandler ::
      Ptr.Ptr MeasurementHandler
@@ -294,6 +316,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b172585709f9d48" 
     __defined at:__ @functions\/callbacks.h:64:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeexecutePipeline@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_25a56dfc7b259e7d" executePipeline ::
      Ptr.Ptr Measurement
@@ -309,6 +333,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_25a56dfc7b259e7d" 
     __defined at:__ @functions\/callbacks.h:80:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SaferunProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_5908d37641d70953" runProcessor ::
      Ptr.Ptr Measurement
@@ -324,6 +350,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_5908d37641d70953" 
     __defined at:__ @functions\/callbacks.h:85:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust SafeprocessMeasurementWithValidation@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f3c99b4af7808e7f" processMeasurementWithValidation ::
      Ptr.Ptr Measurement
@@ -339,6 +367,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_f3c99b4af7808e7f" 
     __defined at:__ @functions\/callbacks.h:96:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Safef@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_fcce70013c76ce8b" f ::
      Ptr.FunPtr (Foo -> IO ())
@@ -351,6 +381,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_fcce70013c76ce8b" 
     __defined at:__ @functions\/callbacks.h:97:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Safef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_1d043de05a457e90" f2 ::
      Ptr.FunPtr (Foo2 -> IO ())

--- a/hs-bindgen/fixtures/functions/callbacks/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/Unsafe.hs
@@ -150,6 +150,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/callbacks.h:4:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafereadFileWithProcessor@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f0d72410d79899b5" readFileWithProcessor ::
      Ptr.FunPtr (FC.CInt -> IO ())
@@ -165,6 +167,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f0d72410d79899b5
     __defined at:__ @functions\/callbacks.h:5:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafewatchTemperature@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_a445b9cacb08ed71" watchTemperature ::
      Ptr.FunPtr (FC.CInt -> IO ())
@@ -180,6 +184,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_a445b9cacb08ed71
     __defined at:__ @functions\/callbacks.h:14:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonFileOpened@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_b71e59965bcc2316" onFileOpened ::
      FileOpenedNotification
@@ -192,6 +198,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_b71e59965bcc2316
     __defined at:__ @functions\/callbacks.h:15:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonProgressChanged@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_013e79fc3cd3b1b4" onProgressChanged ::
      ProgressUpdate
@@ -204,6 +212,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_013e79fc3cd3b1b4
     __defined at:__ @functions\/callbacks.h:16:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafevalidateInput@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_697a7b01b3d64c58" validateInput ::
      DataValidator
@@ -219,6 +229,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_697a7b01b3d64c58
     __defined at:__ @functions\/callbacks.h:27:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f291b861b36d5a90" onNewMeasurement ::
      MeasurementReceived
@@ -231,6 +243,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f291b861b36d5a90
     __defined at:__ @functions\/callbacks.h:30:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_4f36523b7d965e44" onNewMeasurement2 ::
      MeasurementReceived2
@@ -243,6 +257,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_4f36523b7d965e44
     __defined at:__ @functions\/callbacks.h:33:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonBufferReady@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_92d54aaf9e8a1c8e" onBufferReady ::
      SampleBufferFull
@@ -255,6 +271,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_92d54aaf9e8a1c8e
     __defined at:__ @functions\/callbacks.h:38:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafetransformMeasurement@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_0e22183e51a42eab" transformMeasurement ::
      Ptr.Ptr Measurement
@@ -270,6 +288,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_0e22183e51a42eab
     __defined at:__ @functions\/callbacks.h:43:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessWithCallbacks@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_9b4727ea289ff135" processWithCallbacks ::
      Ptr.FunPtr ((Ptr.Ptr Measurement) -> FileOpenedNotification -> FC.CInt -> IO ())
@@ -282,6 +302,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_9b4727ea289ff135
     __defined at:__ @functions\/callbacks.h:56:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferegisterHandler@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_aea76777f06b51ce" registerHandler ::
      Ptr.Ptr MeasurementHandler
@@ -294,6 +316,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_aea76777f06b51ce
     __defined at:__ @functions\/callbacks.h:64:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeexecutePipeline@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_54fc81d3b44b84d5" executePipeline ::
      Ptr.Ptr Measurement
@@ -309,6 +333,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_54fc81d3b44b84d5
     __defined at:__ @functions\/callbacks.h:80:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferunProcessor@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_4bb32ee774218053" runProcessor ::
      Ptr.Ptr Measurement
@@ -324,6 +350,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_4bb32ee774218053
     __defined at:__ @functions\/callbacks.h:85:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessMeasurementWithValidation@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f453b618c9ab0234" processMeasurementWithValidation ::
      Ptr.Ptr Measurement
@@ -339,6 +367,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_f453b618c9ab0234
     __defined at:__ @functions\/callbacks.h:96:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_b68b2cffacc97c1d" f ::
      Ptr.FunPtr (Foo -> IO ())
@@ -351,6 +381,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_b68b2cffacc97c1d
     __defined at:__ @functions\/callbacks.h:97:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionscallbacks_14361e995fb5684a" f2 ::
      Ptr.FunPtr (Foo2 -> IO ())

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -1455,6 +1455,8 @@ instance FromFunPtr (Foo2 -> IO Unit)
     __defined at:__ @functions\/callbacks.h:4:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafereadFileWithProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_a0a59181c714c131" readFileWithProcessor :: FunPtr (CInt ->
                                                                                                                  IO Unit) ->
@@ -1465,6 +1467,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_a0a59181c714c131" 
     __defined at:__ @functions\/callbacks.h:5:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafewatchTemperature@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_d59e6698796971ea" watchTemperature :: FunPtr (CInt ->
                                                                                                             IO Unit) ->
@@ -1475,6 +1479,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_d59e6698796971ea" 
     __defined at:__ @functions\/callbacks.h:14:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonFileOpened@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c9fb8fdc3d0d3978" onFileOpened :: FileOpenedNotification ->
                                                                                                 IO Unit
@@ -1483,6 +1489,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_c9fb8fdc3d0d3978" 
     __defined at:__ @functions\/callbacks.h:15:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonProgressChanged@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_7921ad1b219190e4" onProgressChanged :: ProgressUpdate ->
                                                                                                      IO Unit
@@ -1491,6 +1499,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_7921ad1b219190e4" 
     __defined at:__ @functions\/callbacks.h:16:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafevalidateInput@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_ae19d658f098584a" validateInput :: DataValidator ->
                                                                                                  CInt ->
@@ -1500,6 +1510,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_ae19d658f098584a" 
     __defined at:__ @functions\/callbacks.h:27:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_d2fdffe85523b3ef" onNewMeasurement :: MeasurementReceived ->
                                                                                                     IO Unit
@@ -1508,6 +1520,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_d2fdffe85523b3ef" 
     __defined at:__ @functions\/callbacks.h:30:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c5b555bbc07b808d" onNewMeasurement2 :: MeasurementReceived2 ->
                                                                                                      IO Unit
@@ -1516,6 +1530,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_c5b555bbc07b808d" 
     __defined at:__ @functions\/callbacks.h:33:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonBufferReady@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_65927c77229ad893" onBufferReady :: SampleBufferFull ->
                                                                                                  IO Unit
@@ -1524,6 +1540,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_65927c77229ad893" 
     __defined at:__ @functions\/callbacks.h:38:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafetransformMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b6a9249f49b986f" transformMeasurement :: Ptr Measurement ->
                                                                                                         FunPtr (Ptr Measurement ->
@@ -1538,6 +1556,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b6a9249f49b986f" 
     __defined at:__ @functions\/callbacks.h:43:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessWithCallbacks@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_2c3e0e84ae9cde51" processWithCallbacks :: FunPtr (Ptr Measurement ->
                                                                                                                 FileOpenedNotification ->
@@ -1549,6 +1569,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_2c3e0e84ae9cde51" 
     __defined at:__ @functions\/callbacks.h:56:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferegisterHandler@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b172585709f9d48" registerHandler :: Ptr MeasurementHandler ->
                                                                                                    IO Unit
@@ -1557,6 +1579,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_0b172585709f9d48" 
     __defined at:__ @functions\/callbacks.h:64:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeexecutePipeline@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_25a56dfc7b259e7d" executePipeline :: Ptr Measurement ->
                                                                                                    Ptr DataPipeline ->
@@ -1566,6 +1590,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_25a56dfc7b259e7d" 
     __defined at:__ @functions\/callbacks.h:80:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferunProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_5908d37641d70953" runProcessor :: Ptr Measurement ->
                                                                                                 Ptr Processor ->
@@ -1575,6 +1601,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_5908d37641d70953" 
     __defined at:__ @functions\/callbacks.h:85:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessMeasurementWithValidation@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f3c99b4af7808e7f" processMeasurementWithValidation :: Ptr Measurement ->
                                                                                                                     FunPtr (Ptr Measurement ->
@@ -1590,6 +1618,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_f3c99b4af7808e7f" 
     __defined at:__ @functions\/callbacks.h:96:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_fcce70013c76ce8b" f :: FunPtr (Foo ->
                                                                                              IO Unit) ->
@@ -1599,6 +1629,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_fcce70013c76ce8b" 
     __defined at:__ @functions\/callbacks.h:97:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_1d043de05a457e90" f2 :: FunPtr (Foo2 ->
                                                                                               IO Unit) ->
@@ -1608,6 +1640,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_1d043de05a457e90" 
     __defined at:__ @functions\/callbacks.h:4:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafereadFileWithProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f0d72410d79899b5" readFileWithProcessor :: FunPtr (CInt ->
                                                                                                                  IO Unit) ->
@@ -1618,6 +1652,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_f0d72410d79899b5" 
     __defined at:__ @functions\/callbacks.h:5:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafewatchTemperature@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_a445b9cacb08ed71" watchTemperature :: FunPtr (CInt ->
                                                                                                             IO Unit) ->
@@ -1628,6 +1664,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_a445b9cacb08ed71" 
     __defined at:__ @functions\/callbacks.h:14:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonFileOpened@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_b71e59965bcc2316" onFileOpened :: FileOpenedNotification ->
                                                                                                 IO Unit
@@ -1636,6 +1674,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_b71e59965bcc2316" 
     __defined at:__ @functions\/callbacks.h:15:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonProgressChanged@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_013e79fc3cd3b1b4" onProgressChanged :: ProgressUpdate ->
                                                                                                      IO Unit
@@ -1644,6 +1684,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_013e79fc3cd3b1b4" 
     __defined at:__ @functions\/callbacks.h:16:5@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafevalidateInput@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_697a7b01b3d64c58" validateInput :: DataValidator ->
                                                                                                  CInt ->
@@ -1653,6 +1695,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_697a7b01b3d64c58" 
     __defined at:__ @functions\/callbacks.h:27:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f291b861b36d5a90" onNewMeasurement :: MeasurementReceived ->
                                                                                                     IO Unit
@@ -1661,6 +1705,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_f291b861b36d5a90" 
     __defined at:__ @functions\/callbacks.h:30:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonNewMeasurement2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_4f36523b7d965e44" onNewMeasurement2 :: MeasurementReceived2 ->
                                                                                                      IO Unit
@@ -1669,6 +1715,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_4f36523b7d965e44" 
     __defined at:__ @functions\/callbacks.h:33:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeonBufferReady@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_92d54aaf9e8a1c8e" onBufferReady :: SampleBufferFull ->
                                                                                                  IO Unit
@@ -1677,6 +1725,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_92d54aaf9e8a1c8e" 
     __defined at:__ @functions\/callbacks.h:38:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafetransformMeasurement@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_0e22183e51a42eab" transformMeasurement :: Ptr Measurement ->
                                                                                                         FunPtr (Ptr Measurement ->
@@ -1691,6 +1741,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_0e22183e51a42eab" 
     __defined at:__ @functions\/callbacks.h:43:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessWithCallbacks@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_9b4727ea289ff135" processWithCallbacks :: FunPtr (Ptr Measurement ->
                                                                                                                 FileOpenedNotification ->
@@ -1702,6 +1754,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_9b4727ea289ff135" 
     __defined at:__ @functions\/callbacks.h:56:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferegisterHandler@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_aea76777f06b51ce" registerHandler :: Ptr MeasurementHandler ->
                                                                                                    IO Unit
@@ -1710,6 +1764,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_aea76777f06b51ce" 
     __defined at:__ @functions\/callbacks.h:64:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeexecutePipeline@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_54fc81d3b44b84d5" executePipeline :: Ptr Measurement ->
                                                                                                    Ptr DataPipeline ->
@@ -1719,6 +1775,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_54fc81d3b44b84d5" 
     __defined at:__ @functions\/callbacks.h:80:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsaferunProcessor@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_4bb32ee774218053" runProcessor :: Ptr Measurement ->
                                                                                                 Ptr Processor ->
@@ -1728,6 +1786,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_4bb32ee774218053" 
     __defined at:__ @functions\/callbacks.h:85:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust UnsafeprocessMeasurementWithValidation@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f453b618c9ab0234" processMeasurementWithValidation :: Ptr Measurement ->
                                                                                                                     FunPtr (Ptr Measurement ->
@@ -1743,6 +1803,8 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_f453b618c9ab0234" 
     __defined at:__ @functions\/callbacks.h:96:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_b68b2cffacc97c1d" f :: FunPtr (Foo ->
                                                                                              IO Unit) ->
@@ -1752,10 +1814,14 @@ foreign import ccall safe "hs_bindgen_test_functionscallbacks_b68b2cffacc97c1d" 
     __defined at:__ @functions\/callbacks.h:97:6@
 
     __exported by:__ @functions\/callbacks.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_14361e995fb5684a" f2 :: FunPtr (Foo2 ->
                                                                                               IO Unit) ->
                                                                                       IO Unit
+{-| __unique:__ @ExampleNothingget_readFileWithProcessor_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c4b06d89a94616dd" hs_bindgen_test_functionscallbacks_c4b06d89a94616dd :: IO (FunPtr (FunPtr (CInt ->
                                                                                                                                                            IO Unit) ->
                                                                                                                                                    CInt ->
@@ -1776,6 +1842,8 @@ readFileWithProcessor_ptr :: FunPtr (FunPtr (CInt -> IO Unit) ->
     __exported by:__ @functions\/callbacks.h@
 -}
 readFileWithProcessor_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_c4b06d89a94616dd
+{-| __unique:__ @ExampleNothingget_watchTemperature_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_22c54726df44b640" hs_bindgen_test_functionscallbacks_22c54726df44b640 :: IO (FunPtr (FunPtr (CInt ->
                                                                                                                                                            IO Unit) ->
                                                                                                                                                    CInt ->
@@ -1796,6 +1864,8 @@ watchTemperature_ptr :: FunPtr (FunPtr (CInt -> IO Unit) ->
     __exported by:__ @functions\/callbacks.h@
 -}
 watchTemperature_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_22c54726df44b640
+{-| __unique:__ @ExampleNothingget_onFileOpened_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_8167a5b82d621c9d" hs_bindgen_test_functionscallbacks_8167a5b82d621c9d :: IO (FunPtr (FileOpenedNotification ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE onFileOpened_ptr #-}
@@ -1813,6 +1883,8 @@ onFileOpened_ptr :: FunPtr (FileOpenedNotification -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 onFileOpened_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_8167a5b82d621c9d
+{-| __unique:__ @ExampleNothingget_onProgressChanged_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3" hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3 :: IO (FunPtr (ProgressUpdate ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE onProgressChanged_ptr #-}
@@ -1830,6 +1902,8 @@ onProgressChanged_ptr :: FunPtr (ProgressUpdate -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 onProgressChanged_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_ef51ad75ce9862a3
+{-| __unique:__ @ExampleNothingget_validateInput_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb" hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb :: IO (FunPtr (DataValidator ->
                                                                                                                                                    CInt ->
                                                                                                                                                    IO CInt))
@@ -1848,6 +1922,8 @@ validateInput_ptr :: FunPtr (DataValidator -> CInt -> IO CInt)
     __exported by:__ @functions\/callbacks.h@
 -}
 validateInput_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_9eaedb1b1c5b3fdb
+{-| __unique:__ @ExampleNothingget_onNewMeasurement_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431" hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431 :: IO (FunPtr (MeasurementReceived ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE onNewMeasurement_ptr #-}
@@ -1865,6 +1941,8 @@ onNewMeasurement_ptr :: FunPtr (MeasurementReceived -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 onNewMeasurement_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_f9f4f5ec3dd82431
+{-| __unique:__ @ExampleNothingget_onNewMeasurement2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce" hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce :: IO (FunPtr (MeasurementReceived2 ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE onNewMeasurement2_ptr #-}
@@ -1882,6 +1960,8 @@ onNewMeasurement2_ptr :: FunPtr (MeasurementReceived2 -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 onNewMeasurement2_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_9c5afeda25ede1ce
+{-| __unique:__ @ExampleNothingget_onBufferReady_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_8091188123328aa8" hs_bindgen_test_functionscallbacks_8091188123328aa8 :: IO (FunPtr (SampleBufferFull ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE onBufferReady_ptr #-}
@@ -1899,6 +1979,8 @@ onBufferReady_ptr :: FunPtr (SampleBufferFull -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 onBufferReady_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_8091188123328aa8
+{-| __unique:__ @ExampleNothingget_transformMeasurement_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa" hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa :: IO (FunPtr (Ptr Measurement ->
                                                                                                                                                    FunPtr (Ptr Measurement ->
                                                                                                                                                            FunPtr (CDouble ->
@@ -1926,6 +2008,8 @@ transformMeasurement_ptr :: FunPtr (Ptr Measurement ->
     __exported by:__ @functions\/callbacks.h@
 -}
 transformMeasurement_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_6c9fe4dae03a37fa
+{-| __unique:__ @ExampleNothingget_processWithCallbacks_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7" hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7 :: IO (FunPtr (FunPtr (Ptr Measurement ->
                                                                                                                                                            FileOpenedNotification ->
                                                                                                                                                            CInt ->
@@ -1948,6 +2032,8 @@ processWithCallbacks_ptr :: FunPtr (FunPtr (Ptr Measurement ->
     __exported by:__ @functions\/callbacks.h@
 -}
 processWithCallbacks_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_2ee8d8889cd31fb7
+{-| __unique:__ @ExampleNothingget_registerHandler_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_5a70e34ecc71835b" hs_bindgen_test_functionscallbacks_5a70e34ecc71835b :: IO (FunPtr (Ptr MeasurementHandler ->
                                                                                                                                                    IO Unit))
 {-# NOINLINE registerHandler_ptr #-}
@@ -1965,6 +2051,8 @@ registerHandler_ptr :: FunPtr (Ptr MeasurementHandler -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 registerHandler_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_5a70e34ecc71835b
+{-| __unique:__ @ExampleNothingget_executePipeline_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_1a0881ba01e93710" hs_bindgen_test_functionscallbacks_1a0881ba01e93710 :: IO (FunPtr (Ptr Measurement ->
                                                                                                                                                    Ptr DataPipeline ->
                                                                                                                                                    IO Unit))
@@ -1984,6 +2072,8 @@ executePipeline_ptr :: FunPtr (Ptr Measurement ->
     __exported by:__ @functions\/callbacks.h@
 -}
 executePipeline_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_1a0881ba01e93710
+{-| __unique:__ @ExampleNothingget_runProcessor_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f" hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f :: IO (FunPtr (Ptr Measurement ->
                                                                                                                                                    Ptr Processor ->
                                                                                                                                                    IO Unit))
@@ -2003,6 +2093,8 @@ runProcessor_ptr :: FunPtr (Ptr Measurement ->
     __exported by:__ @functions\/callbacks.h@
 -}
 runProcessor_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_1e7d8fd6cb5a199f
+{-| __unique:__ @ExampleNothingget_processMeasurementWithValidation_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b" hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b :: IO (FunPtr (Ptr Measurement ->
                                                                                                                                                    FunPtr (Ptr Measurement ->
                                                                                                                                                            FunPtr (Ptr Measurement ->
@@ -2032,6 +2124,8 @@ processMeasurementWithValidation_ptr :: FunPtr (Ptr Measurement ->
     __exported by:__ @functions\/callbacks.h@
 -}
 processMeasurementWithValidation_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_6621b1bf8ef7af3b
+{-| __unique:__ @ExampleNothingget_f_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_c34fd33eedc1490d" hs_bindgen_test_functionscallbacks_c34fd33eedc1490d :: IO (FunPtr (FunPtr (Foo ->
                                                                                                                                                            IO Unit) ->
                                                                                                                                                    IO Unit))
@@ -2050,6 +2144,8 @@ f_ptr :: FunPtr (FunPtr (Foo -> IO Unit) -> IO Unit)
     __exported by:__ @functions\/callbacks.h@
 -}
 f_ptr = unsafePerformIO hs_bindgen_test_functionscallbacks_c34fd33eedc1490d
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionscallbacks_490ca7e8c8282a69" hs_bindgen_test_functionscallbacks_490ca7e8c8282a69 :: IO (FunPtr (FunPtr (Foo2 ->
                                                                                                                                                            IO Unit) ->
                                                                                                                                                    IO Unit))

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/FunPtr.hs
@@ -41,6 +41,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_normal_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e" hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e ::
      IO (Ptr.FunPtr ((Ptr.Ptr Opaque) -> (Ptr.Ptr Outside) -> Outside -> IO ()))
 
@@ -56,6 +58,8 @@ normal_ptr :: Ptr.FunPtr ((Ptr.Ptr Opaque) -> (Ptr.Ptr Outside) -> Outside -> IO
 normal_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e
 
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1" hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1 ::
      IO (Ptr.FunPtr (Named_struct -> IO ()))
 
@@ -75,6 +79,8 @@ f1_ptr :: Ptr.FunPtr (Named_struct -> IO ())
 f1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1
 
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_490ca7e8c8282a69" hs_bindgen_test_functionsdecls_in_signature_490ca7e8c8282a69 ::
      IO (Ptr.FunPtr (Named_union -> IO ()))
 

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/Safe.hs
@@ -37,6 +37,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'normal'
 
+__unique:__ @ExampleJust Safenormal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_001a08d4459ec455" normal_wrapper ::
      Ptr.Ptr Opaque
@@ -68,6 +69,7 @@ normal =
 
 {-| Pointer-based API for 'f1'
 
+__unique:__ @ExampleJust Safef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_a2f84d2570ef3892" f1_wrapper ::
      Ptr.Ptr Named_struct
@@ -92,6 +94,7 @@ f1 = \x0 -> F.with x0 (\y1 -> f1_wrapper y1)
 
 {-| Pointer-based API for 'f2'
 
+__unique:__ @ExampleJust Safef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_1d043de05a457e90" f2_wrapper ::
      Ptr.Ptr Named_union

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/Unsafe.hs
@@ -37,6 +37,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'normal'
 
+__unique:__ @ExampleJust Unsafenormal@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_35c28995abc46de4" normal_wrapper ::
      Ptr.Ptr Opaque
@@ -68,6 +69,7 @@ normal =
 
 {-| Pointer-based API for 'f1'
 
+__unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_c1788128a5b1c813" f1_wrapper ::
      Ptr.Ptr Named_struct
@@ -92,6 +94,7 @@ f1 = \x0 -> F.with x0 (\y1 -> f1_wrapper y1)
 
 {-| Pointer-based API for 'f2'
 
+__unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsdecls_in_signature_14361e995fb5684a" f2_wrapper ::
      Ptr.Ptr Named_union

--- a/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
@@ -272,6 +272,7 @@ instance TyEq ty (CFieldType Named_union "named_union_y") =>
     where getField = ptrToCField (Proxy @"named_union_y")
 {-| Pointer-based API for 'normal'
 
+__unique:__ @ExampleJust Unsafenormal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_001a08d4459ec455" normal_wrapper :: Ptr Opaque ->
                                                                                                            Ptr Outside ->
@@ -293,6 +294,7 @@ normal :: Ptr Opaque -> Ptr Outside -> Outside -> IO Unit
 normal = \x_0 -> \x_1 -> \x_2 -> with x_2 (\y_3 -> normal_wrapper x_0 x_1 y_3)
 {-| Pointer-based API for 'f1'
 
+__unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_a2f84d2570ef3892" f1_wrapper :: Ptr Named_struct ->
                                                                                                        IO Unit
@@ -320,6 +322,7 @@ __exported by:__ @functions\/decls_in_signature.h@
 f1 = \x_0 -> with x_0 (\y_1 -> f1_wrapper y_1)
 {-| Pointer-based API for 'f2'
 
+__unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_1d043de05a457e90" f2_wrapper :: Ptr Named_union ->
                                                                                                        IO Unit
@@ -339,6 +342,7 @@ f2 :: Named_union -> IO Unit
 f2 = \x_0 -> with x_0 (\y_1 -> f2_wrapper y_1)
 {-| Pointer-based API for 'normal'
 
+__unique:__ @ExampleJust Unsafenormal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_35c28995abc46de4" normal_wrapper :: Ptr Opaque ->
                                                                                                            Ptr Outside ->
@@ -360,6 +364,7 @@ normal :: Ptr Opaque -> Ptr Outside -> Outside -> IO Unit
 normal = \x_0 -> \x_1 -> \x_2 -> with x_2 (\y_3 -> normal_wrapper x_0 x_1 y_3)
 {-| Pointer-based API for 'f1'
 
+__unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_c1788128a5b1c813" f1_wrapper :: Ptr Named_struct ->
                                                                                                        IO Unit
@@ -387,6 +392,7 @@ __exported by:__ @functions\/decls_in_signature.h@
 f1 = \x_0 -> with x_0 (\y_1 -> f1_wrapper y_1)
 {-| Pointer-based API for 'f2'
 
+__unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_14361e995fb5684a" f2_wrapper :: Ptr Named_union ->
                                                                                                        IO Unit
@@ -404,6 +410,8 @@ f2 :: Named_union -> IO Unit
     __exported by:__ @functions\/decls_in_signature.h@
 -}
 f2 = \x_0 -> with x_0 (\y_1 -> f2_wrapper y_1)
+{-| __unique:__ @ExampleNothingget_normal_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e" hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e :: IO (FunPtr (Ptr Opaque ->
                                                                                                                                                                      Ptr Outside ->
                                                                                                                                                                      Outside ->
@@ -424,6 +432,8 @@ normal_ptr :: FunPtr (Ptr Opaque ->
     __exported by:__ @functions\/decls_in_signature.h@
 -}
 normal_ptr = unsafePerformIO hs_bindgen_test_functionsdecls_in_signature_b040d51578b7b05e
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1" hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1 :: IO (FunPtr (Named_struct ->
                                                                                                                                                                      IO Unit))
 {-# NOINLINE f1_ptr #-}
@@ -449,6 +459,8 @@ __defined at:__ @functions\/decls_in_signature.h:17:6@
 __exported by:__ @functions\/decls_in_signature.h@
 -}
 f1_ptr = unsafePerformIO hs_bindgen_test_functionsdecls_in_signature_5469bdc0395f86c1
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsdecls_in_signature_490ca7e8c8282a69" hs_bindgen_test_functionsdecls_in_signature_490ca7e8c8282a69 :: IO (FunPtr (Named_union ->
                                                                                                                                                                      IO Unit))
 {-# NOINLINE f2_ptr #-}

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/FunPtr.hs
@@ -190,6 +190,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget___f1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_7003b306f73c174b" hs_bindgen_test_functionsfun_attributes_7003b306f73c174b ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -205,6 +207,8 @@ __f1_ptr :: Ptr.FunPtr (IO ())
 __f1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_7003b306f73c174b
 
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1" hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -220,6 +224,8 @@ f1_ptr :: Ptr.FunPtr (IO ())
 f1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1
 
+{-| __unique:__ @ExampleNothingget_my_memalign_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b3c956e53724162c" hs_bindgen_test_functionsfun_attributes_b3c956e53724162c ::
      IO (Ptr.FunPtr (Size_t -> Size_t -> IO (Ptr.Ptr Void)))
 
@@ -235,6 +241,8 @@ my_memalign_ptr :: Ptr.FunPtr (Size_t -> Size_t -> IO (Ptr.Ptr Void))
 my_memalign_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_b3c956e53724162c
 
+{-| __unique:__ @ExampleNothingget_my_calloc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_733646ca96f39979" hs_bindgen_test_functionsfun_attributes_733646ca96f39979 ::
      IO (Ptr.FunPtr (Size_t -> Size_t -> IO (Ptr.Ptr Void)))
 
@@ -250,6 +258,8 @@ my_calloc_ptr :: Ptr.FunPtr (Size_t -> Size_t -> IO (Ptr.Ptr Void))
 my_calloc_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_733646ca96f39979
 
+{-| __unique:__ @ExampleNothingget_my_realloc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_94e8271f186110fd" hs_bindgen_test_functionsfun_attributes_94e8271f186110fd ::
      IO (Ptr.FunPtr ((Ptr.Ptr Void) -> Size_t -> IO (Ptr.Ptr Void)))
 
@@ -265,6 +275,8 @@ my_realloc_ptr :: Ptr.FunPtr ((Ptr.Ptr Void) -> Size_t -> IO (Ptr.Ptr Void))
 my_realloc_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_94e8271f186110fd
 
+{-| __unique:__ @ExampleNothingget_my_alloc1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70" hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70 ::
      IO (Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void)))
 
@@ -280,6 +292,8 @@ my_alloc1_ptr :: Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void))
 my_alloc1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70
 
+{-| __unique:__ @ExampleNothingget_my_alloc2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357" hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357 ::
      IO (Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void)))
 
@@ -295,6 +309,8 @@ my_alloc2_ptr :: Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void))
 my_alloc2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357
 
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9" hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -310,6 +326,8 @@ square_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 square_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9
 
+{-| __unique:__ @ExampleNothingget_old_fn_deprecated_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20" hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -325,6 +343,8 @@ old_fn_deprecated_ptr :: Ptr.FunPtr (IO FC.CInt)
 old_fn_deprecated_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20
 
+{-| __unique:__ @ExampleNothingget_my_dgettext_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_a0be4f488601c252" hs_bindgen_test_functionsfun_attributes_a0be4f488601c252 ::
      IO (Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> (Ptr.Ptr FC.CChar) -> IO (Ptr.Ptr FC.CChar)))
 
@@ -340,6 +360,8 @@ my_dgettext_ptr :: Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> (Ptr.Ptr FC.CChar) -> IO (P
 my_dgettext_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_a0be4f488601c252
 
+{-| __unique:__ @ExampleNothingget_fdopen_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326" hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326 ::
      IO (Ptr.FunPtr (FC.CInt -> (Ptr.Ptr FC.CChar) -> IO (Ptr.Ptr FILE)))
 
@@ -355,6 +377,8 @@ fdopen_ptr :: Ptr.FunPtr (FC.CInt -> (Ptr.Ptr FC.CChar) -> IO (Ptr.Ptr FILE))
 fdopen_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326
 
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69" hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -370,6 +394,8 @@ f2_ptr :: Ptr.FunPtr (IO ())
 f2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69
 
+{-| __unique:__ @ExampleNothingget_my_memcpy_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8" hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Void) -> (Ptr.Ptr Void) -> Size_t -> IO (Ptr.Ptr Void)))
 
@@ -385,6 +411,8 @@ my_memcpy_ptr :: Ptr.FunPtr ((Ptr.Ptr Void) -> (Ptr.Ptr Void) -> Size_t -> IO (P
 my_memcpy_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8
 
+{-| __unique:__ @ExampleNothingget_fatal_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5" hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -400,6 +428,8 @@ fatal_ptr :: Ptr.FunPtr (IO ())
 fatal_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5
 
+{-| __unique:__ @ExampleNothingget_hash_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01" hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01 ::
      IO (Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt))
 
@@ -415,6 +445,8 @@ hash_ptr :: Ptr.FunPtr ((Ptr.Ptr FC.CChar) -> IO FC.CInt)
 hash_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01
 
+{-| __unique:__ @ExampleNothingget_mymalloc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_4ce141c884649d49" hs_bindgen_test_functionsfun_attributes_4ce141c884649d49 ::
      IO (Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void)))
 
@@ -430,6 +462,8 @@ mymalloc_ptr :: Ptr.FunPtr (Size_t -> IO (Ptr.Ptr Void))
 mymalloc_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_4ce141c884649d49
 
+{-| __unique:__ @ExampleNothingget_foobar_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa" hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -445,6 +479,8 @@ foobar_ptr :: Ptr.FunPtr (IO ())
 foobar_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa
 
+{-| __unique:__ @ExampleNothingget_core2_func_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_14ef55245a14f816" hs_bindgen_test_functionsfun_attributes_14ef55245a14f816 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -460,6 +496,8 @@ core2_func_ptr :: Ptr.FunPtr (IO FC.CInt)
 core2_func_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_14ef55245a14f816
 
+{-| __unique:__ @ExampleNothingget_sse3_func_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_72956748bb6eee67" hs_bindgen_test_functionsfun_attributes_72956748bb6eee67 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -475,6 +513,8 @@ sse3_func_ptr :: Ptr.FunPtr (IO FC.CInt)
 sse3_func_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_72956748bb6eee67
 
+{-| __unique:__ @ExampleNothingget_f3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2" hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2 ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -490,6 +530,8 @@ f3_ptr :: Ptr.FunPtr (IO ())
 f3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2
 
+{-| __unique:__ @ExampleNothingget_fn_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_5929da82079150d1" hs_bindgen_test_functionsfun_attributes_5929da82079150d1 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -505,6 +547,8 @@ fn_ptr :: Ptr.FunPtr (IO FC.CInt)
 fn_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_5929da82079150d1
 
+{-| __unique:__ @ExampleNothingget_y_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6" hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -520,6 +564,8 @@ y_ptr :: Ptr.FunPtr (IO FC.CInt)
 y_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6
 
+{-| __unique:__ @ExampleNothingget_x1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_11098262b345351a" hs_bindgen_test_functionsfun_attributes_11098262b345351a ::
      IO (Ptr.FunPtr (IO FC.CInt))
 
@@ -535,6 +581,8 @@ x1_ptr :: Ptr.FunPtr (IO FC.CInt)
 x1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_11098262b345351a
 
+{-| __unique:__ @ExampleNothingget_x2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_0d19f83087f278f9" hs_bindgen_test_functionsfun_attributes_0d19f83087f278f9 ::
      IO (Ptr.FunPtr (IO FC.CInt))
 

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Global.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_i_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_cdc30ae5fb72cd6e" hs_bindgen_test_functionsfun_attributes_cdc30ae5fb72cd6e ::
      IO (Ptr.Ptr FC.CInt)
 

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Safe.hs
@@ -146,6 +146,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/fun_attributes.h:16:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safe__f1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8de545512324157b" __f1 ::
      IO ()
@@ -155,6 +157,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8de5455123241
     __defined at:__ @functions\/fun_attributes.h:19:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a2f84d2570ef3892" f1 ::
      IO ()
@@ -164,6 +168,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a2f84d2570ef3
     __defined at:__ @functions\/fun_attributes.h:23:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_memalign@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cefda6b95395d829" my_memalign ::
      Size_t
@@ -175,6 +181,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cefda6b95395d
     __defined at:__ @functions\/fun_attributes.h:28:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_calloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e25f06c3ebec2536" my_calloc ::
      Size_t
@@ -186,6 +194,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e25f06c3ebec2
     __defined at:__ @functions\/fun_attributes.h:29:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_realloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_51fa664668350a00" my_realloc ::
      Ptr.Ptr Void
@@ -197,6 +207,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_51fa664668350
     __defined at:__ @functions\/fun_attributes.h:34:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_alloc1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_93a5d6b7d4e02c33" my_alloc1 ::
      Size_t
@@ -207,6 +219,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_93a5d6b7d4e02
     __defined at:__ @functions\/fun_attributes.h:35:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_alloc2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c948fd867be322fa" my_alloc2 ::
      Size_t
@@ -217,6 +231,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c948fd867be32
     __defined at:__ @functions\/fun_attributes.h:39:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_55e5eb89e54abf83" square ::
      FC.CInt
@@ -227,6 +243,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_55e5eb89e54ab
     __defined at:__ @functions\/fun_attributes.h:48:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safeold_fn_deprecated@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e9647b9c99c68776" old_fn_deprecated ::
      IO FC.CInt
@@ -236,6 +254,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e9647b9c99c68
     __defined at:__ @functions\/fun_attributes.h:64:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_dgettext@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_023f7813e909f518" my_dgettext ::
      Ptr.Ptr FC.CChar
@@ -251,6 +271,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_023f7813e909f
     __defined at:__ @functions\/fun_attributes.h:75:9@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safefdopen@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e39bbd59f1c96c14" fdopen ::
      FC.CInt
@@ -262,6 +284,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e39bbd59f1c96
     __defined at:__ @functions\/fun_attributes.h:79:65@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_1d043de05a457e90" f2 ::
      IO ()
@@ -271,6 +295,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_1d043de05a457
     __defined at:__ @functions\/fun_attributes.h:85:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4b3bfd2d72a2db5d" my_memcpy ::
      Ptr.Ptr Void
@@ -289,6 +315,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4b3bfd2d72a2d
     __defined at:__ @functions\/fun_attributes.h:102:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safefatal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_348fe595d62421cf" fatal ::
      IO ()
@@ -302,6 +330,8 @@ __C declaration:__ @hash@
 __defined at:__ @functions\/fun_attributes.h:110:5@
 
 __exported by:__ @functions\/fun_attributes.h@
+
+__unique:__ @ExampleJust Safehash@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e30754e2591f701a" hash ::
      Ptr.Ptr FC.CChar
@@ -312,6 +342,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e30754e2591f7
     __defined at:__ @functions\/fun_attributes.h:115:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safemymalloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_f6f68a022a15937a" mymalloc ::
      Size_t
@@ -324,6 +356,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_f6f68a022a159
     __defined at:__ @functions\/fun_attributes.h:119:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safefoobar@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d1bf41da7ab64db1" foobar ::
      IO ()
@@ -333,6 +367,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d1bf41da7ab64
     __defined at:__ @functions\/fun_attributes.h:126:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safecore2_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_00405e83bcb9b271" core2_func ::
      IO FC.CInt
@@ -342,6 +378,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_00405e83bcb9b
     __defined at:__ @functions\/fun_attributes.h:127:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safesse3_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_06e7d2f8bcf43684" sse3_func ::
      IO FC.CInt
@@ -351,6 +389,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_06e7d2f8bcf43
     __defined at:__ @functions\/fun_attributes.h:131:49@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safef3@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e23eff1955ebb459" f3 ::
      IO ()
@@ -360,6 +400,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e23eff1955ebb
     __defined at:__ @functions\/fun_attributes.h:136:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safefn@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ef0eea5f61ef9228" fn ::
      IO FC.CInt
@@ -369,6 +411,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ef0eea5f61ef9
     __defined at:__ @functions\/fun_attributes.h:142:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safey@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b007466f7ff1cf28" y ::
      IO FC.CInt
@@ -378,6 +422,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b007466f7ff1c
     __defined at:__ @functions\/fun_attributes.h:145:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safex1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8c9825e1b20a7ea1" x1 ::
      IO FC.CInt
@@ -387,6 +433,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8c9825e1b20a7
     __defined at:__ @functions\/fun_attributes.h:148:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Safex2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c80d61b7727dab77" x2 ::
      IO FC.CInt

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Unsafe.hs
@@ -146,6 +146,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/fun_attributes.h:16:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafe__f1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b44da51a357ae983" __f1 ::
      IO ()
@@ -155,6 +157,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b44da51a357
     __defined at:__ @functions\/fun_attributes.h:19:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_c1788128a5b1c813" f1 ::
      IO ()
@@ -164,6 +168,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_c1788128a5b
     __defined at:__ @functions\/fun_attributes.h:23:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memalign@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_9ca07f6722bd48dc" my_memalign ::
      Size_t
@@ -175,6 +181,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_9ca07f6722b
     __defined at:__ @functions\/fun_attributes.h:28:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_calloc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_72df124450cc6d26" my_calloc ::
      Size_t
@@ -186,6 +194,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_72df124450c
     __defined at:__ @functions\/fun_attributes.h:29:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_realloc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_effc1fd567613950" my_realloc ::
      Ptr.Ptr Void
@@ -197,6 +207,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_effc1fd5676
     __defined at:__ @functions\/fun_attributes.h:34:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b3544e53af074ef1" my_alloc1 ::
      Size_t
@@ -207,6 +219,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b3544e53af0
     __defined at:__ @functions\/fun_attributes.h:35:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_0b659f90fec40284" my_alloc2 ::
      Size_t
@@ -217,6 +231,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_0b659f90fec
     __defined at:__ @functions\/fun_attributes.h:39:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_cb3c687f16289bb3" square ::
      FC.CInt
@@ -227,6 +243,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_cb3c687f162
     __defined at:__ @functions\/fun_attributes.h:48:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafeold_fn_deprecated@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_c48f18f4f06068eb" old_fn_deprecated ::
      IO FC.CInt
@@ -236,6 +254,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_c48f18f4f06
     __defined at:__ @functions\/fun_attributes.h:64:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_dgettext@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_d492bd76e82890da" my_dgettext ::
      Ptr.Ptr FC.CChar
@@ -251,6 +271,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_d492bd76e82
     __defined at:__ @functions\/fun_attributes.h:75:9@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefdopen@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_3c91a267bd66cc10" fdopen ::
      FC.CInt
@@ -262,6 +284,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_3c91a267bd6
     __defined at:__ @functions\/fun_attributes.h:79:65@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_14361e995fb5684a" f2 ::
      IO ()
@@ -271,6 +295,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_14361e995fb
     __defined at:__ @functions\/fun_attributes.h:85:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_e8c4a96cefd6117e" my_memcpy ::
      Ptr.Ptr Void
@@ -289,6 +315,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_e8c4a96cefd
     __defined at:__ @functions\/fun_attributes.h:102:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefatal@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_64aa41e835dbb892" fatal ::
      IO ()
@@ -302,6 +330,8 @@ __C declaration:__ @hash@
 __defined at:__ @functions\/fun_attributes.h:110:5@
 
 __exported by:__ @functions\/fun_attributes.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_88887d4b5f42f079" hash ::
      Ptr.Ptr FC.CChar
@@ -312,6 +342,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_88887d4b5f4
     __defined at:__ @functions\/fun_attributes.h:115:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemymalloc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_31e6e14ecb251fa2" mymalloc ::
      Size_t
@@ -324,6 +356,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_31e6e14ecb2
     __defined at:__ @functions\/fun_attributes.h:119:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefoobar@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_bb77a71513994934" foobar ::
      IO ()
@@ -333,6 +367,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_bb77a715139
     __defined at:__ @functions\/fun_attributes.h:126:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafecore2_func@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_640ec5b51b0819d1" core2_func ::
      IO FC.CInt
@@ -342,6 +378,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_640ec5b51b0
     __defined at:__ @functions\/fun_attributes.h:127:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesse3_func@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_a1f7636643d63586" sse3_func ::
      IO FC.CInt
@@ -351,6 +389,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_a1f7636643d
     __defined at:__ @functions\/fun_attributes.h:131:49@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_2bef032cbe15ffd0" f3 ::
      IO ()
@@ -360,6 +400,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_2bef032cbe1
     __defined at:__ @functions\/fun_attributes.h:136:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefn@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_8f406104a21ff66e" fn ::
      IO FC.CInt
@@ -369,6 +411,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_8f406104a21
     __defined at:__ @functions\/fun_attributes.h:142:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafey@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_4beb0cbf65b462bd" y ::
      IO FC.CInt
@@ -378,6 +422,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_4beb0cbf65b
     __defined at:__ @functions\/fun_attributes.h:145:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_ac7386c785058f4d" x1 ::
      IO FC.CInt
@@ -387,6 +433,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_ac7386c7850
     __defined at:__ @functions\/fun_attributes.h:148:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_b6f428ed915f03cc" x2 ::
      IO FC.CInt

--- a/hs-bindgen/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes/th.txt
@@ -489,6 +489,8 @@ instance HasCField Size_t "un_Size_t"
     __defined at:__ @functions\/fun_attributes.h:16:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafe__f1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8de545512324157b" __f1 :: IO Unit
 {-| __C declaration:__ @f1@
@@ -496,6 +498,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8de5455123241
     __defined at:__ @functions\/fun_attributes.h:19:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a2f84d2570ef3892" f1 :: IO Unit
 {-| __C declaration:__ @my_memalign@
@@ -503,6 +507,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a2f84d2570ef3
     __defined at:__ @functions\/fun_attributes.h:23:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memalign@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cefda6b95395d829" my_memalign :: Size_t ->
                                                                                                     Size_t ->
@@ -512,6 +518,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cefda6b95395d
     __defined at:__ @functions\/fun_attributes.h:28:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_calloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e25f06c3ebec2536" my_calloc :: Size_t ->
                                                                                                   Size_t ->
@@ -521,6 +529,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e25f06c3ebec2
     __defined at:__ @functions\/fun_attributes.h:29:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_realloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_51fa664668350a00" my_realloc :: Ptr Void ->
                                                                                                    Size_t ->
@@ -530,6 +540,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_51fa664668350
     __defined at:__ @functions\/fun_attributes.h:34:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_93a5d6b7d4e02c33" my_alloc1 :: Size_t ->
                                                                                                   IO (Ptr Void)
@@ -538,6 +550,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_93a5d6b7d4e02
     __defined at:__ @functions\/fun_attributes.h:35:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c948fd867be322fa" my_alloc2 :: Size_t ->
                                                                                                   IO (Ptr Void)
@@ -546,6 +560,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c948fd867be32
     __defined at:__ @functions\/fun_attributes.h:39:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_55e5eb89e54abf83" square :: CInt ->
                                                                                                CInt
@@ -554,6 +570,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_55e5eb89e54ab
     __defined at:__ @functions\/fun_attributes.h:48:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafeold_fn_deprecated@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e9647b9c99c68776" old_fn_deprecated :: IO CInt
 {-| __C declaration:__ @my_dgettext@
@@ -561,6 +579,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e9647b9c99c68
     __defined at:__ @functions\/fun_attributes.h:64:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_dgettext@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_023f7813e909f518" my_dgettext :: Ptr CChar ->
                                                                                                     Ptr CChar ->
@@ -570,6 +590,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_023f7813e909f
     __defined at:__ @functions\/fun_attributes.h:75:9@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefdopen@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e39bbd59f1c96c14" fdopen :: CInt ->
                                                                                                Ptr CChar ->
@@ -579,6 +601,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e39bbd59f1c96
     __defined at:__ @functions\/fun_attributes.h:79:65@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_1d043de05a457e90" f2 :: IO Unit
 {-| __C declaration:__ @my_memcpy@
@@ -586,6 +610,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_1d043de05a457
     __defined at:__ @functions\/fun_attributes.h:85:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4b3bfd2d72a2db5d" my_memcpy :: Ptr Void ->
                                                                                                   Ptr Void ->
@@ -596,6 +622,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4b3bfd2d72a2d
     __defined at:__ @functions\/fun_attributes.h:102:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefatal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_348fe595d62421cf" fatal :: IO Unit
 {-|
@@ -607,6 +635,8 @@ __C declaration:__ @hash@
 __defined at:__ @functions\/fun_attributes.h:110:5@
 
 __exported by:__ @functions\/fun_attributes.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e30754e2591f701a" hash :: Ptr CChar ->
                                                                                              IO CInt
@@ -615,6 +645,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e30754e2591f7
     __defined at:__ @functions\/fun_attributes.h:115:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemymalloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_f6f68a022a15937a" mymalloc :: Size_t ->
                                                                                                  IO (Ptr Void)
@@ -623,6 +655,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_f6f68a022a159
     __defined at:__ @functions\/fun_attributes.h:119:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefoobar@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d1bf41da7ab64db1" foobar :: IO Unit
 {-| __C declaration:__ @core2_func@
@@ -630,6 +664,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d1bf41da7ab64
     __defined at:__ @functions\/fun_attributes.h:126:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafecore2_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_00405e83bcb9b271" core2_func :: IO CInt
 {-| __C declaration:__ @sse3_func@
@@ -637,6 +673,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_00405e83bcb9b
     __defined at:__ @functions\/fun_attributes.h:127:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesse3_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_06e7d2f8bcf43684" sse3_func :: IO CInt
 {-| __C declaration:__ @f3@
@@ -644,6 +682,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_06e7d2f8bcf43
     __defined at:__ @functions\/fun_attributes.h:131:49@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e23eff1955ebb459" f3 :: IO Unit
 {-| __C declaration:__ @fn@
@@ -651,6 +691,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e23eff1955ebb
     __defined at:__ @functions\/fun_attributes.h:136:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefn@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ef0eea5f61ef9228" fn :: IO CInt
 {-| __C declaration:__ @y@
@@ -658,6 +700,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ef0eea5f61ef9
     __defined at:__ @functions\/fun_attributes.h:142:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafey@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b007466f7ff1cf28" y :: IO CInt
 {-| __C declaration:__ @x1@
@@ -665,6 +709,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b007466f7ff1c
     __defined at:__ @functions\/fun_attributes.h:145:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8c9825e1b20a7ea1" x1 :: IO CInt
 {-| __C declaration:__ @x2@
@@ -672,6 +718,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8c9825e1b20a7
     __defined at:__ @functions\/fun_attributes.h:148:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c80d61b7727dab77" x2 :: IO CInt
 {-| __C declaration:__ @__f1@
@@ -679,6 +727,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c80d61b7727da
     __defined at:__ @functions\/fun_attributes.h:16:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafe__f1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b44da51a357ae983" __f1 :: IO Unit
 {-| __C declaration:__ @f1@
@@ -686,6 +736,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b44da51a357ae
     __defined at:__ @functions\/fun_attributes.h:19:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c1788128a5b1c813" f1 :: IO Unit
 {-| __C declaration:__ @my_memalign@
@@ -693,6 +745,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c1788128a5b1c
     __defined at:__ @functions\/fun_attributes.h:23:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memalign@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_9ca07f6722bd48dc" my_memalign :: Size_t ->
                                                                                                     Size_t ->
@@ -702,6 +756,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_9ca07f6722bd4
     __defined at:__ @functions\/fun_attributes.h:28:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_calloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_72df124450cc6d26" my_calloc :: Size_t ->
                                                                                                   Size_t ->
@@ -711,6 +767,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_72df124450cc6
     __defined at:__ @functions\/fun_attributes.h:29:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_realloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_effc1fd567613950" my_realloc :: Ptr Void ->
                                                                                                    Size_t ->
@@ -720,6 +778,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_effc1fd567613
     __defined at:__ @functions\/fun_attributes.h:34:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b3544e53af074ef1" my_alloc1 :: Size_t ->
                                                                                                   IO (Ptr Void)
@@ -728,6 +788,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b3544e53af074
     __defined at:__ @functions\/fun_attributes.h:35:7@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_alloc2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_0b659f90fec40284" my_alloc2 :: Size_t ->
                                                                                                   IO (Ptr Void)
@@ -736,6 +798,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_0b659f90fec40
     __defined at:__ @functions\/fun_attributes.h:39:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cb3c687f16289bb3" square :: CInt ->
                                                                                                CInt
@@ -744,6 +808,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cb3c687f16289
     __defined at:__ @functions\/fun_attributes.h:48:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafeold_fn_deprecated@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c48f18f4f06068eb" old_fn_deprecated :: IO CInt
 {-| __C declaration:__ @my_dgettext@
@@ -751,6 +817,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c48f18f4f0606
     __defined at:__ @functions\/fun_attributes.h:64:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_dgettext@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d492bd76e82890da" my_dgettext :: Ptr CChar ->
                                                                                                     Ptr CChar ->
@@ -760,6 +828,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_d492bd76e8289
     __defined at:__ @functions\/fun_attributes.h:75:9@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefdopen@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_3c91a267bd66cc10" fdopen :: CInt ->
                                                                                                Ptr CChar ->
@@ -769,6 +839,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_3c91a267bd66c
     __defined at:__ @functions\/fun_attributes.h:79:65@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_14361e995fb5684a" f2 :: IO Unit
 {-| __C declaration:__ @my_memcpy@
@@ -776,6 +848,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_14361e995fb56
     __defined at:__ @functions\/fun_attributes.h:85:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemy_memcpy@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e8c4a96cefd6117e" my_memcpy :: Ptr Void ->
                                                                                                   Ptr Void ->
@@ -786,6 +860,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e8c4a96cefd61
     __defined at:__ @functions\/fun_attributes.h:102:6@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefatal@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_64aa41e835dbb892" fatal :: IO Unit
 {-|
@@ -797,6 +873,8 @@ __C declaration:__ @hash@
 __defined at:__ @functions\/fun_attributes.h:110:5@
 
 __exported by:__ @functions\/fun_attributes.h@
+
+__unique:__ @ExampleJust Unsafehash@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_88887d4b5f42f079" hash :: Ptr CChar ->
                                                                                              IO CInt
@@ -805,6 +883,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_88887d4b5f42f
     __defined at:__ @functions\/fun_attributes.h:115:1@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafemymalloc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_31e6e14ecb251fa2" mymalloc :: Size_t ->
                                                                                                  IO (Ptr Void)
@@ -813,6 +893,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_31e6e14ecb251
     __defined at:__ @functions\/fun_attributes.h:119:13@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefoobar@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_bb77a71513994934" foobar :: IO Unit
 {-| __C declaration:__ @core2_func@
@@ -820,6 +902,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_bb77a71513994
     __defined at:__ @functions\/fun_attributes.h:126:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafecore2_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_640ec5b51b0819d1" core2_func :: IO CInt
 {-| __C declaration:__ @sse3_func@
@@ -827,6 +911,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_640ec5b51b081
     __defined at:__ @functions\/fun_attributes.h:127:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafesse3_func@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a1f7636643d63586" sse3_func :: IO CInt
 {-| __C declaration:__ @f3@
@@ -834,6 +920,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a1f7636643d63
     __defined at:__ @functions\/fun_attributes.h:131:49@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafef3@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_2bef032cbe15ffd0" f3 :: IO Unit
 {-| __C declaration:__ @fn@
@@ -841,6 +929,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_2bef032cbe15f
     __defined at:__ @functions\/fun_attributes.h:136:5@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafefn@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8f406104a21ff66e" fn :: IO CInt
 {-| __C declaration:__ @y@
@@ -848,6 +938,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_8f406104a21ff
     __defined at:__ @functions\/fun_attributes.h:142:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafey@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4beb0cbf65b462bd" y :: IO CInt
 {-| __C declaration:__ @x1@
@@ -855,6 +947,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4beb0cbf65b46
     __defined at:__ @functions\/fun_attributes.h:145:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex1@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ac7386c785058f4d" x1 :: IO CInt
 {-| __C declaration:__ @x2@
@@ -862,8 +956,12 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ac7386c785058
     __defined at:__ @functions\/fun_attributes.h:148:12@
 
     __exported by:__ @functions\/fun_attributes.h@
+
+    __unique:__ @ExampleJust Unsafex2@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b6f428ed915f03cc" x2 :: IO CInt
+{-| __unique:__ @ExampleNothingget___f1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_7003b306f73c174b" hs_bindgen_test_functionsfun_attributes_7003b306f73c174b :: IO (FunPtr (IO Unit))
 {-# NOINLINE __f1_ptr #-}
 {-| __C declaration:__ @__f1@
@@ -880,6 +978,8 @@ __f1_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 __f1_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_7003b306f73c174b
+{-| __unique:__ @ExampleNothingget_f1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1" hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f1_ptr #-}
 {-| __C declaration:__ @f1@
@@ -896,6 +996,8 @@ f1_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 f1_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_5469bdc0395f86c1
+{-| __unique:__ @ExampleNothingget_my_memalign_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_b3c956e53724162c" hs_bindgen_test_functionsfun_attributes_b3c956e53724162c :: IO (FunPtr (Size_t ->
                                                                                                                                                              Size_t ->
                                                                                                                                                              IO (Ptr Void)))
@@ -914,6 +1016,8 @@ my_memalign_ptr :: FunPtr (Size_t -> Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_memalign_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_b3c956e53724162c
+{-| __unique:__ @ExampleNothingget_my_calloc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_733646ca96f39979" hs_bindgen_test_functionsfun_attributes_733646ca96f39979 :: IO (FunPtr (Size_t ->
                                                                                                                                                              Size_t ->
                                                                                                                                                              IO (Ptr Void)))
@@ -932,6 +1036,8 @@ my_calloc_ptr :: FunPtr (Size_t -> Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_calloc_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_733646ca96f39979
+{-| __unique:__ @ExampleNothingget_my_realloc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_94e8271f186110fd" hs_bindgen_test_functionsfun_attributes_94e8271f186110fd :: IO (FunPtr (Ptr Void ->
                                                                                                                                                              Size_t ->
                                                                                                                                                              IO (Ptr Void)))
@@ -950,6 +1056,8 @@ my_realloc_ptr :: FunPtr (Ptr Void -> Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_realloc_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_94e8271f186110fd
+{-| __unique:__ @ExampleNothingget_my_alloc1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70" hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70 :: IO (FunPtr (Size_t ->
                                                                                                                                                              IO (Ptr Void)))
 {-# NOINLINE my_alloc1_ptr #-}
@@ -967,6 +1075,8 @@ my_alloc1_ptr :: FunPtr (Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_alloc1_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_48d9862d70f58e70
+{-| __unique:__ @ExampleNothingget_my_alloc2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357" hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357 :: IO (FunPtr (Size_t ->
                                                                                                                                                              IO (Ptr Void)))
 {-# NOINLINE my_alloc2_ptr #-}
@@ -984,6 +1094,8 @@ my_alloc2_ptr :: FunPtr (Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_alloc2_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_17a11fd10dc57357
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9" hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9 :: IO (FunPtr (CInt ->
                                                                                                                                                              IO CInt))
 {-# NOINLINE square_ptr #-}
@@ -1001,6 +1113,8 @@ square_ptr :: FunPtr (CInt -> IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 square_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_c41111f40a04cdc9
+{-| __unique:__ @ExampleNothingget_old_fn_deprecated_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20" hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20 :: IO (FunPtr (IO CInt))
 {-# NOINLINE old_fn_deprecated_ptr #-}
 {-| __C declaration:__ @old_fn_deprecated@
@@ -1017,6 +1131,8 @@ old_fn_deprecated_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 old_fn_deprecated_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_17f68fdc3f464b20
+{-| __unique:__ @ExampleNothingget_my_dgettext_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_a0be4f488601c252" hs_bindgen_test_functionsfun_attributes_a0be4f488601c252 :: IO (FunPtr (Ptr CChar ->
                                                                                                                                                              Ptr CChar ->
                                                                                                                                                              IO (Ptr CChar)))
@@ -1036,6 +1152,8 @@ my_dgettext_ptr :: FunPtr (Ptr CChar ->
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_dgettext_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_a0be4f488601c252
+{-| __unique:__ @ExampleNothingget_fdopen_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326" hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326 :: IO (FunPtr (CInt ->
                                                                                                                                                              Ptr CChar ->
                                                                                                                                                              IO (Ptr FILE)))
@@ -1054,6 +1172,8 @@ fdopen_ptr :: FunPtr (CInt -> Ptr CChar -> IO (Ptr FILE))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 fdopen_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_2b987c3b5c01a326
+{-| __unique:__ @ExampleNothingget_f2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69" hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f2_ptr #-}
 {-| __C declaration:__ @f2@
@@ -1070,6 +1190,8 @@ f2_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 f2_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_490ca7e8c8282a69
+{-| __unique:__ @ExampleNothingget_my_memcpy_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8" hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8 :: IO (FunPtr (Ptr Void ->
                                                                                                                                                              Ptr Void ->
                                                                                                                                                              Size_t ->
@@ -1090,6 +1212,8 @@ my_memcpy_ptr :: FunPtr (Ptr Void ->
     __exported by:__ @functions\/fun_attributes.h@
 -}
 my_memcpy_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_e2e8b5d5ac435de8
+{-| __unique:__ @ExampleNothingget_fatal_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5" hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5 :: IO (FunPtr (IO Unit))
 {-# NOINLINE fatal_ptr #-}
 {-| __C declaration:__ @fatal@
@@ -1106,6 +1230,8 @@ fatal_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 fatal_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_ea0bb781f9eca7f5
+{-| __unique:__ @ExampleNothingget_hash_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01" hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01 :: IO (FunPtr (Ptr CChar ->
                                                                                                                                                              IO CInt))
 {-# NOINLINE hash_ptr #-}
@@ -1123,6 +1249,8 @@ hash_ptr :: FunPtr (Ptr CChar -> IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 hash_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_4de9606eb9c5dd01
+{-| __unique:__ @ExampleNothingget_mymalloc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_4ce141c884649d49" hs_bindgen_test_functionsfun_attributes_4ce141c884649d49 :: IO (FunPtr (Size_t ->
                                                                                                                                                              IO (Ptr Void)))
 {-# NOINLINE mymalloc_ptr #-}
@@ -1140,6 +1268,8 @@ mymalloc_ptr :: FunPtr (Size_t -> IO (Ptr Void))
     __exported by:__ @functions\/fun_attributes.h@
 -}
 mymalloc_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_4ce141c884649d49
+{-| __unique:__ @ExampleNothingget_foobar_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa" hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa :: IO (FunPtr (IO Unit))
 {-# NOINLINE foobar_ptr #-}
 {-| __C declaration:__ @foobar@
@@ -1156,6 +1286,8 @@ foobar_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 foobar_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_5c243ced544ab0aa
+{-| __unique:__ @ExampleNothingget_core2_func_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_14ef55245a14f816" hs_bindgen_test_functionsfun_attributes_14ef55245a14f816 :: IO (FunPtr (IO CInt))
 {-# NOINLINE core2_func_ptr #-}
 {-| __C declaration:__ @core2_func@
@@ -1172,6 +1304,8 @@ core2_func_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 core2_func_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_14ef55245a14f816
+{-| __unique:__ @ExampleNothingget_sse3_func_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_72956748bb6eee67" hs_bindgen_test_functionsfun_attributes_72956748bb6eee67 :: IO (FunPtr (IO CInt))
 {-# NOINLINE sse3_func_ptr #-}
 {-| __C declaration:__ @sse3_func@
@@ -1188,6 +1322,8 @@ sse3_func_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 sse3_func_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_72956748bb6eee67
+{-| __unique:__ @ExampleNothingget_f3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2" hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2 :: IO (FunPtr (IO Unit))
 {-# NOINLINE f3_ptr #-}
 {-| __C declaration:__ @f3@
@@ -1204,6 +1340,8 @@ f3_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 f3_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_38506a9ac5626bf2
+{-| __unique:__ @ExampleNothingget_fn_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_5929da82079150d1" hs_bindgen_test_functionsfun_attributes_5929da82079150d1 :: IO (FunPtr (IO CInt))
 {-# NOINLINE fn_ptr #-}
 {-| __C declaration:__ @fn@
@@ -1220,6 +1358,8 @@ fn_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 fn_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_5929da82079150d1
+{-| __unique:__ @ExampleNothingget_y_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6" hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6 :: IO (FunPtr (IO CInt))
 {-# NOINLINE y_ptr #-}
 {-| __C declaration:__ @y@
@@ -1236,6 +1376,8 @@ y_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 y_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_7bcb4a1873e6ece6
+{-| __unique:__ @ExampleNothingget_x1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_11098262b345351a" hs_bindgen_test_functionsfun_attributes_11098262b345351a :: IO (FunPtr (IO CInt))
 {-# NOINLINE x1_ptr #-}
 {-| __C declaration:__ @x1@
@@ -1252,6 +1394,8 @@ x1_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 x1_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_11098262b345351a
+{-| __unique:__ @ExampleNothingget_x2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_0d19f83087f278f9" hs_bindgen_test_functionsfun_attributes_0d19f83087f278f9 :: IO (FunPtr (IO CInt))
 {-# NOINLINE x2_ptr #-}
 {-| __C declaration:__ @x2@
@@ -1268,6 +1412,8 @@ x2_ptr :: FunPtr (IO CInt)
     __exported by:__ @functions\/fun_attributes.h@
 -}
 x2_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_0d19f83087f278f9
+{-| __unique:__ @ExampleNothingget_i_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_cdc30ae5fb72cd6e" hs_bindgen_test_functionsfun_attributes_cdc30ae5fb72cd6e :: IO (Ptr CInt)
 {-# NOINLINE i_ptr #-}
 {-| __C declaration:__ @i@

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/FunPtr.hs
@@ -47,6 +47,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_square_cp_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8" hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -66,6 +68,8 @@ square_cp_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 square_cp_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8
 
+{-| __unique:__ @ExampleNothingget_square_pc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5" hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -81,6 +85,8 @@ square_pc_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 square_pc_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5
 
+{-| __unique:__ @ExampleNothingget_square_cc_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009" hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -96,6 +102,8 @@ square_cc_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 square_cc_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009
 
+{-| __unique:__ @ExampleNothingget_square_pp_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_dca75c8c02c209b2" hs_bindgen_test_functionsfun_attributes_confl_dca75c8c02c209b2 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Safe.hs
@@ -46,6 +46,8 @@ __C declaration:__ @square_cp@
 __defined at:__ @functions\/fun_attributes_conflict.h:9:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Safesquare_cp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_5f961556d5c4089a" square_cp ::
      FC.CInt
@@ -58,6 +60,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_5f96155
     __defined at:__ @functions\/fun_attributes_conflict.h:11:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Safesquare_pc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_7dbcbb58ce184f13" square_pc ::
      FC.CInt
@@ -70,6 +74,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_7dbcbb5
     __defined at:__ @functions\/fun_attributes_conflict.h:13:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Safesquare_cc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_79823cdb6d9c52ff" square_cc ::
      FC.CInt
@@ -86,6 +92,8 @@ __C declaration:__ @square_pp@
 __defined at:__ @functions\/fun_attributes_conflict.h:15:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Safesquare_pp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_3dd09f52296e7452" square_pp ::
      FC.CInt

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Unsafe.hs
@@ -46,6 +46,8 @@ __C declaration:__ @square_cp@
 __defined at:__ @functions\/fun_attributes_conflict.h:9:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_cp@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_564ce99eace0df40" square_cp ::
      FC.CInt
@@ -58,6 +60,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_564ce
     __defined at:__ @functions\/fun_attributes_conflict.h:11:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_pc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_216e7c195e335424" square_pc ::
      FC.CInt
@@ -70,6 +74,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_216e7
     __defined at:__ @functions\/fun_attributes_conflict.h:13:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_cc@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_64cd3d5e7e4c6a2d" square_cc ::
      FC.CInt
@@ -86,6 +92,8 @@ __C declaration:__ @square_pp@
 __defined at:__ @functions\/fun_attributes_conflict.h:15:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_pp@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsfun_attributes_confl_fab086c774e84aae" square_pp ::
      FC.CInt

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/th.txt
@@ -89,6 +89,8 @@ __C declaration:__ @square_cp@
 __defined at:__ @functions\/fun_attributes_conflict.h:9:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_cp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_5f961556d5c4089a" square_cp :: CInt ->
                                                                                                         CInt
@@ -97,6 +99,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_5f96155
     __defined at:__ @functions\/fun_attributes_conflict.h:11:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_pc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_7dbcbb58ce184f13" square_pc :: CInt ->
                                                                                                         CInt
@@ -105,6 +109,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_7dbcbb5
     __defined at:__ @functions\/fun_attributes_conflict.h:13:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_cc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_79823cdb6d9c52ff" square_cc :: CInt ->
                                                                                                         CInt
@@ -117,6 +123,8 @@ __C declaration:__ @square_pp@
 __defined at:__ @functions\/fun_attributes_conflict.h:15:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_pp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_3dd09f52296e7452" square_pp :: CInt ->
                                                                                                         IO CInt
@@ -129,6 +137,8 @@ __C declaration:__ @square_cp@
 __defined at:__ @functions\/fun_attributes_conflict.h:9:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_cp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_564ce99eace0df40" square_cp :: CInt ->
                                                                                                         CInt
@@ -137,6 +147,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_564ce99
     __defined at:__ @functions\/fun_attributes_conflict.h:11:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_pc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_216e7c195e335424" square_pc :: CInt ->
                                                                                                         CInt
@@ -145,6 +157,8 @@ foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_216e7c1
     __defined at:__ @functions\/fun_attributes_conflict.h:13:5@
 
     __exported by:__ @functions\/fun_attributes_conflict.h@
+
+    __unique:__ @ExampleJust Unsafesquare_cc@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_64cd3d5e7e4c6a2d" square_cc :: CInt ->
                                                                                                         CInt
@@ -157,9 +171,13 @@ __C declaration:__ @square_pp@
 __defined at:__ @functions\/fun_attributes_conflict.h:15:5@
 
 __exported by:__ @functions\/fun_attributes_conflict.h@
+
+__unique:__ @ExampleJust Unsafesquare_pp@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_fab086c774e84aae" square_pp :: CInt ->
                                                                                                         IO CInt
+{-| __unique:__ @ExampleNothingget_square_cp_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8" hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8 :: IO (FunPtr (CInt ->
                                                                                                                                                                          IO CInt))
 {-# NOINLINE square_cp_ptr #-}
@@ -185,6 +203,8 @@ __defined at:__ @functions\/fun_attributes_conflict.h:9:5@
 __exported by:__ @functions\/fun_attributes_conflict.h@
 -}
 square_cp_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_a488b67527d299f8
+{-| __unique:__ @ExampleNothingget_square_pc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5" hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5 :: IO (FunPtr (CInt ->
                                                                                                                                                                          IO CInt))
 {-# NOINLINE square_pc_ptr #-}
@@ -202,6 +222,8 @@ square_pc_ptr :: FunPtr (CInt -> IO CInt)
     __exported by:__ @functions\/fun_attributes_conflict.h@
 -}
 square_pc_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_c4cea088a40be2f5
+{-| __unique:__ @ExampleNothingget_square_cc_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009" hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009 :: IO (FunPtr (CInt ->
                                                                                                                                                                          IO CInt))
 {-# NOINLINE square_cc_ptr #-}
@@ -219,6 +241,8 @@ square_cc_ptr :: FunPtr (CInt -> IO CInt)
     __exported by:__ @functions\/fun_attributes_conflict.h@
 -}
 square_cc_ptr = unsafePerformIO hs_bindgen_test_functionsfun_attributes_confl_3bc327fede4fc009
+{-| __unique:__ @ExampleNothingget_square_pp_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsfun_attributes_confl_dca75c8c02c209b2" hs_bindgen_test_functionsfun_attributes_confl_dca75c8c02c209b2 :: IO (FunPtr (CInt ->
                                                                                                                                                                          IO CInt))
 {-# NOINLINE square_pp_ptr #-}

--- a/hs-bindgen/fixtures/functions/simple_func/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/FunPtr.hs
@@ -54,6 +54,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_erf_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_723348151ff43970" hs_bindgen_test_functionssimple_func_723348151ff43970 ::
      IO (Ptr.FunPtr (FC.CDouble -> IO FC.CDouble))
 
@@ -69,6 +71,8 @@ erf_ptr :: Ptr.FunPtr (FC.CDouble -> IO FC.CDouble)
 erf_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionssimple_func_723348151ff43970
 
+{-| __unique:__ @ExampleNothingget_bad_fma_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_f3190cb919f94cd9" hs_bindgen_test_functionssimple_func_f3190cb919f94cd9 ::
      IO (Ptr.FunPtr (FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDouble))
 
@@ -84,6 +88,8 @@ bad_fma_ptr :: Ptr.FunPtr (FC.CDouble -> FC.CDouble -> FC.CDouble -> IO FC.CDoub
 bad_fma_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionssimple_func_f3190cb919f94cd9
 
+{-| __unique:__ @ExampleNothingget_no_args_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_fbdbb067d942094e" hs_bindgen_test_functionssimple_func_fbdbb067d942094e ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -99,6 +105,8 @@ no_args_ptr :: Ptr.FunPtr (IO ())
 no_args_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionssimple_func_fbdbb067d942094e
 
+{-| __unique:__ @ExampleNothingget_no_args_no_void_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_452280b5085b4ccd" hs_bindgen_test_functionssimple_func_452280b5085b4ccd ::
      IO (Ptr.FunPtr (IO ()))
 
@@ -114,6 +122,8 @@ no_args_no_void_ptr :: Ptr.FunPtr (IO ())
 no_args_no_void_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_functionssimple_func_452280b5085b4ccd
 
+{-| __unique:__ @ExampleNothingget_fun_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_b16b846810561073" hs_bindgen_test_functionssimple_func_b16b846810561073 ::
      IO (Ptr.FunPtr (FC.CChar -> FC.CDouble -> IO FC.CInt))
 

--- a/hs-bindgen/fixtures/functions/simple_func/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/Safe.hs
@@ -47,6 +47,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/simple_func.h:1:8@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Safeerf@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_4b858faf89c6033a" erf ::
      FC.CDouble
@@ -59,6 +61,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_4b858faf89c6033a
     __defined at:__ @functions\/simple_func.h:3:22@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Safebad_fma@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_175251e70d29cd73" bad_fma ::
      FC.CDouble
@@ -77,6 +81,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_175251e70d29cd73
     __defined at:__ @functions\/simple_func.h:7:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Safeno_args@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_bda1aaa13afe437a" no_args ::
      IO ()
@@ -86,6 +92,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_bda1aaa13afe437a
     __defined at:__ @functions\/simple_func.h:9:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Safeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_8d4283a1963012db" no_args_no_void ::
      IO ()
@@ -95,6 +103,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_8d4283a1963012db
     __defined at:__ @functions\/simple_func.h:11:5@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Safefun@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_51ad12b64aea929d" fun ::
      FC.CChar

--- a/hs-bindgen/fixtures/functions/simple_func/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/Unsafe.hs
@@ -47,6 +47,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/simple_func.h:1:8@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeerf@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_95132d8ec7fd8434" erf ::
      FC.CDouble
@@ -59,6 +61,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_95132d8ec7fd84
     __defined at:__ @functions\/simple_func.h:3:22@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafebad_fma@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_a5a0efe959abb90a" bad_fma ::
      FC.CDouble
@@ -77,6 +81,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_a5a0efe959abb9
     __defined at:__ @functions\/simple_func.h:7:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_3a78cdef137ffe84" no_args ::
      IO ()
@@ -86,6 +92,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_3a78cdef137ffe
     __defined at:__ @functions\/simple_func.h:9:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_26de47450bbc61e3" no_args_no_void ::
      IO ()
@@ -95,6 +103,8 @@ foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_26de47450bbc61
     __defined at:__ @functions\/simple_func.h:11:5@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafefun@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionssimple_func_8735e0253ab4e9ad" fun ::
      FC.CChar

--- a/hs-bindgen/fixtures/functions/simple_func/th.txt
+++ b/hs-bindgen/fixtures/functions/simple_func/th.txt
@@ -102,6 +102,8 @@
     __defined at:__ @functions\/simple_func.h:1:8@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeerf@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_4b858faf89c6033a" erf :: CDouble ->
                                                                                          CDouble
@@ -110,6 +112,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_4b858faf89c6033a
     __defined at:__ @functions\/simple_func.h:3:22@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafebad_fma@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_175251e70d29cd73" bad_fma :: CDouble ->
                                                                                              CDouble ->
@@ -120,6 +124,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_175251e70d29cd73
     __defined at:__ @functions\/simple_func.h:7:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_bda1aaa13afe437a" no_args :: IO Unit
 {-| __C declaration:__ @no_args_no_void@
@@ -127,6 +133,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_bda1aaa13afe437a
     __defined at:__ @functions\/simple_func.h:9:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_8d4283a1963012db" no_args_no_void :: IO Unit
 {-| __C declaration:__ @fun@
@@ -134,6 +142,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_8d4283a1963012db
     __defined at:__ @functions\/simple_func.h:11:5@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafefun@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_51ad12b64aea929d" fun :: CChar ->
                                                                                          CDouble ->
@@ -143,6 +153,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_51ad12b64aea929d
     __defined at:__ @functions\/simple_func.h:1:8@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeerf@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_95132d8ec7fd8434" erf :: CDouble ->
                                                                                          CDouble
@@ -151,6 +163,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_95132d8ec7fd8434
     __defined at:__ @functions\/simple_func.h:3:22@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafebad_fma@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_a5a0efe959abb90a" bad_fma :: CDouble ->
                                                                                              CDouble ->
@@ -161,6 +175,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_a5a0efe959abb90a
     __defined at:__ @functions\/simple_func.h:7:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_3a78cdef137ffe84" no_args :: IO Unit
 {-| __C declaration:__ @no_args_no_void@
@@ -168,6 +184,8 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_3a78cdef137ffe84
     __defined at:__ @functions\/simple_func.h:9:6@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_26de47450bbc61e3" no_args_no_void :: IO Unit
 {-| __C declaration:__ @fun@
@@ -175,10 +193,14 @@ foreign import ccall safe "hs_bindgen_test_functionssimple_func_26de47450bbc61e3
     __defined at:__ @functions\/simple_func.h:11:5@
 
     __exported by:__ @functions\/simple_func.h@
+
+    __unique:__ @ExampleJust Unsafefun@
 -}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_8735e0253ab4e9ad" fun :: CChar ->
                                                                                          CDouble ->
                                                                                          IO CInt
+{-| __unique:__ @ExampleNothingget_erf_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_723348151ff43970" hs_bindgen_test_functionssimple_func_723348151ff43970 :: IO (FunPtr (CDouble ->
                                                                                                                                                        IO CDouble))
 {-# NOINLINE erf_ptr #-}
@@ -196,6 +218,8 @@ erf_ptr :: FunPtr (CDouble -> IO CDouble)
     __exported by:__ @functions\/simple_func.h@
 -}
 erf_ptr = unsafePerformIO hs_bindgen_test_functionssimple_func_723348151ff43970
+{-| __unique:__ @ExampleNothingget_bad_fma_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_f3190cb919f94cd9" hs_bindgen_test_functionssimple_func_f3190cb919f94cd9 :: IO (FunPtr (CDouble ->
                                                                                                                                                        CDouble ->
                                                                                                                                                        CDouble ->
@@ -215,6 +239,8 @@ bad_fma_ptr :: FunPtr (CDouble -> CDouble -> CDouble -> IO CDouble)
     __exported by:__ @functions\/simple_func.h@
 -}
 bad_fma_ptr = unsafePerformIO hs_bindgen_test_functionssimple_func_f3190cb919f94cd9
+{-| __unique:__ @ExampleNothingget_no_args_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_fbdbb067d942094e" hs_bindgen_test_functionssimple_func_fbdbb067d942094e :: IO (FunPtr (IO Unit))
 {-# NOINLINE no_args_ptr #-}
 {-| __C declaration:__ @no_args@
@@ -231,6 +257,8 @@ no_args_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/simple_func.h@
 -}
 no_args_ptr = unsafePerformIO hs_bindgen_test_functionssimple_func_fbdbb067d942094e
+{-| __unique:__ @ExampleNothingget_no_args_no_void_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_452280b5085b4ccd" hs_bindgen_test_functionssimple_func_452280b5085b4ccd :: IO (FunPtr (IO Unit))
 {-# NOINLINE no_args_no_void_ptr #-}
 {-| __C declaration:__ @no_args_no_void@
@@ -247,6 +275,8 @@ no_args_no_void_ptr :: FunPtr (IO Unit)
     __exported by:__ @functions\/simple_func.h@
 -}
 no_args_no_void_ptr = unsafePerformIO hs_bindgen_test_functionssimple_func_452280b5085b4ccd
+{-| __unique:__ @ExampleNothingget_fun_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionssimple_func_b16b846810561073" hs_bindgen_test_functionssimple_func_b16b846810561073 :: IO (FunPtr (CChar ->
                                                                                                                                                        CDouble ->
                                                                                                                                                        IO CInt))

--- a/hs-bindgen/fixtures/functions/varargs/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/FunPtr.hs
@@ -20,6 +20,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_h_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_functionsvarargs_6344539fe0b25338" hs_bindgen_test_functionsvarargs_6344539fe0b25338 ::
      IO (Ptr.FunPtr (IO ()))
 

--- a/hs-bindgen/fixtures/functions/varargs/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/Safe.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/varargs.h:8:6@
 
     __exported by:__ @functions\/varargs.h@
+
+    __unique:__ @ExampleJust Safeh@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsvarargs_a17c4f0272bbe42a" h ::
      IO ()

--- a/hs-bindgen/fixtures/functions/varargs/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/Unsafe.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @functions\/varargs.h:8:6@
 
     __exported by:__ @functions\/varargs.h@
+
+    __unique:__ @ExampleJust Unsafeh@
 -}
 foreign import ccall unsafe "hs_bindgen_test_functionsvarargs_ec9e8ecfd27bead3" h ::
      IO ()

--- a/hs-bindgen/fixtures/functions/varargs/th.txt
+++ b/hs-bindgen/fixtures/functions/varargs/th.txt
@@ -21,6 +21,8 @@
     __defined at:__ @functions\/varargs.h:8:6@
 
     __exported by:__ @functions\/varargs.h@
+
+    __unique:__ @ExampleJust Unsafeh@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsvarargs_a17c4f0272bbe42a" h :: IO Unit
 {-| __C declaration:__ @h@
@@ -28,8 +30,12 @@ foreign import ccall safe "hs_bindgen_test_functionsvarargs_a17c4f0272bbe42a" h 
     __defined at:__ @functions\/varargs.h:8:6@
 
     __exported by:__ @functions\/varargs.h@
+
+    __unique:__ @ExampleJust Unsafeh@
 -}
 foreign import ccall safe "hs_bindgen_test_functionsvarargs_ec9e8ecfd27bead3" h :: IO Unit
+{-| __unique:__ @ExampleNothingget_h_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_functionsvarargs_6344539fe0b25338" hs_bindgen_test_functionsvarargs_6344539fe0b25338 :: IO (FunPtr (IO Unit))
 {-# NOINLINE h_ptr #-}
 {-| __C declaration:__ @h@

--- a/hs-bindgen/fixtures/globals/globals/Example/Global.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example/Global.hs
@@ -199,6 +199,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_simpleGlobal_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60" hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -216,6 +218,8 @@ simpleGlobal_ptr :: Ptr.Ptr FC.CInt
 simpleGlobal_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60
 
+{-| __unique:__ @ExampleNothingget_compoundGlobal1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_89495849c6dfe834" hs_bindgen_test_globalsglobals_89495849c6dfe834 ::
      IO (Ptr.Ptr Config)
 
@@ -231,6 +235,8 @@ compoundGlobal1_ptr :: Ptr.Ptr Config
 compoundGlobal1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_89495849c6dfe834
 
+{-| __unique:__ @ExampleNothingget_compoundGlobal2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_4b79fc96cf429b3a" hs_bindgen_test_globalsglobals_4b79fc96cf429b3a ::
      IO (Ptr.Ptr Inline_struct)
 
@@ -246,6 +252,8 @@ compoundGlobal2_ptr :: Ptr.Ptr Inline_struct
 compoundGlobal2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_4b79fc96cf429b3a
 
+{-| __unique:__ @ExampleNothingget_nesInteger_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_e408a99291c13956" hs_bindgen_test_globalsglobals_e408a99291c13956 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -269,6 +277,8 @@ nesInteger_ptr :: Ptr.Ptr FC.CInt
 nesInteger_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_e408a99291c13956
 
+{-| __unique:__ @ExampleNothingget_nesFloating_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_572819a2ae538f9e" hs_bindgen_test_globalsglobals_572819a2ae538f9e ::
      IO (Ptr.Ptr FC.CFloat)
 
@@ -284,6 +294,8 @@ nesFloating_ptr :: Ptr.Ptr FC.CFloat
 nesFloating_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_572819a2ae538f9e
 
+{-| __unique:__ @ExampleNothingget_nesString1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_b9c5b2253881699a" hs_bindgen_test_globalsglobals_b9c5b2253881699a ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CChar))
 
@@ -299,6 +311,8 @@ nesString1_ptr :: Ptr.Ptr (Ptr.Ptr FC.CChar)
 nesString1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_b9c5b2253881699a
 
+{-| __unique:__ @ExampleNothingget_nesString2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_cea7b6d95dd81460" hs_bindgen_test_globalsglobals_cea7b6d95dd81460 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CChar))
 
@@ -314,6 +328,8 @@ nesString2_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.
 nesString2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_cea7b6d95dd81460
 
+{-| __unique:__ @ExampleNothingget_nesCharacter_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a" hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a ::
      IO (Ptr.Ptr FC.CChar)
 
@@ -329,6 +345,8 @@ nesCharacter_ptr :: Ptr.Ptr FC.CChar
 nesCharacter_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a
 
+{-| __unique:__ @ExampleNothingget_nesParen_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_5e7165450285240d" hs_bindgen_test_globalsglobals_5e7165450285240d ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -344,6 +362,8 @@ nesParen_ptr :: Ptr.Ptr FC.CInt
 nesParen_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_5e7165450285240d
 
+{-| __unique:__ @ExampleNothingget_nesUnary_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_f00692845b6c8efd" hs_bindgen_test_globalsglobals_f00692845b6c8efd ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -359,6 +379,8 @@ nesUnary_ptr :: Ptr.Ptr FC.CInt
 nesUnary_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_f00692845b6c8efd
 
+{-| __unique:__ @ExampleNothingget_nesBinary_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_d737cdc355737c2b" hs_bindgen_test_globalsglobals_d737cdc355737c2b ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -374,6 +396,8 @@ nesBinary_ptr :: Ptr.Ptr FC.CInt
 nesBinary_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_d737cdc355737c2b
 
+{-| __unique:__ @ExampleNothingget_nesConditional_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d" hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -389,6 +413,8 @@ nesConditional_ptr :: Ptr.Ptr FC.CInt
 nesConditional_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d
 
+{-| __unique:__ @ExampleNothingget_nesCast_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_ea6b1f97253ae23c" hs_bindgen_test_globalsglobals_ea6b1f97253ae23c ::
      IO (Ptr.Ptr FC.CFloat)
 
@@ -404,6 +430,8 @@ nesCast_ptr :: Ptr.Ptr FC.CFloat
 nesCast_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_ea6b1f97253ae23c
 
+{-| __unique:__ @ExampleNothingget_nesCompound_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_34ed05675f69bccd" hs_bindgen_test_globalsglobals_34ed05675f69bccd ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 
@@ -419,6 +447,8 @@ nesCompound_ptr :: Ptr.Ptr (Ptr.Ptr FC.CInt)
 nesCompound_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_34ed05675f69bccd
 
+{-| __unique:__ @ExampleNothingget_nesInitList_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_9e7c70b133f8e175" hs_bindgen_test_globalsglobals_9e7c70b133f8e175 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.Prelude.Word8))
 
@@ -434,6 +464,8 @@ nesInitList_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) Hs
 nesInitList_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_9e7c70b133f8e175
 
+{-| __unique:__ @ExampleNothingget_nesBool_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_bd8b34eff62c9b12" hs_bindgen_test_globalsglobals_bd8b34eff62c9b12 ::
      IO (Ptr.Ptr FC.CBool)
 
@@ -449,6 +481,8 @@ nesBool_ptr :: Ptr.Ptr FC.CBool
 nesBool_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_bd8b34eff62c9b12
 
+{-| __unique:__ @ExampleNothingget_streamBinary_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_235c0c54701b0df5" hs_bindgen_test_globalsglobals_235c0c54701b0df5 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4096) HsBindgen.Runtime.Prelude.Word8))
 
@@ -470,6 +504,8 @@ streamBinary_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4096
 streamBinary_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_235c0c54701b0df5
 
+{-| __unique:__ @ExampleNothingget_streamBinary_len_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_b1ee511251d335dd" hs_bindgen_test_globalsglobals_b1ee511251d335dd ::
      IO (Ptr.Ptr HsBindgen.Runtime.Prelude.Word32)
 
@@ -485,6 +521,8 @@ streamBinary_len_ptr :: Ptr.Ptr HsBindgen.Runtime.Prelude.Word32
 streamBinary_len_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_b1ee511251d335dd
 
+{-| __unique:__ @ExampleNothingget_some_global_struct_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_6a47eaca372272ae" hs_bindgen_test_globalsglobals_6a47eaca372272ae ::
      IO (Ptr.Ptr Struct2_t)
 
@@ -500,6 +538,8 @@ some_global_struct_ptr :: Ptr.Ptr Struct2_t
 some_global_struct_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_6a47eaca372272ae
 
+{-| __unique:__ @ExampleNothingget_globalConstant_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_b8fe2f6ed308e786" hs_bindgen_test_globalsglobals_b8fe2f6ed308e786 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -525,6 +565,8 @@ globalConstant :: FC.CInt
 globalConstant =
   GHC.IO.Unsafe.unsafePerformIO (F.peek globalConstant_ptr)
 
+{-| __unique:__ @ExampleNothingget_anotherGlobalConstant_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_3f4a524bb162b165" hs_bindgen_test_globalsglobals_3f4a524bb162b165 ::
      IO (Ptr.Ptr ConstInt)
 
@@ -546,6 +588,8 @@ anotherGlobalConstant :: ConstInt
 anotherGlobalConstant =
   GHC.IO.Unsafe.unsafePerformIO (F.peek anotherGlobalConstant_ptr)
 
+{-| __unique:__ @ExampleNothingget_staticConst_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_834271d76b418960" hs_bindgen_test_globalsglobals_834271d76b418960 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -571,6 +615,8 @@ staticConst :: FC.CInt
 staticConst =
   GHC.IO.Unsafe.unsafePerformIO (F.peek staticConst_ptr)
 
+{-| __unique:__ @ExampleNothingget_classless_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_c98b4d346a0bb607" hs_bindgen_test_globalsglobals_c98b4d346a0bb607 ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -594,6 +640,8 @@ classless :: FC.CInt
 classless =
   GHC.IO.Unsafe.unsafePerformIO (F.peek classless_ptr)
 
+{-| __unique:__ @ExampleNothingget_constArray1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_e7a61097e2415261" hs_bindgen_test_globalsglobals_e7a61097e2415261 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) FC.CInt))
 
@@ -617,6 +665,8 @@ constArray1 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) FC.CInt
 constArray1 =
   GHC.IO.Unsafe.unsafePerformIO (F.peek constArray1_ptr)
 
+{-| __unique:__ @ExampleNothingget_constArray2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_5e76637230135838" hs_bindgen_test_globalsglobals_5e76637230135838 ::
      IO (Ptr.Ptr ConstIntArray)
 
@@ -632,6 +682,8 @@ constArray2_ptr :: Ptr.Ptr ConstIntArray
 constArray2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_5e76637230135838
 
+{-| __unique:__ @ExampleNothingget_constTuple_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_c7d3a2347092dfe0" hs_bindgen_test_globalsglobals_c7d3a2347092dfe0 ::
      IO (Ptr.Ptr Tuple)
 
@@ -655,6 +707,8 @@ constTuple :: Tuple
 constTuple =
   GHC.IO.Unsafe.unsafePerformIO (F.peek constTuple_ptr)
 
+{-| __unique:__ @ExampleNothingget_nonConstTuple_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_3639a5c5b63aad84" hs_bindgen_test_globalsglobals_3639a5c5b63aad84 ::
      IO (Ptr.Ptr Tuple)
 
@@ -672,6 +726,8 @@ nonConstTuple_ptr :: Ptr.Ptr Tuple
 nonConstTuple_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_3639a5c5b63aad84
 
+{-| __unique:__ @ExampleNothingget_ptrToConstInt_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4" hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4 ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 
@@ -689,6 +745,8 @@ ptrToConstInt_ptr :: Ptr.Ptr (Ptr.Ptr FC.CInt)
 ptrToConstInt_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4
 
+{-| __unique:__ @ExampleNothingget_constPtrToInt_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_10cf1344894b0264" hs_bindgen_test_globalsglobals_10cf1344894b0264 ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 
@@ -712,6 +770,8 @@ constPtrToInt :: Ptr.Ptr FC.CInt
 constPtrToInt =
   GHC.IO.Unsafe.unsafePerformIO (F.peek constPtrToInt_ptr)
 
+{-| __unique:__ @ExampleNothingget_constPtrToConstInt_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_globalsglobals_1b236183822e0d24" hs_bindgen_test_globalsglobals_1b236183822e0d24 ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -532,6 +532,8 @@ instance HasCField Tuple "tuple_y"
 instance TyEq ty (CFieldType Tuple "tuple_y") =>
          HasField "tuple_y" (Ptr Tuple) (Ptr ty)
     where getField = ptrToCField (Proxy @"tuple_y")
+{-| __unique:__ @ExampleNothingget_simpleGlobal_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60" hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60 :: IO (Ptr CInt)
 {-# NOINLINE simpleGlobal_ptr #-}
 {-| Global variables
@@ -552,6 +554,8 @@ __defined at:__ @globals\/globals.h:9:12@
 __exported by:__ @globals\/globals.h@
 -}
 simpleGlobal_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_454b1c1a1b7d5b60
+{-| __unique:__ @ExampleNothingget_compoundGlobal1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_89495849c6dfe834" hs_bindgen_test_globalsglobals_89495849c6dfe834 :: IO (Ptr Config)
 {-# NOINLINE compoundGlobal1_ptr #-}
 {-| __C declaration:__ @compoundGlobal1@
@@ -568,6 +572,8 @@ compoundGlobal1_ptr :: Ptr Config
     __exported by:__ @globals\/globals.h@
 -}
 compoundGlobal1_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_89495849c6dfe834
+{-| __unique:__ @ExampleNothingget_compoundGlobal2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_4b79fc96cf429b3a" hs_bindgen_test_globalsglobals_4b79fc96cf429b3a :: IO (Ptr Inline_struct)
 {-# NOINLINE compoundGlobal2_ptr #-}
 {-| __C declaration:__ @compoundGlobal2@
@@ -584,6 +590,8 @@ compoundGlobal2_ptr :: Ptr Inline_struct
     __exported by:__ @globals\/globals.h@
 -}
 compoundGlobal2_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_4b79fc96cf429b3a
+{-| __unique:__ @ExampleNothingget_nesInteger_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_e408a99291c13956" hs_bindgen_test_globalsglobals_e408a99291c13956 :: IO (Ptr CInt)
 {-# NOINLINE nesInteger_ptr #-}
 {-| Non-extern non-static global variables
@@ -616,6 +624,8 @@ __defined at:__ @globals\/globals.h:35:9@
 __exported by:__ @globals\/globals.h@
 -}
 nesInteger_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_e408a99291c13956
+{-| __unique:__ @ExampleNothingget_nesFloating_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_572819a2ae538f9e" hs_bindgen_test_globalsglobals_572819a2ae538f9e :: IO (Ptr CFloat)
 {-# NOINLINE nesFloating_ptr #-}
 {-| __C declaration:__ @nesFloating@
@@ -632,6 +642,8 @@ nesFloating_ptr :: Ptr CFloat
     __exported by:__ @globals\/globals.h@
 -}
 nesFloating_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_572819a2ae538f9e
+{-| __unique:__ @ExampleNothingget_nesString1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_b9c5b2253881699a" hs_bindgen_test_globalsglobals_b9c5b2253881699a :: IO (Ptr (Ptr CChar))
 {-# NOINLINE nesString1_ptr #-}
 {-| __C declaration:__ @nesString1@
@@ -648,6 +660,8 @@ nesString1_ptr :: Ptr (Ptr CChar)
     __exported by:__ @globals\/globals.h@
 -}
 nesString1_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_b9c5b2253881699a
+{-| __unique:__ @ExampleNothingget_nesString2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_cea7b6d95dd81460" hs_bindgen_test_globalsglobals_cea7b6d95dd81460 :: IO (Ptr (ConstantArray 3
                                                                                                                                                       CChar))
 {-# NOINLINE nesString2_ptr #-}
@@ -665,6 +679,8 @@ nesString2_ptr :: Ptr (ConstantArray 3 CChar)
     __exported by:__ @globals\/globals.h@
 -}
 nesString2_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_cea7b6d95dd81460
+{-| __unique:__ @ExampleNothingget_nesCharacter_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a" hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a :: IO (Ptr CChar)
 {-# NOINLINE nesCharacter_ptr #-}
 {-| __C declaration:__ @nesCharacter@
@@ -681,6 +697,8 @@ nesCharacter_ptr :: Ptr CChar
     __exported by:__ @globals\/globals.h@
 -}
 nesCharacter_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_1e474dd7b5a92e6a
+{-| __unique:__ @ExampleNothingget_nesParen_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_5e7165450285240d" hs_bindgen_test_globalsglobals_5e7165450285240d :: IO (Ptr CInt)
 {-# NOINLINE nesParen_ptr #-}
 {-| __C declaration:__ @nesParen@
@@ -697,6 +715,8 @@ nesParen_ptr :: Ptr CInt
     __exported by:__ @globals\/globals.h@
 -}
 nesParen_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_5e7165450285240d
+{-| __unique:__ @ExampleNothingget_nesUnary_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_f00692845b6c8efd" hs_bindgen_test_globalsglobals_f00692845b6c8efd :: IO (Ptr CInt)
 {-# NOINLINE nesUnary_ptr #-}
 {-| __C declaration:__ @nesUnary@
@@ -713,6 +733,8 @@ nesUnary_ptr :: Ptr CInt
     __exported by:__ @globals\/globals.h@
 -}
 nesUnary_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_f00692845b6c8efd
+{-| __unique:__ @ExampleNothingget_nesBinary_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_d737cdc355737c2b" hs_bindgen_test_globalsglobals_d737cdc355737c2b :: IO (Ptr CInt)
 {-# NOINLINE nesBinary_ptr #-}
 {-| __C declaration:__ @nesBinary@
@@ -729,6 +751,8 @@ nesBinary_ptr :: Ptr CInt
     __exported by:__ @globals\/globals.h@
 -}
 nesBinary_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_d737cdc355737c2b
+{-| __unique:__ @ExampleNothingget_nesConditional_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d" hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d :: IO (Ptr CInt)
 {-# NOINLINE nesConditional_ptr #-}
 {-| __C declaration:__ @nesConditional@
@@ -745,6 +769,8 @@ nesConditional_ptr :: Ptr CInt
     __exported by:__ @globals\/globals.h@
 -}
 nesConditional_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_a8a7382ba67a6c7d
+{-| __unique:__ @ExampleNothingget_nesCast_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_ea6b1f97253ae23c" hs_bindgen_test_globalsglobals_ea6b1f97253ae23c :: IO (Ptr CFloat)
 {-# NOINLINE nesCast_ptr #-}
 {-| __C declaration:__ @nesCast@
@@ -761,6 +787,8 @@ nesCast_ptr :: Ptr CFloat
     __exported by:__ @globals\/globals.h@
 -}
 nesCast_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_ea6b1f97253ae23c
+{-| __unique:__ @ExampleNothingget_nesCompound_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_34ed05675f69bccd" hs_bindgen_test_globalsglobals_34ed05675f69bccd :: IO (Ptr (Ptr CInt))
 {-# NOINLINE nesCompound_ptr #-}
 {-| __C declaration:__ @nesCompound@
@@ -777,6 +805,8 @@ nesCompound_ptr :: Ptr (Ptr CInt)
     __exported by:__ @globals\/globals.h@
 -}
 nesCompound_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_34ed05675f69bccd
+{-| __unique:__ @ExampleNothingget_nesInitList_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_9e7c70b133f8e175" hs_bindgen_test_globalsglobals_9e7c70b133f8e175 :: IO (Ptr (ConstantArray 4
                                                                                                                                                       HsBindgen.Runtime.Prelude.Word8))
 {-# NOINLINE nesInitList_ptr #-}
@@ -795,6 +825,8 @@ nesInitList_ptr :: Ptr (ConstantArray 4
     __exported by:__ @globals\/globals.h@
 -}
 nesInitList_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_9e7c70b133f8e175
+{-| __unique:__ @ExampleNothingget_nesBool_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_bd8b34eff62c9b12" hs_bindgen_test_globalsglobals_bd8b34eff62c9b12 :: IO (Ptr CBool)
 {-# NOINLINE nesBool_ptr #-}
 {-| __C declaration:__ @nesBool@
@@ -811,6 +843,8 @@ nesBool_ptr :: Ptr CBool
     __exported by:__ @globals\/globals.h@
 -}
 nesBool_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_bd8b34eff62c9b12
+{-| __unique:__ @ExampleNothingget_streamBinary_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_235c0c54701b0df5" hs_bindgen_test_globalsglobals_235c0c54701b0df5 :: IO (Ptr (ConstantArray 4096
                                                                                                                                                       HsBindgen.Runtime.Prelude.Word8))
 {-# NOINLINE streamBinary_ptr #-}
@@ -841,6 +875,8 @@ __defined at:__ @globals\/globals.h:60:9@
 __exported by:__ @globals\/globals.h@
 -}
 streamBinary_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_235c0c54701b0df5
+{-| __unique:__ @ExampleNothingget_streamBinary_len_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_b1ee511251d335dd" hs_bindgen_test_globalsglobals_b1ee511251d335dd :: IO (Ptr HsBindgen.Runtime.Prelude.Word32)
 {-# NOINLINE streamBinary_len_ptr #-}
 {-| __C declaration:__ @streamBinary_len@
@@ -857,6 +893,8 @@ streamBinary_len_ptr :: Ptr HsBindgen.Runtime.Prelude.Word32
     __exported by:__ @globals\/globals.h@
 -}
 streamBinary_len_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_b1ee511251d335dd
+{-| __unique:__ @ExampleNothingget_some_global_struct_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_6a47eaca372272ae" hs_bindgen_test_globalsglobals_6a47eaca372272ae :: IO (Ptr Struct2_t)
 {-# NOINLINE some_global_struct_ptr #-}
 {-| __C declaration:__ @some_global_struct@
@@ -873,6 +911,8 @@ some_global_struct_ptr :: Ptr Struct2_t
     __exported by:__ @globals\/globals.h@
 -}
 some_global_struct_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_6a47eaca372272ae
+{-| __unique:__ @ExampleNothingget_globalConstant_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_b8fe2f6ed308e786" hs_bindgen_test_globalsglobals_b8fe2f6ed308e786 :: IO (Ptr CInt)
 {-# NOINLINE globalConstant_ptr #-}
 {-| Constant
@@ -900,6 +940,8 @@ globalConstant_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_b8fe2f6ed308
 {-# NOINLINE globalConstant #-}
 globalConstant :: CInt
 globalConstant = unsafePerformIO (peek globalConstant_ptr)
+{-| __unique:__ @ExampleNothingget_anotherGlobalConstant_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_3f4a524bb162b165" hs_bindgen_test_globalsglobals_3f4a524bb162b165 :: IO (Ptr ConstInt)
 {-# NOINLINE anotherGlobalConstant_ptr #-}
 {-| __C declaration:__ @anotherGlobalConstant@
@@ -919,6 +961,8 @@ anotherGlobalConstant_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_3f4a5
 {-# NOINLINE anotherGlobalConstant #-}
 anotherGlobalConstant :: ConstInt
 anotherGlobalConstant = unsafePerformIO (peek anotherGlobalConstant_ptr)
+{-| __unique:__ @ExampleNothingget_staticConst_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_834271d76b418960" hs_bindgen_test_globalsglobals_834271d76b418960 :: IO (Ptr CInt)
 {-# NOINLINE staticConst_ptr #-}
 {-| Constant, but local to the file
@@ -946,6 +990,8 @@ staticConst_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_834271d76b41896
 {-# NOINLINE staticConst #-}
 staticConst :: CInt
 staticConst = unsafePerformIO (peek staticConst_ptr)
+{-| __unique:__ @ExampleNothingget_classless_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_c98b4d346a0bb607" hs_bindgen_test_globalsglobals_c98b4d346a0bb607 :: IO (Ptr CInt)
 {-# NOINLINE classless_ptr #-}
 {-| No storage class specified
@@ -969,6 +1015,8 @@ classless_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_c98b4d346a0bb607
 {-# NOINLINE classless #-}
 classless :: CInt
 classless = unsafePerformIO (peek classless_ptr)
+{-| __unique:__ @ExampleNothingget_constArray1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_e7a61097e2415261" hs_bindgen_test_globalsglobals_e7a61097e2415261 :: IO (Ptr (ConstantArray 4
                                                                                                                                                       CInt))
 {-# NOINLINE constArray1_ptr #-}
@@ -993,6 +1041,8 @@ constArray1_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_e7a61097e241526
 {-# NOINLINE constArray1 #-}
 constArray1 :: ConstantArray 4 CInt
 constArray1 = unsafePerformIO (peek constArray1_ptr)
+{-| __unique:__ @ExampleNothingget_constArray2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_5e76637230135838" hs_bindgen_test_globalsglobals_5e76637230135838 :: IO (Ptr ConstIntArray)
 {-# NOINLINE constArray2_ptr #-}
 {-| __C declaration:__ @constArray2@
@@ -1009,6 +1059,8 @@ constArray2_ptr :: Ptr ConstIntArray
     __exported by:__ @globals\/globals.h@
 -}
 constArray2_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_5e76637230135838
+{-| __unique:__ @ExampleNothingget_constTuple_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_c7d3a2347092dfe0" hs_bindgen_test_globalsglobals_c7d3a2347092dfe0 :: IO (Ptr Tuple)
 {-# NOINLINE constTuple_ptr #-}
 {-| A constant tuple
@@ -1032,6 +1084,8 @@ constTuple_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_c7d3a2347092dfe0
 {-# NOINLINE constTuple #-}
 constTuple :: Tuple
 constTuple = unsafePerformIO (peek constTuple_ptr)
+{-| __unique:__ @ExampleNothingget_nonConstTuple_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_3639a5c5b63aad84" hs_bindgen_test_globalsglobals_3639a5c5b63aad84 :: IO (Ptr Tuple)
 {-# NOINLINE nonConstTuple_ptr #-}
 {-| A non-constant tuple with a constant member
@@ -1052,6 +1106,8 @@ __defined at:__ @globals\/globals.h:470:21@
 __exported by:__ @globals\/globals.h@
 -}
 nonConstTuple_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_3639a5c5b63aad84
+{-| __unique:__ @ExampleNothingget_ptrToConstInt_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4" hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4 :: IO (Ptr (Ptr CInt))
 {-# NOINLINE ptrToConstInt_ptr #-}
 {-| A pointer to const int
@@ -1072,6 +1128,8 @@ __defined at:__ @globals\/globals.h:473:20@
 __exported by:__ @globals\/globals.h@
 -}
 ptrToConstInt_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_9fd2e0d3b265dee4
+{-| __unique:__ @ExampleNothingget_constPtrToInt_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_10cf1344894b0264" hs_bindgen_test_globalsglobals_10cf1344894b0264 :: IO (Ptr (Ptr CInt))
 {-# NOINLINE constPtrToInt_ptr #-}
 {-| A const pointer to int
@@ -1095,6 +1153,8 @@ constPtrToInt_ptr = unsafePerformIO hs_bindgen_test_globalsglobals_10cf1344894b0
 {-# NOINLINE constPtrToInt #-}
 constPtrToInt :: Ptr CInt
 constPtrToInt = unsafePerformIO (peek constPtrToInt_ptr)
+{-| __unique:__ @ExampleNothingget_constPtrToConstInt_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_globalsglobals_1b236183822e0d24" hs_bindgen_test_globalsglobals_1b236183822e0d24 :: IO (Ptr (Ptr CInt))
 {-# NOINLINE constPtrToConstInt_ptr #-}
 {-| A const pointer to const int

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/FunPtr.hs
@@ -139,6 +139,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_quux_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367" hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367 ::
      IO (Ptr.FunPtr (F -> FC.CChar -> IO FC.CChar))
 
@@ -154,6 +156,8 @@ quux_ptr :: Ptr.FunPtr (F -> FC.CChar -> IO FC.CChar)
 quux_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367
 
+{-| __unique:__ @ExampleNothingget_wam_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da" hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da ::
      IO (Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr C) -> IO (Ptr.Ptr C)))
 
@@ -169,6 +173,8 @@ wam_ptr :: Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr C) -> IO (Ptr.Ptr C))
 wam_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da
 
+{-| __unique:__ @ExampleNothingget_foo1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd" hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd ::
      IO (Ptr.FunPtr (FC.CFloat -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (Ptr.Ptr FC.CChar)))
 
@@ -184,6 +190,8 @@ foo1_ptr :: Ptr.FunPtr (FC.CFloat -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO 
 foo1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd
 
+{-| __unique:__ @ExampleNothingget_foo2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda" hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda ::
      IO (Ptr.FunPtr (F -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (Ptr.Ptr FC.CChar)))
 
@@ -199,6 +207,8 @@ foo2_ptr :: Ptr.FunPtr (F -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (Ptr.Ptr
 foo2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda
 
+{-| __unique:__ @ExampleNothingget_foo3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e" hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e ::
      IO (Ptr.FunPtr (FC.CFloat -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO (Ptr.Ptr C)))
 
@@ -214,6 +224,8 @@ foo3_ptr :: Ptr.FunPtr (FC.CFloat -> (Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> IO 
 foo3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e
 
+{-| __unique:__ @ExampleNothingget_bar1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d" hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d ::
      IO (Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (FC.CShort -> IO FC.CInt))))
 
@@ -229,6 +241,8 @@ bar1_ptr :: Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (FC.CShort -> IO FC.CInt)))
 bar1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d
 
+{-| __unique:__ @ExampleNothingget_bar2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3" hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3 ::
      IO (Ptr.FunPtr (L -> IO (Ptr.FunPtr (FC.CShort -> IO FC.CInt))))
 
@@ -244,6 +258,8 @@ bar2_ptr :: Ptr.FunPtr (L -> IO (Ptr.FunPtr (FC.CShort -> IO FC.CInt)))
 bar2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3
 
+{-| __unique:__ @ExampleNothingget_bar3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71" hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71 ::
      IO (Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (S -> IO FC.CInt))))
 
@@ -259,6 +275,8 @@ bar3_ptr :: Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (S -> IO FC.CInt)))
 bar3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71
 
+{-| __unique:__ @ExampleNothingget_bar4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19" hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19 ::
      IO (Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (FC.CShort -> IO I))))
 
@@ -274,6 +292,8 @@ bar4_ptr :: Ptr.FunPtr (FC.CLong -> IO (Ptr.FunPtr (FC.CShort -> IO I)))
 bar4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19
 
+{-| __unique:__ @ExampleNothingget_baz1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee" hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee ::
      IO (Ptr.FunPtr (FC.CInt -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))))
 
@@ -289,6 +309,8 @@ baz1_ptr :: Ptr.FunPtr (FC.CInt -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray
 baz1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee
 
+{-| __unique:__ @ExampleNothingget_baz2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6" hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6 ::
      IO (Ptr.FunPtr (I -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))))
 
@@ -304,6 +326,8 @@ baz2_ptr :: Ptr.FunPtr (I -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.Const
 baz2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6
 
+{-| __unique:__ @ExampleNothingget_baz3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146" hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146 ::
      IO (Ptr.FunPtr (FC.CInt -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 2) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) I)))))
 
@@ -319,6 +343,8 @@ baz3_ptr :: Ptr.FunPtr (FC.CInt -> IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray
 baz3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146
 
+{-| __unique:__ @ExampleNothingget_no_args_no_void_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_452280b5085b4ccd" hs_bindgen_test_macrosmacro_in_fundecl_452280b5085b4ccd ::
      IO (Ptr.FunPtr (IO I))
 

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Safe.hs
@@ -117,6 +117,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @macros\/macro_in_fundecl.h:12:6@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safequux@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_9c091e7a5fbe00eb" quux ::
      F
@@ -132,6 +134,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_9c091e7a5fbe00
     __defined at:__ @macros\/macro_in_fundecl.h:13:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safewam@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ca29786771bf115c" wam ::
      FC.CFloat
@@ -147,6 +151,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ca29786771bf11
     __defined at:__ @macros\/macro_in_fundecl.h:16:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safefoo1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_a1ddb0ab90dd90ae" foo1 ::
      FC.CFloat
@@ -162,6 +168,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_a1ddb0ab90dd90
     __defined at:__ @macros\/macro_in_fundecl.h:17:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safefoo2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_39158ea36a52c749" foo2 ::
      F
@@ -177,6 +185,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_39158ea36a52c7
     __defined at:__ @macros\/macro_in_fundecl.h:18:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safefoo3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_30c473506139927c" foo3 ::
      FC.CFloat
@@ -192,6 +202,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_30c47350613992
     __defined at:__ @macros\/macro_in_fundecl.h:21:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebar1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ef6d9a2254300a4a" bar1 ::
      FC.CLong
@@ -204,6 +216,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ef6d9a2254300a
     __defined at:__ @macros\/macro_in_fundecl.h:22:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebar2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_6570ce6435b60197" bar2 ::
      L
@@ -216,6 +230,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_6570ce6435b601
     __defined at:__ @macros\/macro_in_fundecl.h:23:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebar3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ac35ce1ad86420e1" bar3 ::
      FC.CLong
@@ -228,6 +244,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ac35ce1ad86420
     __defined at:__ @macros\/macro_in_fundecl.h:24:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebar4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c5e59f203c41c1c2" bar4 ::
      FC.CLong
@@ -240,6 +258,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c5e59f203c41c1
     __defined at:__ @macros\/macro_in_fundecl.h:27:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebaz1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_f2b917ad9122f0e2" baz1 ::
      FC.CInt
@@ -252,6 +272,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_f2b917ad9122f0
     __defined at:__ @macros\/macro_in_fundecl.h:35:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebaz2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d27cd45b344a00d3" baz2 ::
      I
@@ -264,6 +286,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d27cd45b344a00
     __defined at:__ @macros\/macro_in_fundecl.h:43:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safebaz3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c4ed14d761bc89ba" baz3 ::
      FC.CInt
@@ -276,6 +300,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c4ed14d761bc89
     __defined at:__ @macros\/macro_in_fundecl.h:53:3@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Safeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8d4283a1963012db" no_args_no_void ::
      IO I

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Unsafe.hs
@@ -117,6 +117,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @macros\/macro_in_fundecl.h:12:6@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafequux@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_7542f939354dfc0b" quux ::
      F
@@ -132,6 +134,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_7542f939354d
     __defined at:__ @macros\/macro_in_fundecl.h:13:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafewam@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_e19961744945a727" wam ::
      FC.CFloat
@@ -147,6 +151,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_e19961744945
     __defined at:__ @macros\/macro_in_fundecl.h:16:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_3ce18d84b02c9784" foo1 ::
      FC.CFloat
@@ -162,6 +168,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_3ce18d84b02c
     __defined at:__ @macros\/macro_in_fundecl.h:17:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_483294beebe8552d" foo2 ::
      F
@@ -177,6 +185,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_483294beebe8
     __defined at:__ @macros\/macro_in_fundecl.h:18:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_5fb7e024e43f13d7" foo3 ::
      FC.CFloat
@@ -192,6 +202,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_5fb7e024e43f
     __defined at:__ @macros\/macro_in_fundecl.h:21:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_5c62229deaba458d" bar1 ::
      FC.CLong
@@ -204,6 +216,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_5c62229deaba
     __defined at:__ @macros\/macro_in_fundecl.h:22:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_120cb32a2369f37f" bar2 ::
      L
@@ -216,6 +230,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_120cb32a2369
     __defined at:__ @macros\/macro_in_fundecl.h:23:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8163c1d52847d0b4" bar3 ::
      FC.CLong
@@ -228,6 +244,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8163c1d52847
     __defined at:__ @macros\/macro_in_fundecl.h:24:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_d7df5128adb899bb" bar4 ::
      FC.CLong
@@ -240,6 +258,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_d7df5128adb8
     __defined at:__ @macros\/macro_in_fundecl.h:27:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_af25911956e2e01d" baz1 ::
      FC.CInt
@@ -252,6 +272,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_af25911956e2
     __defined at:__ @macros\/macro_in_fundecl.h:35:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_21c316299046fe75" baz2 ::
      I
@@ -264,6 +286,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_21c316299046
     __defined at:__ @macros\/macro_in_fundecl.h:43:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8d077398ab5e3b39" baz3 ::
      FC.CInt
@@ -276,6 +300,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_8d077398ab5e
     __defined at:__ @macros\/macro_in_fundecl.h:53:3@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_26de47450bbc61e3" no_args_no_void ::
      IO I

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -435,6 +435,8 @@ newtype S
     __defined at:__ @macros\/macro_in_fundecl.h:12:6@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafequux@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_9c091e7a5fbe00eb" quux :: F ->
                                                                                             CChar ->
@@ -444,6 +446,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_9c091e7a5fbe00
     __defined at:__ @macros\/macro_in_fundecl.h:13:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafewam@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ca29786771bf115c" wam :: CFloat ->
                                                                                            Ptr C ->
@@ -453,6 +457,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ca29786771bf11
     __defined at:__ @macros\/macro_in_fundecl.h:16:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_a1ddb0ab90dd90ae" foo1 :: CFloat ->
                                                                                             FunPtr (CInt ->
@@ -463,6 +469,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_a1ddb0ab90dd90
     __defined at:__ @macros\/macro_in_fundecl.h:17:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_39158ea36a52c749" foo2 :: F ->
                                                                                             FunPtr (CInt ->
@@ -473,6 +481,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_39158ea36a52c7
     __defined at:__ @macros\/macro_in_fundecl.h:18:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_30c473506139927c" foo3 :: CFloat ->
                                                                                             FunPtr (CInt ->
@@ -483,6 +493,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_30c47350613992
     __defined at:__ @macros\/macro_in_fundecl.h:21:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ef6d9a2254300a4a" bar1 :: CLong ->
                                                                                             IO (FunPtr (CShort ->
@@ -492,6 +504,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ef6d9a2254300a
     __defined at:__ @macros\/macro_in_fundecl.h:22:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_6570ce6435b60197" bar2 :: L ->
                                                                                             IO (FunPtr (CShort ->
@@ -501,6 +515,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_6570ce6435b601
     __defined at:__ @macros\/macro_in_fundecl.h:23:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ac35ce1ad86420e1" bar3 :: CLong ->
                                                                                             IO (FunPtr (S ->
@@ -510,6 +526,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_ac35ce1ad86420
     __defined at:__ @macros\/macro_in_fundecl.h:24:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c5e59f203c41c1c2" bar4 :: CLong ->
                                                                                             IO (FunPtr (CShort ->
@@ -519,6 +537,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c5e59f203c41c1
     __defined at:__ @macros\/macro_in_fundecl.h:27:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_f2b917ad9122f0e2" baz1 :: CInt ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -529,6 +549,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_f2b917ad9122f0
     __defined at:__ @macros\/macro_in_fundecl.h:35:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d27cd45b344a00d3" baz2 :: I ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -539,6 +561,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d27cd45b344a00
     __defined at:__ @macros\/macro_in_fundecl.h:43:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c4ed14d761bc89ba" baz3 :: CInt ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -549,6 +573,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_c4ed14d761bc89
     __defined at:__ @macros\/macro_in_fundecl.h:53:3@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8d4283a1963012db" no_args_no_void :: IO I
 {-| __C declaration:__ @quux@
@@ -556,6 +582,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8d4283a1963012
     __defined at:__ @macros\/macro_in_fundecl.h:12:6@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafequux@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_7542f939354dfc0b" quux :: F ->
                                                                                             CChar ->
@@ -565,6 +593,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_7542f939354dfc
     __defined at:__ @macros\/macro_in_fundecl.h:13:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafewam@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_e19961744945a727" wam :: CFloat ->
                                                                                            Ptr C ->
@@ -574,6 +604,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_e19961744945a7
     __defined at:__ @macros\/macro_in_fundecl.h:16:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_3ce18d84b02c9784" foo1 :: CFloat ->
                                                                                             FunPtr (CInt ->
@@ -584,6 +616,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_3ce18d84b02c97
     __defined at:__ @macros\/macro_in_fundecl.h:17:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_483294beebe8552d" foo2 :: F ->
                                                                                             FunPtr (CInt ->
@@ -594,6 +628,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_483294beebe855
     __defined at:__ @macros\/macro_in_fundecl.h:18:4@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafefoo3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_5fb7e024e43f13d7" foo3 :: CFloat ->
                                                                                             FunPtr (CInt ->
@@ -604,6 +640,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_5fb7e024e43f13
     __defined at:__ @macros\/macro_in_fundecl.h:21:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_5c62229deaba458d" bar1 :: CLong ->
                                                                                             IO (FunPtr (CShort ->
@@ -613,6 +651,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_5c62229deaba45
     __defined at:__ @macros\/macro_in_fundecl.h:22:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_120cb32a2369f37f" bar2 :: L ->
                                                                                             IO (FunPtr (CShort ->
@@ -622,6 +662,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_120cb32a2369f3
     __defined at:__ @macros\/macro_in_fundecl.h:23:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8163c1d52847d0b4" bar3 :: CLong ->
                                                                                             IO (FunPtr (S ->
@@ -631,6 +673,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8163c1d52847d0
     __defined at:__ @macros\/macro_in_fundecl.h:24:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebar4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d7df5128adb899bb" bar4 :: CLong ->
                                                                                             IO (FunPtr (CShort ->
@@ -640,6 +684,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_d7df5128adb899
     __defined at:__ @macros\/macro_in_fundecl.h:27:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_af25911956e2e01d" baz1 :: CInt ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -650,6 +696,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_af25911956e2e0
     __defined at:__ @macros\/macro_in_fundecl.h:35:7@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_21c316299046fe75" baz2 :: I ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -660,6 +708,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_21c316299046fe
     __defined at:__ @macros\/macro_in_fundecl.h:43:5@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafebaz3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8d077398ab5e3b39" baz3 :: CInt ->
                                                                                             IO (Ptr (ConstantArray 2
@@ -670,8 +720,12 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8d077398ab5e3b
     __defined at:__ @macros\/macro_in_fundecl.h:53:3@
 
     __exported by:__ @macros\/macro_in_fundecl.h@
+
+    __unique:__ @ExampleJust Unsafeno_args_no_void@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_26de47450bbc61e3" no_args_no_void :: IO I
+{-| __unique:__ @ExampleNothingget_quux_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367" hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367 :: IO (FunPtr (F ->
                                                                                                                                                            CChar ->
                                                                                                                                                            IO CChar))
@@ -690,6 +744,8 @@ quux_ptr :: FunPtr (F -> CChar -> IO CChar)
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 quux_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_75296b863af23367
+{-| __unique:__ @ExampleNothingget_wam_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da" hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da :: IO (FunPtr (CFloat ->
                                                                                                                                                            Ptr C ->
                                                                                                                                                            IO (Ptr C)))
@@ -708,6 +764,8 @@ wam_ptr :: FunPtr (CFloat -> Ptr C -> IO (Ptr C))
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 wam_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_fd1ccca5616729da
+{-| __unique:__ @ExampleNothingget_foo1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd" hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd :: IO (FunPtr (CFloat ->
                                                                                                                                                            FunPtr (CInt ->
                                                                                                                                                                    IO CInt) ->
@@ -728,6 +786,8 @@ foo1_ptr :: FunPtr (CFloat ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 foo1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_786c8d7bfea481fd
+{-| __unique:__ @ExampleNothingget_foo2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda" hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda :: IO (FunPtr (F ->
                                                                                                                                                            FunPtr (CInt ->
                                                                                                                                                                    IO CInt) ->
@@ -748,6 +808,8 @@ foo2_ptr :: FunPtr (F ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 foo2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_42a47aecc35f5bda
+{-| __unique:__ @ExampleNothingget_foo3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e" hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e :: IO (FunPtr (CFloat ->
                                                                                                                                                            FunPtr (CInt ->
                                                                                                                                                                    IO CInt) ->
@@ -768,6 +830,8 @@ foo3_ptr :: FunPtr (CFloat ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 foo3_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_17760ec60140242e
+{-| __unique:__ @ExampleNothingget_bar1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d" hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d :: IO (FunPtr (CLong ->
                                                                                                                                                            IO (FunPtr (CShort ->
                                                                                                                                                                        IO CInt))))
@@ -786,6 +850,8 @@ bar1_ptr :: FunPtr (CLong -> IO (FunPtr (CShort -> IO CInt)))
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 bar1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_13fa512840072e8d
+{-| __unique:__ @ExampleNothingget_bar2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3" hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3 :: IO (FunPtr (L ->
                                                                                                                                                            IO (FunPtr (CShort ->
                                                                                                                                                                        IO CInt))))
@@ -804,6 +870,8 @@ bar2_ptr :: FunPtr (L -> IO (FunPtr (CShort -> IO CInt)))
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 bar2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_0d63f3c4f98f04a3
+{-| __unique:__ @ExampleNothingget_bar3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71" hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71 :: IO (FunPtr (CLong ->
                                                                                                                                                            IO (FunPtr (S ->
                                                                                                                                                                        IO CInt))))
@@ -822,6 +890,8 @@ bar3_ptr :: FunPtr (CLong -> IO (FunPtr (S -> IO CInt)))
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 bar3_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_8bd44eebdbce7f71
+{-| __unique:__ @ExampleNothingget_bar4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19" hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19 :: IO (FunPtr (CLong ->
                                                                                                                                                            IO (FunPtr (CShort ->
                                                                                                                                                                        IO I))))
@@ -840,6 +910,8 @@ bar4_ptr :: FunPtr (CLong -> IO (FunPtr (CShort -> IO I)))
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 bar4_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_0515cdde3c6f0f19
+{-| __unique:__ @ExampleNothingget_baz1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee" hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee :: IO (FunPtr (CInt ->
                                                                                                                                                            IO (Ptr (ConstantArray 2
                                                                                                                                                                                   (ConstantArray 3
@@ -860,6 +932,8 @@ baz1_ptr :: FunPtr (CInt ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 baz1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_8edeef2444de2cee
+{-| __unique:__ @ExampleNothingget_baz2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6" hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6 :: IO (FunPtr (I ->
                                                                                                                                                            IO (Ptr (ConstantArray 2
                                                                                                                                                                                   (ConstantArray 3
@@ -880,6 +954,8 @@ baz2_ptr :: FunPtr (I ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 baz2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_61853d26cc39ced6
+{-| __unique:__ @ExampleNothingget_baz3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146" hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146 :: IO (FunPtr (CInt ->
                                                                                                                                                            IO (Ptr (ConstantArray 2
                                                                                                                                                                                   (ConstantArray 3
@@ -900,6 +976,8 @@ baz3_ptr :: FunPtr (CInt ->
     __exported by:__ @macros\/macro_in_fundecl.h@
 -}
 baz3_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_b465262d2f67a146
+{-| __unique:__ @ExampleNothingget_no_args_no_void_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_452280b5085b4ccd" hs_bindgen_test_macrosmacro_in_fundecl_452280b5085b4ccd :: IO (FunPtr (IO I))
 {-# NOINLINE no_args_no_void_ptr #-}
 {-| __C declaration:__ @no_args_no_void@

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/FunPtr.hs
@@ -106,6 +106,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_quux1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293 ::
      IO (Ptr.FunPtr (MC -> TC -> IO FC.CChar))
 
@@ -121,6 +123,8 @@ quux1_ptr :: Ptr.FunPtr (MC -> TC -> IO FC.CChar)
 quux1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293
 
+{-| __unique:__ @ExampleNothingget_quux2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b ::
      IO (Ptr.FunPtr (MC -> FC.CChar -> IO TC))
 
@@ -136,6 +140,8 @@ quux2_ptr :: Ptr.FunPtr (MC -> FC.CChar -> IO TC)
 quux2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b
 
+{-| __unique:__ @ExampleNothingget_wam1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe ::
      IO (Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr TC) -> IO (Ptr.Ptr MC)))
 
@@ -151,6 +157,8 @@ wam1_ptr :: Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr TC) -> IO (Ptr.Ptr MC))
 wam1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe
 
+{-| __unique:__ @ExampleNothingget_wam2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63 ::
      IO (Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr MC) -> IO (Ptr.Ptr TC)))
 
@@ -166,6 +174,8 @@ wam2_ptr :: Ptr.FunPtr (FC.CFloat -> (Ptr.Ptr MC) -> IO (Ptr.Ptr TC))
 wam2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63
 
+{-| __unique:__ @ExampleNothingget_struct_typedef1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct2) -> MC -> IO ()))
 
@@ -181,6 +191,8 @@ struct_typedef1_ptr :: Ptr.FunPtr ((Ptr.Ptr Struct2) -> MC -> IO ())
 struct_typedef1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152
 
+{-| __unique:__ @ExampleNothingget_struct_typedef2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct3_t) -> MC -> IO ()))
 
@@ -196,6 +208,8 @@ struct_typedef2_ptr :: Ptr.FunPtr ((Ptr.Ptr Struct3_t) -> MC -> IO ())
 struct_typedef2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043
 
+{-| __unique:__ @ExampleNothingget_struct_typedef3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct4) -> MC -> IO ()))
 
@@ -211,6 +225,8 @@ struct_typedef3_ptr :: Ptr.FunPtr ((Ptr.Ptr Struct4) -> MC -> IO ())
 struct_typedef3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368
 
+{-| __unique:__ @ExampleNothingget_struct_name1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct1) -> MC -> IO ()))
 
@@ -226,6 +242,8 @@ struct_name1_ptr :: Ptr.FunPtr ((Ptr.Ptr Struct1) -> MC -> IO ())
 struct_name1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042
 
+{-| __unique:__ @ExampleNothingget_struct_name2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct3) -> MC -> IO ()))
 
@@ -241,6 +259,8 @@ struct_name2_ptr :: Ptr.FunPtr ((Ptr.Ptr Struct3) -> MC -> IO ())
 struct_name2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2
 
+{-| __unique:__ @ExampleNothingget_struct_name3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d52310663e8daa5c" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d52310663e8daa5c ::
      IO (Ptr.FunPtr ((Ptr.Ptr Struct4) -> MC -> IO ()))
 

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Safe.hs
@@ -90,6 +90,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:8:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safequux1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_c7ba346f3006b36f" quux1 ::
      MC
@@ -105,6 +107,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_c7ba346
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:9:4@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safequux2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_db114519a8645d1f" quux2 ::
      MC
@@ -120,6 +124,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_db11451
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:10:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safewam1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_0a613fb26d413eaa" wam1 ::
      FC.CFloat
@@ -135,6 +141,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_0a613fb
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:11:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safewam2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_279b15c6940eb4f8" wam2 ::
      FC.CFloat
@@ -150,6 +158,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_279b15c
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:23:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_typedef1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_27a965a9bfd8c176" struct_typedef1 ::
      Ptr.Ptr Struct2
@@ -165,6 +175,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_27a965a
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:24:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_typedef2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_8e7c55302a7b5716" struct_typedef2 ::
      Ptr.Ptr Struct3_t
@@ -180,6 +192,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_8e7c553
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:25:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_typedef3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_fe83edb35a817050" struct_typedef3 ::
      Ptr.Ptr Struct4
@@ -195,6 +209,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_fe83edb
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:27:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_name1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_162df9fabcbef0c4" struct_name1 ::
      Ptr.Ptr Struct1
@@ -210,6 +226,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_162df9f
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:28:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_name2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a6b5f272333b19d4" struct_name2 ::
      Ptr.Ptr Struct3
@@ -225,6 +243,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a6b5f27
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:29:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Safestruct_name3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_9eadc48880259e4a" struct_name3 ::
      Ptr.Ptr Struct4

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Unsafe.hs
@@ -90,6 +90,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:8:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d8e3530b80cd03ff" quux1 ::
      MC
@@ -105,6 +107,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d8e35
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:9:4@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_857e3b8d0292d39d" quux2 ::
      MC
@@ -120,6 +124,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_857e3
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:10:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_81d53aede4a7b424" wam1 ::
      FC.CFloat
@@ -135,6 +141,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_81d53
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:11:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_035abb3b83b92fea" wam2 ::
      FC.CFloat
@@ -150,6 +158,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_035ab
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:23:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_34300aead966e212" struct_typedef1 ::
      Ptr.Ptr Struct2
@@ -165,6 +175,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_34300
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:24:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_cc4abaeb55d1e034" struct_typedef2 ::
      Ptr.Ptr Struct3_t
@@ -180,6 +192,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_cc4ab
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:25:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d068247e5a3b03e6" struct_typedef3 ::
      Ptr.Ptr Struct4
@@ -195,6 +209,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d0682
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:27:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4107c49ec0f22d0c" struct_name1 ::
      Ptr.Ptr Struct1
@@ -210,6 +226,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4107c
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:28:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_124c6e0ae4b86063" struct_name2 ::
      Ptr.Ptr Struct3
@@ -225,6 +243,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_124c6
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:29:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4241bc0cd1393d99" struct_name3 ::
      Ptr.Ptr Struct4

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -439,6 +439,8 @@ instance TyEq ty (CFieldType Struct4 "struct4_a") =>
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:8:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_c7ba346f3006b36f" quux1 :: MC ->
                                                                                                     TC ->
@@ -448,6 +450,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_c7ba346
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:9:4@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_db114519a8645d1f" quux2 :: MC ->
                                                                                                     CChar ->
@@ -457,6 +461,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_db11451
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:10:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_0a613fb26d413eaa" wam1 :: CFloat ->
                                                                                                    Ptr TC ->
@@ -466,6 +472,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_0a613fb
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:11:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_279b15c6940eb4f8" wam2 :: CFloat ->
                                                                                                    Ptr MC ->
@@ -475,6 +483,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_279b15c
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:23:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_27a965a9bfd8c176" struct_typedef1 :: Ptr Struct2 ->
                                                                                                               MC ->
@@ -484,6 +494,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_27a965a
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:24:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_8e7c55302a7b5716" struct_typedef2 :: Ptr Struct3_t ->
                                                                                                               MC ->
@@ -493,6 +505,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_8e7c553
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:25:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_fe83edb35a817050" struct_typedef3 :: Ptr Struct4 ->
                                                                                                               MC ->
@@ -502,6 +516,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_fe83edb
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:27:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_162df9fabcbef0c4" struct_name1 :: Ptr Struct1 ->
                                                                                                            MC ->
@@ -511,6 +527,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_162df9f
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:28:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a6b5f272333b19d4" struct_name2 :: Ptr Struct3 ->
                                                                                                            MC ->
@@ -520,6 +538,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a6b5f27
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:29:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_9eadc48880259e4a" struct_name3 :: Ptr Struct4 ->
                                                                                                            MC ->
@@ -529,6 +549,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_9eadc48
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:8:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d8e3530b80cd03ff" quux1 :: MC ->
                                                                                                     TC ->
@@ -538,6 +560,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d8e3530
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:9:4@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafequux2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_857e3b8d0292d39d" quux2 :: MC ->
                                                                                                     CChar ->
@@ -547,6 +571,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_857e3b8
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:10:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_81d53aede4a7b424" wam1 :: CFloat ->
                                                                                                    Ptr TC ->
@@ -556,6 +582,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_81d53ae
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:11:5@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafewam2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_035abb3b83b92fea" wam2 :: CFloat ->
                                                                                                    Ptr MC ->
@@ -565,6 +593,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_035abb3
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:23:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_34300aead966e212" struct_typedef1 :: Ptr Struct2 ->
                                                                                                               MC ->
@@ -574,6 +604,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_34300ae
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:24:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_cc4abaeb55d1e034" struct_typedef2 :: Ptr Struct3_t ->
                                                                                                               MC ->
@@ -583,6 +615,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_cc4abae
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:25:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_typedef3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d068247e5a3b03e6" struct_typedef3 :: Ptr Struct4 ->
                                                                                                               MC ->
@@ -592,6 +626,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d068247
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:27:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4107c49ec0f22d0c" struct_name1 :: Ptr Struct1 ->
                                                                                                            MC ->
@@ -601,6 +637,8 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4107c49
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:28:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_124c6e0ae4b86063" struct_name2 :: Ptr Struct3 ->
                                                                                                            MC ->
@@ -610,10 +648,14 @@ foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_124c6e0
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h:29:6@
 
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
+
+    __unique:__ @ExampleJust Unsafestruct_name3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_4241bc0cd1393d99" struct_name3 :: Ptr Struct4 ->
                                                                                                            MC ->
                                                                                                            IO Unit
+{-| __unique:__ @ExampleNothingget_quux1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293 :: IO (FunPtr (MC ->
                                                                                                                                                                          TC ->
                                                                                                                                                                          IO CChar))
@@ -632,6 +674,8 @@ quux1_ptr :: FunPtr (MC -> TC -> IO CChar)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 quux1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7d7a63ab896ed293
+{-| __unique:__ @ExampleNothingget_quux2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b :: IO (FunPtr (MC ->
                                                                                                                                                                          CChar ->
                                                                                                                                                                          IO TC))
@@ -650,6 +694,8 @@ quux2_ptr :: FunPtr (MC -> CChar -> IO TC)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 quux2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_b64c564dd7071f5b
+{-| __unique:__ @ExampleNothingget_wam1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe :: IO (FunPtr (CFloat ->
                                                                                                                                                                          Ptr TC ->
                                                                                                                                                                          IO (Ptr MC)))
@@ -668,6 +714,8 @@ wam1_ptr :: FunPtr (CFloat -> Ptr TC -> IO (Ptr MC))
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 wam1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_aa26b3a0f4d0aefe
+{-| __unique:__ @ExampleNothingget_wam2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63 :: IO (FunPtr (CFloat ->
                                                                                                                                                                          Ptr MC ->
                                                                                                                                                                          IO (Ptr TC)))
@@ -686,6 +734,8 @@ wam2_ptr :: FunPtr (CFloat -> Ptr MC -> IO (Ptr TC))
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 wam2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_5cb5ead73c0a3d63
+{-| __unique:__ @ExampleNothingget_struct_typedef1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152 :: IO (FunPtr (Ptr Struct2 ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))
@@ -704,6 +754,8 @@ struct_typedef1_ptr :: FunPtr (Ptr Struct2 -> MC -> IO Unit)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 struct_typedef1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_a1aadeb6878a5152
+{-| __unique:__ @ExampleNothingget_struct_typedef2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043 :: IO (FunPtr (Ptr Struct3_t ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))
@@ -722,6 +774,8 @@ struct_typedef2_ptr :: FunPtr (Ptr Struct3_t -> MC -> IO Unit)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 struct_typedef2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e1dac8a006e6b043
+{-| __unique:__ @ExampleNothingget_struct_typedef3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368 :: IO (FunPtr (Ptr Struct4 ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))
@@ -740,6 +794,8 @@ struct_typedef3_ptr :: FunPtr (Ptr Struct4 -> MC -> IO Unit)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 struct_typedef3_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_078075d0a80d4368
+{-| __unique:__ @ExampleNothingget_struct_name1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042 :: IO (FunPtr (Ptr Struct1 ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))
@@ -758,6 +814,8 @@ struct_name1_ptr :: FunPtr (Ptr Struct1 -> MC -> IO Unit)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 struct_name1_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_7574edf86480f042
+{-| __unique:__ @ExampleNothingget_struct_name2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2 :: IO (FunPtr (Ptr Struct3 ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))
@@ -776,6 +834,8 @@ struct_name2_ptr :: FunPtr (Ptr Struct3 -> MC -> IO Unit)
     __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
 -}
 struct_name2_ptr = unsafePerformIO hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_e7a8c1f45f8b20c2
+{-| __unique:__ @ExampleNothingget_struct_name3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d52310663e8daa5c" hs_bindgen_test_macrosmacro_in_fundecl_vs_typ_d52310663e8daa5c :: IO (FunPtr (Ptr Struct4 ->
                                                                                                                                                                          MC ->
                                                                                                                                                                          IO Unit))

--- a/hs-bindgen/fixtures/macros/reparse/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/FunPtr.hs
@@ -990,6 +990,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_args_char1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1cbcf8b84924816c" hs_bindgen_test_macrosreparse_1cbcf8b84924816c ::
      IO (Ptr.FunPtr (A -> FC.CChar -> IO ()))
 
@@ -1007,6 +1009,8 @@ args_char1_ptr :: Ptr.FunPtr (A -> FC.CChar -> IO ())
 args_char1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_1cbcf8b84924816c
 
+{-| __unique:__ @ExampleNothingget_args_char2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ec2d78b82f444fd0" hs_bindgen_test_macrosreparse_ec2d78b82f444fd0 ::
      IO (Ptr.FunPtr (A -> FC.CSChar -> IO ()))
 
@@ -1022,6 +1026,8 @@ args_char2_ptr :: Ptr.FunPtr (A -> FC.CSChar -> IO ())
 args_char2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ec2d78b82f444fd0
 
+{-| __unique:__ @ExampleNothingget_args_char3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1baa18e723594389" hs_bindgen_test_macrosreparse_1baa18e723594389 ::
      IO (Ptr.FunPtr (A -> FC.CUChar -> IO ()))
 
@@ -1037,6 +1043,8 @@ args_char3_ptr :: Ptr.FunPtr (A -> FC.CUChar -> IO ())
 args_char3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_1baa18e723594389
 
+{-| __unique:__ @ExampleNothingget_args_short1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c96cef4ef5f5e180" hs_bindgen_test_macrosreparse_c96cef4ef5f5e180 ::
      IO (Ptr.FunPtr (A -> FC.CShort -> IO ()))
 
@@ -1052,6 +1060,8 @@ args_short1_ptr :: Ptr.FunPtr (A -> FC.CShort -> IO ())
 args_short1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c96cef4ef5f5e180
 
+{-| __unique:__ @ExampleNothingget_args_short2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3a683552d4f772c7" hs_bindgen_test_macrosreparse_3a683552d4f772c7 ::
      IO (Ptr.FunPtr (A -> FC.CShort -> IO ()))
 
@@ -1067,6 +1077,8 @@ args_short2_ptr :: Ptr.FunPtr (A -> FC.CShort -> IO ())
 args_short2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3a683552d4f772c7
 
+{-| __unique:__ @ExampleNothingget_args_short3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f3284022ac706255" hs_bindgen_test_macrosreparse_f3284022ac706255 ::
      IO (Ptr.FunPtr (A -> FC.CUShort -> IO ()))
 
@@ -1082,6 +1094,8 @@ args_short3_ptr :: Ptr.FunPtr (A -> FC.CUShort -> IO ())
 args_short3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_f3284022ac706255
 
+{-| __unique:__ @ExampleNothingget_args_int1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5c4d785286ccca6b" hs_bindgen_test_macrosreparse_5c4d785286ccca6b ::
      IO (Ptr.FunPtr (A -> FC.CInt -> IO ()))
 
@@ -1097,6 +1111,8 @@ args_int1_ptr :: Ptr.FunPtr (A -> FC.CInt -> IO ())
 args_int1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_5c4d785286ccca6b
 
+{-| __unique:__ @ExampleNothingget_args_int2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e323b837afe40be7" hs_bindgen_test_macrosreparse_e323b837afe40be7 ::
      IO (Ptr.FunPtr (A -> FC.CInt -> IO ()))
 
@@ -1112,6 +1128,8 @@ args_int2_ptr :: Ptr.FunPtr (A -> FC.CInt -> IO ())
 args_int2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e323b837afe40be7
 
+{-| __unique:__ @ExampleNothingget_args_int3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d" hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d ::
      IO (Ptr.FunPtr (A -> FC.CUInt -> IO ()))
 
@@ -1127,6 +1145,8 @@ args_int3_ptr :: Ptr.FunPtr (A -> FC.CUInt -> IO ())
 args_int3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d
 
+{-| __unique:__ @ExampleNothingget_args_long1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d7d322f23a65f43b" hs_bindgen_test_macrosreparse_d7d322f23a65f43b ::
      IO (Ptr.FunPtr (A -> FC.CLong -> IO ()))
 
@@ -1142,6 +1162,8 @@ args_long1_ptr :: Ptr.FunPtr (A -> FC.CLong -> IO ())
 args_long1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_d7d322f23a65f43b
 
+{-| __unique:__ @ExampleNothingget_args_long2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_378c16768a6f6f21" hs_bindgen_test_macrosreparse_378c16768a6f6f21 ::
      IO (Ptr.FunPtr (A -> FC.CLong -> IO ()))
 
@@ -1157,6 +1179,8 @@ args_long2_ptr :: Ptr.FunPtr (A -> FC.CLong -> IO ())
 args_long2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_378c16768a6f6f21
 
+{-| __unique:__ @ExampleNothingget_args_long3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_548dcd4760226ee2" hs_bindgen_test_macrosreparse_548dcd4760226ee2 ::
      IO (Ptr.FunPtr (A -> FC.CULong -> IO ()))
 
@@ -1172,6 +1196,8 @@ args_long3_ptr :: Ptr.FunPtr (A -> FC.CULong -> IO ())
 args_long3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_548dcd4760226ee2
 
+{-| __unique:__ @ExampleNothingget_args_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_701d01261043851b" hs_bindgen_test_macrosreparse_701d01261043851b ::
      IO (Ptr.FunPtr (A -> FC.CFloat -> IO ()))
 
@@ -1187,6 +1213,8 @@ args_float_ptr :: Ptr.FunPtr (A -> FC.CFloat -> IO ())
 args_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_701d01261043851b
 
+{-| __unique:__ @ExampleNothingget_args_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ff631e42f704e4cd" hs_bindgen_test_macrosreparse_ff631e42f704e4cd ::
      IO (Ptr.FunPtr (A -> FC.CDouble -> IO ()))
 
@@ -1202,6 +1230,8 @@ args_double_ptr :: Ptr.FunPtr (A -> FC.CDouble -> IO ())
 args_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ff631e42f704e4cd
 
+{-| __unique:__ @ExampleNothingget_args_bool1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6e289c6cc6d382bf" hs_bindgen_test_macrosreparse_6e289c6cc6d382bf ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -1217,6 +1247,8 @@ args_bool1_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 args_bool1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_6e289c6cc6d382bf
 
+{-| __unique:__ @ExampleNothingget_args_struct_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_26b20c1b89e46b02" hs_bindgen_test_macrosreparse_26b20c1b89e46b02 ::
      IO (Ptr.FunPtr (A -> Some_struct -> IO ()))
 
@@ -1232,6 +1264,8 @@ args_struct_ptr :: Ptr.FunPtr (A -> Some_struct -> IO ())
 args_struct_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_26b20c1b89e46b02
 
+{-| __unique:__ @ExampleNothingget_args_union_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cfd37f06f21b8755" hs_bindgen_test_macrosreparse_cfd37f06f21b8755 ::
      IO (Ptr.FunPtr (A -> Some_union -> IO ()))
 
@@ -1247,6 +1281,8 @@ args_union_ptr :: Ptr.FunPtr (A -> Some_union -> IO ())
 args_union_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_cfd37f06f21b8755
 
+{-| __unique:__ @ExampleNothingget_args_enum_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_69882f8f862fffc2" hs_bindgen_test_macrosreparse_69882f8f862fffc2 ::
      IO (Ptr.FunPtr (A -> Some_enum -> IO ()))
 
@@ -1262,6 +1298,8 @@ args_enum_ptr :: Ptr.FunPtr (A -> Some_enum -> IO ())
 args_enum_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_69882f8f862fffc2
 
+{-| __unique:__ @ExampleNothingget_args_pointer1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_23bde4e97b66c470" hs_bindgen_test_macrosreparse_23bde4e97b66c470 ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -1277,6 +1315,8 @@ args_pointer1_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 args_pointer1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_23bde4e97b66c470
 
+{-| __unique:__ @ExampleNothingget_args_pointer2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fceb546239df3c0a" hs_bindgen_test_macrosreparse_fceb546239df3c0a ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr (Ptr.Ptr FC.CInt)) -> IO ()))
 
@@ -1292,6 +1332,8 @@ args_pointer2_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr (Ptr.Ptr FC.CInt)) -> IO ())
 args_pointer2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_fceb546239df3c0a
 
+{-| __unique:__ @ExampleNothingget_args_pointer3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0cb396fb06dd816a" hs_bindgen_test_macrosreparse_0cb396fb06dd816a ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr Void) -> IO ()))
 
@@ -1307,6 +1349,8 @@ args_pointer3_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr Void) -> IO ())
 args_pointer3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_0cb396fb06dd816a
 
+{-| __unique:__ @ExampleNothingget_ret_A_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a7564eacf3ad149f" hs_bindgen_test_macrosreparse_a7564eacf3ad149f ::
      IO (Ptr.FunPtr (IO A))
 
@@ -1322,6 +1366,8 @@ ret_A_ptr :: Ptr.FunPtr (IO A)
 ret_A_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_a7564eacf3ad149f
 
+{-| __unique:__ @ExampleNothingget_ret_char1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7b5b646ee4e06777" hs_bindgen_test_macrosreparse_7b5b646ee4e06777 ::
      IO (Ptr.FunPtr (A -> IO FC.CChar))
 
@@ -1337,6 +1383,8 @@ ret_char1_ptr :: Ptr.FunPtr (A -> IO FC.CChar)
 ret_char1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_7b5b646ee4e06777
 
+{-| __unique:__ @ExampleNothingget_ret_char2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6" hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6 ::
      IO (Ptr.FunPtr (A -> IO FC.CSChar))
 
@@ -1352,6 +1400,8 @@ ret_char2_ptr :: Ptr.FunPtr (A -> IO FC.CSChar)
 ret_char2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6
 
+{-| __unique:__ @ExampleNothingget_ret_char3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0fc74f839f906d7e" hs_bindgen_test_macrosreparse_0fc74f839f906d7e ::
      IO (Ptr.FunPtr (A -> IO FC.CUChar))
 
@@ -1367,6 +1417,8 @@ ret_char3_ptr :: Ptr.FunPtr (A -> IO FC.CUChar)
 ret_char3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_0fc74f839f906d7e
 
+{-| __unique:__ @ExampleNothingget_ret_short1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8" hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8 ::
      IO (Ptr.FunPtr (A -> IO FC.CShort))
 
@@ -1382,6 +1434,8 @@ ret_short1_ptr :: Ptr.FunPtr (A -> IO FC.CShort)
 ret_short1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8
 
+{-| __unique:__ @ExampleNothingget_ret_short2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e" hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e ::
      IO (Ptr.FunPtr (A -> IO FC.CShort))
 
@@ -1397,6 +1451,8 @@ ret_short2_ptr :: Ptr.FunPtr (A -> IO FC.CShort)
 ret_short2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e
 
+{-| __unique:__ @ExampleNothingget_ret_short3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_823adc61eed1550c" hs_bindgen_test_macrosreparse_823adc61eed1550c ::
      IO (Ptr.FunPtr (A -> IO FC.CUShort))
 
@@ -1412,6 +1468,8 @@ ret_short3_ptr :: Ptr.FunPtr (A -> IO FC.CUShort)
 ret_short3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_823adc61eed1550c
 
+{-| __unique:__ @ExampleNothingget_ret_int1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_79ce8d81113cf766" hs_bindgen_test_macrosreparse_79ce8d81113cf766 ::
      IO (Ptr.FunPtr (A -> IO FC.CInt))
 
@@ -1427,6 +1485,8 @@ ret_int1_ptr :: Ptr.FunPtr (A -> IO FC.CInt)
 ret_int1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_79ce8d81113cf766
 
+{-| __unique:__ @ExampleNothingget_ret_int2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d369bd4861f00c84" hs_bindgen_test_macrosreparse_d369bd4861f00c84 ::
      IO (Ptr.FunPtr (A -> IO FC.CInt))
 
@@ -1442,6 +1502,8 @@ ret_int2_ptr :: Ptr.FunPtr (A -> IO FC.CInt)
 ret_int2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_d369bd4861f00c84
 
+{-| __unique:__ @ExampleNothingget_ret_int3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0336d583fc7b5951" hs_bindgen_test_macrosreparse_0336d583fc7b5951 ::
      IO (Ptr.FunPtr (A -> IO FC.CUInt))
 
@@ -1457,6 +1519,8 @@ ret_int3_ptr :: Ptr.FunPtr (A -> IO FC.CUInt)
 ret_int3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_0336d583fc7b5951
 
+{-| __unique:__ @ExampleNothingget_ret_long1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_36845109a4ce7992" hs_bindgen_test_macrosreparse_36845109a4ce7992 ::
      IO (Ptr.FunPtr (A -> IO FC.CLong))
 
@@ -1472,6 +1536,8 @@ ret_long1_ptr :: Ptr.FunPtr (A -> IO FC.CLong)
 ret_long1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_36845109a4ce7992
 
+{-| __unique:__ @ExampleNothingget_ret_long2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ac32dbc1e79e704e" hs_bindgen_test_macrosreparse_ac32dbc1e79e704e ::
      IO (Ptr.FunPtr (A -> IO FC.CLong))
 
@@ -1487,6 +1553,8 @@ ret_long2_ptr :: Ptr.FunPtr (A -> IO FC.CLong)
 ret_long2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ac32dbc1e79e704e
 
+{-| __unique:__ @ExampleNothingget_ret_long3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e" hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e ::
      IO (Ptr.FunPtr (A -> IO FC.CULong))
 
@@ -1502,6 +1570,8 @@ ret_long3_ptr :: Ptr.FunPtr (A -> IO FC.CULong)
 ret_long3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e
 
+{-| __unique:__ @ExampleNothingget_ret_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e9ac779a7c943add" hs_bindgen_test_macrosreparse_e9ac779a7c943add ::
      IO (Ptr.FunPtr (A -> IO FC.CFloat))
 
@@ -1517,6 +1587,8 @@ ret_float_ptr :: Ptr.FunPtr (A -> IO FC.CFloat)
 ret_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e9ac779a7c943add
 
+{-| __unique:__ @ExampleNothingget_ret_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c" hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c ::
      IO (Ptr.FunPtr (A -> IO FC.CDouble))
 
@@ -1532,6 +1604,8 @@ ret_double_ptr :: Ptr.FunPtr (A -> IO FC.CDouble)
 ret_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c
 
+{-| __unique:__ @ExampleNothingget_ret_bool1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c7b5be49f4314899" hs_bindgen_test_macrosreparse_c7b5be49f4314899 ::
      IO (Ptr.FunPtr (A -> IO FC.CBool))
 
@@ -1547,6 +1621,8 @@ ret_bool1_ptr :: Ptr.FunPtr (A -> IO FC.CBool)
 ret_bool1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c7b5be49f4314899
 
+{-| __unique:__ @ExampleNothingget_ret_struct_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_03ec23cf81b62ce3" hs_bindgen_test_macrosreparse_03ec23cf81b62ce3 ::
      IO (Ptr.FunPtr (A -> IO Some_struct))
 
@@ -1562,6 +1638,8 @@ ret_struct_ptr :: Ptr.FunPtr (A -> IO Some_struct)
 ret_struct_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_03ec23cf81b62ce3
 
+{-| __unique:__ @ExampleNothingget_ret_union_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5315544d48ea5b07" hs_bindgen_test_macrosreparse_5315544d48ea5b07 ::
      IO (Ptr.FunPtr (A -> IO Some_union))
 
@@ -1577,6 +1655,8 @@ ret_union_ptr :: Ptr.FunPtr (A -> IO Some_union)
 ret_union_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_5315544d48ea5b07
 
+{-| __unique:__ @ExampleNothingget_ret_enum_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1" hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1 ::
      IO (Ptr.FunPtr (A -> IO Some_enum))
 
@@ -1592,6 +1672,8 @@ ret_enum_ptr :: Ptr.FunPtr (A -> IO Some_enum)
 ret_enum_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1
 
+{-| __unique:__ @ExampleNothingget_ret_pointer1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0638bcad8813a303" hs_bindgen_test_macrosreparse_0638bcad8813a303 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -1607,6 +1689,8 @@ ret_pointer1_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 ret_pointer1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_0638bcad8813a303
 
+{-| __unique:__ @ExampleNothingget_ret_pointer2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5d9ced9e4887782b" hs_bindgen_test_macrosreparse_5d9ced9e4887782b ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr (Ptr.Ptr FC.CInt))))
 
@@ -1622,6 +1706,8 @@ ret_pointer2_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr (Ptr.Ptr FC.CInt)))
 ret_pointer2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_5d9ced9e4887782b
 
+{-| __unique:__ @ExampleNothingget_ret_pointer3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_60e99361ec0a4b5b" hs_bindgen_test_macrosreparse_60e99361ec0a4b5b ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr Void)))
 
@@ -1637,6 +1723,8 @@ ret_pointer3_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr Void))
 ret_pointer3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_60e99361ec0a4b5b
 
+{-| __unique:__ @ExampleNothingget_body1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cca1935605a94051" hs_bindgen_test_macrosreparse_cca1935605a94051 ::
      IO (Ptr.FunPtr (A -> IO FC.CInt))
 
@@ -1652,6 +1740,8 @@ body1_ptr :: Ptr.FunPtr (A -> IO FC.CInt)
 body1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_cca1935605a94051
 
+{-| __unique:__ @ExampleNothingget_body2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a1900daea7e14e95" hs_bindgen_test_macrosreparse_a1900daea7e14e95 ::
      IO (Ptr.FunPtr (IO A))
 
@@ -1667,6 +1757,8 @@ body2_ptr :: Ptr.FunPtr (IO A)
 body2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_a1900daea7e14e95
 
+{-| __unique:__ @ExampleNothingget_args_complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c62f1e9d47469a1c" hs_bindgen_test_macrosreparse_c62f1e9d47469a1c ::
      IO (Ptr.FunPtr (A -> (Data.Complex.Complex FC.CFloat) -> IO ()))
 
@@ -1682,6 +1774,8 @@ args_complex_float_ptr :: Ptr.FunPtr (A -> (Data.Complex.Complex FC.CFloat) -> I
 args_complex_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c62f1e9d47469a1c
 
+{-| __unique:__ @ExampleNothingget_args_complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697" hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697 ::
      IO (Ptr.FunPtr (A -> (Data.Complex.Complex FC.CDouble) -> IO ()))
 
@@ -1697,6 +1791,8 @@ args_complex_double_ptr :: Ptr.FunPtr (A -> (Data.Complex.Complex FC.CDouble) ->
 args_complex_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697
 
+{-| __unique:__ @ExampleNothingget_ret_complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d" hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d ::
      IO (Ptr.FunPtr (A -> IO (Data.Complex.Complex FC.CFloat)))
 
@@ -1712,6 +1808,8 @@ ret_complex_float_ptr :: Ptr.FunPtr (A -> IO (Data.Complex.Complex FC.CFloat))
 ret_complex_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d
 
+{-| __unique:__ @ExampleNothingget_ret_complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c95961d571f78868" hs_bindgen_test_macrosreparse_c95961d571f78868 ::
      IO (Ptr.FunPtr (A -> IO (Data.Complex.Complex FC.CDouble)))
 
@@ -1727,6 +1825,8 @@ ret_complex_double_ptr :: Ptr.FunPtr (A -> IO (Data.Complex.Complex FC.CDouble))
 ret_complex_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c95961d571f78868
 
+{-| __unique:__ @ExampleNothingget_bespoke_args1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_94c8a2d3574ba283" hs_bindgen_test_macrosreparse_94c8a2d3574ba283 ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -1742,6 +1842,8 @@ bespoke_args1_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 bespoke_args1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_94c8a2d3574ba283
 
+{-| __unique:__ @ExampleNothingget_bespoke_args2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2165985767a8d24e" hs_bindgen_test_macrosreparse_2165985767a8d24e ::
      IO (Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSize -> IO ()))
 
@@ -1757,6 +1859,8 @@ bespoke_args2_ptr :: Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSize -> IO ())
 bespoke_args2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_2165985767a8d24e
 
+{-| __unique:__ @ExampleNothingget_bespoke_ret1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7913bf38675bd912" hs_bindgen_test_macrosreparse_7913bf38675bd912 ::
      IO (Ptr.FunPtr (A -> IO FC.CBool))
 
@@ -1772,6 +1876,8 @@ bespoke_ret1_ptr :: Ptr.FunPtr (A -> IO FC.CBool)
 bespoke_ret1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_7913bf38675bd912
 
+{-| __unique:__ @ExampleNothingget_bespoke_ret2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_07c419cb648cdf65" hs_bindgen_test_macrosreparse_07c419cb648cdf65 ::
      IO (Ptr.FunPtr (A -> IO HsBindgen.Runtime.Prelude.CSize))
 
@@ -1787,6 +1893,8 @@ bespoke_ret2_ptr :: Ptr.FunPtr (A -> IO HsBindgen.Runtime.Prelude.CSize)
 bespoke_ret2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_07c419cb648cdf65
 
+{-| __unique:__ @ExampleNothingget_arr_args1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ed19e51bcac06a9e" hs_bindgen_test_macrosreparse_ed19e51bcac06a9e ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray A) -> IO ()))
 
@@ -1804,6 +1912,8 @@ arr_args1_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray 
 arr_args1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ed19e51bcac06a9e
 
+{-| __unique:__ @ExampleNothingget_arr_args2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_de3931a21a8a71fc" hs_bindgen_test_macrosreparse_de3931a21a8a71fc ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A)) -> IO ()))
 
@@ -1819,6 +1929,8 @@ arr_args2_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray 
 arr_args2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_de3931a21a8a71fc
 
+{-| __unique:__ @ExampleNothingget_arr_args3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2c02effa6288a26b" hs_bindgen_test_macrosreparse_2c02effa6288a26b ::
      IO (Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 5) A) -> IO ()))
 
@@ -1834,6 +1946,8 @@ arr_args3_ptr :: Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 5) 
 arr_args3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_2c02effa6288a26b
 
+{-| __unique:__ @ExampleNothingget_arr_args4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2144e300082f115c" hs_bindgen_test_macrosreparse_2144e300082f115c ::
      IO (Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A)) -> IO ()))
 
@@ -1849,6 +1963,8 @@ arr_args4_ptr :: Ptr.FunPtr (((HsBindgen.Runtime.ConstantArray.ConstantArray 5) 
 arr_args4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_2144e300082f115c
 
+{-| __unique:__ @ExampleNothingget_funptr_args1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d1645262a53743f6" hs_bindgen_test_macrosreparse_d1645262a53743f6 ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (IO ())) -> IO ()))
 
@@ -1866,6 +1982,8 @@ funptr_args1_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (IO ())) -> IO ())
 funptr_args1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_d1645262a53743f6
 
+{-| __unique:__ @ExampleNothingget_funptr_args2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d66507630e4e38e3" hs_bindgen_test_macrosreparse_d66507630e4e38e3 ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (IO FC.CInt)) -> IO ()))
 
@@ -1881,6 +1999,8 @@ funptr_args2_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (IO FC.CInt)) -> IO ())
 funptr_args2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_d66507630e4e38e3
 
+{-| __unique:__ @ExampleNothingget_funptr_args3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3d7907ab53b617cf" hs_bindgen_test_macrosreparse_3d7907ab53b617cf ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> IO ())) -> IO ()))
 
@@ -1896,6 +2016,8 @@ funptr_args3_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> IO ())) -> IO ())
 funptr_args3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3d7907ab53b617cf
 
+{-| __unique:__ @ExampleNothingget_funptr_args4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e4d15a9c3b04292a" hs_bindgen_test_macrosreparse_e4d15a9c3b04292a ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO FC.CChar)) -> IO ()))
 
@@ -1911,6 +2033,8 @@ funptr_args4_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO FC
 funptr_args4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e4d15a9c3b04292a
 
+{-| __unique:__ @ExampleNothingget_funptr_args5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ced7918b6e42102f" hs_bindgen_test_macrosreparse_ced7918b6e42102f ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt))) -> IO ()))
 
@@ -1926,6 +2050,8 @@ funptr_args5_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (P
 funptr_args5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ced7918b6e42102f
 
+{-| __unique:__ @ExampleNothingget_comments1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c90ec05081ef4e64" hs_bindgen_test_macrosreparse_c90ec05081ef4e64 ::
      IO (Ptr.FunPtr (A -> IO ()))
 
@@ -1945,6 +2071,8 @@ comments1_ptr :: Ptr.FunPtr (A -> IO ())
 comments1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c90ec05081ef4e64
 
+{-| __unique:__ @ExampleNothingget_const_prim_before1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6ac4b42c66a36448" hs_bindgen_test_macrosreparse_6ac4b42c66a36448 ::
      IO (Ptr.FunPtr (A -> FC.CChar -> IO ()))
 
@@ -1964,6 +2092,8 @@ const_prim_before1_ptr :: Ptr.FunPtr (A -> FC.CChar -> IO ())
 const_prim_before1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_6ac4b42c66a36448
 
+{-| __unique:__ @ExampleNothingget_const_prim_before2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f98632ef2e69b003" hs_bindgen_test_macrosreparse_f98632ef2e69b003 ::
      IO (Ptr.FunPtr (A -> FC.CSChar -> IO ()))
 
@@ -1979,6 +2109,8 @@ const_prim_before2_ptr :: Ptr.FunPtr (A -> FC.CSChar -> IO ())
 const_prim_before2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_f98632ef2e69b003
 
+{-| __unique:__ @ExampleNothingget_const_prim_before3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cc9db1f6a36b8221" hs_bindgen_test_macrosreparse_cc9db1f6a36b8221 ::
      IO (Ptr.FunPtr (A -> FC.CUChar -> IO ()))
 
@@ -1994,6 +2126,8 @@ const_prim_before3_ptr :: Ptr.FunPtr (A -> FC.CUChar -> IO ())
 const_prim_before3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_cc9db1f6a36b8221
 
+{-| __unique:__ @ExampleNothingget_const_prim_after1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb" hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb ::
      IO (Ptr.FunPtr (A -> FC.CChar -> IO ()))
 
@@ -2009,6 +2143,8 @@ const_prim_after1_ptr :: Ptr.FunPtr (A -> FC.CChar -> IO ())
 const_prim_after1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb
 
+{-| __unique:__ @ExampleNothingget_const_prim_after2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f9b4beeca8253333" hs_bindgen_test_macrosreparse_f9b4beeca8253333 ::
      IO (Ptr.FunPtr (A -> FC.CSChar -> IO ()))
 
@@ -2024,6 +2160,8 @@ const_prim_after2_ptr :: Ptr.FunPtr (A -> FC.CSChar -> IO ())
 const_prim_after2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_f9b4beeca8253333
 
+{-| __unique:__ @ExampleNothingget_const_prim_after3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_bf14e2fd88b25311" hs_bindgen_test_macrosreparse_bf14e2fd88b25311 ::
      IO (Ptr.FunPtr (A -> FC.CUChar -> IO ()))
 
@@ -2039,6 +2177,8 @@ const_prim_after3_ptr :: Ptr.FunPtr (A -> FC.CUChar -> IO ())
 const_prim_after3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_bf14e2fd88b25311
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3649293fcaa1543c" hs_bindgen_test_macrosreparse_3649293fcaa1543c ::
      IO (Ptr.FunPtr (A -> FC.CFloat -> IO ()))
 
@@ -2054,6 +2194,8 @@ const_withoutSign_before1_ptr :: Ptr.FunPtr (A -> FC.CFloat -> IO ())
 const_withoutSign_before1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3649293fcaa1543c
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ad5903c28e22dd2c" hs_bindgen_test_macrosreparse_ad5903c28e22dd2c ::
      IO (Ptr.FunPtr (A -> FC.CDouble -> IO ()))
 
@@ -2069,6 +2211,8 @@ const_withoutSign_before2_ptr :: Ptr.FunPtr (A -> FC.CDouble -> IO ())
 const_withoutSign_before2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_ad5903c28e22dd2c
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a" hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -2084,6 +2228,8 @@ const_withoutSign_before3_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 const_withoutSign_before3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4fd66b696848dd98" hs_bindgen_test_macrosreparse_4fd66b696848dd98 ::
      IO (Ptr.FunPtr (A -> Some_struct -> IO ()))
 
@@ -2099,6 +2245,8 @@ const_withoutSign_before4_ptr :: Ptr.FunPtr (A -> Some_struct -> IO ())
 const_withoutSign_before4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_4fd66b696848dd98
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_42582e1882927f7e" hs_bindgen_test_macrosreparse_42582e1882927f7e ::
      IO (Ptr.FunPtr (A -> Some_union -> IO ()))
 
@@ -2114,6 +2262,8 @@ const_withoutSign_before5_ptr :: Ptr.FunPtr (A -> Some_union -> IO ())
 const_withoutSign_before5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_42582e1882927f7e
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b6876e53e4b27a98" hs_bindgen_test_macrosreparse_b6876e53e4b27a98 ::
      IO (Ptr.FunPtr (A -> Some_enum -> IO ()))
 
@@ -2129,6 +2279,8 @@ const_withoutSign_before6_ptr :: Ptr.FunPtr (A -> Some_enum -> IO ())
 const_withoutSign_before6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_b6876e53e4b27a98
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_78763cbecd2b0750" hs_bindgen_test_macrosreparse_78763cbecd2b0750 ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -2144,6 +2296,8 @@ const_withoutSign_before7_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 const_withoutSign_before7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_78763cbecd2b0750
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4098c4a4ccd31d36" hs_bindgen_test_macrosreparse_4098c4a4ccd31d36 ::
      IO (Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSize -> IO ()))
 
@@ -2159,6 +2313,8 @@ const_withoutSign_before8_ptr :: Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSiz
 const_withoutSign_before8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_4098c4a4ccd31d36
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e9148eb7b8dac901" hs_bindgen_test_macrosreparse_e9148eb7b8dac901 ::
      IO (Ptr.FunPtr (A -> FC.CFloat -> IO ()))
 
@@ -2174,6 +2330,8 @@ const_withoutSign_after1_ptr :: Ptr.FunPtr (A -> FC.CFloat -> IO ())
 const_withoutSign_after1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_e9148eb7b8dac901
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8663653d89116be9" hs_bindgen_test_macrosreparse_8663653d89116be9 ::
      IO (Ptr.FunPtr (A -> FC.CDouble -> IO ()))
 
@@ -2189,6 +2347,8 @@ const_withoutSign_after2_ptr :: Ptr.FunPtr (A -> FC.CDouble -> IO ())
 const_withoutSign_after2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_8663653d89116be9
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_136dcba145bf241b" hs_bindgen_test_macrosreparse_136dcba145bf241b ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -2204,6 +2364,8 @@ const_withoutSign_after3_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 const_withoutSign_after3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_136dcba145bf241b
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_380e01acce794cab" hs_bindgen_test_macrosreparse_380e01acce794cab ::
      IO (Ptr.FunPtr (A -> Some_struct -> IO ()))
 
@@ -2219,6 +2381,8 @@ const_withoutSign_after4_ptr :: Ptr.FunPtr (A -> Some_struct -> IO ())
 const_withoutSign_after4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_380e01acce794cab
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_af0d84d0757f6c2c" hs_bindgen_test_macrosreparse_af0d84d0757f6c2c ::
      IO (Ptr.FunPtr (A -> Some_union -> IO ()))
 
@@ -2234,6 +2398,8 @@ const_withoutSign_after5_ptr :: Ptr.FunPtr (A -> Some_union -> IO ())
 const_withoutSign_after5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_af0d84d0757f6c2c
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_df92501d07bf6c5f" hs_bindgen_test_macrosreparse_df92501d07bf6c5f ::
      IO (Ptr.FunPtr (A -> Some_enum -> IO ()))
 
@@ -2249,6 +2415,8 @@ const_withoutSign_after6_ptr :: Ptr.FunPtr (A -> Some_enum -> IO ())
 const_withoutSign_after6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_df92501d07bf6c5f
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b41148ca40ec8eb5" hs_bindgen_test_macrosreparse_b41148ca40ec8eb5 ::
      IO (Ptr.FunPtr (A -> FC.CBool -> IO ()))
 
@@ -2264,6 +2432,8 @@ const_withoutSign_after7_ptr :: Ptr.FunPtr (A -> FC.CBool -> IO ())
 const_withoutSign_after7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_b41148ca40ec8eb5
 
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_560c9dfdb530548b" hs_bindgen_test_macrosreparse_560c9dfdb530548b ::
      IO (Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSize -> IO ()))
 
@@ -2279,6 +2449,8 @@ const_withoutSign_after8_ptr :: Ptr.FunPtr (A -> HsBindgen.Runtime.Prelude.CSize
 const_withoutSign_after8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_560c9dfdb530548b
 
+{-| __unique:__ @ExampleNothingget_const_pointers_args1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a34d16c099748839" hs_bindgen_test_macrosreparse_a34d16c099748839 ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -2294,6 +2466,8 @@ const_pointers_args1_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 const_pointers_args1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_a34d16c099748839
 
+{-| __unique:__ @ExampleNothingget_const_pointers_args2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_45235edaf5c3b599" hs_bindgen_test_macrosreparse_45235edaf5c3b599 ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -2309,6 +2483,8 @@ const_pointers_args2_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 const_pointers_args2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_45235edaf5c3b599
 
+{-| __unique:__ @ExampleNothingget_const_pointers_args3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3dbcf1c7202f2878" hs_bindgen_test_macrosreparse_3dbcf1c7202f2878 ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -2324,6 +2500,8 @@ const_pointers_args3_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 const_pointers_args3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3dbcf1c7202f2878
 
+{-| __unique:__ @ExampleNothingget_const_pointers_args4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a6624f6cc0a062af" hs_bindgen_test_macrosreparse_a6624f6cc0a062af ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -2339,6 +2517,8 @@ const_pointers_args4_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 const_pointers_args4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_a6624f6cc0a062af
 
+{-| __unique:__ @ExampleNothingget_const_pointers_args5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c5f3253c57910315" hs_bindgen_test_macrosreparse_c5f3253c57910315 ::
      IO (Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ()))
 
@@ -2354,6 +2534,8 @@ const_pointers_args5_ptr :: Ptr.FunPtr (A -> (Ptr.Ptr FC.CInt) -> IO ())
 const_pointers_args5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c5f3253c57910315
 
+{-| __unique:__ @ExampleNothingget_const_pointers_ret1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1990ded85ea3850d" hs_bindgen_test_macrosreparse_1990ded85ea3850d ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -2369,6 +2551,8 @@ const_pointers_ret1_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 const_pointers_ret1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_1990ded85ea3850d
 
+{-| __unique:__ @ExampleNothingget_const_pointers_ret2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_627cc570c3ca7d19" hs_bindgen_test_macrosreparse_627cc570c3ca7d19 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -2384,6 +2568,8 @@ const_pointers_ret2_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 const_pointers_ret2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_627cc570c3ca7d19
 
+{-| __unique:__ @ExampleNothingget_const_pointers_ret3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2f449708b5a275b1" hs_bindgen_test_macrosreparse_2f449708b5a275b1 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -2399,6 +2585,8 @@ const_pointers_ret3_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 const_pointers_ret3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_2f449708b5a275b1
 
+{-| __unique:__ @ExampleNothingget_const_pointers_ret4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_67662618cd011c8a" hs_bindgen_test_macrosreparse_67662618cd011c8a ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -2414,6 +2602,8 @@ const_pointers_ret4_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 const_pointers_ret4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_67662618cd011c8a
 
+{-| __unique:__ @ExampleNothingget_const_pointers_ret5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fcafd9f8ac329995" hs_bindgen_test_macrosreparse_fcafd9f8ac329995 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt)))
 
@@ -2429,6 +2619,8 @@ const_pointers_ret5_ptr :: Ptr.FunPtr (A -> IO (Ptr.Ptr FC.CInt))
 const_pointers_ret5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_fcafd9f8ac329995
 
+{-| __unique:__ @ExampleNothingget_const_array_elem1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6928906fc9a88dfc" hs_bindgen_test_macrosreparse_6928906fc9a88dfc ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray A) -> IO ()))
 
@@ -2444,6 +2636,8 @@ const_array_elem1_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.Incomple
 const_array_elem1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_6928906fc9a88dfc
 
+{-| __unique:__ @ExampleNothingget_const_array_elem2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_625a37e9c030891a" hs_bindgen_test_macrosreparse_625a37e9c030891a ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A)) -> IO ()))
 
@@ -2459,6 +2653,8 @@ const_array_elem2_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.Incomple
 const_array_elem2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_625a37e9c030891a
 
+{-| __unique:__ @ExampleNothingget_const_array_elem3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5e23f87114cf51fb" hs_bindgen_test_macrosreparse_5e23f87114cf51fb ::
      IO (Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A)) -> IO ()))
 
@@ -2474,6 +2670,8 @@ const_array_elem3_ptr :: Ptr.FunPtr ((HsBindgen.Runtime.IncompleteArray.Incomple
 const_array_elem3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_5e23f87114cf51fb
 
+{-| __unique:__ @ExampleNothingget_noParams1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d50620a002265139" hs_bindgen_test_macrosreparse_d50620a002265139 ::
      IO (Ptr.FunPtr (IO A))
 
@@ -2491,6 +2689,8 @@ noParams1_ptr :: Ptr.FunPtr (IO A)
 noParams1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_d50620a002265139
 
+{-| __unique:__ @ExampleNothingget_noParams2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_03b0e24786b82ad5" hs_bindgen_test_macrosreparse_03b0e24786b82ad5 ::
      IO (Ptr.FunPtr (IO A))
 
@@ -2506,6 +2706,8 @@ noParams2_ptr :: Ptr.FunPtr (IO A)
 noParams2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_03b0e24786b82ad5
 
+{-| __unique:__ @ExampleNothingget_noParams3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_36508fd99a0556c5" hs_bindgen_test_macrosreparse_36508fd99a0556c5 ::
      IO (Ptr.FunPtr (A -> (Ptr.FunPtr (IO FC.CInt)) -> IO ()))
 
@@ -2521,6 +2723,8 @@ noParams3_ptr :: Ptr.FunPtr (A -> (Ptr.FunPtr (IO FC.CInt)) -> IO ())
 noParams3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_36508fd99a0556c5
 
+{-| __unique:__ @ExampleNothingget_funptr_ret1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6f83a48dd177c25f" hs_bindgen_test_macrosreparse_6f83a48dd177c25f ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (IO ()))))
 
@@ -2536,6 +2740,8 @@ funptr_ret1_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (IO ())))
 funptr_ret1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_6f83a48dd177c25f
 
+{-| __unique:__ @ExampleNothingget_funptr_ret2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f12efafd1525ef7f" hs_bindgen_test_macrosreparse_f12efafd1525ef7f ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (IO FC.CInt))))
 
@@ -2551,6 +2757,8 @@ funptr_ret2_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (IO FC.CInt)))
 funptr_ret2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_f12efafd1525ef7f
 
+{-| __unique:__ @ExampleNothingget_funptr_ret3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b00baa5b9708b9e7" hs_bindgen_test_macrosreparse_b00baa5b9708b9e7 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> IO ()))))
 
@@ -2566,6 +2774,8 @@ funptr_ret3_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> IO ())))
 funptr_ret3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_b00baa5b9708b9e7
 
+{-| __unique:__ @ExampleNothingget_funptr_ret4_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c51872479ceff42e" hs_bindgen_test_macrosreparse_c51872479ceff42e ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO FC.CChar))))
 
@@ -2581,6 +2791,8 @@ funptr_ret4_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret4_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_c51872479ceff42e
 
+{-| __unique:__ @ExampleNothingget_funptr_ret5_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea" hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 
@@ -2596,6 +2808,8 @@ funptr_ret5_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret5_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea
 
+{-| __unique:__ @ExampleNothingget_funptr_ret6_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_3df5ab4b0b306845" hs_bindgen_test_macrosreparse_3df5ab4b0b306845 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 
@@ -2611,6 +2825,8 @@ funptr_ret6_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret6_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_3df5ab4b0b306845
 
+{-| __unique:__ @ExampleNothingget_funptr_ret7_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2ac4454d93b6f04a" hs_bindgen_test_macrosreparse_2ac4454d93b6f04a ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 
@@ -2626,6 +2842,8 @@ funptr_ret7_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret7_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_2ac4454d93b6f04a
 
+{-| __unique:__ @ExampleNothingget_funptr_ret8_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_411c5128f18364b3" hs_bindgen_test_macrosreparse_411c5128f18364b3 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 
@@ -2641,6 +2859,8 @@ funptr_ret8_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret8_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_411c5128f18364b3
 
+{-| __unique:__ @ExampleNothingget_funptr_ret9_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_693a8d16e17d0cdc" hs_bindgen_test_macrosreparse_693a8d16e17d0cdc ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 
@@ -2656,6 +2876,8 @@ funptr_ret9_ptr :: Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO 
 funptr_ret9_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_macrosreparse_693a8d16e17d0cdc
 
+{-| __unique:__ @ExampleNothingget_funptr_ret10_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9d2da81bbfe49ab6" hs_bindgen_test_macrosreparse_9d2da81bbfe49ab6 ::
      IO (Ptr.FunPtr (A -> IO (Ptr.FunPtr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr FC.CInt)))))
 

--- a/hs-bindgen/fixtures/macros/reparse/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/Safe.hs
@@ -778,6 +778,8 @@ __C declaration:__ @args_char1@
 __defined at:__ @macros\/reparse.h:17:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Safeargs_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_394853579d622671" args_char1 ::
      A
@@ -793,6 +795,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_394853579d622671" args_
     __defined at:__ @macros\/reparse.h:18:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_da98fe949f347bb4" args_char2 ::
      A
@@ -808,6 +812,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_da98fe949f347bb4" args_
     __defined at:__ @macros\/reparse.h:19:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1b54575fa299f64d" args_char3 ::
      A
@@ -823,6 +829,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1b54575fa299f64d" args_
     __defined at:__ @macros\/reparse.h:21:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5eb574c361d453a5" args_short1 ::
      A
@@ -838,6 +846,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5eb574c361d453a5" args_
     __defined at:__ @macros\/reparse.h:22:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_47d5b6ac9938a676" args_short2 ::
      A
@@ -853,6 +863,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_47d5b6ac9938a676" args_
     __defined at:__ @macros\/reparse.h:23:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7b3f1c99ea5c31ce" args_short3 ::
      A
@@ -868,6 +880,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7b3f1c99ea5c31ce" args_
     __defined at:__ @macros\/reparse.h:25:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3103fa698febc2e4" args_int1 ::
      A
@@ -883,6 +897,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3103fa698febc2e4" args_
     __defined at:__ @macros\/reparse.h:26:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f73bd21e02a58e0f" args_int2 ::
      A
@@ -898,6 +914,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f73bd21e02a58e0f" args_
     __defined at:__ @macros\/reparse.h:27:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6d36b4892d340141" args_int3 ::
      A
@@ -913,6 +931,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_6d36b4892d340141" args_
     __defined at:__ @macros\/reparse.h:29:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c80fdb5f86f0e67e" args_long1 ::
      A
@@ -928,6 +948,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c80fdb5f86f0e67e" args_
     __defined at:__ @macros\/reparse.h:30:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b0db0696cda23a78" args_long2 ::
      A
@@ -943,6 +965,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b0db0696cda23a78" args_
     __defined at:__ @macros\/reparse.h:31:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_78868ddd9e2ed516" args_long3 ::
      A
@@ -958,6 +982,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_78868ddd9e2ed516" args_
     __defined at:__ @macros\/reparse.h:33:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_555dbd0a04bc0304" args_float ::
      A
@@ -973,6 +999,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_555dbd0a04bc0304" args_
     __defined at:__ @macros\/reparse.h:34:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fe4a06766df0d1e6" args_double ::
      A
@@ -988,6 +1016,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fe4a06766df0d1e6" args_
     __defined at:__ @macros\/reparse.h:35:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a607c108df5a1598" args_bool1 ::
      A
@@ -1000,6 +1030,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a607c108df5a1598" args_
 
 {-| Pointer-based API for 'args_struct'
 
+__unique:__ @ExampleJust Safeargs_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2867c64e14a8b4b4" args_struct_wrapper ::
      A
@@ -1026,6 +1057,7 @@ args_struct =
 
 {-| Pointer-based API for 'args_union'
 
+__unique:__ @ExampleJust Safeargs_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dbccce7991402835" args_union_wrapper ::
      A
@@ -1055,6 +1087,8 @@ args_union =
     __defined at:__ @macros\/reparse.h:39:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_58e9df8b58217744" args_enum ::
      A
@@ -1070,6 +1104,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_58e9df8b58217744" args_
     __defined at:__ @macros\/reparse.h:41:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_da0ab238a099dc49" args_pointer1 ::
      A
@@ -1085,6 +1121,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_da0ab238a099dc49" args_
     __defined at:__ @macros\/reparse.h:42:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_abd9ce8bdda564f4" args_pointer2 ::
      A
@@ -1100,6 +1138,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_abd9ce8bdda564f4" args_
     __defined at:__ @macros\/reparse.h:43:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeargs_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ed43d3d8eb25de8f" args_pointer3 ::
      A
@@ -1115,6 +1155,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ed43d3d8eb25de8f" args_
     __defined at:__ @macros\/reparse.h:47:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_A@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a45e66140bccd9e3" ret_A ::
      IO A
@@ -1124,6 +1166,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a45e66140bccd9e3" ret_A
     __defined at:__ @macros\/reparse.h:49:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_44f364f98d9773fa" ret_char1 ::
      A
@@ -1136,6 +1180,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_44f364f98d9773fa" ret_c
     __defined at:__ @macros\/reparse.h:50:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c0ccab4edfec7750" ret_char2 ::
      A
@@ -1148,6 +1194,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c0ccab4edfec7750" ret_c
     __defined at:__ @macros\/reparse.h:51:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_22570fd6296f553c" ret_char3 ::
      A
@@ -1160,6 +1208,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_22570fd6296f553c" ret_c
     __defined at:__ @macros\/reparse.h:53:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_60148c950d753d1d" ret_short1 ::
      A
@@ -1172,6 +1222,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_60148c950d753d1d" ret_s
     __defined at:__ @macros\/reparse.h:54:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1f5d60c2fc8391f8" ret_short2 ::
      A
@@ -1184,6 +1236,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1f5d60c2fc8391f8" ret_s
     __defined at:__ @macros\/reparse.h:55:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c35d296d9df5f67d" ret_short3 ::
      A
@@ -1196,6 +1250,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c35d296d9df5f67d" ret_s
     __defined at:__ @macros\/reparse.h:57:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_edcb4249e75b3e31" ret_int1 ::
      A
@@ -1208,6 +1264,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_edcb4249e75b3e31" ret_i
     __defined at:__ @macros\/reparse.h:58:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_28e6902c5d5c160d" ret_int2 ::
      A
@@ -1220,6 +1278,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_28e6902c5d5c160d" ret_i
     __defined at:__ @macros\/reparse.h:59:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_42873a9aa50685f7" ret_int3 ::
      A
@@ -1232,6 +1292,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_42873a9aa50685f7" ret_i
     __defined at:__ @macros\/reparse.h:61:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ef0217b739070465" ret_long1 ::
      A
@@ -1244,6 +1306,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ef0217b739070465" ret_l
     __defined at:__ @macros\/reparse.h:62:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8baea451432efe" ret_long2 ::
      A
@@ -1256,6 +1320,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8baea451432efe" ret_l
     __defined at:__ @macros\/reparse.h:63:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_264e25c048487a65" ret_long3 ::
      A
@@ -1268,6 +1334,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_264e25c048487a65" ret_l
     __defined at:__ @macros\/reparse.h:65:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d4f4783fa3bcf0fd" ret_float ::
      A
@@ -1280,6 +1348,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_d4f4783fa3bcf0fd" ret_f
     __defined at:__ @macros\/reparse.h:66:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_94ae038975c7b6e8" ret_double ::
      A
@@ -1292,6 +1362,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_94ae038975c7b6e8" ret_d
     __defined at:__ @macros\/reparse.h:67:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c6e57fb4c8ccc002" ret_bool1 ::
      A
@@ -1301,6 +1373,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c6e57fb4c8ccc002" ret_b
 
 {-| Pointer-based API for 'ret_struct'
 
+__unique:__ @ExampleJust Saferet_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4d9a2038e7abf410" ret_struct_wrapper ::
      A
@@ -1325,6 +1398,7 @@ ret_struct =
 
 {-| Pointer-based API for 'ret_union'
 
+__unique:__ @ExampleJust Saferet_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6614cf4950ce1e7c" ret_union_wrapper ::
      A
@@ -1352,6 +1426,8 @@ ret_union =
     __defined at:__ @macros\/reparse.h:71:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4a8e0e395958b0ed" ret_enum ::
      A
@@ -1364,6 +1440,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4a8e0e395958b0ed" ret_e
     __defined at:__ @macros\/reparse.h:73:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_59ba78873de08998" ret_pointer1 ::
      A
@@ -1376,6 +1454,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_59ba78873de08998" ret_p
     __defined at:__ @macros\/reparse.h:74:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f075faf1943231c1" ret_pointer2 ::
      A
@@ -1388,6 +1468,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f075faf1943231c1" ret_p
     __defined at:__ @macros\/reparse.h:75:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Saferet_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a865c16cbfd0f2b1" ret_pointer3 ::
      A
@@ -1400,6 +1482,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a865c16cbfd0f2b1" ret_p
     __defined at:__ @macros\/reparse.h:79:5@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebody1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0dd10e2baacf20e1" body1 ::
      A
@@ -1412,12 +1496,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0dd10e2baacf20e1" body1
     __defined at:__ @macros\/reparse.h:80:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebody2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e40f2da3eda8e4ab" body2 ::
      IO A
 
 {-| Pointer-based API for 'args_complex_float'
 
+__unique:__ @ExampleJust Safeargs_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cabceb6db44b7d81" args_complex_float_wrapper ::
      A
@@ -1445,6 +1532,7 @@ args_complex_float =
 
 {-| Pointer-based API for 'args_complex_double'
 
+__unique:__ @ExampleJust Safeargs_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ef2a09e9cd3eec0c" args_complex_double_wrapper ::
      A
@@ -1472,6 +1560,7 @@ args_complex_double =
 
 {-| Pointer-based API for 'ret_complex_float'
 
+__unique:__ @ExampleJust Saferet_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_26ada386c6fc7617" ret_complex_float_wrapper ::
      A
@@ -1496,6 +1585,7 @@ ret_complex_float =
 
 {-| Pointer-based API for 'ret_complex_double'
 
+__unique:__ @ExampleJust Saferet_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b99f35785e9f9b5c" ret_complex_double_wrapper ::
      A
@@ -1523,6 +1613,8 @@ ret_complex_double =
     __defined at:__ @macros\/reparse.h:94:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebespoke_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c1c48b67908e0ad" bespoke_args1 ::
      A
@@ -1538,6 +1630,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4c1c48b67908e0ad" bespo
     __defined at:__ @macros\/reparse.h:95:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebespoke_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7bd6c9115d303872" bespoke_args2 ::
      A
@@ -1553,6 +1647,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7bd6c9115d303872" bespo
     __defined at:__ @macros\/reparse.h:97:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebespoke_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_994d22fc993523bf" bespoke_ret1 ::
      A
@@ -1565,6 +1661,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_994d22fc993523bf" bespo
     __defined at:__ @macros\/reparse.h:98:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safebespoke_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c7649a4aa2e14a89" bespoke_ret2 ::
      A
@@ -1579,6 +1677,8 @@ __C declaration:__ @arr_args1@
 __defined at:__ @macros\/reparse.h:104:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Safearr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_69045f97d21cfcd3" arr_args1 ::
      Ptr.Ptr A
@@ -1591,6 +1691,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_69045f97d21cfcd3" arr_a
     __defined at:__ @macros\/reparse.h:105:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safearr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_75b7d6fa15700a72" arr_args2 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -1603,6 +1705,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_75b7d6fa15700a72" arr_a
     __defined at:__ @macros\/reparse.h:106:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safearr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_64bcbef92728339f" arr_args3 ::
      Ptr.Ptr A
@@ -1615,6 +1719,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_64bcbef92728339f" arr_a
     __defined at:__ @macros\/reparse.h:107:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safearr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1635b68f717cc6df" arr_args4 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -1629,6 +1735,8 @@ __C declaration:__ @funptr_args1@
 __defined at:__ @macros\/reparse.h:126:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Safefunptr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_09ca38f534ba1397" funptr_args1 ::
      A
@@ -1644,6 +1752,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_09ca38f534ba1397" funpt
     __defined at:__ @macros\/reparse.h:127:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_43e32eb1c4511130" funptr_args2 ::
      A
@@ -1659,6 +1769,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_43e32eb1c4511130" funpt
     __defined at:__ @macros\/reparse.h:128:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_639eb292178302da" funptr_args3 ::
      A
@@ -1674,6 +1786,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_639eb292178302da" funpt
     __defined at:__ @macros\/reparse.h:129:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_deaef357745591d1" funptr_args4 ::
      A
@@ -1689,6 +1803,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_deaef357745591d1" funpt
     __defined at:__ @macros\/reparse.h:130:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_bd58865f6f33ce14" funptr_args5 ::
      A
@@ -1708,6 +1824,8 @@ __C declaration:__ @comments1@
 __defined at:__ @macros\/reparse.h:144:25@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Safecomments1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a609cc59a266965e" comments1 ::
      A
@@ -1724,6 +1842,8 @@ __C declaration:__ @const_prim_before1@
 __defined at:__ @macros\/reparse.h:179:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Safeconst_prim_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_55af49e081d3af5c" const_prim_before1 ::
      A
@@ -1739,6 +1859,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_55af49e081d3af5c" const
     __defined at:__ @macros\/reparse.h:180:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_prim_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_17a6476d46f98f53" const_prim_before2 ::
      A
@@ -1754,6 +1876,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_17a6476d46f98f53" const
     __defined at:__ @macros\/reparse.h:181:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_prim_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1fce4989a8ceca6d" const_prim_before3 ::
      A
@@ -1769,6 +1893,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1fce4989a8ceca6d" const
     __defined at:__ @macros\/reparse.h:182:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_prim_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8f21af35a88318" const_prim_after1 ::
      A
@@ -1784,6 +1910,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8f21af35a88318" const
     __defined at:__ @macros\/reparse.h:183:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_prim_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_069042df961b78f1" const_prim_after2 ::
      A
@@ -1799,6 +1927,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_069042df961b78f1" const
     __defined at:__ @macros\/reparse.h:184:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_prim_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_14ab286beb6d7436" const_prim_after3 ::
      A
@@ -1814,6 +1944,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_14ab286beb6d7436" const
     __defined at:__ @macros\/reparse.h:188:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3f5a39bd9a93581a" const_withoutSign_before1 ::
      A
@@ -1829,6 +1961,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3f5a39bd9a93581a" const
     __defined at:__ @macros\/reparse.h:189:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5a190462ddfe8168" const_withoutSign_before2 ::
      A
@@ -1844,6 +1978,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5a190462ddfe8168" const
     __defined at:__ @macros\/reparse.h:190:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_70a40d82bb46c21c" const_withoutSign_before3 ::
      A
@@ -1856,6 +1992,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_70a40d82bb46c21c" const
 
 {-| Pointer-based API for 'const_withoutSign_before4'
 
+__unique:__ @ExampleJust Safeconst_withoutSign_before4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_81ce15a9b9be53f8" const_withoutSign_before4_wrapper ::
      A
@@ -1884,6 +2021,7 @@ const_withoutSign_before4 =
 
 {-| Pointer-based API for 'const_withoutSign_before5'
 
+__unique:__ @ExampleJust Safeconst_withoutSign_before5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_39c58819fdca0585" const_withoutSign_before5_wrapper ::
      A
@@ -1915,6 +2053,8 @@ const_withoutSign_before5 =
     __defined at:__ @macros\/reparse.h:193:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c5a32cae31a651c" const_withoutSign_before6 ::
      A
@@ -1930,6 +2070,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4c5a32cae31a651c" const
     __defined at:__ @macros\/reparse.h:194:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0341b56dd9dde729" const_withoutSign_before7 ::
      A
@@ -1945,6 +2087,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0341b56dd9dde729" const
     __defined at:__ @macros\/reparse.h:195:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_before8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d43c37be4d91bd6c" const_withoutSign_before8 ::
      A
@@ -1960,6 +2104,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_d43c37be4d91bd6c" const
     __defined at:__ @macros\/reparse.h:197:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f456a2b015543748" const_withoutSign_after1 ::
      A
@@ -1975,6 +2121,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f456a2b015543748" const
     __defined at:__ @macros\/reparse.h:198:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_729c897c9a9bfc92" const_withoutSign_after2 ::
      A
@@ -1990,6 +2138,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_729c897c9a9bfc92" const
     __defined at:__ @macros\/reparse.h:199:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e46eebba0299b49" const_withoutSign_after3 ::
      A
@@ -2002,6 +2152,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5e46eebba0299b49" const
 
 {-| Pointer-based API for 'const_withoutSign_after4'
 
+__unique:__ @ExampleJust Safeconst_withoutSign_after4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_18b842a824ecef09" const_withoutSign_after4_wrapper ::
      A
@@ -2030,6 +2181,7 @@ const_withoutSign_after4 =
 
 {-| Pointer-based API for 'const_withoutSign_after5'
 
+__unique:__ @ExampleJust Safeconst_withoutSign_after5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_75feb5260081201b" const_withoutSign_after5_wrapper ::
      A
@@ -2061,6 +2213,8 @@ const_withoutSign_after5 =
     __defined at:__ @macros\/reparse.h:202:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3375ca58017bcbeb" const_withoutSign_after6 ::
      A
@@ -2076,6 +2230,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3375ca58017bcbeb" const
     __defined at:__ @macros\/reparse.h:203:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5da184668d3e18ba" const_withoutSign_after7 ::
      A
@@ -2091,6 +2247,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5da184668d3e18ba" const
     __defined at:__ @macros\/reparse.h:204:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_withoutSign_after8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3cae7641509d64fa" const_withoutSign_after8 ::
      A
@@ -2106,6 +2264,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3cae7641509d64fa" const
     __defined at:__ @macros\/reparse.h:208:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4dcc1a25c1ecaaa2" const_pointers_args1 ::
      A
@@ -2121,6 +2281,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4dcc1a25c1ecaaa2" const
     __defined at:__ @macros\/reparse.h:209:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fec0ae82f5b0ad81" const_pointers_args2 ::
      A
@@ -2136,6 +2298,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fec0ae82f5b0ad81" const
     __defined at:__ @macros\/reparse.h:210:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fe0313a1b7b08d51" const_pointers_args3 ::
      A
@@ -2151,6 +2315,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fe0313a1b7b08d51" const
     __defined at:__ @macros\/reparse.h:211:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_33f3fc94401a8bfe" const_pointers_args4 ::
      A
@@ -2166,6 +2332,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_33f3fc94401a8bfe" const
     __defined at:__ @macros\/reparse.h:212:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_391d9682b9dc51ac" const_pointers_args5 ::
      A
@@ -2181,6 +2349,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_391d9682b9dc51ac" const
     __defined at:__ @macros\/reparse.h:214:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8bf23a9981153f56" const_pointers_ret1 ::
      A
@@ -2193,6 +2363,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8bf23a9981153f56" const
     __defined at:__ @macros\/reparse.h:215:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_849c6f0a166afc3c" const_pointers_ret2 ::
      A
@@ -2205,6 +2377,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_849c6f0a166afc3c" const
     __defined at:__ @macros\/reparse.h:216:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2bcb395289e776af" const_pointers_ret3 ::
      A
@@ -2217,6 +2391,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2bcb395289e776af" const
     __defined at:__ @macros\/reparse.h:217:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_10d30d6be4435bb5" const_pointers_ret4 ::
      A
@@ -2229,6 +2405,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_10d30d6be4435bb5" const
     __defined at:__ @macros\/reparse.h:218:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_pointers_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4e0a9385778eeea9" const_pointers_ret5 ::
      A
@@ -2238,6 +2416,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4e0a9385778eeea9" const
 
 {-| Pointer-based API for 'const_array_elem1'
 
+__unique:__ @ExampleJust Safeconst_array_elem1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_216b4842313741d6" const_array_elem1_wrapper ::
      Ptr.Ptr A
@@ -2264,6 +2443,8 @@ const_array_elem1 =
     __defined at:__ @macros\/reparse.h:247:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safeconst_array_elem2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1c0be30090d3f0b4" const_array_elem2 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -2273,6 +2454,7 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1c0be30090d3f0b4" const
 
 {-| Pointer-based API for 'const_array_elem3'
 
+__unique:__ @ExampleJust Safeconst_array_elem3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_30c17e3a462eeecc" const_array_elem3_wrapper ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -2301,6 +2483,8 @@ __C declaration:__ @noParams1@
 __defined at:__ @macros\/reparse.h:256:3@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust SafenoParams1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8ab2f7d7d9185985" noParams1 ::
      IO A
@@ -2310,6 +2494,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8ab2f7d7d9185985" noPar
     __defined at:__ @macros\/reparse.h:257:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust SafenoParams2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3154e7cc23e3e0f3" noParams2 ::
      IO A
@@ -2319,6 +2505,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3154e7cc23e3e0f3" noPar
     __defined at:__ @macros\/reparse.h:258:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust SafenoParams3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3d23de5d2d770dfe" noParams3 ::
      A
@@ -2334,6 +2522,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3d23de5d2d770dfe" noPar
     __defined at:__ @macros\/reparse.h:262:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cfe9601f75800453" funptr_ret1 ::
      A
@@ -2346,6 +2536,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_cfe9601f75800453" funpt
     __defined at:__ @macros\/reparse.h:263:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ca3824f5cf114f19" funptr_ret2 ::
      A
@@ -2358,6 +2550,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ca3824f5cf114f19" funpt
     __defined at:__ @macros\/reparse.h:264:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2de886ad95f674f5" funptr_ret3 ::
      A
@@ -2370,6 +2564,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2de886ad95f674f5" funpt
     __defined at:__ @macros\/reparse.h:265:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b4856eab77ec0cbf" funptr_ret4 ::
      A
@@ -2382,6 +2578,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b4856eab77ec0cbf" funpt
     __defined at:__ @macros\/reparse.h:269:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_39273a56f1a80904" funptr_ret5 ::
      A
@@ -2394,6 +2592,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_39273a56f1a80904" funpt
     __defined at:__ @macros\/reparse.h:270:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e2dfa9b8f6075ee" funptr_ret6 ::
      A
@@ -2406,6 +2606,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5e2dfa9b8f6075ee" funpt
     __defined at:__ @macros\/reparse.h:271:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b65a87e08b5a1a7" funptr_ret7 ::
      A
@@ -2418,6 +2620,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b65a87e08b5a1a7" funpt
     __defined at:__ @macros\/reparse.h:272:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_629050352113405f" funptr_ret8 ::
      A
@@ -2430,6 +2634,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_629050352113405f" funpt
     __defined at:__ @macros\/reparse.h:273:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret9@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a1dcda8f782ad284" funptr_ret9 ::
      A
@@ -2442,6 +2648,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a1dcda8f782ad284" funpt
     __defined at:__ @macros\/reparse.h:274:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Safefunptr_ret10@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ca08b018fda612eb" funptr_ret10 ::
      A

--- a/hs-bindgen/fixtures/macros/reparse/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/Unsafe.hs
@@ -778,6 +778,8 @@ __C declaration:__ @args_char1@
 __defined at:__ @macros\/reparse.h:17:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeargs_char1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a10d23a1cebc3f58" args_char1 ::
      A
@@ -793,6 +795,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a10d23a1cebc3f58" arg
     __defined at:__ @macros\/reparse.h:18:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a76a90b5f6e68b22" args_char2 ::
      A
@@ -808,6 +812,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a76a90b5f6e68b22" arg
     __defined at:__ @macros\/reparse.h:19:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8d42e2ffb839cfb7" args_char3 ::
      A
@@ -823,6 +829,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8d42e2ffb839cfb7" arg
     __defined at:__ @macros\/reparse.h:21:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0919acaf21bc8eb1" args_short1 ::
      A
@@ -838,6 +846,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0919acaf21bc8eb1" arg
     __defined at:__ @macros\/reparse.h:22:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_42f4e1b66fbe1d85" args_short2 ::
      A
@@ -853,6 +863,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_42f4e1b66fbe1d85" arg
     __defined at:__ @macros\/reparse.h:23:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cfd148e6676f4393" args_short3 ::
      A
@@ -868,6 +880,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cfd148e6676f4393" arg
     __defined at:__ @macros\/reparse.h:25:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b55222b08f54d08a" args_int1 ::
      A
@@ -883,6 +897,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b55222b08f54d08a" arg
     __defined at:__ @macros\/reparse.h:26:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5ab884050f61f378" args_int2 ::
      A
@@ -898,6 +914,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5ab884050f61f378" arg
     __defined at:__ @macros\/reparse.h:27:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5b3642adbf8d8c09" args_int3 ::
      A
@@ -913,6 +931,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5b3642adbf8d8c09" arg
     __defined at:__ @macros\/reparse.h:29:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fb02cb0320aff007" args_long1 ::
      A
@@ -928,6 +948,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fb02cb0320aff007" arg
     __defined at:__ @macros\/reparse.h:30:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c6b81a1422f5535e" args_long2 ::
      A
@@ -943,6 +965,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c6b81a1422f5535e" arg
     __defined at:__ @macros\/reparse.h:31:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7279876c6cff5eed" args_long3 ::
      A
@@ -958,6 +982,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7279876c6cff5eed" arg
     __defined at:__ @macros\/reparse.h:33:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_float@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7dec78ee43c784cf" args_float ::
      A
@@ -973,6 +999,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7dec78ee43c784cf" arg
     __defined at:__ @macros\/reparse.h:34:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_double@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_af9629b17c5c01eb" args_double ::
      A
@@ -988,6 +1016,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_af9629b17c5c01eb" arg
     __defined at:__ @macros\/reparse.h:35:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_bool1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b1e345616dae25b7" args_bool1 ::
      A
@@ -1000,6 +1030,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b1e345616dae25b7" arg
 
 {-| Pointer-based API for 'args_struct'
 
+__unique:__ @ExampleJust Unsafeargs_struct@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e20137c4ab18a66e" args_struct_wrapper ::
      A
@@ -1026,6 +1057,7 @@ args_struct =
 
 {-| Pointer-based API for 'args_union'
 
+__unique:__ @ExampleJust Unsafeargs_union@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8468152f3130816a" args_union_wrapper ::
      A
@@ -1055,6 +1087,8 @@ args_union =
     __defined at:__ @macros\/reparse.h:39:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_enum@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2ee1baf211b5f628" args_enum ::
      A
@@ -1070,6 +1104,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2ee1baf211b5f628" arg
     __defined at:__ @macros\/reparse.h:41:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_42e8807b857ec8be" args_pointer1 ::
      A
@@ -1085,6 +1121,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_42e8807b857ec8be" arg
     __defined at:__ @macros\/reparse.h:42:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_decf0f1fad98cc09" args_pointer2 ::
      A
@@ -1100,6 +1138,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_decf0f1fad98cc09" arg
     __defined at:__ @macros\/reparse.h:43:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c2bfa7966be9fc8a" args_pointer3 ::
      A
@@ -1115,6 +1155,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c2bfa7966be9fc8a" arg
     __defined at:__ @macros\/reparse.h:47:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_A@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_733ed36b28b7932b" ret_A ::
      IO A
@@ -1124,6 +1166,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_733ed36b28b7932b" ret
     __defined at:__ @macros\/reparse.h:49:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_954b53887fa8a7bf" ret_char1 ::
      A
@@ -1136,6 +1180,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_954b53887fa8a7bf" ret
     __defined at:__ @macros\/reparse.h:50:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_20d1e28fced60632" ret_char2 ::
      A
@@ -1148,6 +1194,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_20d1e28fced60632" ret
     __defined at:__ @macros\/reparse.h:51:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e55f76ceed24192d" ret_char3 ::
      A
@@ -1160,6 +1208,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e55f76ceed24192d" ret
     __defined at:__ @macros\/reparse.h:53:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1b8d9484010475fd" ret_short1 ::
      A
@@ -1172,6 +1222,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1b8d9484010475fd" ret
     __defined at:__ @macros\/reparse.h:54:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9b4291556b50f99f" ret_short2 ::
      A
@@ -1184,6 +1236,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9b4291556b50f99f" ret
     __defined at:__ @macros\/reparse.h:55:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_658bd87f6fba088a" ret_short3 ::
      A
@@ -1196,6 +1250,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_658bd87f6fba088a" ret
     __defined at:__ @macros\/reparse.h:57:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f39ba97cac5f7b69" ret_int1 ::
      A
@@ -1208,6 +1264,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f39ba97cac5f7b69" ret
     __defined at:__ @macros\/reparse.h:58:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2811bb2a6c369ff8" ret_int2 ::
      A
@@ -1220,6 +1278,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2811bb2a6c369ff8" ret
     __defined at:__ @macros\/reparse.h:59:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4d1047d184259f2a" ret_int3 ::
      A
@@ -1232,6 +1292,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4d1047d184259f2a" ret
     __defined at:__ @macros\/reparse.h:61:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fe651b499cb756e7" ret_long1 ::
      A
@@ -1244,6 +1306,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fe651b499cb756e7" ret
     __defined at:__ @macros\/reparse.h:62:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e1e78ae00ab5d6fb" ret_long2 ::
      A
@@ -1256,6 +1320,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e1e78ae00ab5d6fb" ret
     __defined at:__ @macros\/reparse.h:63:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dc6449bb75895cea" ret_long3 ::
      A
@@ -1268,6 +1334,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dc6449bb75895cea" ret
     __defined at:__ @macros\/reparse.h:65:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_float@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ae67ab94cf0f147" ret_float ::
      A
@@ -1280,6 +1348,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ae67ab94cf0f147" ret
     __defined at:__ @macros\/reparse.h:66:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_double@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8a715139fcb185f1" ret_double ::
      A
@@ -1292,6 +1362,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_8a715139fcb185f1" ret
     __defined at:__ @macros\/reparse.h:67:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_bool1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_330b3d59b2b9e0ac" ret_bool1 ::
      A
@@ -1301,6 +1373,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_330b3d59b2b9e0ac" ret
 
 {-| Pointer-based API for 'ret_struct'
 
+__unique:__ @ExampleJust Unsaferet_struct@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_843df9379b58bc51" ret_struct_wrapper ::
      A
@@ -1325,6 +1398,7 @@ ret_struct =
 
 {-| Pointer-based API for 'ret_union'
 
+__unique:__ @ExampleJust Unsaferet_union@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d1fb1f1235b044ef" ret_union_wrapper ::
      A
@@ -1352,6 +1426,8 @@ ret_union =
     __defined at:__ @macros\/reparse.h:71:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_enum@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5706a52e565b1a0c" ret_enum ::
      A
@@ -1364,6 +1440,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5706a52e565b1a0c" ret
     __defined at:__ @macros\/reparse.h:73:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1539645657f24f97" ret_pointer1 ::
      A
@@ -1376,6 +1454,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1539645657f24f97" ret
     __defined at:__ @macros\/reparse.h:74:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_14db602035a357c9" ret_pointer2 ::
      A
@@ -1388,6 +1468,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_14db602035a357c9" ret
     __defined at:__ @macros\/reparse.h:75:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_347fc9fe6ee0e39f" ret_pointer3 ::
      A
@@ -1400,6 +1482,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_347fc9fe6ee0e39f" ret
     __defined at:__ @macros\/reparse.h:79:5@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_31d344eb39edbb32" body1 ::
      A
@@ -1412,12 +1496,15 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_31d344eb39edbb32" bod
     __defined at:__ @macros\/reparse.h:80:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9a49ad9d6fd009aa" body2 ::
      IO A
 
 {-| Pointer-based API for 'args_complex_float'
 
+__unique:__ @ExampleJust Unsafeargs_complex_float@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f09e648ac9470faf" args_complex_float_wrapper ::
      A
@@ -1445,6 +1532,7 @@ args_complex_float =
 
 {-| Pointer-based API for 'args_complex_double'
 
+__unique:__ @ExampleJust Unsafeargs_complex_double@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a334455360f1e746" args_complex_double_wrapper ::
      A
@@ -1472,6 +1560,7 @@ args_complex_double =
 
 {-| Pointer-based API for 'ret_complex_float'
 
+__unique:__ @ExampleJust Unsaferet_complex_float@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0c94b79e37a671f3" ret_complex_float_wrapper ::
      A
@@ -1496,6 +1585,7 @@ ret_complex_float =
 
 {-| Pointer-based API for 'ret_complex_double'
 
+__unique:__ @ExampleJust Unsaferet_complex_double@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_52e016b143848038" ret_complex_double_wrapper ::
      A
@@ -1523,6 +1613,8 @@ ret_complex_double =
     __defined at:__ @macros\/reparse.h:94:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_28f85791b3039264" bespoke_args1 ::
      A
@@ -1538,6 +1630,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_28f85791b3039264" bes
     __defined at:__ @macros\/reparse.h:95:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_833c75e57b012dcc" bespoke_args2 ::
      A
@@ -1553,6 +1647,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_833c75e57b012dcc" bes
     __defined at:__ @macros\/reparse.h:97:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_434418d9d1f41c66" bespoke_ret1 ::
      A
@@ -1565,6 +1661,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_434418d9d1f41c66" bes
     __defined at:__ @macros\/reparse.h:98:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7a13d4c1ed935df0" bespoke_ret2 ::
      A
@@ -1579,6 +1677,8 @@ __C declaration:__ @arr_args1@
 __defined at:__ @macros\/reparse.h:104:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafearr_args1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_802c66e1efc0f556" arr_args1 ::
      Ptr.Ptr A
@@ -1591,6 +1691,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_802c66e1efc0f556" arr
     __defined at:__ @macros\/reparse.h:105:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f516070848930af9" arr_args2 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -1603,6 +1705,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_f516070848930af9" arr
     __defined at:__ @macros\/reparse.h:106:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c0db4046bcf7da77" arr_args3 ::
      Ptr.Ptr A
@@ -1615,6 +1719,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c0db4046bcf7da77" arr
     __defined at:__ @macros\/reparse.h:107:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_881ede0e81c9ed45" arr_args4 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -1629,6 +1735,8 @@ __C declaration:__ @funptr_args1@
 __defined at:__ @macros\/reparse.h:126:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafefunptr_args1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_91151b594cc92e09" funptr_args1 ::
      A
@@ -1644,6 +1752,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_91151b594cc92e09" fun
     __defined at:__ @macros\/reparse.h:127:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_543290455260832c" funptr_args2 ::
      A
@@ -1659,6 +1769,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_543290455260832c" fun
     __defined at:__ @macros\/reparse.h:128:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fbdf924574cb6295" funptr_args3 ::
      A
@@ -1674,6 +1786,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_fbdf924574cb6295" fun
     __defined at:__ @macros\/reparse.h:129:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5e0a2c10ccd9a8c4" funptr_args4 ::
      A
@@ -1689,6 +1803,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5e0a2c10ccd9a8c4" fun
     __defined at:__ @macros\/reparse.h:130:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c13f66d86b4b5ef6" funptr_args5 ::
      A
@@ -1708,6 +1824,8 @@ __C declaration:__ @comments1@
 __defined at:__ @macros\/reparse.h:144:25@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafecomments1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0b54f704cff3ab9b" comments1 ::
      A
@@ -1724,6 +1842,8 @@ __C declaration:__ @const_prim_before1@
 __defined at:__ @macros\/reparse.h:179:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeconst_prim_before1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4a390ee488c3a1b1" const_prim_before1 ::
      A
@@ -1739,6 +1859,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4a390ee488c3a1b1" con
     __defined at:__ @macros\/reparse.h:180:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_349252e982c28bae" const_prim_before2 ::
      A
@@ -1754,6 +1876,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_349252e982c28bae" con
     __defined at:__ @macros\/reparse.h:181:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ffeb1784fe8b2f2" const_prim_before3 ::
      A
@@ -1769,6 +1893,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ffeb1784fe8b2f2" con
     __defined at:__ @macros\/reparse.h:182:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0dae8ba3b65c77d2" const_prim_after1 ::
      A
@@ -1784,6 +1910,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_0dae8ba3b65c77d2" con
     __defined at:__ @macros\/reparse.h:183:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dc74f73eff3fac62" const_prim_after2 ::
      A
@@ -1799,6 +1927,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dc74f73eff3fac62" con
     __defined at:__ @macros\/reparse.h:184:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_aeea75713b67f6d8" const_prim_after3 ::
      A
@@ -1814,6 +1944,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_aeea75713b67f6d8" con
     __defined at:__ @macros\/reparse.h:188:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9f70419bf10f327e" const_withoutSign_before1 ::
      A
@@ -1829,6 +1961,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9f70419bf10f327e" con
     __defined at:__ @macros\/reparse.h:189:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7867bb0d71ef4b6d" const_withoutSign_before2 ::
      A
@@ -1844,6 +1978,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7867bb0d71ef4b6d" con
     __defined at:__ @macros\/reparse.h:190:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_80de805eb016225b" const_withoutSign_before3 ::
      A
@@ -1856,6 +1992,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_80de805eb016225b" con
 
 {-| Pointer-based API for 'const_withoutSign_before4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_69cef8742b4b119b" const_withoutSign_before4_wrapper ::
      A
@@ -1884,6 +2021,7 @@ const_withoutSign_before4 =
 
 {-| Pointer-based API for 'const_withoutSign_before5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1ad5aadb8be4d493" const_withoutSign_before5_wrapper ::
      A
@@ -1915,6 +2053,8 @@ const_withoutSign_before5 =
     __defined at:__ @macros\/reparse.h:193:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before6@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7106059de99b7682" const_withoutSign_before6 ::
      A
@@ -1930,6 +2070,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7106059de99b7682" con
     __defined at:__ @macros\/reparse.h:194:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before7@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b61cf3c21bf8b00b" const_withoutSign_before7 ::
      A
@@ -1945,6 +2087,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_b61cf3c21bf8b00b" con
     __defined at:__ @macros\/reparse.h:195:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before8@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_47573f5eb4cb92a9" const_withoutSign_before8 ::
      A
@@ -1960,6 +2104,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_47573f5eb4cb92a9" con
     __defined at:__ @macros\/reparse.h:197:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ffb1a87ed1f94b31" const_withoutSign_after1 ::
      A
@@ -1975,6 +2121,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ffb1a87ed1f94b31" con
     __defined at:__ @macros\/reparse.h:198:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1ec7c37faacfcd64" const_withoutSign_after2 ::
      A
@@ -1990,6 +2138,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1ec7c37faacfcd64" con
     __defined at:__ @macros\/reparse.h:199:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_34233036f1e22371" const_withoutSign_after3 ::
      A
@@ -2002,6 +2152,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_34233036f1e22371" con
 
 {-| Pointer-based API for 'const_withoutSign_after4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4c909292e290aa0a" const_withoutSign_after4_wrapper ::
      A
@@ -2030,6 +2181,7 @@ const_withoutSign_after4 =
 
 {-| Pointer-based API for 'const_withoutSign_after5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ab1abd31c91696b9" const_withoutSign_after5_wrapper ::
      A
@@ -2061,6 +2213,8 @@ const_withoutSign_after5 =
     __defined at:__ @macros\/reparse.h:202:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after6@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_342c1139871906f3" const_withoutSign_after6 ::
      A
@@ -2076,6 +2230,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_342c1139871906f3" con
     __defined at:__ @macros\/reparse.h:203:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after7@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_446758003fdc3418" const_withoutSign_after7 ::
      A
@@ -2091,6 +2247,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_446758003fdc3418" con
     __defined at:__ @macros\/reparse.h:204:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after8@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_161f0b5d4c06966c" const_withoutSign_after8 ::
      A
@@ -2106,6 +2264,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_161f0b5d4c06966c" con
     __defined at:__ @macros\/reparse.h:208:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ec8e91fa9341dad6" const_pointers_args1 ::
      A
@@ -2121,6 +2281,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_ec8e91fa9341dad6" con
     __defined at:__ @macros\/reparse.h:209:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cf24549623cd56c1" const_pointers_args2 ::
      A
@@ -2136,6 +2298,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_cf24549623cd56c1" con
     __defined at:__ @macros\/reparse.h:210:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_71cfb5062c931668" const_pointers_args3 ::
      A
@@ -2151,6 +2315,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_71cfb5062c931668" con
     __defined at:__ @macros\/reparse.h:211:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_74894da577575f87" const_pointers_args4 ::
      A
@@ -2166,6 +2332,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_74894da577575f87" con
     __defined at:__ @macros\/reparse.h:212:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5493c91c677fe8d0" const_pointers_args5 ::
      A
@@ -2181,6 +2349,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_5493c91c677fe8d0" con
     __defined at:__ @macros\/reparse.h:214:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a302fca87b1aa099" const_pointers_ret1 ::
      A
@@ -2193,6 +2363,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_a302fca87b1aa099" con
     __defined at:__ @macros\/reparse.h:215:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_825f0c60f6c63862" const_pointers_ret2 ::
      A
@@ -2205,6 +2377,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_825f0c60f6c63862" con
     __defined at:__ @macros\/reparse.h:216:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c36f7d270a11e1cd" const_pointers_ret3 ::
      A
@@ -2217,6 +2391,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_c36f7d270a11e1cd" con
     __defined at:__ @macros\/reparse.h:217:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4a82390c6e38a4ad" const_pointers_ret4 ::
      A
@@ -2229,6 +2405,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4a82390c6e38a4ad" con
     __defined at:__ @macros\/reparse.h:218:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_763d600d2f5c49bb" const_pointers_ret5 ::
      A
@@ -2238,6 +2416,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_763d600d2f5c49bb" con
 
 {-| Pointer-based API for 'const_array_elem1'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4b3bef3ab591a329" const_array_elem1_wrapper ::
      Ptr.Ptr A
@@ -2264,6 +2443,8 @@ const_array_elem1 =
     __defined at:__ @macros\/reparse.h:247:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_array_elem2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dd69ef198e368a38" const_array_elem2 ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -2273,6 +2454,7 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dd69ef198e368a38" con
 
 {-| Pointer-based API for 'const_array_elem3'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_1842bc8653aa9c3f" const_array_elem3_wrapper ::
      Ptr.Ptr (Ptr.Ptr A)
@@ -2301,6 +2483,8 @@ __C declaration:__ @noParams1@
 __defined at:__ @macros\/reparse.h:256:3@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust UnsafenoParams1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4c99a8a7824a66d4" noParams1 ::
      IO A
@@ -2310,6 +2494,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4c99a8a7824a66d4" noP
     __defined at:__ @macros\/reparse.h:257:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ae14613ab7f3b03" noParams2 ::
      IO A
@@ -2319,6 +2505,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_7ae14613ab7f3b03" noP
     __defined at:__ @macros\/reparse.h:258:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2f4d972da222d332" noParams3 ::
      A
@@ -2334,6 +2522,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_2f4d972da222d332" noP
     __defined at:__ @macros\/reparse.h:262:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dbe5f5ae726e36b3" funptr_ret1 ::
      A
@@ -2346,6 +2536,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_dbe5f5ae726e36b3" fun
     __defined at:__ @macros\/reparse.h:263:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_081cb5fbeb6f4506" funptr_ret2 ::
      A
@@ -2358,6 +2550,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_081cb5fbeb6f4506" fun
     __defined at:__ @macros\/reparse.h:264:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret3@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4fc16e9f894820ff" funptr_ret3 ::
      A
@@ -2370,6 +2564,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4fc16e9f894820ff" fun
     __defined at:__ @macros\/reparse.h:265:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret4@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9e8aa8193619dbbe" funptr_ret4 ::
      A
@@ -2382,6 +2578,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_9e8aa8193619dbbe" fun
     __defined at:__ @macros\/reparse.h:269:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret5@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4b914fec0c848647" funptr_ret5 ::
      A
@@ -2394,6 +2592,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_4b914fec0c848647" fun
     __defined at:__ @macros\/reparse.h:270:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret6@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6c188a6c3899a751" funptr_ret6 ::
      A
@@ -2406,6 +2606,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_6c188a6c3899a751" fun
     __defined at:__ @macros\/reparse.h:271:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret7@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e4468a6e0afe686b" funptr_ret7 ::
      A
@@ -2418,6 +2620,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_e4468a6e0afe686b" fun
     __defined at:__ @macros\/reparse.h:272:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret8@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_16740b4fc6d6c8ec" funptr_ret8 ::
      A
@@ -2430,6 +2634,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_16740b4fc6d6c8ec" fun
     __defined at:__ @macros\/reparse.h:273:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret9@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d82b69157b543190" funptr_ret9 ::
      A
@@ -2442,6 +2648,8 @@ foreign import ccall unsafe "hs_bindgen_test_macrosreparse_d82b69157b543190" fun
     __defined at:__ @macros\/reparse.h:274:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret10@
 -}
 foreign import ccall unsafe "hs_bindgen_test_macrosreparse_317f5f7c8c2496cd" funptr_ret10 ::
      A

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -3945,6 +3945,8 @@ __C declaration:__ @args_char1@
 __defined at:__ @macros\/reparse.h:17:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeargs_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_394853579d622671" args_char1 :: A ->
                                                                                          CChar ->
@@ -3954,6 +3956,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_394853579d622671" args_
     __defined at:__ @macros\/reparse.h:18:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_da98fe949f347bb4" args_char2 :: A ->
                                                                                          CSChar ->
@@ -3963,6 +3967,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_da98fe949f347bb4" args_
     __defined at:__ @macros\/reparse.h:19:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1b54575fa299f64d" args_char3 :: A ->
                                                                                          CUChar ->
@@ -3972,6 +3978,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1b54575fa299f64d" args_
     __defined at:__ @macros\/reparse.h:21:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5eb574c361d453a5" args_short1 :: A ->
                                                                                           CShort ->
@@ -3981,6 +3989,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5eb574c361d453a5" args_
     __defined at:__ @macros\/reparse.h:22:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_47d5b6ac9938a676" args_short2 :: A ->
                                                                                           CShort ->
@@ -3990,6 +4000,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_47d5b6ac9938a676" args_
     __defined at:__ @macros\/reparse.h:23:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7b3f1c99ea5c31ce" args_short3 :: A ->
                                                                                           CUShort ->
@@ -3999,6 +4011,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7b3f1c99ea5c31ce" args_
     __defined at:__ @macros\/reparse.h:25:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3103fa698febc2e4" args_int1 :: A ->
                                                                                         CInt ->
@@ -4008,6 +4022,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3103fa698febc2e4" args_
     __defined at:__ @macros\/reparse.h:26:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f73bd21e02a58e0f" args_int2 :: A ->
                                                                                         CInt ->
@@ -4017,6 +4033,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f73bd21e02a58e0f" args_
     __defined at:__ @macros\/reparse.h:27:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6d36b4892d340141" args_int3 :: A ->
                                                                                         CUInt ->
@@ -4026,6 +4044,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_6d36b4892d340141" args_
     __defined at:__ @macros\/reparse.h:29:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c80fdb5f86f0e67e" args_long1 :: A ->
                                                                                          CLong ->
@@ -4035,6 +4055,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c80fdb5f86f0e67e" args_
     __defined at:__ @macros\/reparse.h:30:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b0db0696cda23a78" args_long2 :: A ->
                                                                                          CLong ->
@@ -4044,6 +4066,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b0db0696cda23a78" args_
     __defined at:__ @macros\/reparse.h:31:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_78868ddd9e2ed516" args_long3 :: A ->
                                                                                          CULong ->
@@ -4053,6 +4077,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_78868ddd9e2ed516" args_
     __defined at:__ @macros\/reparse.h:33:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_555dbd0a04bc0304" args_float :: A ->
                                                                                          CFloat ->
@@ -4062,6 +4088,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_555dbd0a04bc0304" args_
     __defined at:__ @macros\/reparse.h:34:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fe4a06766df0d1e6" args_double :: A ->
                                                                                           CDouble ->
@@ -4071,12 +4099,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fe4a06766df0d1e6" args_
     __defined at:__ @macros\/reparse.h:35:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a607c108df5a1598" args_bool1 :: A ->
                                                                                          CBool ->
                                                                                          IO Unit
 {-| Pointer-based API for 'args_struct'
 
+__unique:__ @ExampleJust Unsafeargs_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2867c64e14a8b4b4" args_struct_wrapper :: A ->
                                                                                                   Ptr Some_struct ->
@@ -4097,6 +4128,7 @@ args_struct :: A -> Some_struct -> IO Unit
 args_struct = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_struct_wrapper x_0 y_2)
 {-| Pointer-based API for 'args_union'
 
+__unique:__ @ExampleJust Unsafeargs_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dbccce7991402835" args_union_wrapper :: A ->
                                                                                                  Ptr Some_union ->
@@ -4120,6 +4152,8 @@ args_union = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_union_wrapper x_0 y_2)
     __defined at:__ @macros\/reparse.h:39:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_58e9df8b58217744" args_enum :: A ->
                                                                                         Some_enum ->
@@ -4129,6 +4163,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_58e9df8b58217744" args_
     __defined at:__ @macros\/reparse.h:41:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_da0ab238a099dc49" args_pointer1 :: A ->
                                                                                             Ptr CInt ->
@@ -4138,6 +4174,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_da0ab238a099dc49" args_
     __defined at:__ @macros\/reparse.h:42:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_abd9ce8bdda564f4" args_pointer2 :: A ->
                                                                                             Ptr (Ptr CInt) ->
@@ -4147,6 +4185,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_abd9ce8bdda564f4" args_
     __defined at:__ @macros\/reparse.h:43:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ed43d3d8eb25de8f" args_pointer3 :: A ->
                                                                                             Ptr Void ->
@@ -4156,6 +4196,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ed43d3d8eb25de8f" args_
     __defined at:__ @macros\/reparse.h:47:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_A@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a45e66140bccd9e3" ret_A :: IO A
 {-| __C declaration:__ @ret_char1@
@@ -4163,6 +4205,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a45e66140bccd9e3" ret_A
     __defined at:__ @macros\/reparse.h:49:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_44f364f98d9773fa" ret_char1 :: A ->
                                                                                         IO CChar
@@ -4171,6 +4215,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_44f364f98d9773fa" ret_c
     __defined at:__ @macros\/reparse.h:50:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c0ccab4edfec7750" ret_char2 :: A ->
                                                                                         IO CSChar
@@ -4179,6 +4225,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c0ccab4edfec7750" ret_c
     __defined at:__ @macros\/reparse.h:51:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_22570fd6296f553c" ret_char3 :: A ->
                                                                                         IO CUChar
@@ -4187,6 +4235,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_22570fd6296f553c" ret_c
     __defined at:__ @macros\/reparse.h:53:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_60148c950d753d1d" ret_short1 :: A ->
                                                                                          IO CShort
@@ -4195,6 +4245,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_60148c950d753d1d" ret_s
     __defined at:__ @macros\/reparse.h:54:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1f5d60c2fc8391f8" ret_short2 :: A ->
                                                                                          IO CShort
@@ -4203,6 +4255,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1f5d60c2fc8391f8" ret_s
     __defined at:__ @macros\/reparse.h:55:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c35d296d9df5f67d" ret_short3 :: A ->
                                                                                          IO CUShort
@@ -4211,6 +4265,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c35d296d9df5f67d" ret_s
     __defined at:__ @macros\/reparse.h:57:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_edcb4249e75b3e31" ret_int1 :: A ->
                                                                                        IO CInt
@@ -4219,6 +4275,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_edcb4249e75b3e31" ret_i
     __defined at:__ @macros\/reparse.h:58:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_28e6902c5d5c160d" ret_int2 :: A ->
                                                                                        IO CInt
@@ -4227,6 +4285,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_28e6902c5d5c160d" ret_i
     __defined at:__ @macros\/reparse.h:59:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_42873a9aa50685f7" ret_int3 :: A ->
                                                                                        IO CUInt
@@ -4235,6 +4295,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_42873a9aa50685f7" ret_i
     __defined at:__ @macros\/reparse.h:61:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ef0217b739070465" ret_long1 :: A ->
                                                                                         IO CLong
@@ -4243,6 +4305,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ef0217b739070465" ret_l
     __defined at:__ @macros\/reparse.h:62:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8baea451432efe" ret_long2 :: A ->
                                                                                         IO CLong
@@ -4251,6 +4315,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8baea451432efe" ret_l
     __defined at:__ @macros\/reparse.h:63:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_264e25c048487a65" ret_long3 :: A ->
                                                                                         IO CULong
@@ -4259,6 +4325,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_264e25c048487a65" ret_l
     __defined at:__ @macros\/reparse.h:65:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d4f4783fa3bcf0fd" ret_float :: A ->
                                                                                         IO CFloat
@@ -4267,6 +4335,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_d4f4783fa3bcf0fd" ret_f
     __defined at:__ @macros\/reparse.h:66:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_94ae038975c7b6e8" ret_double :: A ->
                                                                                          IO CDouble
@@ -4275,11 +4345,14 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_94ae038975c7b6e8" ret_d
     __defined at:__ @macros\/reparse.h:67:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c6e57fb4c8ccc002" ret_bool1 :: A ->
                                                                                         IO CBool
 {-| Pointer-based API for 'ret_struct'
 
+__unique:__ @ExampleJust Unsaferet_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4d9a2038e7abf410" ret_struct_wrapper :: A ->
                                                                                                  Ptr Some_struct ->
@@ -4300,6 +4373,7 @@ ret_struct :: A -> IO Some_struct
 ret_struct = \x_0 -> allocaAndPeek (\z_1 -> ret_struct_wrapper x_0 z_1)
 {-| Pointer-based API for 'ret_union'
 
+__unique:__ @ExampleJust Unsaferet_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6614cf4950ce1e7c" ret_union_wrapper :: A ->
                                                                                                 Ptr Some_union ->
@@ -4323,6 +4397,8 @@ ret_union = \x_0 -> allocaAndPeek (\z_1 -> ret_union_wrapper x_0 z_1)
     __defined at:__ @macros\/reparse.h:71:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4a8e0e395958b0ed" ret_enum :: A ->
                                                                                        IO Some_enum
@@ -4331,6 +4407,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4a8e0e395958b0ed" ret_e
     __defined at:__ @macros\/reparse.h:73:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_59ba78873de08998" ret_pointer1 :: A ->
                                                                                            IO (Ptr CInt)
@@ -4339,6 +4417,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_59ba78873de08998" ret_p
     __defined at:__ @macros\/reparse.h:74:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f075faf1943231c1" ret_pointer2 :: A ->
                                                                                            IO (Ptr (Ptr CInt))
@@ -4347,6 +4427,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f075faf1943231c1" ret_p
     __defined at:__ @macros\/reparse.h:75:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a865c16cbfd0f2b1" ret_pointer3 :: A ->
                                                                                            IO (Ptr Void)
@@ -4355,6 +4437,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a865c16cbfd0f2b1" ret_p
     __defined at:__ @macros\/reparse.h:79:5@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0dd10e2baacf20e1" body1 :: A ->
                                                                                     IO CInt
@@ -4363,10 +4447,13 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0dd10e2baacf20e1" body1
     __defined at:__ @macros\/reparse.h:80:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e40f2da3eda8e4ab" body2 :: IO A
 {-| Pointer-based API for 'args_complex_float'
 
+__unique:__ @ExampleJust Unsafeargs_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cabceb6db44b7d81" args_complex_float_wrapper :: A ->
                                                                                                          Ptr (Complex CFloat) ->
@@ -4387,6 +4474,7 @@ args_complex_float :: A -> Complex CFloat -> IO Unit
 args_complex_float = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_complex_float_wrapper x_0 y_2)
 {-| Pointer-based API for 'args_complex_double'
 
+__unique:__ @ExampleJust Unsafeargs_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ef2a09e9cd3eec0c" args_complex_double_wrapper :: A ->
                                                                                                           Ptr (Complex CDouble) ->
@@ -4407,6 +4495,7 @@ args_complex_double :: A -> Complex CDouble -> IO Unit
 args_complex_double = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_complex_double_wrapper x_0 y_2)
 {-| Pointer-based API for 'ret_complex_float'
 
+__unique:__ @ExampleJust Unsaferet_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_26ada386c6fc7617" ret_complex_float_wrapper :: A ->
                                                                                                         Ptr (Complex CFloat) ->
@@ -4427,6 +4516,7 @@ ret_complex_float :: A -> IO (Complex CFloat)
 ret_complex_float = \x_0 -> allocaAndPeek (\z_1 -> ret_complex_float_wrapper x_0 z_1)
 {-| Pointer-based API for 'ret_complex_double'
 
+__unique:__ @ExampleJust Unsaferet_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b99f35785e9f9b5c" ret_complex_double_wrapper :: A ->
                                                                                                          Ptr (Complex CDouble) ->
@@ -4450,6 +4540,8 @@ ret_complex_double = \x_0 -> allocaAndPeek (\z_1 -> ret_complex_double_wrapper x
     __defined at:__ @macros\/reparse.h:94:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c1c48b67908e0ad" bespoke_args1 :: A ->
                                                                                             CBool ->
@@ -4459,6 +4551,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4c1c48b67908e0ad" bespo
     __defined at:__ @macros\/reparse.h:95:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7bd6c9115d303872" bespoke_args2 :: A ->
                                                                                             HsBindgen.Runtime.Prelude.CSize ->
@@ -4468,6 +4562,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7bd6c9115d303872" bespo
     __defined at:__ @macros\/reparse.h:97:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_994d22fc993523bf" bespoke_ret1 :: A ->
                                                                                            IO CBool
@@ -4476,6 +4572,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_994d22fc993523bf" bespo
     __defined at:__ @macros\/reparse.h:98:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c7649a4aa2e14a89" bespoke_ret2 :: A ->
                                                                                            IO HsBindgen.Runtime.Prelude.CSize
@@ -4486,6 +4584,8 @@ __C declaration:__ @arr_args1@
 __defined at:__ @macros\/reparse.h:104:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafearr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_69045f97d21cfcd3" arr_args1 :: Ptr A ->
                                                                                         IO Unit
@@ -4494,6 +4594,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_69045f97d21cfcd3" arr_a
     __defined at:__ @macros\/reparse.h:105:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_75b7d6fa15700a72" arr_args2 :: Ptr (Ptr A) ->
                                                                                         IO Unit
@@ -4502,6 +4604,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_75b7d6fa15700a72" arr_a
     __defined at:__ @macros\/reparse.h:106:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_64bcbef92728339f" arr_args3 :: Ptr A ->
                                                                                         IO Unit
@@ -4510,6 +4614,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_64bcbef92728339f" arr_a
     __defined at:__ @macros\/reparse.h:107:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1635b68f717cc6df" arr_args4 :: Ptr (Ptr A) ->
                                                                                         IO Unit
@@ -4520,6 +4626,8 @@ __C declaration:__ @funptr_args1@
 __defined at:__ @macros\/reparse.h:126:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafefunptr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_09ca38f534ba1397" funptr_args1 :: A ->
                                                                                            FunPtr (IO Unit) ->
@@ -4529,6 +4637,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_09ca38f534ba1397" funpt
     __defined at:__ @macros\/reparse.h:127:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_43e32eb1c4511130" funptr_args2 :: A ->
                                                                                            FunPtr (IO CInt) ->
@@ -4538,6 +4648,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_43e32eb1c4511130" funpt
     __defined at:__ @macros\/reparse.h:128:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_639eb292178302da" funptr_args3 :: A ->
                                                                                            FunPtr (CInt ->
@@ -4548,6 +4660,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_639eb292178302da" funpt
     __defined at:__ @macros\/reparse.h:129:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_deaef357745591d1" funptr_args4 :: A ->
                                                                                            FunPtr (CInt ->
@@ -4559,6 +4673,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_deaef357745591d1" funpt
     __defined at:__ @macros\/reparse.h:130:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_bd58865f6f33ce14" funptr_args5 :: A ->
                                                                                            FunPtr (CInt ->
@@ -4574,6 +4690,8 @@ __C declaration:__ @comments1@
 __defined at:__ @macros\/reparse.h:144:25@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafecomments1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a609cc59a266965e" comments1 :: A ->
                                                                                         IO Unit
@@ -4586,6 +4704,8 @@ __C declaration:__ @const_prim_before1@
 __defined at:__ @macros\/reparse.h:179:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeconst_prim_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_55af49e081d3af5c" const_prim_before1 :: A ->
                                                                                                  CChar ->
@@ -4595,6 +4715,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_55af49e081d3af5c" const
     __defined at:__ @macros\/reparse.h:180:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_17a6476d46f98f53" const_prim_before2 :: A ->
                                                                                                  CSChar ->
@@ -4604,6 +4726,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_17a6476d46f98f53" const
     __defined at:__ @macros\/reparse.h:181:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1fce4989a8ceca6d" const_prim_before3 :: A ->
                                                                                                  CUChar ->
@@ -4613,6 +4737,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1fce4989a8ceca6d" const
     __defined at:__ @macros\/reparse.h:182:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8f21af35a88318" const_prim_after1 :: A ->
                                                                                                 CChar ->
@@ -4622,6 +4748,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b8f21af35a88318" const
     __defined at:__ @macros\/reparse.h:183:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_069042df961b78f1" const_prim_after2 :: A ->
                                                                                                 CSChar ->
@@ -4631,6 +4759,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_069042df961b78f1" const
     __defined at:__ @macros\/reparse.h:184:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_14ab286beb6d7436" const_prim_after3 :: A ->
                                                                                                 CUChar ->
@@ -4640,6 +4770,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_14ab286beb6d7436" const
     __defined at:__ @macros\/reparse.h:188:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3f5a39bd9a93581a" const_withoutSign_before1 :: A ->
                                                                                                         CFloat ->
@@ -4649,6 +4781,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3f5a39bd9a93581a" const
     __defined at:__ @macros\/reparse.h:189:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5a190462ddfe8168" const_withoutSign_before2 :: A ->
                                                                                                         CDouble ->
@@ -4658,12 +4792,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5a190462ddfe8168" const
     __defined at:__ @macros\/reparse.h:190:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_70a40d82bb46c21c" const_withoutSign_before3 :: A ->
                                                                                                         CBool ->
                                                                                                         IO Unit
 {-| Pointer-based API for 'const_withoutSign_before4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_81ce15a9b9be53f8" const_withoutSign_before4_wrapper :: A ->
                                                                                                                 Ptr Some_struct ->
@@ -4684,6 +4821,7 @@ const_withoutSign_before4 :: A -> Some_struct -> IO Unit
 const_withoutSign_before4 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_before4_wrapper x_0 y_2)
 {-| Pointer-based API for 'const_withoutSign_before5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_39c58819fdca0585" const_withoutSign_before5_wrapper :: A ->
                                                                                                                 Ptr Some_union ->
@@ -4707,6 +4845,8 @@ const_withoutSign_before5 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_
     __defined at:__ @macros\/reparse.h:193:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c5a32cae31a651c" const_withoutSign_before6 :: A ->
                                                                                                         Some_enum ->
@@ -4716,6 +4856,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4c5a32cae31a651c" const
     __defined at:__ @macros\/reparse.h:194:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0341b56dd9dde729" const_withoutSign_before7 :: A ->
                                                                                                         CBool ->
@@ -4725,6 +4867,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0341b56dd9dde729" const
     __defined at:__ @macros\/reparse.h:195:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d43c37be4d91bd6c" const_withoutSign_before8 :: A ->
                                                                                                         HsBindgen.Runtime.Prelude.CSize ->
@@ -4734,6 +4878,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_d43c37be4d91bd6c" const
     __defined at:__ @macros\/reparse.h:197:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f456a2b015543748" const_withoutSign_after1 :: A ->
                                                                                                        CFloat ->
@@ -4743,6 +4889,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f456a2b015543748" const
     __defined at:__ @macros\/reparse.h:198:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_729c897c9a9bfc92" const_withoutSign_after2 :: A ->
                                                                                                        CDouble ->
@@ -4752,12 +4900,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_729c897c9a9bfc92" const
     __defined at:__ @macros\/reparse.h:199:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e46eebba0299b49" const_withoutSign_after3 :: A ->
                                                                                                        CBool ->
                                                                                                        IO Unit
 {-| Pointer-based API for 'const_withoutSign_after4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_18b842a824ecef09" const_withoutSign_after4_wrapper :: A ->
                                                                                                                Ptr Some_struct ->
@@ -4778,6 +4929,7 @@ const_withoutSign_after4 :: A -> Some_struct -> IO Unit
 const_withoutSign_after4 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_after4_wrapper x_0 y_2)
 {-| Pointer-based API for 'const_withoutSign_after5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_75feb5260081201b" const_withoutSign_after5_wrapper :: A ->
                                                                                                                Ptr Some_union ->
@@ -4801,6 +4953,8 @@ const_withoutSign_after5 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_a
     __defined at:__ @macros\/reparse.h:202:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3375ca58017bcbeb" const_withoutSign_after6 :: A ->
                                                                                                        Some_enum ->
@@ -4810,6 +4964,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3375ca58017bcbeb" const
     __defined at:__ @macros\/reparse.h:203:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5da184668d3e18ba" const_withoutSign_after7 :: A ->
                                                                                                        CBool ->
@@ -4819,6 +4975,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5da184668d3e18ba" const
     __defined at:__ @macros\/reparse.h:204:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3cae7641509d64fa" const_withoutSign_after8 :: A ->
                                                                                                        HsBindgen.Runtime.Prelude.CSize ->
@@ -4828,6 +4986,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3cae7641509d64fa" const
     __defined at:__ @macros\/reparse.h:208:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4dcc1a25c1ecaaa2" const_pointers_args1 :: A ->
                                                                                                    Ptr CInt ->
@@ -4837,6 +4997,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4dcc1a25c1ecaaa2" const
     __defined at:__ @macros\/reparse.h:209:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fec0ae82f5b0ad81" const_pointers_args2 :: A ->
                                                                                                    Ptr CInt ->
@@ -4846,6 +5008,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fec0ae82f5b0ad81" const
     __defined at:__ @macros\/reparse.h:210:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fe0313a1b7b08d51" const_pointers_args3 :: A ->
                                                                                                    Ptr CInt ->
@@ -4855,6 +5019,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fe0313a1b7b08d51" const
     __defined at:__ @macros\/reparse.h:211:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_33f3fc94401a8bfe" const_pointers_args4 :: A ->
                                                                                                    Ptr CInt ->
@@ -4864,6 +5030,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_33f3fc94401a8bfe" const
     __defined at:__ @macros\/reparse.h:212:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_391d9682b9dc51ac" const_pointers_args5 :: A ->
                                                                                                    Ptr CInt ->
@@ -4873,6 +5041,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_391d9682b9dc51ac" const
     __defined at:__ @macros\/reparse.h:214:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8bf23a9981153f56" const_pointers_ret1 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -4881,6 +5051,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8bf23a9981153f56" const
     __defined at:__ @macros\/reparse.h:215:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_849c6f0a166afc3c" const_pointers_ret2 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -4889,6 +5061,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_849c6f0a166afc3c" const
     __defined at:__ @macros\/reparse.h:216:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2bcb395289e776af" const_pointers_ret3 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -4897,6 +5071,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2bcb395289e776af" const
     __defined at:__ @macros\/reparse.h:217:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_10d30d6be4435bb5" const_pointers_ret4 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -4905,11 +5081,14 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_10d30d6be4435bb5" const
     __defined at:__ @macros\/reparse.h:218:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4e0a9385778eeea9" const_pointers_ret5 :: A ->
                                                                                                   IO (Ptr CInt)
 {-| Pointer-based API for 'const_array_elem1'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_216b4842313741d6" const_array_elem1_wrapper :: Ptr A ->
                                                                                                         IO Unit
@@ -4932,11 +5111,14 @@ const_array_elem1 = \x_0 -> withPtr x_0 (\ptr_1 -> const_array_elem1_wrapper ptr
     __defined at:__ @macros\/reparse.h:247:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_array_elem2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1c0be30090d3f0b4" const_array_elem2 :: Ptr (Ptr A) ->
                                                                                                 IO Unit
 {-| Pointer-based API for 'const_array_elem3'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_30c17e3a462eeecc" const_array_elem3_wrapper :: Ptr (Ptr A) ->
                                                                                                         IO Unit
@@ -4961,6 +5143,8 @@ __C declaration:__ @noParams1@
 __defined at:__ @macros\/reparse.h:256:3@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust UnsafenoParams1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8ab2f7d7d9185985" noParams1 :: IO A
 {-| __C declaration:__ @noParams2@
@@ -4968,6 +5152,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8ab2f7d7d9185985" noPar
     __defined at:__ @macros\/reparse.h:257:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3154e7cc23e3e0f3" noParams2 :: IO A
 {-| __C declaration:__ @noParams3@
@@ -4975,6 +5161,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3154e7cc23e3e0f3" noPar
     __defined at:__ @macros\/reparse.h:258:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3d23de5d2d770dfe" noParams3 :: A ->
                                                                                         FunPtr (IO CInt) ->
@@ -4984,6 +5172,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_3d23de5d2d770dfe" noPar
     __defined at:__ @macros\/reparse.h:262:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cfe9601f75800453" funptr_ret1 :: A ->
                                                                                           IO (FunPtr (IO Unit))
@@ -4992,6 +5182,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_cfe9601f75800453" funpt
     __defined at:__ @macros\/reparse.h:263:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ca3824f5cf114f19" funptr_ret2 :: A ->
                                                                                           IO (FunPtr (IO CInt))
@@ -5000,6 +5192,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ca3824f5cf114f19" funpt
     __defined at:__ @macros\/reparse.h:264:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2de886ad95f674f5" funptr_ret3 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5009,6 +5203,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2de886ad95f674f5" funpt
     __defined at:__ @macros\/reparse.h:265:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b4856eab77ec0cbf" funptr_ret4 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5019,6 +5215,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b4856eab77ec0cbf" funpt
     __defined at:__ @macros\/reparse.h:269:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_39273a56f1a80904" funptr_ret5 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5029,6 +5227,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_39273a56f1a80904" funpt
     __defined at:__ @macros\/reparse.h:270:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e2dfa9b8f6075ee" funptr_ret6 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5039,6 +5239,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5e2dfa9b8f6075ee" funpt
     __defined at:__ @macros\/reparse.h:271:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b65a87e08b5a1a7" funptr_ret7 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5049,6 +5251,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0b65a87e08b5a1a7" funpt
     __defined at:__ @macros\/reparse.h:272:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_629050352113405f" funptr_ret8 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5059,6 +5263,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_629050352113405f" funpt
     __defined at:__ @macros\/reparse.h:273:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret9@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a1dcda8f782ad284" funptr_ret9 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -5069,6 +5275,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a1dcda8f782ad284" funpt
     __defined at:__ @macros\/reparse.h:274:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret10@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ca08b018fda612eb" funptr_ret10 :: A ->
                                                                                            IO (FunPtr (CInt ->
@@ -5081,6 +5289,8 @@ __C declaration:__ @args_char1@
 __defined at:__ @macros\/reparse.h:17:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeargs_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a10d23a1cebc3f58" args_char1 :: A ->
                                                                                          CChar ->
@@ -5090,6 +5300,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a10d23a1cebc3f58" args_
     __defined at:__ @macros\/reparse.h:18:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a76a90b5f6e68b22" args_char2 :: A ->
                                                                                          CSChar ->
@@ -5099,6 +5311,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a76a90b5f6e68b22" args_
     __defined at:__ @macros\/reparse.h:19:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8d42e2ffb839cfb7" args_char3 :: A ->
                                                                                          CUChar ->
@@ -5108,6 +5322,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8d42e2ffb839cfb7" args_
     __defined at:__ @macros\/reparse.h:21:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0919acaf21bc8eb1" args_short1 :: A ->
                                                                                           CShort ->
@@ -5117,6 +5333,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0919acaf21bc8eb1" args_
     __defined at:__ @macros\/reparse.h:22:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_42f4e1b66fbe1d85" args_short2 :: A ->
                                                                                           CShort ->
@@ -5126,6 +5344,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_42f4e1b66fbe1d85" args_
     __defined at:__ @macros\/reparse.h:23:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cfd148e6676f4393" args_short3 :: A ->
                                                                                           CUShort ->
@@ -5135,6 +5355,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_cfd148e6676f4393" args_
     __defined at:__ @macros\/reparse.h:25:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b55222b08f54d08a" args_int1 :: A ->
                                                                                         CInt ->
@@ -5144,6 +5366,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b55222b08f54d08a" args_
     __defined at:__ @macros\/reparse.h:26:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5ab884050f61f378" args_int2 :: A ->
                                                                                         CInt ->
@@ -5153,6 +5377,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5ab884050f61f378" args_
     __defined at:__ @macros\/reparse.h:27:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5b3642adbf8d8c09" args_int3 :: A ->
                                                                                         CUInt ->
@@ -5162,6 +5388,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5b3642adbf8d8c09" args_
     __defined at:__ @macros\/reparse.h:29:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fb02cb0320aff007" args_long1 :: A ->
                                                                                          CLong ->
@@ -5171,6 +5399,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fb02cb0320aff007" args_
     __defined at:__ @macros\/reparse.h:30:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c6b81a1422f5535e" args_long2 :: A ->
                                                                                          CLong ->
@@ -5180,6 +5410,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c6b81a1422f5535e" args_
     __defined at:__ @macros\/reparse.h:31:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7279876c6cff5eed" args_long3 :: A ->
                                                                                          CULong ->
@@ -5189,6 +5421,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7279876c6cff5eed" args_
     __defined at:__ @macros\/reparse.h:33:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7dec78ee43c784cf" args_float :: A ->
                                                                                          CFloat ->
@@ -5198,6 +5432,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7dec78ee43c784cf" args_
     __defined at:__ @macros\/reparse.h:34:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_af9629b17c5c01eb" args_double :: A ->
                                                                                           CDouble ->
@@ -5207,12 +5443,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_af9629b17c5c01eb" args_
     __defined at:__ @macros\/reparse.h:35:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b1e345616dae25b7" args_bool1 :: A ->
                                                                                          CBool ->
                                                                                          IO Unit
 {-| Pointer-based API for 'args_struct'
 
+__unique:__ @ExampleJust Unsafeargs_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e20137c4ab18a66e" args_struct_wrapper :: A ->
                                                                                                   Ptr Some_struct ->
@@ -5233,6 +5472,7 @@ args_struct :: A -> Some_struct -> IO Unit
 args_struct = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_struct_wrapper x_0 y_2)
 {-| Pointer-based API for 'args_union'
 
+__unique:__ @ExampleJust Unsafeargs_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8468152f3130816a" args_union_wrapper :: A ->
                                                                                                  Ptr Some_union ->
@@ -5256,6 +5496,8 @@ args_union = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_union_wrapper x_0 y_2)
     __defined at:__ @macros\/reparse.h:39:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2ee1baf211b5f628" args_enum :: A ->
                                                                                         Some_enum ->
@@ -5265,6 +5507,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2ee1baf211b5f628" args_
     __defined at:__ @macros\/reparse.h:41:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_42e8807b857ec8be" args_pointer1 :: A ->
                                                                                             Ptr CInt ->
@@ -5274,6 +5518,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_42e8807b857ec8be" args_
     __defined at:__ @macros\/reparse.h:42:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_decf0f1fad98cc09" args_pointer2 :: A ->
                                                                                             Ptr (Ptr CInt) ->
@@ -5283,6 +5529,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_decf0f1fad98cc09" args_
     __defined at:__ @macros\/reparse.h:43:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeargs_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c2bfa7966be9fc8a" args_pointer3 :: A ->
                                                                                             Ptr Void ->
@@ -5292,6 +5540,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c2bfa7966be9fc8a" args_
     __defined at:__ @macros\/reparse.h:47:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_A@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_733ed36b28b7932b" ret_A :: IO A
 {-| __C declaration:__ @ret_char1@
@@ -5299,6 +5549,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_733ed36b28b7932b" ret_A
     __defined at:__ @macros\/reparse.h:49:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_954b53887fa8a7bf" ret_char1 :: A ->
                                                                                         IO CChar
@@ -5307,6 +5559,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_954b53887fa8a7bf" ret_c
     __defined at:__ @macros\/reparse.h:50:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_20d1e28fced60632" ret_char2 :: A ->
                                                                                         IO CSChar
@@ -5315,6 +5569,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_20d1e28fced60632" ret_c
     __defined at:__ @macros\/reparse.h:51:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_char3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e55f76ceed24192d" ret_char3 :: A ->
                                                                                         IO CUChar
@@ -5323,6 +5579,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_e55f76ceed24192d" ret_c
     __defined at:__ @macros\/reparse.h:53:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1b8d9484010475fd" ret_short1 :: A ->
                                                                                          IO CShort
@@ -5331,6 +5589,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1b8d9484010475fd" ret_s
     __defined at:__ @macros\/reparse.h:54:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9b4291556b50f99f" ret_short2 :: A ->
                                                                                          IO CShort
@@ -5339,6 +5599,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_9b4291556b50f99f" ret_s
     __defined at:__ @macros\/reparse.h:55:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_short3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_658bd87f6fba088a" ret_short3 :: A ->
                                                                                          IO CUShort
@@ -5347,6 +5609,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_658bd87f6fba088a" ret_s
     __defined at:__ @macros\/reparse.h:57:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f39ba97cac5f7b69" ret_int1 :: A ->
                                                                                        IO CInt
@@ -5355,6 +5619,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f39ba97cac5f7b69" ret_i
     __defined at:__ @macros\/reparse.h:58:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2811bb2a6c369ff8" ret_int2 :: A ->
                                                                                        IO CInt
@@ -5363,6 +5629,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2811bb2a6c369ff8" ret_i
     __defined at:__ @macros\/reparse.h:59:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_int3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4d1047d184259f2a" ret_int3 :: A ->
                                                                                        IO CUInt
@@ -5371,6 +5639,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4d1047d184259f2a" ret_i
     __defined at:__ @macros\/reparse.h:61:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fe651b499cb756e7" ret_long1 :: A ->
                                                                                         IO CLong
@@ -5379,6 +5649,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fe651b499cb756e7" ret_l
     __defined at:__ @macros\/reparse.h:62:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e1e78ae00ab5d6fb" ret_long2 :: A ->
                                                                                         IO CLong
@@ -5387,6 +5659,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_e1e78ae00ab5d6fb" ret_l
     __defined at:__ @macros\/reparse.h:63:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_long3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dc6449bb75895cea" ret_long3 :: A ->
                                                                                         IO CULong
@@ -5395,6 +5669,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_dc6449bb75895cea" ret_l
     __defined at:__ @macros\/reparse.h:65:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7ae67ab94cf0f147" ret_float :: A ->
                                                                                         IO CFloat
@@ -5403,6 +5679,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7ae67ab94cf0f147" ret_f
     __defined at:__ @macros\/reparse.h:66:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8a715139fcb185f1" ret_double :: A ->
                                                                                          IO CDouble
@@ -5411,11 +5689,14 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_8a715139fcb185f1" ret_d
     __defined at:__ @macros\/reparse.h:67:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_bool1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_330b3d59b2b9e0ac" ret_bool1 :: A ->
                                                                                         IO CBool
 {-| Pointer-based API for 'ret_struct'
 
+__unique:__ @ExampleJust Unsaferet_struct@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_843df9379b58bc51" ret_struct_wrapper :: A ->
                                                                                                  Ptr Some_struct ->
@@ -5436,6 +5717,7 @@ ret_struct :: A -> IO Some_struct
 ret_struct = \x_0 -> allocaAndPeek (\z_1 -> ret_struct_wrapper x_0 z_1)
 {-| Pointer-based API for 'ret_union'
 
+__unique:__ @ExampleJust Unsaferet_union@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d1fb1f1235b044ef" ret_union_wrapper :: A ->
                                                                                                 Ptr Some_union ->
@@ -5459,6 +5741,8 @@ ret_union = \x_0 -> allocaAndPeek (\z_1 -> ret_union_wrapper x_0 z_1)
     __defined at:__ @macros\/reparse.h:71:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_enum@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5706a52e565b1a0c" ret_enum :: A ->
                                                                                        IO Some_enum
@@ -5467,6 +5751,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5706a52e565b1a0c" ret_e
     __defined at:__ @macros\/reparse.h:73:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1539645657f24f97" ret_pointer1 :: A ->
                                                                                            IO (Ptr CInt)
@@ -5475,6 +5761,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1539645657f24f97" ret_p
     __defined at:__ @macros\/reparse.h:74:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_14db602035a357c9" ret_pointer2 :: A ->
                                                                                            IO (Ptr (Ptr CInt))
@@ -5483,6 +5771,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_14db602035a357c9" ret_p
     __defined at:__ @macros\/reparse.h:75:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsaferet_pointer3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_347fc9fe6ee0e39f" ret_pointer3 :: A ->
                                                                                            IO (Ptr Void)
@@ -5491,6 +5781,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_347fc9fe6ee0e39f" ret_p
     __defined at:__ @macros\/reparse.h:79:5@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_31d344eb39edbb32" body1 :: A ->
                                                                                     IO CInt
@@ -5499,10 +5791,13 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_31d344eb39edbb32" body1
     __defined at:__ @macros\/reparse.h:80:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebody2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9a49ad9d6fd009aa" body2 :: IO A
 {-| Pointer-based API for 'args_complex_float'
 
+__unique:__ @ExampleJust Unsafeargs_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f09e648ac9470faf" args_complex_float_wrapper :: A ->
                                                                                                          Ptr (Complex CFloat) ->
@@ -5523,6 +5818,7 @@ args_complex_float :: A -> Complex CFloat -> IO Unit
 args_complex_float = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_complex_float_wrapper x_0 y_2)
 {-| Pointer-based API for 'args_complex_double'
 
+__unique:__ @ExampleJust Unsafeargs_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a334455360f1e746" args_complex_double_wrapper :: A ->
                                                                                                           Ptr (Complex CDouble) ->
@@ -5543,6 +5839,7 @@ args_complex_double :: A -> Complex CDouble -> IO Unit
 args_complex_double = \x_0 -> \x_1 -> with x_1 (\y_2 -> args_complex_double_wrapper x_0 y_2)
 {-| Pointer-based API for 'ret_complex_float'
 
+__unique:__ @ExampleJust Unsaferet_complex_float@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0c94b79e37a671f3" ret_complex_float_wrapper :: A ->
                                                                                                         Ptr (Complex CFloat) ->
@@ -5563,6 +5860,7 @@ ret_complex_float :: A -> IO (Complex CFloat)
 ret_complex_float = \x_0 -> allocaAndPeek (\z_1 -> ret_complex_float_wrapper x_0 z_1)
 {-| Pointer-based API for 'ret_complex_double'
 
+__unique:__ @ExampleJust Unsaferet_complex_double@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_52e016b143848038" ret_complex_double_wrapper :: A ->
                                                                                                          Ptr (Complex CDouble) ->
@@ -5586,6 +5884,8 @@ ret_complex_double = \x_0 -> allocaAndPeek (\z_1 -> ret_complex_double_wrapper x
     __defined at:__ @macros\/reparse.h:94:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_28f85791b3039264" bespoke_args1 :: A ->
                                                                                             CBool ->
@@ -5595,6 +5895,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_28f85791b3039264" bespo
     __defined at:__ @macros\/reparse.h:95:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_833c75e57b012dcc" bespoke_args2 :: A ->
                                                                                             HsBindgen.Runtime.Prelude.CSize ->
@@ -5604,6 +5906,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_833c75e57b012dcc" bespo
     __defined at:__ @macros\/reparse.h:97:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_434418d9d1f41c66" bespoke_ret1 :: A ->
                                                                                            IO CBool
@@ -5612,6 +5916,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_434418d9d1f41c66" bespo
     __defined at:__ @macros\/reparse.h:98:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafebespoke_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7a13d4c1ed935df0" bespoke_ret2 :: A ->
                                                                                            IO HsBindgen.Runtime.Prelude.CSize
@@ -5622,6 +5928,8 @@ __C declaration:__ @arr_args1@
 __defined at:__ @macros\/reparse.h:104:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafearr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_802c66e1efc0f556" arr_args1 :: Ptr A ->
                                                                                         IO Unit
@@ -5630,6 +5938,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_802c66e1efc0f556" arr_a
     __defined at:__ @macros\/reparse.h:105:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f516070848930af9" arr_args2 :: Ptr (Ptr A) ->
                                                                                         IO Unit
@@ -5638,6 +5948,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_f516070848930af9" arr_a
     __defined at:__ @macros\/reparse.h:106:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c0db4046bcf7da77" arr_args3 :: Ptr A ->
                                                                                         IO Unit
@@ -5646,6 +5958,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c0db4046bcf7da77" arr_a
     __defined at:__ @macros\/reparse.h:107:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafearr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_881ede0e81c9ed45" arr_args4 :: Ptr (Ptr A) ->
                                                                                         IO Unit
@@ -5656,6 +5970,8 @@ __C declaration:__ @funptr_args1@
 __defined at:__ @macros\/reparse.h:126:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafefunptr_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_91151b594cc92e09" funptr_args1 :: A ->
                                                                                            FunPtr (IO Unit) ->
@@ -5665,6 +5981,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_91151b594cc92e09" funpt
     __defined at:__ @macros\/reparse.h:127:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_543290455260832c" funptr_args2 :: A ->
                                                                                            FunPtr (IO CInt) ->
@@ -5674,6 +5992,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_543290455260832c" funpt
     __defined at:__ @macros\/reparse.h:128:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fbdf924574cb6295" funptr_args3 :: A ->
                                                                                            FunPtr (CInt ->
@@ -5684,6 +6004,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_fbdf924574cb6295" funpt
     __defined at:__ @macros\/reparse.h:129:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e0a2c10ccd9a8c4" funptr_args4 :: A ->
                                                                                            FunPtr (CInt ->
@@ -5695,6 +6017,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5e0a2c10ccd9a8c4" funpt
     __defined at:__ @macros\/reparse.h:130:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c13f66d86b4b5ef6" funptr_args5 :: A ->
                                                                                            FunPtr (CInt ->
@@ -5710,6 +6034,8 @@ __C declaration:__ @comments1@
 __defined at:__ @macros\/reparse.h:144:25@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafecomments1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0b54f704cff3ab9b" comments1 :: A ->
                                                                                         IO Unit
@@ -5722,6 +6048,8 @@ __C declaration:__ @const_prim_before1@
 __defined at:__ @macros\/reparse.h:179:6@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust Unsafeconst_prim_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4a390ee488c3a1b1" const_prim_before1 :: A ->
                                                                                                  CChar ->
@@ -5731,6 +6059,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4a390ee488c3a1b1" const
     __defined at:__ @macros\/reparse.h:180:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_349252e982c28bae" const_prim_before2 :: A ->
                                                                                                  CSChar ->
@@ -5740,6 +6070,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_349252e982c28bae" const
     __defined at:__ @macros\/reparse.h:181:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7ffeb1784fe8b2f2" const_prim_before3 :: A ->
                                                                                                  CUChar ->
@@ -5749,6 +6081,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7ffeb1784fe8b2f2" const
     __defined at:__ @macros\/reparse.h:182:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0dae8ba3b65c77d2" const_prim_after1 :: A ->
                                                                                                 CChar ->
@@ -5758,6 +6092,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_0dae8ba3b65c77d2" const
     __defined at:__ @macros\/reparse.h:183:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dc74f73eff3fac62" const_prim_after2 :: A ->
                                                                                                 CSChar ->
@@ -5767,6 +6103,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_dc74f73eff3fac62" const
     __defined at:__ @macros\/reparse.h:184:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_prim_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_aeea75713b67f6d8" const_prim_after3 :: A ->
                                                                                                 CUChar ->
@@ -5776,6 +6114,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_aeea75713b67f6d8" const
     __defined at:__ @macros\/reparse.h:188:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9f70419bf10f327e" const_withoutSign_before1 :: A ->
                                                                                                         CFloat ->
@@ -5785,6 +6125,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_9f70419bf10f327e" const
     __defined at:__ @macros\/reparse.h:189:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7867bb0d71ef4b6d" const_withoutSign_before2 :: A ->
                                                                                                         CDouble ->
@@ -5794,12 +6136,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7867bb0d71ef4b6d" const
     __defined at:__ @macros\/reparse.h:190:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_80de805eb016225b" const_withoutSign_before3 :: A ->
                                                                                                         CBool ->
                                                                                                         IO Unit
 {-| Pointer-based API for 'const_withoutSign_before4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_69cef8742b4b119b" const_withoutSign_before4_wrapper :: A ->
                                                                                                                 Ptr Some_struct ->
@@ -5820,6 +6165,7 @@ const_withoutSign_before4 :: A -> Some_struct -> IO Unit
 const_withoutSign_before4 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_before4_wrapper x_0 y_2)
 {-| Pointer-based API for 'const_withoutSign_before5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_before5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1ad5aadb8be4d493" const_withoutSign_before5_wrapper :: A ->
                                                                                                                 Ptr Some_union ->
@@ -5843,6 +6189,8 @@ const_withoutSign_before5 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_
     __defined at:__ @macros\/reparse.h:193:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7106059de99b7682" const_withoutSign_before6 :: A ->
                                                                                                         Some_enum ->
@@ -5852,6 +6200,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7106059de99b7682" const
     __defined at:__ @macros\/reparse.h:194:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b61cf3c21bf8b00b" const_withoutSign_before7 :: A ->
                                                                                                         CBool ->
@@ -5861,6 +6211,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_b61cf3c21bf8b00b" const
     __defined at:__ @macros\/reparse.h:195:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_before8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_47573f5eb4cb92a9" const_withoutSign_before8 :: A ->
                                                                                                         HsBindgen.Runtime.Prelude.CSize ->
@@ -5870,6 +6222,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_47573f5eb4cb92a9" const
     __defined at:__ @macros\/reparse.h:197:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ffb1a87ed1f94b31" const_withoutSign_after1 :: A ->
                                                                                                        CFloat ->
@@ -5879,6 +6233,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ffb1a87ed1f94b31" const
     __defined at:__ @macros\/reparse.h:198:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1ec7c37faacfcd64" const_withoutSign_after2 :: A ->
                                                                                                        CDouble ->
@@ -5888,12 +6244,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_1ec7c37faacfcd64" const
     __defined at:__ @macros\/reparse.h:199:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_34233036f1e22371" const_withoutSign_after3 :: A ->
                                                                                                        CBool ->
                                                                                                        IO Unit
 {-| Pointer-based API for 'const_withoutSign_after4'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c909292e290aa0a" const_withoutSign_after4_wrapper :: A ->
                                                                                                                Ptr Some_struct ->
@@ -5914,6 +6273,7 @@ const_withoutSign_after4 :: A -> Some_struct -> IO Unit
 const_withoutSign_after4 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_after4_wrapper x_0 y_2)
 {-| Pointer-based API for 'const_withoutSign_after5'
 
+__unique:__ @ExampleJust Unsafeconst_withoutSign_after5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ab1abd31c91696b9" const_withoutSign_after5_wrapper :: A ->
                                                                                                                Ptr Some_union ->
@@ -5937,6 +6297,8 @@ const_withoutSign_after5 = \x_0 -> \x_1 -> with x_1 (\y_2 -> const_withoutSign_a
     __defined at:__ @macros\/reparse.h:202:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_342c1139871906f3" const_withoutSign_after6 :: A ->
                                                                                                        Some_enum ->
@@ -5946,6 +6308,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_342c1139871906f3" const
     __defined at:__ @macros\/reparse.h:203:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_446758003fdc3418" const_withoutSign_after7 :: A ->
                                                                                                        CBool ->
@@ -5955,6 +6319,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_446758003fdc3418" const
     __defined at:__ @macros\/reparse.h:204:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_withoutSign_after8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_161f0b5d4c06966c" const_withoutSign_after8 :: A ->
                                                                                                        HsBindgen.Runtime.Prelude.CSize ->
@@ -5964,6 +6330,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_161f0b5d4c06966c" const
     __defined at:__ @macros\/reparse.h:208:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ec8e91fa9341dad6" const_pointers_args1 :: A ->
                                                                                                    Ptr CInt ->
@@ -5973,6 +6341,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_ec8e91fa9341dad6" const
     __defined at:__ @macros\/reparse.h:209:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cf24549623cd56c1" const_pointers_args2 :: A ->
                                                                                                    Ptr CInt ->
@@ -5982,6 +6352,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_cf24549623cd56c1" const
     __defined at:__ @macros\/reparse.h:210:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_71cfb5062c931668" const_pointers_args3 :: A ->
                                                                                                    Ptr CInt ->
@@ -5991,6 +6363,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_71cfb5062c931668" const
     __defined at:__ @macros\/reparse.h:211:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_74894da577575f87" const_pointers_args4 :: A ->
                                                                                                    Ptr CInt ->
@@ -6000,6 +6374,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_74894da577575f87" const
     __defined at:__ @macros\/reparse.h:212:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_args5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5493c91c677fe8d0" const_pointers_args5 :: A ->
                                                                                                    Ptr CInt ->
@@ -6009,6 +6385,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_5493c91c677fe8d0" const
     __defined at:__ @macros\/reparse.h:214:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a302fca87b1aa099" const_pointers_ret1 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -6017,6 +6395,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_a302fca87b1aa099" const
     __defined at:__ @macros\/reparse.h:215:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_825f0c60f6c63862" const_pointers_ret2 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -6025,6 +6405,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_825f0c60f6c63862" const
     __defined at:__ @macros\/reparse.h:216:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c36f7d270a11e1cd" const_pointers_ret3 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -6033,6 +6415,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_c36f7d270a11e1cd" const
     __defined at:__ @macros\/reparse.h:217:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4a82390c6e38a4ad" const_pointers_ret4 :: A ->
                                                                                                   IO (Ptr CInt)
@@ -6041,11 +6425,14 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4a82390c6e38a4ad" const
     __defined at:__ @macros\/reparse.h:218:19@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_pointers_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_763d600d2f5c49bb" const_pointers_ret5 :: A ->
                                                                                                   IO (Ptr CInt)
 {-| Pointer-based API for 'const_array_elem1'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4b3bef3ab591a329" const_array_elem1_wrapper :: Ptr A ->
                                                                                                         IO Unit
@@ -6068,11 +6455,14 @@ const_array_elem1 = \x_0 -> withPtr x_0 (\ptr_1 -> const_array_elem1_wrapper ptr
     __defined at:__ @macros\/reparse.h:247:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafeconst_array_elem2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dd69ef198e368a38" const_array_elem2 :: Ptr (Ptr A) ->
                                                                                                 IO Unit
 {-| Pointer-based API for 'const_array_elem3'
 
+__unique:__ @ExampleJust Unsafeconst_array_elem3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1842bc8653aa9c3f" const_array_elem3_wrapper :: Ptr (Ptr A) ->
                                                                                                         IO Unit
@@ -6097,6 +6487,8 @@ __C declaration:__ @noParams1@
 __defined at:__ @macros\/reparse.h:256:3@
 
 __exported by:__ @macros\/reparse.h@
+
+__unique:__ @ExampleJust UnsafenoParams1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4c99a8a7824a66d4" noParams1 :: IO A
 {-| __C declaration:__ @noParams2@
@@ -6104,6 +6496,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4c99a8a7824a66d4" noPar
     __defined at:__ @macros\/reparse.h:257:3@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7ae14613ab7f3b03" noParams2 :: IO A
 {-| __C declaration:__ @noParams3@
@@ -6111,6 +6505,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_7ae14613ab7f3b03" noPar
     __defined at:__ @macros\/reparse.h:258:6@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust UnsafenoParams3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2f4d972da222d332" noParams3 :: A ->
                                                                                         FunPtr (IO CInt) ->
@@ -6120,6 +6516,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_2f4d972da222d332" noPar
     __defined at:__ @macros\/reparse.h:262:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret1@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_dbe5f5ae726e36b3" funptr_ret1 :: A ->
                                                                                           IO (FunPtr (IO Unit))
@@ -6128,6 +6526,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_dbe5f5ae726e36b3" funpt
     __defined at:__ @macros\/reparse.h:263:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret2@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_081cb5fbeb6f4506" funptr_ret2 :: A ->
                                                                                           IO (FunPtr (IO CInt))
@@ -6136,6 +6536,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_081cb5fbeb6f4506" funpt
     __defined at:__ @macros\/reparse.h:264:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret3@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4fc16e9f894820ff" funptr_ret3 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6145,6 +6547,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4fc16e9f894820ff" funpt
     __defined at:__ @macros\/reparse.h:265:8@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret4@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9e8aa8193619dbbe" funptr_ret4 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6155,6 +6559,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_9e8aa8193619dbbe" funpt
     __defined at:__ @macros\/reparse.h:269:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret5@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4b914fec0c848647" funptr_ret5 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6165,6 +6571,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_4b914fec0c848647" funpt
     __defined at:__ @macros\/reparse.h:270:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret6@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6c188a6c3899a751" funptr_ret6 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6175,6 +6583,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_6c188a6c3899a751" funpt
     __defined at:__ @macros\/reparse.h:271:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret7@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e4468a6e0afe686b" funptr_ret7 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6185,6 +6595,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_e4468a6e0afe686b" funpt
     __defined at:__ @macros\/reparse.h:272:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret8@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_16740b4fc6d6c8ec" funptr_ret8 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6195,6 +6607,8 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_16740b4fc6d6c8ec" funpt
     __defined at:__ @macros\/reparse.h:273:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret9@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d82b69157b543190" funptr_ret9 :: A ->
                                                                                           IO (FunPtr (CInt ->
@@ -6205,11 +6619,15 @@ foreign import ccall safe "hs_bindgen_test_macrosreparse_d82b69157b543190" funpt
     __defined at:__ @macros\/reparse.h:274:20@
 
     __exported by:__ @macros\/reparse.h@
+
+    __unique:__ @ExampleJust Unsafefunptr_ret10@
 -}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_317f5f7c8c2496cd" funptr_ret10 :: A ->
                                                                                            IO (FunPtr (CInt ->
                                                                                                        CDouble ->
                                                                                                        IO (Ptr CInt)))
+{-| __unique:__ @ExampleNothingget_args_char1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1cbcf8b84924816c" hs_bindgen_test_macrosreparse_1cbcf8b84924816c :: IO (FunPtr (A ->
                                                                                                                                          CChar ->
                                                                                                                                          IO Unit))
@@ -6232,6 +6650,8 @@ __defined at:__ @macros\/reparse.h:17:6@
 __exported by:__ @macros\/reparse.h@
 -}
 args_char1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_1cbcf8b84924816c
+{-| __unique:__ @ExampleNothingget_args_char2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ec2d78b82f444fd0" hs_bindgen_test_macrosreparse_ec2d78b82f444fd0 :: IO (FunPtr (A ->
                                                                                                                                          CSChar ->
                                                                                                                                          IO Unit))
@@ -6250,6 +6670,8 @@ args_char2_ptr :: FunPtr (A -> CSChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_char2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ec2d78b82f444fd0
+{-| __unique:__ @ExampleNothingget_args_char3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1baa18e723594389" hs_bindgen_test_macrosreparse_1baa18e723594389 :: IO (FunPtr (A ->
                                                                                                                                          CUChar ->
                                                                                                                                          IO Unit))
@@ -6268,6 +6690,8 @@ args_char3_ptr :: FunPtr (A -> CUChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_char3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_1baa18e723594389
+{-| __unique:__ @ExampleNothingget_args_short1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c96cef4ef5f5e180" hs_bindgen_test_macrosreparse_c96cef4ef5f5e180 :: IO (FunPtr (A ->
                                                                                                                                          CShort ->
                                                                                                                                          IO Unit))
@@ -6286,6 +6710,8 @@ args_short1_ptr :: FunPtr (A -> CShort -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_short1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c96cef4ef5f5e180
+{-| __unique:__ @ExampleNothingget_args_short2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3a683552d4f772c7" hs_bindgen_test_macrosreparse_3a683552d4f772c7 :: IO (FunPtr (A ->
                                                                                                                                          CShort ->
                                                                                                                                          IO Unit))
@@ -6304,6 +6730,8 @@ args_short2_ptr :: FunPtr (A -> CShort -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_short2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3a683552d4f772c7
+{-| __unique:__ @ExampleNothingget_args_short3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f3284022ac706255" hs_bindgen_test_macrosreparse_f3284022ac706255 :: IO (FunPtr (A ->
                                                                                                                                          CUShort ->
                                                                                                                                          IO Unit))
@@ -6322,6 +6750,8 @@ args_short3_ptr :: FunPtr (A -> CUShort -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_short3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_f3284022ac706255
+{-| __unique:__ @ExampleNothingget_args_int1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5c4d785286ccca6b" hs_bindgen_test_macrosreparse_5c4d785286ccca6b :: IO (FunPtr (A ->
                                                                                                                                          CInt ->
                                                                                                                                          IO Unit))
@@ -6340,6 +6770,8 @@ args_int1_ptr :: FunPtr (A -> CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_int1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_5c4d785286ccca6b
+{-| __unique:__ @ExampleNothingget_args_int2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e323b837afe40be7" hs_bindgen_test_macrosreparse_e323b837afe40be7 :: IO (FunPtr (A ->
                                                                                                                                          CInt ->
                                                                                                                                          IO Unit))
@@ -6358,6 +6790,8 @@ args_int2_ptr :: FunPtr (A -> CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_int2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e323b837afe40be7
+{-| __unique:__ @ExampleNothingget_args_int3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d" hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d :: IO (FunPtr (A ->
                                                                                                                                          CUInt ->
                                                                                                                                          IO Unit))
@@ -6376,6 +6810,8 @@ args_int3_ptr :: FunPtr (A -> CUInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_int3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_eb0e5feb8eb4082d
+{-| __unique:__ @ExampleNothingget_args_long1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d7d322f23a65f43b" hs_bindgen_test_macrosreparse_d7d322f23a65f43b :: IO (FunPtr (A ->
                                                                                                                                          CLong ->
                                                                                                                                          IO Unit))
@@ -6394,6 +6830,8 @@ args_long1_ptr :: FunPtr (A -> CLong -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_long1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_d7d322f23a65f43b
+{-| __unique:__ @ExampleNothingget_args_long2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_378c16768a6f6f21" hs_bindgen_test_macrosreparse_378c16768a6f6f21 :: IO (FunPtr (A ->
                                                                                                                                          CLong ->
                                                                                                                                          IO Unit))
@@ -6412,6 +6850,8 @@ args_long2_ptr :: FunPtr (A -> CLong -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_long2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_378c16768a6f6f21
+{-| __unique:__ @ExampleNothingget_args_long3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_548dcd4760226ee2" hs_bindgen_test_macrosreparse_548dcd4760226ee2 :: IO (FunPtr (A ->
                                                                                                                                          CULong ->
                                                                                                                                          IO Unit))
@@ -6430,6 +6870,8 @@ args_long3_ptr :: FunPtr (A -> CULong -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_long3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_548dcd4760226ee2
+{-| __unique:__ @ExampleNothingget_args_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_701d01261043851b" hs_bindgen_test_macrosreparse_701d01261043851b :: IO (FunPtr (A ->
                                                                                                                                          CFloat ->
                                                                                                                                          IO Unit))
@@ -6448,6 +6890,8 @@ args_float_ptr :: FunPtr (A -> CFloat -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_float_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_701d01261043851b
+{-| __unique:__ @ExampleNothingget_args_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ff631e42f704e4cd" hs_bindgen_test_macrosreparse_ff631e42f704e4cd :: IO (FunPtr (A ->
                                                                                                                                          CDouble ->
                                                                                                                                          IO Unit))
@@ -6466,6 +6910,8 @@ args_double_ptr :: FunPtr (A -> CDouble -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_double_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ff631e42f704e4cd
+{-| __unique:__ @ExampleNothingget_args_bool1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6e289c6cc6d382bf" hs_bindgen_test_macrosreparse_6e289c6cc6d382bf :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -6484,6 +6930,8 @@ args_bool1_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_bool1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_6e289c6cc6d382bf
+{-| __unique:__ @ExampleNothingget_args_struct_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_26b20c1b89e46b02" hs_bindgen_test_macrosreparse_26b20c1b89e46b02 :: IO (FunPtr (A ->
                                                                                                                                          Some_struct ->
                                                                                                                                          IO Unit))
@@ -6502,6 +6950,8 @@ args_struct_ptr :: FunPtr (A -> Some_struct -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_struct_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_26b20c1b89e46b02
+{-| __unique:__ @ExampleNothingget_args_union_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cfd37f06f21b8755" hs_bindgen_test_macrosreparse_cfd37f06f21b8755 :: IO (FunPtr (A ->
                                                                                                                                          Some_union ->
                                                                                                                                          IO Unit))
@@ -6520,6 +6970,8 @@ args_union_ptr :: FunPtr (A -> Some_union -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_union_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_cfd37f06f21b8755
+{-| __unique:__ @ExampleNothingget_args_enum_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_69882f8f862fffc2" hs_bindgen_test_macrosreparse_69882f8f862fffc2 :: IO (FunPtr (A ->
                                                                                                                                          Some_enum ->
                                                                                                                                          IO Unit))
@@ -6538,6 +6990,8 @@ args_enum_ptr :: FunPtr (A -> Some_enum -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_enum_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_69882f8f862fffc2
+{-| __unique:__ @ExampleNothingget_args_pointer1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_23bde4e97b66c470" hs_bindgen_test_macrosreparse_23bde4e97b66c470 :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -6556,6 +7010,8 @@ args_pointer1_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_pointer1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_23bde4e97b66c470
+{-| __unique:__ @ExampleNothingget_args_pointer2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fceb546239df3c0a" hs_bindgen_test_macrosreparse_fceb546239df3c0a :: IO (FunPtr (A ->
                                                                                                                                          Ptr (Ptr CInt) ->
                                                                                                                                          IO Unit))
@@ -6574,6 +7030,8 @@ args_pointer2_ptr :: FunPtr (A -> Ptr (Ptr CInt) -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_pointer2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_fceb546239df3c0a
+{-| __unique:__ @ExampleNothingget_args_pointer3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0cb396fb06dd816a" hs_bindgen_test_macrosreparse_0cb396fb06dd816a :: IO (FunPtr (A ->
                                                                                                                                          Ptr Void ->
                                                                                                                                          IO Unit))
@@ -6592,6 +7050,8 @@ args_pointer3_ptr :: FunPtr (A -> Ptr Void -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_pointer3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_0cb396fb06dd816a
+{-| __unique:__ @ExampleNothingget_ret_A_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a7564eacf3ad149f" hs_bindgen_test_macrosreparse_a7564eacf3ad149f :: IO (FunPtr (IO A))
 {-# NOINLINE ret_A_ptr #-}
 {-| __C declaration:__ @ret_A@
@@ -6608,6 +7068,8 @@ ret_A_ptr :: FunPtr (IO A)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_A_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_a7564eacf3ad149f
+{-| __unique:__ @ExampleNothingget_ret_char1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7b5b646ee4e06777" hs_bindgen_test_macrosreparse_7b5b646ee4e06777 :: IO (FunPtr (A ->
                                                                                                                                          IO CChar))
 {-# NOINLINE ret_char1_ptr #-}
@@ -6625,6 +7087,8 @@ ret_char1_ptr :: FunPtr (A -> IO CChar)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_char1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_7b5b646ee4e06777
+{-| __unique:__ @ExampleNothingget_ret_char2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6" hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6 :: IO (FunPtr (A ->
                                                                                                                                          IO CSChar))
 {-# NOINLINE ret_char2_ptr #-}
@@ -6642,6 +7106,8 @@ ret_char2_ptr :: FunPtr (A -> IO CSChar)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_char2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_7c05cbccaf1be8b6
+{-| __unique:__ @ExampleNothingget_ret_char3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0fc74f839f906d7e" hs_bindgen_test_macrosreparse_0fc74f839f906d7e :: IO (FunPtr (A ->
                                                                                                                                          IO CUChar))
 {-# NOINLINE ret_char3_ptr #-}
@@ -6659,6 +7125,8 @@ ret_char3_ptr :: FunPtr (A -> IO CUChar)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_char3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_0fc74f839f906d7e
+{-| __unique:__ @ExampleNothingget_ret_short1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8" hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8 :: IO (FunPtr (A ->
                                                                                                                                          IO CShort))
 {-# NOINLINE ret_short1_ptr #-}
@@ -6676,6 +7144,8 @@ ret_short1_ptr :: FunPtr (A -> IO CShort)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_short1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_72ff9f5cb5daaae8
+{-| __unique:__ @ExampleNothingget_ret_short2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e" hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e :: IO (FunPtr (A ->
                                                                                                                                          IO CShort))
 {-# NOINLINE ret_short2_ptr #-}
@@ -6693,6 +7163,8 @@ ret_short2_ptr :: FunPtr (A -> IO CShort)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_short2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_eb5427ff3ea0d96e
+{-| __unique:__ @ExampleNothingget_ret_short3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_823adc61eed1550c" hs_bindgen_test_macrosreparse_823adc61eed1550c :: IO (FunPtr (A ->
                                                                                                                                          IO CUShort))
 {-# NOINLINE ret_short3_ptr #-}
@@ -6710,6 +7182,8 @@ ret_short3_ptr :: FunPtr (A -> IO CUShort)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_short3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_823adc61eed1550c
+{-| __unique:__ @ExampleNothingget_ret_int1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_79ce8d81113cf766" hs_bindgen_test_macrosreparse_79ce8d81113cf766 :: IO (FunPtr (A ->
                                                                                                                                          IO CInt))
 {-# NOINLINE ret_int1_ptr #-}
@@ -6727,6 +7201,8 @@ ret_int1_ptr :: FunPtr (A -> IO CInt)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_int1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_79ce8d81113cf766
+{-| __unique:__ @ExampleNothingget_ret_int2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d369bd4861f00c84" hs_bindgen_test_macrosreparse_d369bd4861f00c84 :: IO (FunPtr (A ->
                                                                                                                                          IO CInt))
 {-# NOINLINE ret_int2_ptr #-}
@@ -6744,6 +7220,8 @@ ret_int2_ptr :: FunPtr (A -> IO CInt)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_int2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_d369bd4861f00c84
+{-| __unique:__ @ExampleNothingget_ret_int3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0336d583fc7b5951" hs_bindgen_test_macrosreparse_0336d583fc7b5951 :: IO (FunPtr (A ->
                                                                                                                                          IO CUInt))
 {-# NOINLINE ret_int3_ptr #-}
@@ -6761,6 +7239,8 @@ ret_int3_ptr :: FunPtr (A -> IO CUInt)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_int3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_0336d583fc7b5951
+{-| __unique:__ @ExampleNothingget_ret_long1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_36845109a4ce7992" hs_bindgen_test_macrosreparse_36845109a4ce7992 :: IO (FunPtr (A ->
                                                                                                                                          IO CLong))
 {-# NOINLINE ret_long1_ptr #-}
@@ -6778,6 +7258,8 @@ ret_long1_ptr :: FunPtr (A -> IO CLong)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_long1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_36845109a4ce7992
+{-| __unique:__ @ExampleNothingget_ret_long2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ac32dbc1e79e704e" hs_bindgen_test_macrosreparse_ac32dbc1e79e704e :: IO (FunPtr (A ->
                                                                                                                                          IO CLong))
 {-# NOINLINE ret_long2_ptr #-}
@@ -6795,6 +7277,8 @@ ret_long2_ptr :: FunPtr (A -> IO CLong)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_long2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ac32dbc1e79e704e
+{-| __unique:__ @ExampleNothingget_ret_long3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e" hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e :: IO (FunPtr (A ->
                                                                                                                                          IO CULong))
 {-# NOINLINE ret_long3_ptr #-}
@@ -6812,6 +7296,8 @@ ret_long3_ptr :: FunPtr (A -> IO CULong)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_long3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_6fba85ecad7d8d4e
+{-| __unique:__ @ExampleNothingget_ret_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e9ac779a7c943add" hs_bindgen_test_macrosreparse_e9ac779a7c943add :: IO (FunPtr (A ->
                                                                                                                                          IO CFloat))
 {-# NOINLINE ret_float_ptr #-}
@@ -6829,6 +7315,8 @@ ret_float_ptr :: FunPtr (A -> IO CFloat)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_float_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e9ac779a7c943add
+{-| __unique:__ @ExampleNothingget_ret_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c" hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c :: IO (FunPtr (A ->
                                                                                                                                          IO CDouble))
 {-# NOINLINE ret_double_ptr #-}
@@ -6846,6 +7334,8 @@ ret_double_ptr :: FunPtr (A -> IO CDouble)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_double_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_7095a5f5be3ecc0c
+{-| __unique:__ @ExampleNothingget_ret_bool1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c7b5be49f4314899" hs_bindgen_test_macrosreparse_c7b5be49f4314899 :: IO (FunPtr (A ->
                                                                                                                                          IO CBool))
 {-# NOINLINE ret_bool1_ptr #-}
@@ -6863,6 +7353,8 @@ ret_bool1_ptr :: FunPtr (A -> IO CBool)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_bool1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c7b5be49f4314899
+{-| __unique:__ @ExampleNothingget_ret_struct_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_03ec23cf81b62ce3" hs_bindgen_test_macrosreparse_03ec23cf81b62ce3 :: IO (FunPtr (A ->
                                                                                                                                          IO Some_struct))
 {-# NOINLINE ret_struct_ptr #-}
@@ -6880,6 +7372,8 @@ ret_struct_ptr :: FunPtr (A -> IO Some_struct)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_struct_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_03ec23cf81b62ce3
+{-| __unique:__ @ExampleNothingget_ret_union_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5315544d48ea5b07" hs_bindgen_test_macrosreparse_5315544d48ea5b07 :: IO (FunPtr (A ->
                                                                                                                                          IO Some_union))
 {-# NOINLINE ret_union_ptr #-}
@@ -6897,6 +7391,8 @@ ret_union_ptr :: FunPtr (A -> IO Some_union)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_union_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_5315544d48ea5b07
+{-| __unique:__ @ExampleNothingget_ret_enum_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1" hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1 :: IO (FunPtr (A ->
                                                                                                                                          IO Some_enum))
 {-# NOINLINE ret_enum_ptr #-}
@@ -6914,6 +7410,8 @@ ret_enum_ptr :: FunPtr (A -> IO Some_enum)
     __exported by:__ @macros\/reparse.h@
 -}
 ret_enum_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_9fb7ddbcd84c72f1
+{-| __unique:__ @ExampleNothingget_ret_pointer1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_0638bcad8813a303" hs_bindgen_test_macrosreparse_0638bcad8813a303 :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE ret_pointer1_ptr #-}
@@ -6931,6 +7429,8 @@ ret_pointer1_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 ret_pointer1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_0638bcad8813a303
+{-| __unique:__ @ExampleNothingget_ret_pointer2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5d9ced9e4887782b" hs_bindgen_test_macrosreparse_5d9ced9e4887782b :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr (Ptr CInt))))
 {-# NOINLINE ret_pointer2_ptr #-}
@@ -6948,6 +7448,8 @@ ret_pointer2_ptr :: FunPtr (A -> IO (Ptr (Ptr CInt)))
     __exported by:__ @macros\/reparse.h@
 -}
 ret_pointer2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_5d9ced9e4887782b
+{-| __unique:__ @ExampleNothingget_ret_pointer3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_60e99361ec0a4b5b" hs_bindgen_test_macrosreparse_60e99361ec0a4b5b :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr Void)))
 {-# NOINLINE ret_pointer3_ptr #-}
@@ -6965,6 +7467,8 @@ ret_pointer3_ptr :: FunPtr (A -> IO (Ptr Void))
     __exported by:__ @macros\/reparse.h@
 -}
 ret_pointer3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_60e99361ec0a4b5b
+{-| __unique:__ @ExampleNothingget_body1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cca1935605a94051" hs_bindgen_test_macrosreparse_cca1935605a94051 :: IO (FunPtr (A ->
                                                                                                                                          IO CInt))
 {-# NOINLINE body1_ptr #-}
@@ -6982,6 +7486,8 @@ body1_ptr :: FunPtr (A -> IO CInt)
     __exported by:__ @macros\/reparse.h@
 -}
 body1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_cca1935605a94051
+{-| __unique:__ @ExampleNothingget_body2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a1900daea7e14e95" hs_bindgen_test_macrosreparse_a1900daea7e14e95 :: IO (FunPtr (IO A))
 {-# NOINLINE body2_ptr #-}
 {-| __C declaration:__ @body2@
@@ -6998,6 +7504,8 @@ body2_ptr :: FunPtr (IO A)
     __exported by:__ @macros\/reparse.h@
 -}
 body2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_a1900daea7e14e95
+{-| __unique:__ @ExampleNothingget_args_complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c62f1e9d47469a1c" hs_bindgen_test_macrosreparse_c62f1e9d47469a1c :: IO (FunPtr (A ->
                                                                                                                                          Complex CFloat ->
                                                                                                                                          IO Unit))
@@ -7016,6 +7524,8 @@ args_complex_float_ptr :: FunPtr (A -> Complex CFloat -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_complex_float_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c62f1e9d47469a1c
+{-| __unique:__ @ExampleNothingget_args_complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697" hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697 :: IO (FunPtr (A ->
                                                                                                                                          Complex CDouble ->
                                                                                                                                          IO Unit))
@@ -7034,6 +7544,8 @@ args_complex_double_ptr :: FunPtr (A -> Complex CDouble -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 args_complex_double_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_b2ef5ed0a8ed0697
+{-| __unique:__ @ExampleNothingget_ret_complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d" hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d :: IO (FunPtr (A ->
                                                                                                                                          IO (Complex CFloat)))
 {-# NOINLINE ret_complex_float_ptr #-}
@@ -7051,6 +7563,8 @@ ret_complex_float_ptr :: FunPtr (A -> IO (Complex CFloat))
     __exported by:__ @macros\/reparse.h@
 -}
 ret_complex_float_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e2cc2aa2dd12852d
+{-| __unique:__ @ExampleNothingget_ret_complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c95961d571f78868" hs_bindgen_test_macrosreparse_c95961d571f78868 :: IO (FunPtr (A ->
                                                                                                                                          IO (Complex CDouble)))
 {-# NOINLINE ret_complex_double_ptr #-}
@@ -7068,6 +7582,8 @@ ret_complex_double_ptr :: FunPtr (A -> IO (Complex CDouble))
     __exported by:__ @macros\/reparse.h@
 -}
 ret_complex_double_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c95961d571f78868
+{-| __unique:__ @ExampleNothingget_bespoke_args1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_94c8a2d3574ba283" hs_bindgen_test_macrosreparse_94c8a2d3574ba283 :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -7086,6 +7602,8 @@ bespoke_args1_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 bespoke_args1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_94c8a2d3574ba283
+{-| __unique:__ @ExampleNothingget_bespoke_args2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2165985767a8d24e" hs_bindgen_test_macrosreparse_2165985767a8d24e :: IO (FunPtr (A ->
                                                                                                                                          HsBindgen.Runtime.Prelude.CSize ->
                                                                                                                                          IO Unit))
@@ -7105,6 +7623,8 @@ bespoke_args2_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 bespoke_args2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_2165985767a8d24e
+{-| __unique:__ @ExampleNothingget_bespoke_ret1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_7913bf38675bd912" hs_bindgen_test_macrosreparse_7913bf38675bd912 :: IO (FunPtr (A ->
                                                                                                                                          IO CBool))
 {-# NOINLINE bespoke_ret1_ptr #-}
@@ -7122,6 +7642,8 @@ bespoke_ret1_ptr :: FunPtr (A -> IO CBool)
     __exported by:__ @macros\/reparse.h@
 -}
 bespoke_ret1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_7913bf38675bd912
+{-| __unique:__ @ExampleNothingget_bespoke_ret2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_07c419cb648cdf65" hs_bindgen_test_macrosreparse_07c419cb648cdf65 :: IO (FunPtr (A ->
                                                                                                                                          IO HsBindgen.Runtime.Prelude.CSize))
 {-# NOINLINE bespoke_ret2_ptr #-}
@@ -7140,6 +7662,8 @@ bespoke_ret2_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 bespoke_ret2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_07c419cb648cdf65
+{-| __unique:__ @ExampleNothingget_arr_args1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ed19e51bcac06a9e" hs_bindgen_test_macrosreparse_ed19e51bcac06a9e :: IO (FunPtr (IncompleteArray A ->
                                                                                                                                          IO Unit))
 {-# NOINLINE arr_args1_ptr #-}
@@ -7161,6 +7685,8 @@ __defined at:__ @macros\/reparse.h:104:6@
 __exported by:__ @macros\/reparse.h@
 -}
 arr_args1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ed19e51bcac06a9e
+{-| __unique:__ @ExampleNothingget_arr_args2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_de3931a21a8a71fc" hs_bindgen_test_macrosreparse_de3931a21a8a71fc :: IO (FunPtr (IncompleteArray (Ptr A) ->
                                                                                                                                          IO Unit))
 {-# NOINLINE arr_args2_ptr #-}
@@ -7178,6 +7704,8 @@ arr_args2_ptr :: FunPtr (IncompleteArray (Ptr A) -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 arr_args2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_de3931a21a8a71fc
+{-| __unique:__ @ExampleNothingget_arr_args3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2c02effa6288a26b" hs_bindgen_test_macrosreparse_2c02effa6288a26b :: IO (FunPtr (ConstantArray 5
                                                                                                                                                        A ->
                                                                                                                                          IO Unit))
@@ -7196,6 +7724,8 @@ arr_args3_ptr :: FunPtr (ConstantArray 5 A -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 arr_args3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_2c02effa6288a26b
+{-| __unique:__ @ExampleNothingget_arr_args4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2144e300082f115c" hs_bindgen_test_macrosreparse_2144e300082f115c :: IO (FunPtr (ConstantArray 5
                                                                                                                                                        (Ptr A) ->
                                                                                                                                          IO Unit))
@@ -7214,6 +7744,8 @@ arr_args4_ptr :: FunPtr (ConstantArray 5 (Ptr A) -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 arr_args4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_2144e300082f115c
+{-| __unique:__ @ExampleNothingget_funptr_args1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d1645262a53743f6" hs_bindgen_test_macrosreparse_d1645262a53743f6 :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (IO Unit) ->
                                                                                                                                          IO Unit))
@@ -7236,6 +7768,8 @@ __defined at:__ @macros\/reparse.h:126:6@
 __exported by:__ @macros\/reparse.h@
 -}
 funptr_args1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_d1645262a53743f6
+{-| __unique:__ @ExampleNothingget_funptr_args2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d66507630e4e38e3" hs_bindgen_test_macrosreparse_d66507630e4e38e3 :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (IO CInt) ->
                                                                                                                                          IO Unit))
@@ -7254,6 +7788,8 @@ funptr_args2_ptr :: FunPtr (A -> FunPtr (IO CInt) -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_args2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_d66507630e4e38e3
+{-| __unique:__ @ExampleNothingget_funptr_args3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3d7907ab53b617cf" hs_bindgen_test_macrosreparse_3d7907ab53b617cf :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (CInt ->
                                                                                                                                                  IO Unit) ->
@@ -7274,6 +7810,8 @@ funptr_args3_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_args3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3d7907ab53b617cf
+{-| __unique:__ @ExampleNothingget_funptr_args4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e4d15a9c3b04292a" hs_bindgen_test_macrosreparse_e4d15a9c3b04292a :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (CInt ->
                                                                                                                                                  CDouble ->
@@ -7295,6 +7833,8 @@ funptr_args4_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_args4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e4d15a9c3b04292a
+{-| __unique:__ @ExampleNothingget_funptr_args5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ced7918b6e42102f" hs_bindgen_test_macrosreparse_ced7918b6e42102f :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (CInt ->
                                                                                                                                                  CDouble ->
@@ -7316,6 +7856,8 @@ funptr_args5_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_args5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ced7918b6e42102f
+{-| __unique:__ @ExampleNothingget_comments1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c90ec05081ef4e64" hs_bindgen_test_macrosreparse_c90ec05081ef4e64 :: IO (FunPtr (A ->
                                                                                                                                          IO Unit))
 {-# NOINLINE comments1_ptr #-}
@@ -7341,6 +7883,8 @@ __defined at:__ @macros\/reparse.h:144:25@
 __exported by:__ @macros\/reparse.h@
 -}
 comments1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c90ec05081ef4e64
+{-| __unique:__ @ExampleNothingget_const_prim_before1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6ac4b42c66a36448" hs_bindgen_test_macrosreparse_6ac4b42c66a36448 :: IO (FunPtr (A ->
                                                                                                                                          CChar ->
                                                                                                                                          IO Unit))
@@ -7367,6 +7911,8 @@ __defined at:__ @macros\/reparse.h:179:6@
 __exported by:__ @macros\/reparse.h@
 -}
 const_prim_before1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_6ac4b42c66a36448
+{-| __unique:__ @ExampleNothingget_const_prim_before2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f98632ef2e69b003" hs_bindgen_test_macrosreparse_f98632ef2e69b003 :: IO (FunPtr (A ->
                                                                                                                                          CSChar ->
                                                                                                                                          IO Unit))
@@ -7385,6 +7931,8 @@ const_prim_before2_ptr :: FunPtr (A -> CSChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_prim_before2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_f98632ef2e69b003
+{-| __unique:__ @ExampleNothingget_const_prim_before3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_cc9db1f6a36b8221" hs_bindgen_test_macrosreparse_cc9db1f6a36b8221 :: IO (FunPtr (A ->
                                                                                                                                          CUChar ->
                                                                                                                                          IO Unit))
@@ -7403,6 +7951,8 @@ const_prim_before3_ptr :: FunPtr (A -> CUChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_prim_before3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_cc9db1f6a36b8221
+{-| __unique:__ @ExampleNothingget_const_prim_after1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb" hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb :: IO (FunPtr (A ->
                                                                                                                                          CChar ->
                                                                                                                                          IO Unit))
@@ -7421,6 +7971,8 @@ const_prim_after1_ptr :: FunPtr (A -> CChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_prim_after1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3e5b7273bf2ecadb
+{-| __unique:__ @ExampleNothingget_const_prim_after2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f9b4beeca8253333" hs_bindgen_test_macrosreparse_f9b4beeca8253333 :: IO (FunPtr (A ->
                                                                                                                                          CSChar ->
                                                                                                                                          IO Unit))
@@ -7439,6 +7991,8 @@ const_prim_after2_ptr :: FunPtr (A -> CSChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_prim_after2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_f9b4beeca8253333
+{-| __unique:__ @ExampleNothingget_const_prim_after3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_bf14e2fd88b25311" hs_bindgen_test_macrosreparse_bf14e2fd88b25311 :: IO (FunPtr (A ->
                                                                                                                                          CUChar ->
                                                                                                                                          IO Unit))
@@ -7457,6 +8011,8 @@ const_prim_after3_ptr :: FunPtr (A -> CUChar -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_prim_after3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_bf14e2fd88b25311
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3649293fcaa1543c" hs_bindgen_test_macrosreparse_3649293fcaa1543c :: IO (FunPtr (A ->
                                                                                                                                          CFloat ->
                                                                                                                                          IO Unit))
@@ -7475,6 +8031,8 @@ const_withoutSign_before1_ptr :: FunPtr (A -> CFloat -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3649293fcaa1543c
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_ad5903c28e22dd2c" hs_bindgen_test_macrosreparse_ad5903c28e22dd2c :: IO (FunPtr (A ->
                                                                                                                                          CDouble ->
                                                                                                                                          IO Unit))
@@ -7493,6 +8051,8 @@ const_withoutSign_before2_ptr :: FunPtr (A -> CDouble -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_ad5903c28e22dd2c
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a" hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -7511,6 +8071,8 @@ const_withoutSign_before3_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e7b9bc011ec1dd8a
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4fd66b696848dd98" hs_bindgen_test_macrosreparse_4fd66b696848dd98 :: IO (FunPtr (A ->
                                                                                                                                          Some_struct ->
                                                                                                                                          IO Unit))
@@ -7530,6 +8092,8 @@ const_withoutSign_before4_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_4fd66b696848dd98
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_42582e1882927f7e" hs_bindgen_test_macrosreparse_42582e1882927f7e :: IO (FunPtr (A ->
                                                                                                                                          Some_union ->
                                                                                                                                          IO Unit))
@@ -7549,6 +8113,8 @@ const_withoutSign_before5_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_42582e1882927f7e
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b6876e53e4b27a98" hs_bindgen_test_macrosreparse_b6876e53e4b27a98 :: IO (FunPtr (A ->
                                                                                                                                          Some_enum ->
                                                                                                                                          IO Unit))
@@ -7567,6 +8133,8 @@ const_withoutSign_before6_ptr :: FunPtr (A -> Some_enum -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before6_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_b6876e53e4b27a98
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_78763cbecd2b0750" hs_bindgen_test_macrosreparse_78763cbecd2b0750 :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -7585,6 +8153,8 @@ const_withoutSign_before7_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before7_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_78763cbecd2b0750
+{-| __unique:__ @ExampleNothingget_const_withoutSign_before8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_4098c4a4ccd31d36" hs_bindgen_test_macrosreparse_4098c4a4ccd31d36 :: IO (FunPtr (A ->
                                                                                                                                          HsBindgen.Runtime.Prelude.CSize ->
                                                                                                                                          IO Unit))
@@ -7604,6 +8174,8 @@ const_withoutSign_before8_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_before8_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_4098c4a4ccd31d36
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_e9148eb7b8dac901" hs_bindgen_test_macrosreparse_e9148eb7b8dac901 :: IO (FunPtr (A ->
                                                                                                                                          CFloat ->
                                                                                                                                          IO Unit))
@@ -7622,6 +8194,8 @@ const_withoutSign_after1_ptr :: FunPtr (A -> CFloat -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_e9148eb7b8dac901
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_8663653d89116be9" hs_bindgen_test_macrosreparse_8663653d89116be9 :: IO (FunPtr (A ->
                                                                                                                                          CDouble ->
                                                                                                                                          IO Unit))
@@ -7640,6 +8214,8 @@ const_withoutSign_after2_ptr :: FunPtr (A -> CDouble -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_8663653d89116be9
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_136dcba145bf241b" hs_bindgen_test_macrosreparse_136dcba145bf241b :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -7658,6 +8234,8 @@ const_withoutSign_after3_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_136dcba145bf241b
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_380e01acce794cab" hs_bindgen_test_macrosreparse_380e01acce794cab :: IO (FunPtr (A ->
                                                                                                                                          Some_struct ->
                                                                                                                                          IO Unit))
@@ -7677,6 +8255,8 @@ const_withoutSign_after4_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_380e01acce794cab
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_af0d84d0757f6c2c" hs_bindgen_test_macrosreparse_af0d84d0757f6c2c :: IO (FunPtr (A ->
                                                                                                                                          Some_union ->
                                                                                                                                          IO Unit))
@@ -7695,6 +8275,8 @@ const_withoutSign_after5_ptr :: FunPtr (A -> Some_union -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_af0d84d0757f6c2c
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_df92501d07bf6c5f" hs_bindgen_test_macrosreparse_df92501d07bf6c5f :: IO (FunPtr (A ->
                                                                                                                                          Some_enum ->
                                                                                                                                          IO Unit))
@@ -7713,6 +8295,8 @@ const_withoutSign_after6_ptr :: FunPtr (A -> Some_enum -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after6_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_df92501d07bf6c5f
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b41148ca40ec8eb5" hs_bindgen_test_macrosreparse_b41148ca40ec8eb5 :: IO (FunPtr (A ->
                                                                                                                                          CBool ->
                                                                                                                                          IO Unit))
@@ -7731,6 +8315,8 @@ const_withoutSign_after7_ptr :: FunPtr (A -> CBool -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after7_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_b41148ca40ec8eb5
+{-| __unique:__ @ExampleNothingget_const_withoutSign_after8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_560c9dfdb530548b" hs_bindgen_test_macrosreparse_560c9dfdb530548b :: IO (FunPtr (A ->
                                                                                                                                          HsBindgen.Runtime.Prelude.CSize ->
                                                                                                                                          IO Unit))
@@ -7750,6 +8336,8 @@ const_withoutSign_after8_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_withoutSign_after8_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_560c9dfdb530548b
+{-| __unique:__ @ExampleNothingget_const_pointers_args1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a34d16c099748839" hs_bindgen_test_macrosreparse_a34d16c099748839 :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -7768,6 +8356,8 @@ const_pointers_args1_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_args1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_a34d16c099748839
+{-| __unique:__ @ExampleNothingget_const_pointers_args2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_45235edaf5c3b599" hs_bindgen_test_macrosreparse_45235edaf5c3b599 :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -7786,6 +8376,8 @@ const_pointers_args2_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_args2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_45235edaf5c3b599
+{-| __unique:__ @ExampleNothingget_const_pointers_args3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3dbcf1c7202f2878" hs_bindgen_test_macrosreparse_3dbcf1c7202f2878 :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -7804,6 +8396,8 @@ const_pointers_args3_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_args3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3dbcf1c7202f2878
+{-| __unique:__ @ExampleNothingget_const_pointers_args4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_a6624f6cc0a062af" hs_bindgen_test_macrosreparse_a6624f6cc0a062af :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -7822,6 +8416,8 @@ const_pointers_args4_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_args4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_a6624f6cc0a062af
+{-| __unique:__ @ExampleNothingget_const_pointers_args5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c5f3253c57910315" hs_bindgen_test_macrosreparse_c5f3253c57910315 :: IO (FunPtr (A ->
                                                                                                                                          Ptr CInt ->
                                                                                                                                          IO Unit))
@@ -7840,6 +8436,8 @@ const_pointers_args5_ptr :: FunPtr (A -> Ptr CInt -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_args5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c5f3253c57910315
+{-| __unique:__ @ExampleNothingget_const_pointers_ret1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_1990ded85ea3850d" hs_bindgen_test_macrosreparse_1990ded85ea3850d :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE const_pointers_ret1_ptr #-}
@@ -7857,6 +8455,8 @@ const_pointers_ret1_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_ret1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_1990ded85ea3850d
+{-| __unique:__ @ExampleNothingget_const_pointers_ret2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_627cc570c3ca7d19" hs_bindgen_test_macrosreparse_627cc570c3ca7d19 :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE const_pointers_ret2_ptr #-}
@@ -7874,6 +8474,8 @@ const_pointers_ret2_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_ret2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_627cc570c3ca7d19
+{-| __unique:__ @ExampleNothingget_const_pointers_ret3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2f449708b5a275b1" hs_bindgen_test_macrosreparse_2f449708b5a275b1 :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE const_pointers_ret3_ptr #-}
@@ -7891,6 +8493,8 @@ const_pointers_ret3_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_ret3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_2f449708b5a275b1
+{-| __unique:__ @ExampleNothingget_const_pointers_ret4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_67662618cd011c8a" hs_bindgen_test_macrosreparse_67662618cd011c8a :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE const_pointers_ret4_ptr #-}
@@ -7908,6 +8512,8 @@ const_pointers_ret4_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_ret4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_67662618cd011c8a
+{-| __unique:__ @ExampleNothingget_const_pointers_ret5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_fcafd9f8ac329995" hs_bindgen_test_macrosreparse_fcafd9f8ac329995 :: IO (FunPtr (A ->
                                                                                                                                          IO (Ptr CInt)))
 {-# NOINLINE const_pointers_ret5_ptr #-}
@@ -7925,6 +8531,8 @@ const_pointers_ret5_ptr :: FunPtr (A -> IO (Ptr CInt))
     __exported by:__ @macros\/reparse.h@
 -}
 const_pointers_ret5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_fcafd9f8ac329995
+{-| __unique:__ @ExampleNothingget_const_array_elem1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6928906fc9a88dfc" hs_bindgen_test_macrosreparse_6928906fc9a88dfc :: IO (FunPtr (IncompleteArray A ->
                                                                                                                                          IO Unit))
 {-# NOINLINE const_array_elem1_ptr #-}
@@ -7942,6 +8550,8 @@ const_array_elem1_ptr :: FunPtr (IncompleteArray A -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 const_array_elem1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_6928906fc9a88dfc
+{-| __unique:__ @ExampleNothingget_const_array_elem2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_625a37e9c030891a" hs_bindgen_test_macrosreparse_625a37e9c030891a :: IO (FunPtr (IncompleteArray (Ptr A) ->
                                                                                                                                          IO Unit))
 {-# NOINLINE const_array_elem2_ptr #-}
@@ -7960,6 +8570,8 @@ const_array_elem2_ptr :: FunPtr (IncompleteArray (Ptr A) ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_array_elem2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_625a37e9c030891a
+{-| __unique:__ @ExampleNothingget_const_array_elem3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_5e23f87114cf51fb" hs_bindgen_test_macrosreparse_5e23f87114cf51fb :: IO (FunPtr (IncompleteArray (Ptr A) ->
                                                                                                                                          IO Unit))
 {-# NOINLINE const_array_elem3_ptr #-}
@@ -7978,6 +8590,8 @@ const_array_elem3_ptr :: FunPtr (IncompleteArray (Ptr A) ->
     __exported by:__ @macros\/reparse.h@
 -}
 const_array_elem3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_5e23f87114cf51fb
+{-| __unique:__ @ExampleNothingget_noParams1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_d50620a002265139" hs_bindgen_test_macrosreparse_d50620a002265139 :: IO (FunPtr (IO A))
 {-# NOINLINE noParams1_ptr #-}
 {-| Other examples we reparsed /incorrectly/ before language-c
@@ -7998,6 +8612,8 @@ __defined at:__ @macros\/reparse.h:256:3@
 __exported by:__ @macros\/reparse.h@
 -}
 noParams1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_d50620a002265139
+{-| __unique:__ @ExampleNothingget_noParams2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_03b0e24786b82ad5" hs_bindgen_test_macrosreparse_03b0e24786b82ad5 :: IO (FunPtr (IO A))
 {-# NOINLINE noParams2_ptr #-}
 {-| __C declaration:__ @noParams2@
@@ -8014,6 +8630,8 @@ noParams2_ptr :: FunPtr (IO A)
     __exported by:__ @macros\/reparse.h@
 -}
 noParams2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_03b0e24786b82ad5
+{-| __unique:__ @ExampleNothingget_noParams3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_36508fd99a0556c5" hs_bindgen_test_macrosreparse_36508fd99a0556c5 :: IO (FunPtr (A ->
                                                                                                                                          FunPtr (IO CInt) ->
                                                                                                                                          IO Unit))
@@ -8032,6 +8650,8 @@ noParams3_ptr :: FunPtr (A -> FunPtr (IO CInt) -> IO Unit)
     __exported by:__ @macros\/reparse.h@
 -}
 noParams3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_36508fd99a0556c5
+{-| __unique:__ @ExampleNothingget_funptr_ret1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_6f83a48dd177c25f" hs_bindgen_test_macrosreparse_6f83a48dd177c25f :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (IO Unit))))
 {-# NOINLINE funptr_ret1_ptr #-}
@@ -8049,6 +8669,8 @@ funptr_ret1_ptr :: FunPtr (A -> IO (FunPtr (IO Unit)))
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret1_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_6f83a48dd177c25f
+{-| __unique:__ @ExampleNothingget_funptr_ret2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_f12efafd1525ef7f" hs_bindgen_test_macrosreparse_f12efafd1525ef7f :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (IO CInt))))
 {-# NOINLINE funptr_ret2_ptr #-}
@@ -8066,6 +8688,8 @@ funptr_ret2_ptr :: FunPtr (A -> IO (FunPtr (IO CInt)))
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret2_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_f12efafd1525ef7f
+{-| __unique:__ @ExampleNothingget_funptr_ret3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_b00baa5b9708b9e7" hs_bindgen_test_macrosreparse_b00baa5b9708b9e7 :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      IO Unit))))
@@ -8084,6 +8708,8 @@ funptr_ret3_ptr :: FunPtr (A -> IO (FunPtr (CInt -> IO Unit)))
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret3_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_b00baa5b9708b9e7
+{-| __unique:__ @ExampleNothingget_funptr_ret4_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_c51872479ceff42e" hs_bindgen_test_macrosreparse_c51872479ceff42e :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8104,6 +8730,8 @@ funptr_ret4_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret4_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_c51872479ceff42e
+{-| __unique:__ @ExampleNothingget_funptr_ret5_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea" hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8124,6 +8752,8 @@ funptr_ret5_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret5_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3b9b9924b4b4d7ea
+{-| __unique:__ @ExampleNothingget_funptr_ret6_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_3df5ab4b0b306845" hs_bindgen_test_macrosreparse_3df5ab4b0b306845 :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8144,6 +8774,8 @@ funptr_ret6_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret6_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_3df5ab4b0b306845
+{-| __unique:__ @ExampleNothingget_funptr_ret7_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_2ac4454d93b6f04a" hs_bindgen_test_macrosreparse_2ac4454d93b6f04a :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8164,6 +8796,8 @@ funptr_ret7_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret7_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_2ac4454d93b6f04a
+{-| __unique:__ @ExampleNothingget_funptr_ret8_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_411c5128f18364b3" hs_bindgen_test_macrosreparse_411c5128f18364b3 :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8184,6 +8818,8 @@ funptr_ret8_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret8_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_411c5128f18364b3
+{-| __unique:__ @ExampleNothingget_funptr_ret9_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_693a8d16e17d0cdc" hs_bindgen_test_macrosreparse_693a8d16e17d0cdc :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->
@@ -8204,6 +8840,8 @@ funptr_ret9_ptr :: FunPtr (A ->
     __exported by:__ @macros\/reparse.h@
 -}
 funptr_ret9_ptr = unsafePerformIO hs_bindgen_test_macrosreparse_693a8d16e17d0cdc
+{-| __unique:__ @ExampleNothingget_funptr_ret10_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_macrosreparse_9d2da81bbfe49ab6" hs_bindgen_test_macrosreparse_9d2da81bbfe49ab6 :: IO (FunPtr (A ->
                                                                                                                                          IO (FunPtr (CInt ->
                                                                                                                                                      CDouble ->

--- a/hs-bindgen/fixtures/manual/arrays/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/FunPtr.hs
@@ -32,6 +32,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_transpose_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_fc1dad225b555299" hs_bindgen_test_manualarrays_fc1dad225b555299 ::
      IO (Ptr.FunPtr (Matrix -> Matrix -> IO ()))
 
@@ -47,6 +49,8 @@ transpose_ptr :: Ptr.FunPtr (Matrix -> Matrix -> IO ())
 transpose_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_fc1dad225b555299
 
+{-| __unique:__ @ExampleNothingget_pretty_print_triplets_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_0b485cea747ee35d" hs_bindgen_test_manualarrays_0b485cea747ee35d ::
      IO (Ptr.FunPtr (Triplet_ptrs -> IO ()))
 

--- a/hs-bindgen/fixtures/manual/arrays/Example/Global.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Global.hs
@@ -55,6 +55,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_arr1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_1693226264ba4aeb" hs_bindgen_test_manualarrays_1693226264ba4aeb ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt))
 
@@ -72,6 +74,8 @@ arr1_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CInt)
 arr1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_1693226264ba4aeb
 
+{-| __unique:__ @ExampleNothingget_arr2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_dafcf99a73b93389" hs_bindgen_test_manualarrays_dafcf99a73b93389 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
 
@@ -89,6 +93,8 @@ arr2_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
 arr2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_dafcf99a73b93389
 
+{-| __unique:__ @ExampleNothingget_arr3_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_ca1016acc3449dee" hs_bindgen_test_manualarrays_ca1016acc3449dee ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt))
 
@@ -106,6 +112,8 @@ arr3_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
 arr3_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_ca1016acc3449dee
 
+{-| __unique:__ @ExampleNothingget_sudoku_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_76857c9492b9374d" hs_bindgen_test_manualarrays_76857c9492b9374d ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -123,6 +131,8 @@ sudoku_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBin
 sudoku_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_76857c9492b9374d
 
+{-| __unique:__ @ExampleNothingget_triplets_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_76f4df4c63822352" hs_bindgen_test_manualarrays_76f4df4c63822352 ::
      IO (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
 
@@ -140,6 +150,8 @@ triplets_ptr :: Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsB
 triplets_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualarrays_76f4df4c63822352
 
+{-| __unique:__ @ExampleNothingget_global_triplet_ptrs_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_f5de5a56e036b125" hs_bindgen_test_manualarrays_f5de5a56e036b125 ::
      IO (Ptr.Ptr Triplet_ptrs)
 

--- a/hs-bindgen/fixtures/manual/arrays/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Safe.hs
@@ -32,6 +32,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Safetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_f3d0c8dd1a83b3d0" transpose_wrapper ::
      Ptr.Ptr Triplet
@@ -65,6 +66,8 @@ __C declaration:__ @pretty_print_triplets@
 __defined at:__ @manual\/arrays.h:50:13@
 
 __exported by:__ @manual\/arrays.h@
+
+__unique:__ @ExampleJust Safepretty_print_triplets@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_27135f4747eb87db" pretty_print_triplets ::
      Ptr.Ptr (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))

--- a/hs-bindgen/fixtures/manual/arrays/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Unsafe.hs
@@ -32,6 +32,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_d7aa7016f1b951b2" transpose_wrapper ::
      Ptr.Ptr Triplet
@@ -65,6 +66,8 @@ __C declaration:__ @pretty_print_triplets@
 __defined at:__ @manual\/arrays.h:50:13@
 
 __exported by:__ @manual\/arrays.h@
+
+__unique:__ @ExampleJust Unsafepretty_print_triplets@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualarrays_bfd9ee42829f9ddb" pretty_print_triplets ::
      Ptr.Ptr (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))

--- a/hs-bindgen/fixtures/manual/arrays/th.txt
+++ b/hs-bindgen/fixtures/manual/arrays/th.txt
@@ -152,6 +152,7 @@ instance HasCField Triplet_ptrs "un_Triplet_ptrs"
           offset# = \_ -> \_ -> 0
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_f3d0c8dd1a83b3d0" transpose_wrapper :: Ptr Triplet ->
                                                                                                Ptr Triplet ->
@@ -177,12 +178,15 @@ __C declaration:__ @pretty_print_triplets@
 __defined at:__ @manual\/arrays.h:50:13@
 
 __exported by:__ @manual\/arrays.h@
+
+__unique:__ @ExampleJust Unsafepretty_print_triplets@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_27135f4747eb87db" pretty_print_triplets :: Ptr (Ptr (ConstantArray 3
                                                                                                                            CInt)) ->
                                                                                                    IO Unit
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_d7aa7016f1b951b2" transpose_wrapper :: Ptr Triplet ->
                                                                                                Ptr Triplet ->
@@ -208,10 +212,14 @@ __C declaration:__ @pretty_print_triplets@
 __defined at:__ @manual\/arrays.h:50:13@
 
 __exported by:__ @manual\/arrays.h@
+
+__unique:__ @ExampleJust Unsafepretty_print_triplets@
 -}
 foreign import ccall safe "hs_bindgen_test_manualarrays_bfd9ee42829f9ddb" pretty_print_triplets :: Ptr (Ptr (ConstantArray 3
                                                                                                                            CInt)) ->
                                                                                                    IO Unit
+{-| __unique:__ @ExampleNothingget_transpose_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_fc1dad225b555299" hs_bindgen_test_manualarrays_fc1dad225b555299 :: IO (FunPtr (Matrix ->
                                                                                                                                        Matrix ->
                                                                                                                                        IO Unit))
@@ -230,6 +238,8 @@ transpose_ptr :: FunPtr (Matrix -> Matrix -> IO Unit)
     __exported by:__ @manual\/arrays.h@
 -}
 transpose_ptr = unsafePerformIO hs_bindgen_test_manualarrays_fc1dad225b555299
+{-| __unique:__ @ExampleNothingget_pretty_print_triplets_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_0b485cea747ee35d" hs_bindgen_test_manualarrays_0b485cea747ee35d :: IO (FunPtr (Triplet_ptrs ->
                                                                                                                                        IO Unit))
 {-# NOINLINE pretty_print_triplets_ptr #-}
@@ -251,6 +261,8 @@ __defined at:__ @manual\/arrays.h:50:13@
 __exported by:__ @manual\/arrays.h@
 -}
 pretty_print_triplets_ptr = unsafePerformIO hs_bindgen_test_manualarrays_0b485cea747ee35d
+{-| __unique:__ @ExampleNothingget_arr1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_1693226264ba4aeb" hs_bindgen_test_manualarrays_1693226264ba4aeb :: IO (Ptr (ConstantArray 1
                                                                                                                                                   CInt))
 {-# NOINLINE arr1_ptr #-}
@@ -272,6 +284,8 @@ __defined at:__ @manual\/arrays.h:13:12@
 __exported by:__ @manual\/arrays.h@
 -}
 arr1_ptr = unsafePerformIO hs_bindgen_test_manualarrays_1693226264ba4aeb
+{-| __unique:__ @ExampleNothingget_arr2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_dafcf99a73b93389" hs_bindgen_test_manualarrays_dafcf99a73b93389 :: IO (Ptr (ConstantArray 3
                                                                                                                                                   CInt))
 {-# NOINLINE arr2_ptr #-}
@@ -293,6 +307,8 @@ __defined at:__ @manual\/arrays.h:16:12@
 __exported by:__ @manual\/arrays.h@
 -}
 arr2_ptr = unsafePerformIO hs_bindgen_test_manualarrays_dafcf99a73b93389
+{-| __unique:__ @ExampleNothingget_arr3_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_ca1016acc3449dee" hs_bindgen_test_manualarrays_ca1016acc3449dee :: IO (Ptr (IncompleteArray CInt))
 {-# NOINLINE arr3_ptr #-}
 {-| Global, extern, incomplete
@@ -313,6 +329,8 @@ __defined at:__ @manual\/arrays.h:19:12@
 __exported by:__ @manual\/arrays.h@
 -}
 arr3_ptr = unsafePerformIO hs_bindgen_test_manualarrays_ca1016acc3449dee
+{-| __unique:__ @ExampleNothingget_sudoku_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_76857c9492b9374d" hs_bindgen_test_manualarrays_76857c9492b9374d :: IO (Ptr (ConstantArray 3
                                                                                                                                                   (ConstantArray 3
                                                                                                                                                                  CInt)))
@@ -335,6 +353,8 @@ __defined at:__ @manual\/arrays.h:22:12@
 __exported by:__ @manual\/arrays.h@
 -}
 sudoku_ptr = unsafePerformIO hs_bindgen_test_manualarrays_76857c9492b9374d
+{-| __unique:__ @ExampleNothingget_triplets_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_76f4df4c63822352" hs_bindgen_test_manualarrays_76f4df4c63822352 :: IO (Ptr (IncompleteArray (ConstantArray 3
                                                                                                                                                                    CInt)))
 {-# NOINLINE triplets_ptr #-}
@@ -356,6 +376,8 @@ __defined at:__ @manual\/arrays.h:26:12@
 __exported by:__ @manual\/arrays.h@
 -}
 triplets_ptr = unsafePerformIO hs_bindgen_test_manualarrays_76f4df4c63822352
+{-| __unique:__ @ExampleNothingget_global_triplet_ptrs_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualarrays_f5de5a56e036b125" hs_bindgen_test_manualarrays_f5de5a56e036b125 :: IO (Ptr Triplet_ptrs)
 {-# NOINLINE global_triplet_ptrs_ptr #-}
 {-| A global of triplet_ptrs

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/FunPtr.hs
@@ -84,6 +84,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9" hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9 ::
      IO (Ptr.FunPtr (FC.CInt -> IO FC.CInt))
 
@@ -99,6 +101,8 @@ square_ptr :: Ptr.FunPtr (FC.CInt -> IO FC.CInt)
 square_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9
 
+{-| __unique:__ @ExampleNothingget_plus_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_bf838c747898dc42" hs_bindgen_test_manualfunction_pointers_bf838c747898dc42 ::
      IO (Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt))
 
@@ -114,6 +118,8 @@ plus_ptr :: Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)
 plus_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_bf838c747898dc42
 
+{-| __unique:__ @ExampleNothingget_apply1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070" hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070 ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> FC.CInt -> IO FC.CInt))
 
@@ -129,6 +135,8 @@ apply1_ptr :: Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> IO FC.CInt)) -> FC.CInt -> IO 
 apply1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070
 
+{-| __unique:__ @ExampleNothingget_apply2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a" hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a ::
      IO (Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)) -> FC.CInt -> FC.CInt -> IO FC.CInt))
 
@@ -144,6 +152,8 @@ apply2_ptr :: Ptr.FunPtr ((Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)) -> FC.
 apply2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a
 
+{-| __unique:__ @ExampleNothingget_apply1_pointer_arg_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca" hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca ::
      IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))
 
@@ -161,6 +171,8 @@ apply1_pointer_arg_ptr :: Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.C
 apply1_pointer_arg_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca
 
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_arg_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81" hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81 ::
      IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))
 
@@ -178,6 +190,8 @@ apply1_nopointer_arg_ptr :: Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC
 apply1_nopointer_arg_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81
 
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_res_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_f7a08d090f6f7b0f" hs_bindgen_test_manualfunction_pointers_f7a08d090f6f7b0f ::
      IO (Ptr.FunPtr (IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))))
 

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Global.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Global.hs
@@ -38,6 +38,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_var_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_c4bb317da29227a6" hs_bindgen_test_manualfunction_pointers_c4bb317da29227a6 ::
      IO (Ptr.Ptr (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt)))
 
@@ -61,6 +63,8 @@ apply1_nopointer_var :: Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CIn
 apply1_nopointer_var =
   GHC.IO.Unsafe.unsafePerformIO (F.peek apply1_nopointer_var_ptr)
 
+{-| __unique:__ @ExampleNothingget_apply1_struct_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_6799ff6bc99dff2a" hs_bindgen_test_manualfunction_pointers_6799ff6bc99dff2a ::
      IO (Ptr.Ptr Apply1Struct)
 
@@ -82,6 +86,8 @@ apply1_struct :: Apply1Struct
 apply1_struct =
   GHC.IO.Unsafe.unsafePerformIO (F.peek apply1_struct_ptr)
 
+{-| __unique:__ @ExampleNothingget_apply1_union_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_d32b4879673188b6" hs_bindgen_test_manualfunction_pointers_d32b4879673188b6 ::
      IO (Ptr.Ptr Apply1Union)
 

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Safe.hs
@@ -74,6 +74,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @manual\/function_pointers.h:5:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Safesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_55e5eb89e54abf83" square ::
      FC.CInt
@@ -84,6 +86,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_55e5eb89e54ab
     __defined at:__ @manual\/function_pointers.h:7:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Safeplus@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_680daf766a044980" plus ::
      FC.CInt
@@ -95,6 +99,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_680daf766a044
     __defined at:__ @manual\/function_pointers.h:9:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Safeapply1@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_abcb860034253564" apply1 ::
      Ptr.FunPtr (FC.CInt -> IO FC.CInt)
@@ -110,6 +116,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_abcb860034253
     __defined at:__ @manual\/function_pointers.h:11:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Safeapply2@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_1ad13c166a710f40" apply2 ::
      Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)
@@ -130,6 +138,8 @@ __C declaration:__ @apply1_pointer_arg@
 __defined at:__ @manual\/function_pointers.h:22:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Safeapply1_pointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_a8ef4d9e6ce68f54" apply1_pointer_arg ::
      Ptr.FunPtr Int2int
@@ -143,6 +153,8 @@ __C declaration:__ @apply1_nopointer_arg@
 __defined at:__ @manual\/function_pointers.h:26:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Safeapply1_nopointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_7dc4caa1f7f0caf0" apply1_nopointer_arg ::
      Ptr.FunPtr Int2int
@@ -156,6 +168,8 @@ __C declaration:__ @apply1_nopointer_res@
 __defined at:__ @manual\/function_pointers.h:31:21@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Safeapply1_nopointer_res@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3612aa0d10e36d5b" apply1_nopointer_res ::
      IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Unsafe.hs
@@ -74,6 +74,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @manual\/function_pointers.h:5:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_cb3c687f16289bb3" square ::
      FC.CInt
@@ -84,6 +86,8 @@ foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_cb3c687f162
     __defined at:__ @manual\/function_pointers.h:7:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeplus@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_a9730564387164c0" plus ::
      FC.CInt
@@ -95,6 +99,8 @@ foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_a9730564387
     __defined at:__ @manual\/function_pointers.h:9:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_3fb9c4a14d502477" apply1 ::
      Ptr.FunPtr (FC.CInt -> IO FC.CInt)
@@ -110,6 +116,8 @@ foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_3fb9c4a14d5
     __defined at:__ @manual\/function_pointers.h:11:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_75b5699fdabb6333" apply2 ::
      Ptr.FunPtr (FC.CInt -> FC.CInt -> IO FC.CInt)
@@ -130,6 +138,8 @@ __C declaration:__ @apply1_pointer_arg@
 __defined at:__ @manual\/function_pointers.h:22:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_pointer_arg@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_2d5144fc06502862" apply1_pointer_arg ::
      Ptr.FunPtr Int2int
@@ -143,6 +153,8 @@ __C declaration:__ @apply1_nopointer_arg@
 __defined at:__ @manual\/function_pointers.h:26:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_arg@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_b7597a0c4856ebb3" apply1_nopointer_arg ::
      Ptr.FunPtr Int2int
@@ -156,6 +168,8 @@ __C declaration:__ @apply1_nopointer_res@
 __defined at:__ @manual\/function_pointers.h:31:21@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_res@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualfunction_pointers_be3907895c70597f" apply1_nopointer_res ::
      IO (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -344,6 +344,8 @@ instance TyEq ty
     __defined at:__ @manual\/function_pointers.h:5:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_55e5eb89e54abf83" square :: CInt ->
                                                                                                IO CInt
@@ -352,6 +354,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_55e5eb89e54ab
     __defined at:__ @manual\/function_pointers.h:7:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeplus@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_680daf766a044980" plus :: CInt ->
                                                                                              CInt ->
@@ -361,6 +365,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_680daf766a044
     __defined at:__ @manual\/function_pointers.h:9:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply1@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_abcb860034253564" apply1 :: FunPtr (CInt ->
                                                                                                        IO CInt) ->
@@ -371,6 +377,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_abcb860034253
     __defined at:__ @manual\/function_pointers.h:11:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply2@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_1ad13c166a710f40" apply2 :: FunPtr (CInt ->
                                                                                                        CInt ->
@@ -385,6 +393,8 @@ __C declaration:__ @apply1_pointer_arg@
 __defined at:__ @manual\/function_pointers.h:22:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_pointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_a8ef4d9e6ce68f54" apply1_pointer_arg :: FunPtr Int2int ->
                                                                                                            CInt ->
@@ -396,6 +406,8 @@ __C declaration:__ @apply1_nopointer_arg@
 __defined at:__ @manual\/function_pointers.h:26:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_7dc4caa1f7f0caf0" apply1_nopointer_arg :: FunPtr Int2int ->
                                                                                                              CInt ->
@@ -407,6 +419,8 @@ __C declaration:__ @apply1_nopointer_res@
 __defined at:__ @manual\/function_pointers.h:31:21@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_res@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3612aa0d10e36d5b" apply1_nopointer_res :: IO (FunPtr (FunPtr Int2int ->
                                                                                                                          CInt ->
@@ -416,6 +430,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3612aa0d10e36
     __defined at:__ @manual\/function_pointers.h:5:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafesquare@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_cb3c687f16289bb3" square :: CInt ->
                                                                                                IO CInt
@@ -424,6 +440,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_cb3c687f16289
     __defined at:__ @manual\/function_pointers.h:7:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeplus@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_a9730564387164c0" plus :: CInt ->
                                                                                              CInt ->
@@ -433,6 +451,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_a973056438716
     __defined at:__ @manual\/function_pointers.h:9:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply1@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3fb9c4a14d502477" apply1 :: FunPtr (CInt ->
                                                                                                        IO CInt) ->
@@ -443,6 +463,8 @@ foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3fb9c4a14d502
     __defined at:__ @manual\/function_pointers.h:11:12@
 
     __exported by:__ @manual\/function_pointers.h@
+
+    __unique:__ @ExampleJust Unsafeapply2@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_75b5699fdabb6333" apply2 :: FunPtr (CInt ->
                                                                                                        CInt ->
@@ -457,6 +479,8 @@ __C declaration:__ @apply1_pointer_arg@
 __defined at:__ @manual\/function_pointers.h:22:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_pointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_2d5144fc06502862" apply1_pointer_arg :: FunPtr Int2int ->
                                                                                                            CInt ->
@@ -468,6 +492,8 @@ __C declaration:__ @apply1_nopointer_arg@
 __defined at:__ @manual\/function_pointers.h:26:12@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_arg@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_b7597a0c4856ebb3" apply1_nopointer_arg :: FunPtr Int2int ->
                                                                                                              CInt ->
@@ -479,10 +505,14 @@ __C declaration:__ @apply1_nopointer_res@
 __defined at:__ @manual\/function_pointers.h:31:21@
 
 __exported by:__ @manual\/function_pointers.h@
+
+__unique:__ @ExampleJust Unsafeapply1_nopointer_res@
 -}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_be3907895c70597f" apply1_nopointer_res :: IO (FunPtr (FunPtr Int2int ->
                                                                                                                          CInt ->
                                                                                                                          IO CInt))
+{-| __unique:__ @ExampleNothingget_square_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9" hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9 :: IO (FunPtr (CInt ->
                                                                                                                                                              IO CInt))
 {-# NOINLINE square_ptr #-}
@@ -500,6 +530,8 @@ square_ptr :: FunPtr (CInt -> IO CInt)
     __exported by:__ @manual\/function_pointers.h@
 -}
 square_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_c41111f40a04cdc9
+{-| __unique:__ @ExampleNothingget_plus_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_bf838c747898dc42" hs_bindgen_test_manualfunction_pointers_bf838c747898dc42 :: IO (FunPtr (CInt ->
                                                                                                                                                              CInt ->
                                                                                                                                                              IO CInt))
@@ -518,6 +550,8 @@ plus_ptr :: FunPtr (CInt -> CInt -> IO CInt)
     __exported by:__ @manual\/function_pointers.h@
 -}
 plus_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_bf838c747898dc42
+{-| __unique:__ @ExampleNothingget_apply1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070" hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070 :: IO (FunPtr (FunPtr (CInt ->
                                                                                                                                                                      IO CInt) ->
                                                                                                                                                              CInt ->
@@ -537,6 +571,8 @@ apply1_ptr :: FunPtr (FunPtr (CInt -> IO CInt) -> CInt -> IO CInt)
     __exported by:__ @manual\/function_pointers.h@
 -}
 apply1_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_4d1935e01bc37070
+{-| __unique:__ @ExampleNothingget_apply2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a" hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a :: IO (FunPtr (FunPtr (CInt ->
                                                                                                                                                                      CInt ->
                                                                                                                                                                      IO CInt) ->
@@ -559,6 +595,8 @@ apply2_ptr :: FunPtr (FunPtr (CInt -> CInt -> IO CInt) ->
     __exported by:__ @manual\/function_pointers.h@
 -}
 apply2_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_40cb8952bacd236a
+{-| __unique:__ @ExampleNothingget_apply1_pointer_arg_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca" hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca :: IO (FunPtr (FunPtr Int2int ->
                                                                                                                                                              CInt ->
                                                                                                                                                              IO CInt))
@@ -582,6 +620,8 @@ __defined at:__ @manual\/function_pointers.h:22:12@
 __exported by:__ @manual\/function_pointers.h@
 -}
 apply1_pointer_arg_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_653c5bde7704c3ca
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_arg_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81" hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81 :: IO (FunPtr (FunPtr Int2int ->
                                                                                                                                                              CInt ->
                                                                                                                                                              IO CInt))
@@ -605,6 +645,8 @@ __defined at:__ @manual\/function_pointers.h:26:12@
 __exported by:__ @manual\/function_pointers.h@
 -}
 apply1_nopointer_arg_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_3bb9417cd7afec81
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_res_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_f7a08d090f6f7b0f" hs_bindgen_test_manualfunction_pointers_f7a08d090f6f7b0f :: IO (FunPtr (IO (FunPtr (FunPtr Int2int ->
                                                                                                                                                                          CInt ->
                                                                                                                                                                          IO CInt))))
@@ -628,6 +670,8 @@ __defined at:__ @manual\/function_pointers.h:31:21@
 __exported by:__ @manual\/function_pointers.h@
 -}
 apply1_nopointer_res_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_f7a08d090f6f7b0f
+{-| __unique:__ @ExampleNothingget_apply1_nopointer_var_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_c4bb317da29227a6" hs_bindgen_test_manualfunction_pointers_c4bb317da29227a6 :: IO (Ptr (FunPtr (FunPtr Int2int ->
                                                                                                                                                                   CInt ->
                                                                                                                                                                   IO CInt)))
@@ -654,6 +698,8 @@ apply1_nopointer_var_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointe
 {-# NOINLINE apply1_nopointer_var #-}
 apply1_nopointer_var :: FunPtr (FunPtr Int2int -> CInt -> IO CInt)
 apply1_nopointer_var = unsafePerformIO (peek apply1_nopointer_var_ptr)
+{-| __unique:__ @ExampleNothingget_apply1_struct_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_6799ff6bc99dff2a" hs_bindgen_test_manualfunction_pointers_6799ff6bc99dff2a :: IO (Ptr Apply1Struct)
 {-# NOINLINE apply1_struct_ptr #-}
 {-| __C declaration:__ @apply1_struct@
@@ -673,6 +719,8 @@ apply1_struct_ptr = unsafePerformIO hs_bindgen_test_manualfunction_pointers_6799
 {-# NOINLINE apply1_struct #-}
 apply1_struct :: Apply1Struct
 apply1_struct = unsafePerformIO (peek apply1_struct_ptr)
+{-| __unique:__ @ExampleNothingget_apply1_union_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualfunction_pointers_d32b4879673188b6" hs_bindgen_test_manualfunction_pointers_d32b4879673188b6 :: IO (Ptr Apply1Union)
 {-# NOINLINE apply1_union_ptr #-}
 {-| __C declaration:__ @apply1_union@

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/FunPtr.hs
@@ -34,6 +34,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_reverse_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualzero_copy_c3d266ec84fe0678" hs_bindgen_test_manualzero_copy_c3d266ec84fe0678 ::
      IO (Ptr.FunPtr ((Ptr.Ptr Vector) -> (Ptr.Ptr Vector) -> IO FC.CInt))
 
@@ -49,6 +51,8 @@ reverse_ptr :: Ptr.FunPtr ((Ptr.Ptr Vector) -> (Ptr.Ptr Vector) -> IO FC.CInt)
 reverse_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_manualzero_copy_c3d266ec84fe0678
 
+{-| __unique:__ @ExampleNothingget_transpose_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_manualzero_copy_fc1dad225b555299" hs_bindgen_test_manualzero_copy_fc1dad225b555299 ::
      IO (Ptr.FunPtr (Matrix -> Matrix -> IO ()))
 

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/Safe.hs
@@ -35,6 +35,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @manual\/zero_copy.h:77:5@
 
     __exported by:__ @manual\/zero_copy.h@
+
+    __unique:__ @ExampleJust Safereverse@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_a617e0cb5d95cd52" reverse ::
      Ptr.Ptr Vector
@@ -47,6 +49,7 @@ foreign import ccall safe "hs_bindgen_test_manualzero_copy_a617e0cb5d95cd52" rev
 
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Safetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_f3d0c8dd1a83b3d0" transpose_wrapper ::
      Ptr.Ptr Triplet

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/Unsafe.hs
@@ -35,6 +35,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @manual\/zero_copy.h:77:5@
 
     __exported by:__ @manual\/zero_copy.h@
+
+    __unique:__ @ExampleJust Unsafereverse@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualzero_copy_ca203e332b4afe73" reverse ::
      Ptr.Ptr Vector
@@ -47,6 +49,7 @@ foreign import ccall unsafe "hs_bindgen_test_manualzero_copy_ca203e332b4afe73" r
 
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall unsafe "hs_bindgen_test_manualzero_copy_d7aa7016f1b951b2" transpose_wrapper ::
      Ptr.Ptr Triplet

--- a/hs-bindgen/fixtures/manual/zero_copy/th.txt
+++ b/hs-bindgen/fixtures/manual/zero_copy/th.txt
@@ -614,12 +614,15 @@ instance HasCField Matrix "un_Matrix"
     __defined at:__ @manual\/zero_copy.h:77:5@
 
     __exported by:__ @manual\/zero_copy.h@
+
+    __unique:__ @ExampleJust Unsafereverse@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_a617e0cb5d95cd52" reverse :: Ptr Vector ->
                                                                                         Ptr Vector ->
                                                                                         IO CInt
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_f3d0c8dd1a83b3d0" transpose_wrapper :: Ptr Triplet ->
                                                                                                   Ptr Triplet ->
@@ -643,12 +646,15 @@ transpose = \x_0 -> \x_1 -> withPtr x_0 (\ptr_2 -> transpose_wrapper ptr_2 x_1)
     __defined at:__ @manual\/zero_copy.h:77:5@
 
     __exported by:__ @manual\/zero_copy.h@
+
+    __unique:__ @ExampleJust Unsafereverse@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_ca203e332b4afe73" reverse :: Ptr Vector ->
                                                                                         Ptr Vector ->
                                                                                         IO CInt
 {-| Pointer-based API for 'transpose'
 
+__unique:__ @ExampleJust Unsafetranspose@
 -}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_d7aa7016f1b951b2" transpose_wrapper :: Ptr Triplet ->
                                                                                                   Ptr Triplet ->
@@ -667,6 +673,8 @@ transpose :: Matrix -> Ptr Triplet -> IO Unit
     __exported by:__ @manual\/zero_copy.h@
 -}
 transpose = \x_0 -> \x_1 -> withPtr x_0 (\ptr_2 -> transpose_wrapper ptr_2 x_1)
+{-| __unique:__ @ExampleNothingget_reverse_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_c3d266ec84fe0678" hs_bindgen_test_manualzero_copy_c3d266ec84fe0678 :: IO (FunPtr (Ptr Vector ->
                                                                                                                                              Ptr Vector ->
                                                                                                                                              IO CInt))
@@ -685,6 +693,8 @@ reverse_ptr :: FunPtr (Ptr Vector -> Ptr Vector -> IO CInt)
     __exported by:__ @manual\/zero_copy.h@
 -}
 reverse_ptr = unsafePerformIO hs_bindgen_test_manualzero_copy_c3d266ec84fe0678
+{-| __unique:__ @ExampleNothingget_transpose_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_manualzero_copy_fc1dad225b555299" hs_bindgen_test_manualzero_copy_fc1dad225b555299 :: IO (FunPtr (Matrix ->
                                                                                                                                              Matrix ->
                                                                                                                                              IO Unit))

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/FunPtr.hs
@@ -26,6 +26,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_read_file_chunk_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_programanalysisprogram_slici_cc45351e6b02b3b4" hs_bindgen_test_programanalysisprogram_slici_cc45351e6b02b3b4 ::
      IO (Ptr.FunPtr ((Ptr.Ptr HsBindgen.Runtime.Prelude.CFile) -> (Ptr.Ptr Void) -> HsBindgen.Runtime.Prelude.CSize -> IO FileOperationStatus))
 

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Safe.hs
@@ -28,6 +28,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @program-analysis\/program_slicing_selection.h:21:26@
 
     __exported by:__ @program-analysis\/program_slicing_selection.h@
+
+    __unique:__ @ExampleJust Saferead_file_chunk@
 -}
 foreign import ccall safe "hs_bindgen_test_programanalysisprogram_slici_13b0ed81415a625a" read_file_chunk ::
      Ptr.Ptr HsBindgen.Runtime.Prelude.CFile

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Unsafe.hs
@@ -28,6 +28,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @program-analysis\/program_slicing_selection.h:21:26@
 
     __exported by:__ @program-analysis\/program_slicing_selection.h@
+
+    __unique:__ @ExampleJust Unsaferead_file_chunk@
 -}
 foreign import ccall unsafe "hs_bindgen_test_programanalysisprogram_slici_3ade0bc94fb1ed45" read_file_chunk ::
      Ptr.Ptr HsBindgen.Runtime.Prelude.CFile

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -221,6 +221,8 @@ instance TyEq ty
     __defined at:__ @program-analysis\/program_slicing_selection.h:21:26@
 
     __exported by:__ @program-analysis\/program_slicing_selection.h@
+
+    __unique:__ @ExampleJust Unsaferead_file_chunk@
 -}
 foreign import ccall safe "hs_bindgen_test_programanalysisprogram_slici_13b0ed81415a625a" read_file_chunk :: Ptr HsBindgen.Runtime.Prelude.CFile ->
                                                                                                              Ptr Void ->
@@ -231,11 +233,15 @@ foreign import ccall safe "hs_bindgen_test_programanalysisprogram_slici_13b0ed81
     __defined at:__ @program-analysis\/program_slicing_selection.h:21:26@
 
     __exported by:__ @program-analysis\/program_slicing_selection.h@
+
+    __unique:__ @ExampleJust Unsaferead_file_chunk@
 -}
 foreign import ccall safe "hs_bindgen_test_programanalysisprogram_slici_3ade0bc94fb1ed45" read_file_chunk :: Ptr HsBindgen.Runtime.Prelude.CFile ->
                                                                                                              Ptr Void ->
                                                                                                              HsBindgen.Runtime.Prelude.CSize ->
                                                                                                              IO FileOperationStatus
+{-| __unique:__ @ExampleNothingget_read_file_chunk_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_programanalysisprogram_slici_cc45351e6b02b3b4" hs_bindgen_test_programanalysisprogram_slici_cc45351e6b02b3b4 :: IO (FunPtr (Ptr HsBindgen.Runtime.Prelude.CFile ->
                                                                                                                                                                        Ptr Void ->
                                                                                                                                                                        HsBindgen.Runtime.Prelude.CSize ->

--- a/hs-bindgen/fixtures/types/complex/complex_non_float_test/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/complex/complex_non_float_test/Example/Global.hs
@@ -46,6 +46,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_global_complex_unsigned_short_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62" hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CUShort))
 
@@ -61,6 +63,8 @@ global_complex_unsigned_short_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CUShort)
 global_complex_unsigned_short_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62
 
+{-| __unique:__ @ExampleNothingget_global_complex_short_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91" hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CShort))
 
@@ -76,6 +80,8 @@ global_complex_short_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CShort)
 global_complex_short_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91
 
+{-| __unique:__ @ExampleNothingget_global_complex_unsigned_int_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c" hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CUInt))
 
@@ -91,6 +97,8 @@ global_complex_unsigned_int_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CUInt)
 global_complex_unsigned_int_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c
 
+{-| __unique:__ @ExampleNothingget_global_complex_int_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969" hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CInt))
 
@@ -106,6 +114,8 @@ global_complex_int_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CInt)
 global_complex_int_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969
 
+{-| __unique:__ @ExampleNothingget_global_complex_char_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexcomplex_non_floa_4727b3aff4118d69" hs_bindgen_test_typescomplexcomplex_non_floa_4727b3aff4118d69 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CChar))
 

--- a/hs-bindgen/fixtures/types/complex/complex_non_float_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/complex_non_float_test/th.txt
@@ -31,6 +31,8 @@
 -- {
 --   return &global_complex_char;
 -- }
+{-| __unique:__ @ExampleNothingget_global_complex_unsigned_short_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62" hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62 :: IO (Ptr (Complex CUShort))
 {-# NOINLINE global_complex_unsigned_short_ptr #-}
 {-| __C declaration:__ @global_complex_unsigned_short@
@@ -47,6 +49,8 @@ global_complex_unsigned_short_ptr :: Ptr (Complex CUShort)
     __exported by:__ @types\/complex\/complex_non_float_test.h@
 -}
 global_complex_unsigned_short_ptr = unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_1a47f4ebfee55a62
+{-| __unique:__ @ExampleNothingget_global_complex_short_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91" hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91 :: IO (Ptr (Complex CShort))
 {-# NOINLINE global_complex_short_ptr #-}
 {-| __C declaration:__ @global_complex_short@
@@ -63,6 +67,8 @@ global_complex_short_ptr :: Ptr (Complex CShort)
     __exported by:__ @types\/complex\/complex_non_float_test.h@
 -}
 global_complex_short_ptr = unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_d56d4f7328166c91
+{-| __unique:__ @ExampleNothingget_global_complex_unsigned_int_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c" hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c :: IO (Ptr (Complex CUInt))
 {-# NOINLINE global_complex_unsigned_int_ptr #-}
 {-| __C declaration:__ @global_complex_unsigned_int@
@@ -79,6 +85,8 @@ global_complex_unsigned_int_ptr :: Ptr (Complex CUInt)
     __exported by:__ @types\/complex\/complex_non_float_test.h@
 -}
 global_complex_unsigned_int_ptr = unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_b596fcc6ded5636c
+{-| __unique:__ @ExampleNothingget_global_complex_int_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969" hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969 :: IO (Ptr (Complex CInt))
 {-# NOINLINE global_complex_int_ptr #-}
 {-| __C declaration:__ @global_complex_int@
@@ -95,6 +103,8 @@ global_complex_int_ptr :: Ptr (Complex CInt)
     __exported by:__ @types\/complex\/complex_non_float_test.h@
 -}
 global_complex_int_ptr = unsafePerformIO hs_bindgen_test_typescomplexcomplex_non_floa_9f8a73e0d4ba6969
+{-| __unique:__ @ExampleNothingget_global_complex_char_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexcomplex_non_floa_4727b3aff4118d69" hs_bindgen_test_typescomplexcomplex_non_floa_4727b3aff4118d69 :: IO (Ptr (Complex CChar))
 {-# NOINLINE global_complex_char_ptr #-}
 {-| __C declaration:__ @global_complex_char@

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/FunPtr.hs
@@ -34,6 +34,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_multiply_complex_f_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56" hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56 ::
      IO (Ptr.FunPtr ((Data.Complex.Complex FC.CFloat) -> (Data.Complex.Complex FC.CFloat) -> IO (Data.Complex.Complex FC.CFloat)))
 
@@ -49,6 +51,8 @@ multiply_complex_f_ptr :: Ptr.FunPtr ((Data.Complex.Complex FC.CFloat) -> (Data.
 multiply_complex_f_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56
 
+{-| __unique:__ @ExampleNothingget_add_complex_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_b6226a5bde741b3f" hs_bindgen_test_typescomplexhsb_complex_test_b6226a5bde741b3f ::
      IO (Ptr.FunPtr ((Data.Complex.Complex FC.CDouble) -> (Data.Complex.Complex FC.CDouble) -> IO (Data.Complex.Complex FC.CDouble)))
 

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Global.hs
@@ -103,6 +103,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_global_complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b" hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -118,6 +120,8 @@ global_complex_float_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CFloat)
 global_complex_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b
 
+{-| __unique:__ @ExampleNothingget_global_complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3" hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -133,6 +137,8 @@ global_complex_double_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CDouble)
 global_complex_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3
 
+{-| __unique:__ @ExampleNothingget_global_complex_float_flipped_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1" hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -148,6 +154,8 @@ global_complex_float_flipped_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CFloat)
 global_complex_float_flipped_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1
 
+{-| __unique:__ @ExampleNothingget_global_complex_double_flipped_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921" hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -163,6 +171,8 @@ global_complex_double_flipped_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CDouble)
 global_complex_double_flipped_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921
 
+{-| __unique:__ @ExampleNothingget_global_Complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7" hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -178,6 +188,8 @@ global_Complex_float_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CFloat)
 global_Complex_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7
 
+{-| __unique:__ @ExampleNothingget_global_Complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17" hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -193,6 +205,8 @@ global_Complex_double_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CDouble)
 global_Complex_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17
 
+{-| __unique:__ @ExampleNothingget_global_Complex_float_flipped_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee" hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -208,6 +222,8 @@ global_Complex_float_flipped_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CFloat)
 global_Complex_float_flipped_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee
 
+{-| __unique:__ @ExampleNothingget_global_Complex_double_flipped_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50" hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -223,6 +239,8 @@ global_Complex_double_flipped_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CDouble)
 global_Complex_double_flipped_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50
 
+{-| __unique:__ @ExampleNothingget_const_complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_bb0fb18f3dfee47d" hs_bindgen_test_typescomplexhsb_complex_test_bb0fb18f3dfee47d ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -244,6 +262,8 @@ const_complex_float :: Data.Complex.Complex FC.CFloat
 const_complex_float =
   GHC.IO.Unsafe.unsafePerformIO (F.peek const_complex_float_ptr)
 
+{-| __unique:__ @ExampleNothingget_const_complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_f491f52e529a459a" hs_bindgen_test_typescomplexhsb_complex_test_f491f52e529a459a ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -265,6 +285,8 @@ const_complex_double :: Data.Complex.Complex FC.CDouble
 const_complex_double =
   GHC.IO.Unsafe.unsafePerformIO (F.peek const_complex_double_ptr)
 
+{-| __unique:__ @ExampleNothingget_volatile_complex_float_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75" hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CFloat))
 
@@ -280,6 +302,8 @@ volatile_complex_float_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CFloat)
 volatile_complex_float_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75
 
+{-| __unique:__ @ExampleNothingget_volatile_complex_double_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4" hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4 ::
      IO (Ptr.Ptr (Data.Complex.Complex FC.CDouble))
 
@@ -295,6 +319,8 @@ volatile_complex_double_ptr :: Ptr.Ptr (Data.Complex.Complex FC.CDouble)
 volatile_complex_double_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4
 
+{-| __unique:__ @ExampleNothingget_complex_float_array_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70" hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) (Data.Complex.Complex FC.CFloat)))
 
@@ -310,6 +336,8 @@ complex_float_array_ptr :: Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArr
 complex_float_array_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70
 
+{-| __unique:__ @ExampleNothingget_complex_double_array_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_0b63f3bda9243457" hs_bindgen_test_typescomplexhsb_complex_test_0b63f3bda9243457 ::
      IO (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) (Data.Complex.Complex FC.CDouble)))
 

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Safe.hs
@@ -35,6 +35,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'multiply_complex_f'
 
+__unique:__ @ExampleJust Safemultiply_complex_f@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_b84ea846e04d5fd6" multiply_complex_f_wrapper ::
      Ptr.Ptr (Data.Complex.Complex FC.CFloat)
@@ -66,6 +67,7 @@ multiply_complex_f =
 
 {-| Pointer-based API for 'add_complex'
 
+__unique:__ @ExampleJust Safeadd_complex@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_8dd079d1707c36b3" add_complex_wrapper ::
      Ptr.Ptr (Data.Complex.Complex FC.CDouble)

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Unsafe.hs
@@ -35,6 +35,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'multiply_complex_f'
 
+__unique:__ @ExampleJust Unsafemultiply_complex_f@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_5b05fdb10924da35" multiply_complex_f_wrapper ::
      Ptr.Ptr (Data.Complex.Complex FC.CFloat)
@@ -66,6 +67,7 @@ multiply_complex_f =
 
 {-| Pointer-based API for 'add_complex'
 
+__unique:__ @ExampleJust Unsafeadd_complex@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexhsb_complex_test_59f299d5d991ed72" add_complex_wrapper ::
      Ptr.Ptr (Data.Complex.Complex FC.CDouble)

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
@@ -203,6 +203,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"complex_object_t_id")
 {-| Pointer-based API for 'multiply_complex_f'
 
+__unique:__ @ExampleJust Unsafemultiply_complex_f@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_b84ea846e04d5fd6" multiply_complex_f_wrapper :: Ptr (Complex CFloat) ->
                                                                                                                         Ptr (Complex CFloat) ->
@@ -225,6 +226,7 @@ multiply_complex_f :: Complex CFloat ->
 multiply_complex_f = \x_0 -> \x_1 -> with x_1 (\y_2 -> with x_0 (\y_3 -> allocaAndPeek (\z_4 -> multiply_complex_f_wrapper y_3 y_2 z_4)))
 {-| Pointer-based API for 'add_complex'
 
+__unique:__ @ExampleJust Unsafeadd_complex@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_8dd079d1707c36b3" add_complex_wrapper :: Ptr (Complex CDouble) ->
                                                                                                                  Ptr (Complex CDouble) ->
@@ -247,6 +249,7 @@ add_complex :: Complex CDouble ->
 add_complex = \x_0 -> \x_1 -> with x_1 (\y_2 -> with x_0 (\y_3 -> allocaAndPeek (\z_4 -> add_complex_wrapper y_3 y_2 z_4)))
 {-| Pointer-based API for 'multiply_complex_f'
 
+__unique:__ @ExampleJust Unsafemultiply_complex_f@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_5b05fdb10924da35" multiply_complex_f_wrapper :: Ptr (Complex CFloat) ->
                                                                                                                         Ptr (Complex CFloat) ->
@@ -269,6 +272,7 @@ multiply_complex_f :: Complex CFloat ->
 multiply_complex_f = \x_0 -> \x_1 -> with x_1 (\y_2 -> with x_0 (\y_3 -> allocaAndPeek (\z_4 -> multiply_complex_f_wrapper y_3 y_2 z_4)))
 {-| Pointer-based API for 'add_complex'
 
+__unique:__ @ExampleJust Unsafeadd_complex@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_59f299d5d991ed72" add_complex_wrapper :: Ptr (Complex CDouble) ->
                                                                                                                  Ptr (Complex CDouble) ->
@@ -289,6 +293,8 @@ add_complex :: Complex CDouble ->
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 add_complex = \x_0 -> \x_1 -> with x_1 (\y_2 -> with x_0 (\y_3 -> allocaAndPeek (\z_4 -> add_complex_wrapper y_3 y_2 z_4)))
+{-| __unique:__ @ExampleNothingget_multiply_complex_f_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56" hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56 :: IO (FunPtr (Complex CFloat ->
                                                                                                                                                                        Complex CFloat ->
                                                                                                                                                                        IO (Complex CFloat)))
@@ -308,6 +314,8 @@ multiply_complex_f_ptr :: FunPtr (Complex CFloat ->
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 multiply_complex_f_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_a7d89c01385c8c56
+{-| __unique:__ @ExampleNothingget_add_complex_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_b6226a5bde741b3f" hs_bindgen_test_typescomplexhsb_complex_test_b6226a5bde741b3f :: IO (FunPtr (Complex CDouble ->
                                                                                                                                                                        Complex CDouble ->
                                                                                                                                                                        IO (Complex CDouble)))
@@ -327,6 +335,8 @@ add_complex_ptr :: FunPtr (Complex CDouble ->
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 add_complex_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_b6226a5bde741b3f
+{-| __unique:__ @ExampleNothingget_global_complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b" hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b :: IO (Ptr (Complex CFloat))
 {-# NOINLINE global_complex_float_ptr #-}
 {-| __C declaration:__ @global_complex_float@
@@ -343,6 +353,8 @@ global_complex_float_ptr :: Ptr (Complex CFloat)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_complex_float_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_69e4d4972011967b
+{-| __unique:__ @ExampleNothingget_global_complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3" hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3 :: IO (Ptr (Complex CDouble))
 {-# NOINLINE global_complex_double_ptr #-}
 {-| __C declaration:__ @global_complex_double@
@@ -359,6 +371,8 @@ global_complex_double_ptr :: Ptr (Complex CDouble)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_complex_double_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_c3633906ced5dab3
+{-| __unique:__ @ExampleNothingget_global_complex_float_flipped_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1" hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1 :: IO (Ptr (Complex CFloat))
 {-# NOINLINE global_complex_float_flipped_ptr #-}
 {-| __C declaration:__ @global_complex_float_flipped@
@@ -375,6 +389,8 @@ global_complex_float_flipped_ptr :: Ptr (Complex CFloat)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_complex_float_flipped_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_7ef41813e25ff8c1
+{-| __unique:__ @ExampleNothingget_global_complex_double_flipped_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921" hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921 :: IO (Ptr (Complex CDouble))
 {-# NOINLINE global_complex_double_flipped_ptr #-}
 {-| __C declaration:__ @global_complex_double_flipped@
@@ -391,6 +407,8 @@ global_complex_double_flipped_ptr :: Ptr (Complex CDouble)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_complex_double_flipped_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_abdd562bd1b14921
+{-| __unique:__ @ExampleNothingget_global_Complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7" hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7 :: IO (Ptr (Complex CFloat))
 {-# NOINLINE global_Complex_float_ptr #-}
 {-| __C declaration:__ @global_Complex_float@
@@ -407,6 +425,8 @@ global_Complex_float_ptr :: Ptr (Complex CFloat)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_Complex_float_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_02f701d4163d6ce7
+{-| __unique:__ @ExampleNothingget_global_Complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17" hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17 :: IO (Ptr (Complex CDouble))
 {-# NOINLINE global_Complex_double_ptr #-}
 {-| __C declaration:__ @global_Complex_double@
@@ -423,6 +443,8 @@ global_Complex_double_ptr :: Ptr (Complex CDouble)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_Complex_double_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_a6117bb5e7cacd17
+{-| __unique:__ @ExampleNothingget_global_Complex_float_flipped_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee" hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee :: IO (Ptr (Complex CFloat))
 {-# NOINLINE global_Complex_float_flipped_ptr #-}
 {-| __C declaration:__ @global_Complex_float_flipped@
@@ -439,6 +461,8 @@ global_Complex_float_flipped_ptr :: Ptr (Complex CFloat)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_Complex_float_flipped_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_da2309480d364cee
+{-| __unique:__ @ExampleNothingget_global_Complex_double_flipped_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50" hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50 :: IO (Ptr (Complex CDouble))
 {-# NOINLINE global_Complex_double_flipped_ptr #-}
 {-| __C declaration:__ @global_Complex_double_flipped@
@@ -455,6 +479,8 @@ global_Complex_double_flipped_ptr :: Ptr (Complex CDouble)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 global_Complex_double_flipped_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_467427dc59fbef50
+{-| __unique:__ @ExampleNothingget_const_complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_bb0fb18f3dfee47d" hs_bindgen_test_typescomplexhsb_complex_test_bb0fb18f3dfee47d :: IO (Ptr (Complex CFloat))
 {-# NOINLINE const_complex_float_ptr #-}
 {-| __C declaration:__ @const_complex_float@
@@ -474,6 +500,8 @@ const_complex_float_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_comple
 {-# NOINLINE const_complex_float #-}
 const_complex_float :: Complex CFloat
 const_complex_float = unsafePerformIO (peek const_complex_float_ptr)
+{-| __unique:__ @ExampleNothingget_const_complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_f491f52e529a459a" hs_bindgen_test_typescomplexhsb_complex_test_f491f52e529a459a :: IO (Ptr (Complex CDouble))
 {-# NOINLINE const_complex_double_ptr #-}
 {-| __C declaration:__ @const_complex_double@
@@ -493,6 +521,8 @@ const_complex_double_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_compl
 {-# NOINLINE const_complex_double #-}
 const_complex_double :: Complex CDouble
 const_complex_double = unsafePerformIO (peek const_complex_double_ptr)
+{-| __unique:__ @ExampleNothingget_volatile_complex_float_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75" hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75 :: IO (Ptr (Complex CFloat))
 {-# NOINLINE volatile_complex_float_ptr #-}
 {-| __C declaration:__ @volatile_complex_float@
@@ -509,6 +539,8 @@ volatile_complex_float_ptr :: Ptr (Complex CFloat)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 volatile_complex_float_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_ecb5f4a0ccb7ee75
+{-| __unique:__ @ExampleNothingget_volatile_complex_double_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4" hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4 :: IO (Ptr (Complex CDouble))
 {-# NOINLINE volatile_complex_double_ptr #-}
 {-| __C declaration:__ @volatile_complex_double@
@@ -525,6 +557,8 @@ volatile_complex_double_ptr :: Ptr (Complex CDouble)
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 volatile_complex_double_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_6b136090c38a69c4
+{-| __unique:__ @ExampleNothingget_complex_float_array_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70" hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70 :: IO (Ptr (ConstantArray 10
                                                                                                                                                                                   (Complex CFloat)))
 {-# NOINLINE complex_float_array_ptr #-}
@@ -542,6 +576,8 @@ complex_float_array_ptr :: Ptr (ConstantArray 10 (Complex CFloat))
     __exported by:__ @types\/complex\/hsb_complex_test.h@
 -}
 complex_float_array_ptr = unsafePerformIO hs_bindgen_test_typescomplexhsb_complex_test_55b7fb104be53f70
+{-| __unique:__ @ExampleNothingget_complex_double_array_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexhsb_complex_test_0b63f3bda9243457" hs_bindgen_test_typescomplexhsb_complex_test_0b63f3bda9243457 :: IO (Ptr (ConstantArray 10
                                                                                                                                                                                   (Complex CDouble)))
 {-# NOINLINE complex_double_array_ptr #-}

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/FunPtr.hs
@@ -25,6 +25,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_new_vector_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexvector_test_7672b9e7f001c998" hs_bindgen_test_typescomplexvector_test_7672b9e7f001c998 ::
      IO (Ptr.FunPtr (FC.CDouble -> FC.CDouble -> IO (Ptr.Ptr Vector)))
 

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/Safe.hs
@@ -27,6 +27,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/complex\/vector_test.h:6:9@
 
     __exported by:__ @types\/complex\/vector_test.h@
+
+    __unique:__ @ExampleJust Safenew_vector@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexvector_test_c8cd49ec7dbcac25" new_vector ::
      FC.CDouble

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/Unsafe.hs
@@ -27,6 +27,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/complex\/vector_test.h:6:9@
 
     __exported by:__ @types\/complex\/vector_test.h@
+
+    __unique:__ @ExampleJust Unsafenew_vector@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typescomplexvector_test_30a7381111c0131a" new_vector ::
      FC.CDouble

--- a/hs-bindgen/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/vector_test/th.txt
@@ -71,6 +71,8 @@ instance TyEq ty (CFieldType Vector "vector_y") =>
     __defined at:__ @types\/complex\/vector_test.h:6:9@
 
     __exported by:__ @types\/complex\/vector_test.h@
+
+    __unique:__ @ExampleJust Unsafenew_vector@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexvector_test_c8cd49ec7dbcac25" new_vector :: CDouble ->
                                                                                                    CDouble ->
@@ -80,10 +82,14 @@ foreign import ccall safe "hs_bindgen_test_typescomplexvector_test_c8cd49ec7dbca
     __defined at:__ @types\/complex\/vector_test.h:6:9@
 
     __exported by:__ @types\/complex\/vector_test.h@
+
+    __unique:__ @ExampleJust Unsafenew_vector@
 -}
 foreign import ccall safe "hs_bindgen_test_typescomplexvector_test_30a7381111c0131a" new_vector :: CDouble ->
                                                                                                    CDouble ->
                                                                                                    IO (Ptr Vector)
+{-| __unique:__ @ExampleNothingget_new_vector_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typescomplexvector_test_7672b9e7f001c998" hs_bindgen_test_typescomplexvector_test_7672b9e7f001c998 :: IO (FunPtr (CDouble ->
                                                                                                                                                              CDouble ->
                                                                                                                                                              IO (Ptr Vector)))

--- a/hs-bindgen/fixtures/types/primitives/bool_c23/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool_c23/Example/Global.hs
@@ -21,6 +21,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_b_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesprimitivesbool_c23_fcd0c984d664f6ee" hs_bindgen_test_typesprimitivesbool_c23_fcd0c984d664f6ee ::
      IO (Ptr.Ptr FC.CBool)
 

--- a/hs-bindgen/fixtures/types/primitives/bool_c23/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/bool_c23/th.txt
@@ -6,6 +6,8 @@
 -- {
 --   return &b;
 -- }
+{-| __unique:__ @ExampleNothingget_b_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesprimitivesbool_c23_fcd0c984d664f6ee" hs_bindgen_test_typesprimitivesbool_c23_fcd0c984d664f6ee :: IO (Ptr CBool)
 {-# NOINLINE b_ptr #-}
 {-| __C declaration:__ @b@

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/FunPtr.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_list_example_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_24b25f22222ce366" hs_bindgen_test_typesqualifierstype_qualifie_24b25f22222ce366 ::
      IO (Ptr.FunPtr ((Ptr.Ptr (Ptr.Ptr FC.CChar)) -> HsBindgen.Runtime.Prelude.CSize -> IO FC.CBool))
 

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Global.hs
@@ -40,6 +40,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_a_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_3afcbd8536cf21bd" hs_bindgen_test_typesqualifierstype_qualifie_3afcbd8536cf21bd ::
      IO (Ptr.Ptr FC.CInt)
 
@@ -60,6 +62,8 @@ a_ptr =
 a :: FC.CInt
 a = GHC.IO.Unsafe.unsafePerformIO (F.peek a_ptr)
 
+{-| __unique:__ @ExampleNothingget_b_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee" hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 
@@ -75,6 +79,8 @@ b_ptr :: Ptr.Ptr (Ptr.Ptr FC.CInt)
 b_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee
 
+{-| __unique:__ @ExampleNothingget_c_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_d61ea07e27589aef" hs_bindgen_test_typesqualifierstype_qualifie_d61ea07e27589aef ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 
@@ -95,6 +101,8 @@ c_ptr =
 c :: Ptr.Ptr FC.CInt
 c = GHC.IO.Unsafe.unsafePerformIO (F.peek c_ptr)
 
+{-| __unique:__ @ExampleNothingget_d_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_d1d6489b06a70107" hs_bindgen_test_typesqualifierstype_qualifie_d1d6489b06a70107 ::
      IO (Ptr.Ptr (Ptr.Ptr FC.CInt))
 

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Safe.hs
@@ -26,6 +26,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/qualifiers\/type_qualifiers.h:14:6@
 
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
+
+    __unique:__ @ExampleJust Safelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_b42fb41209c21d6e" list_example ::
      Ptr.Ptr (Ptr.Ptr FC.CChar)

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Unsafe.hs
@@ -26,6 +26,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/qualifiers\/type_qualifiers.h:14:6@
 
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
+
+    __unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesqualifierstype_qualifie_41af05ef1797fa6d" list_example ::
      Ptr.Ptr (Ptr.Ptr FC.CChar)

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/th.txt
@@ -55,6 +55,8 @@
     __defined at:__ @types\/qualifiers\/type_qualifiers.h:14:6@
 
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
+
+    __unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_b42fb41209c21d6e" list_example :: Ptr (Ptr CChar) ->
                                                                                                           HsBindgen.Runtime.Prelude.CSize ->
@@ -64,10 +66,14 @@ foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_b42fb412
     __defined at:__ @types\/qualifiers\/type_qualifiers.h:14:6@
 
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
+
+    __unique:__ @ExampleJust Unsafelist_example@
 -}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_41af05ef1797fa6d" list_example :: Ptr (Ptr CChar) ->
                                                                                                           HsBindgen.Runtime.Prelude.CSize ->
                                                                                                           IO CBool
+{-| __unique:__ @ExampleNothingget_list_example_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_24b25f22222ce366" hs_bindgen_test_typesqualifierstype_qualifie_24b25f22222ce366 :: IO (FunPtr (Ptr (Ptr CChar) ->
                                                                                                                                                                        HsBindgen.Runtime.Prelude.CSize ->
                                                                                                                                                                        IO CBool))
@@ -87,6 +93,8 @@ list_example_ptr :: FunPtr (Ptr (Ptr CChar) ->
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
 -}
 list_example_ptr = unsafePerformIO hs_bindgen_test_typesqualifierstype_qualifie_24b25f22222ce366
+{-| __unique:__ @ExampleNothingget_a_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_3afcbd8536cf21bd" hs_bindgen_test_typesqualifierstype_qualifie_3afcbd8536cf21bd :: IO (Ptr CInt)
 {-# NOINLINE a_ptr #-}
 {-| __C declaration:__ @a@
@@ -106,6 +114,8 @@ a_ptr = unsafePerformIO hs_bindgen_test_typesqualifierstype_qualifie_3afcbd8536c
 {-# NOINLINE a #-}
 a :: CInt
 a = unsafePerformIO (peek a_ptr)
+{-| __unique:__ @ExampleNothingget_b_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee" hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee :: IO (Ptr (Ptr CInt))
 {-# NOINLINE b_ptr #-}
 {-| __C declaration:__ @b@
@@ -122,6 +132,8 @@ b_ptr :: Ptr (Ptr CInt)
     __exported by:__ @types\/qualifiers\/type_qualifiers.h@
 -}
 b_ptr = unsafePerformIO hs_bindgen_test_typesqualifierstype_qualifie_fcd0c984d664f6ee
+{-| __unique:__ @ExampleNothingget_c_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_d61ea07e27589aef" hs_bindgen_test_typesqualifierstype_qualifie_d61ea07e27589aef :: IO (Ptr (Ptr CInt))
 {-# NOINLINE c_ptr #-}
 {-| __C declaration:__ @c@
@@ -141,6 +153,8 @@ c_ptr = unsafePerformIO hs_bindgen_test_typesqualifierstype_qualifie_d61ea07e275
 {-# NOINLINE c #-}
 c :: Ptr CInt
 c = unsafePerformIO (peek c_ptr)
+{-| __unique:__ @ExampleNothingget_d_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesqualifierstype_qualifie_d1d6489b06a70107" hs_bindgen_test_typesqualifierstype_qualifie_d1d6489b06a70107 :: IO (Ptr (Ptr CInt))
 {-# NOINLINE d_ptr #-}
 {-| __C declaration:__ @d@

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/FunPtr.hs
@@ -23,6 +23,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_fun2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesspecialparse_failure_lo_d1bf59c1516f6bfa" hs_bindgen_test_typesspecialparse_failure_lo_d1bf59c1516f6bfa ::
      IO (Ptr.FunPtr (FC.CInt -> IO ()))
 

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Safe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/special\/parse_failure_long_double.h:7:6@
 
     __exported by:__ @types\/special\/parse_failure_long_double.h@
+
+    __unique:__ @ExampleJust Safefun2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesspecialparse_failure_lo_fb32cb593bc1f7b8" fun2 ::
      FC.CInt

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Unsafe.hs
@@ -24,6 +24,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
     __defined at:__ @types\/special\/parse_failure_long_double.h:7:6@
 
     __exported by:__ @types\/special\/parse_failure_long_double.h@
+
+    __unique:__ @ExampleJust Unsafefun2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesspecialparse_failure_lo_5ebf8088e71802cc" fun2 ::
      FC.CInt

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
@@ -58,6 +58,8 @@ instance TyEq ty (CFieldType Struct2 "struct2_x") =>
     __defined at:__ @types\/special\/parse_failure_long_double.h:7:6@
 
     __exported by:__ @types\/special\/parse_failure_long_double.h@
+
+    __unique:__ @ExampleJust Unsafefun2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesspecialparse_failure_lo_fb32cb593bc1f7b8" fun2 :: CInt ->
                                                                                                   IO Unit
@@ -66,9 +68,13 @@ foreign import ccall safe "hs_bindgen_test_typesspecialparse_failure_lo_fb32cb59
     __defined at:__ @types\/special\/parse_failure_long_double.h:7:6@
 
     __exported by:__ @types\/special\/parse_failure_long_double.h@
+
+    __unique:__ @ExampleJust Unsafefun2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesspecialparse_failure_lo_5ebf8088e71802cc" fun2 :: CInt ->
                                                                                                   IO Unit
+{-| __unique:__ @ExampleNothingget_fun2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesspecialparse_failure_lo_d1bf59c1516f6bfa" hs_bindgen_test_typesspecialparse_failure_lo_d1bf59c1516f6bfa :: IO (FunPtr (CInt ->
                                                                                                                                                                        IO Unit))
 {-# NOINLINE fun2_ptr #-}

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/FunPtr.hs
@@ -52,6 +52,8 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
   , "}"
   ]))
 
+{-| __unique:__ @ExampleNothingget_thing_fun_1_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a" hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a ::
      IO (Ptr.FunPtr (Thing -> IO FC.CInt))
 
@@ -67,6 +69,8 @@ thing_fun_1_ptr :: Ptr.FunPtr (Thing -> IO FC.CInt)
 thing_fun_1_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a
 
+{-| __unique:__ @ExampleNothingget_thing_fun_2_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a" hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a ::
      IO (Ptr.FunPtr (FC.CInt -> IO Thing))
 
@@ -82,6 +86,8 @@ thing_fun_2_ptr :: Ptr.FunPtr (FC.CInt -> IO Thing)
 thing_fun_2_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a
 
+{-| __unique:__ @ExampleNothingget_thing_fun_3a_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf" hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf ::
      IO (Ptr.FunPtr (FC.CInt -> Thing -> FC.CDouble -> IO Thing))
 
@@ -97,6 +103,8 @@ thing_fun_3a_ptr :: Ptr.FunPtr (FC.CInt -> Thing -> FC.CDouble -> IO Thing)
 thing_fun_3a_ptr =
   GHC.IO.Unsafe.unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf
 
+{-| __unique:__ @ExampleNothingget_thing_fun_3b_ptr@
+-}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_0d6597dfc03e312f" hs_bindgen_test_typesstructsstruct_arg_0d6597dfc03e312f ::
      IO (Ptr.FunPtr (FC.CInt -> Thing -> FC.CDouble -> IO FC.CChar))
 

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/Safe.hs
@@ -49,6 +49,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'thing_fun_1'
 
+__unique:__ @ExampleJust Safething_fun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_61dfa2c4506feb8f" thing_fun_1_wrapper ::
      Ptr.Ptr Thing
@@ -70,6 +71,7 @@ thing_fun_1 =
 
 {-| Pointer-based API for 'thing_fun_2'
 
+__unique:__ @ExampleJust Safething_fun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_022cc8107f565c95" thing_fun_2_wrapper ::
      FC.CInt
@@ -94,6 +96,7 @@ thing_fun_2 =
 
 {-| Pointer-based API for 'thing_fun_3a'
 
+__unique:__ @ExampleJust Safething_fun_3a@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_4d9304280cca3098" thing_fun_3a_wrapper ::
      FC.CInt
@@ -129,6 +132,7 @@ thing_fun_3a =
 
 {-| Pointer-based API for 'thing_fun_3b'
 
+__unique:__ @ExampleJust Safething_fun_3b@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_f39687b254852452" thing_fun_3b_wrapper ::
      FC.CInt

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/Unsafe.hs
@@ -49,6 +49,7 @@ $(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
 
 {-| Pointer-based API for 'thing_fun_1'
 
+__unique:__ @ExampleJust Unsafething_fun_1@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_409d8c948bf989f6" thing_fun_1_wrapper ::
      Ptr.Ptr Thing
@@ -70,6 +71,7 @@ thing_fun_1 =
 
 {-| Pointer-based API for 'thing_fun_2'
 
+__unique:__ @ExampleJust Unsafething_fun_2@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_2d20059791239ef2" thing_fun_2_wrapper ::
      FC.CInt
@@ -94,6 +96,7 @@ thing_fun_2 =
 
 {-| Pointer-based API for 'thing_fun_3a'
 
+__unique:__ @ExampleJust Unsafething_fun_3a@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_ce442967da2c37cd" thing_fun_3a_wrapper ::
      FC.CInt
@@ -129,6 +132,7 @@ thing_fun_3a =
 
 {-| Pointer-based API for 'thing_fun_3b'
 
+__unique:__ @ExampleJust Unsafething_fun_3b@
 -}
 foreign import ccall unsafe "hs_bindgen_test_typesstructsstruct_arg_e8bc8fce45854092" thing_fun_3b_wrapper ::
      FC.CInt

--- a/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
@@ -131,6 +131,7 @@ instance TyEq ty (CFieldType Thing "thing_x") =>
     where getField = ptrToCField (Proxy @"thing_x")
 {-| Pointer-based API for 'thing_fun_1'
 
+__unique:__ @ExampleJust Unsafething_fun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_61dfa2c4506feb8f" thing_fun_1_wrapper :: Ptr Thing ->
                                                                                                            IO CInt
@@ -150,6 +151,7 @@ thing_fun_1 :: Thing -> IO CInt
 thing_fun_1 = \x_0 -> with x_0 (\y_1 -> thing_fun_1_wrapper y_1)
 {-| Pointer-based API for 'thing_fun_2'
 
+__unique:__ @ExampleJust Unsafething_fun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_022cc8107f565c95" thing_fun_2_wrapper :: CInt ->
                                                                                                            Ptr Thing ->
@@ -170,6 +172,7 @@ thing_fun_2 :: CInt -> IO Thing
 thing_fun_2 = \x_0 -> allocaAndPeek (\z_1 -> thing_fun_2_wrapper x_0 z_1)
 {-| Pointer-based API for 'thing_fun_3a'
 
+__unique:__ @ExampleJust Unsafething_fun_3a@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_4d9304280cca3098" thing_fun_3a_wrapper :: CInt ->
                                                                                                             Ptr Thing ->
@@ -192,6 +195,7 @@ thing_fun_3a :: CInt -> Thing -> CDouble -> IO Thing
 thing_fun_3a = \x_0 -> \x_1 -> \x_2 -> with x_1 (\y_3 -> allocaAndPeek (\z_4 -> thing_fun_3a_wrapper x_0 y_3 x_2 z_4))
 {-| Pointer-based API for 'thing_fun_3b'
 
+__unique:__ @ExampleJust Unsafething_fun_3b@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_f39687b254852452" thing_fun_3b_wrapper :: CInt ->
                                                                                                             Ptr Thing ->
@@ -213,6 +217,7 @@ thing_fun_3b :: CInt -> Thing -> CDouble -> IO CChar
 thing_fun_3b = \x_0 -> \x_1 -> \x_2 -> with x_1 (\y_3 -> thing_fun_3b_wrapper x_0 y_3 x_2)
 {-| Pointer-based API for 'thing_fun_1'
 
+__unique:__ @ExampleJust Unsafething_fun_1@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_409d8c948bf989f6" thing_fun_1_wrapper :: Ptr Thing ->
                                                                                                            IO CInt
@@ -232,6 +237,7 @@ thing_fun_1 :: Thing -> IO CInt
 thing_fun_1 = \x_0 -> with x_0 (\y_1 -> thing_fun_1_wrapper y_1)
 {-| Pointer-based API for 'thing_fun_2'
 
+__unique:__ @ExampleJust Unsafething_fun_2@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_2d20059791239ef2" thing_fun_2_wrapper :: CInt ->
                                                                                                            Ptr Thing ->
@@ -252,6 +258,7 @@ thing_fun_2 :: CInt -> IO Thing
 thing_fun_2 = \x_0 -> allocaAndPeek (\z_1 -> thing_fun_2_wrapper x_0 z_1)
 {-| Pointer-based API for 'thing_fun_3a'
 
+__unique:__ @ExampleJust Unsafething_fun_3a@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_ce442967da2c37cd" thing_fun_3a_wrapper :: CInt ->
                                                                                                             Ptr Thing ->
@@ -274,6 +281,7 @@ thing_fun_3a :: CInt -> Thing -> CDouble -> IO Thing
 thing_fun_3a = \x_0 -> \x_1 -> \x_2 -> with x_1 (\y_3 -> allocaAndPeek (\z_4 -> thing_fun_3a_wrapper x_0 y_3 x_2 z_4))
 {-| Pointer-based API for 'thing_fun_3b'
 
+__unique:__ @ExampleJust Unsafething_fun_3b@
 -}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_e8bc8fce45854092" thing_fun_3b_wrapper :: CInt ->
                                                                                                             Ptr Thing ->
@@ -293,6 +301,8 @@ thing_fun_3b :: CInt -> Thing -> CDouble -> IO CChar
     __exported by:__ @types\/structs\/struct_arg.h@
 -}
 thing_fun_3b = \x_0 -> \x_1 -> \x_2 -> with x_1 (\y_3 -> thing_fun_3b_wrapper x_0 y_3 x_2)
+{-| __unique:__ @ExampleNothingget_thing_fun_1_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a" hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a :: IO (FunPtr (Thing ->
                                                                                                                                                            IO CInt))
 {-# NOINLINE thing_fun_1_ptr #-}
@@ -310,6 +320,8 @@ thing_fun_1_ptr :: FunPtr (Thing -> IO CInt)
     __exported by:__ @types\/structs\/struct_arg.h@
 -}
 thing_fun_1_ptr = unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_c5f0c295b311010a
+{-| __unique:__ @ExampleNothingget_thing_fun_2_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a" hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a :: IO (FunPtr (CInt ->
                                                                                                                                                            IO Thing))
 {-# NOINLINE thing_fun_2_ptr #-}
@@ -327,6 +339,8 @@ thing_fun_2_ptr :: FunPtr (CInt -> IO Thing)
     __exported by:__ @types\/structs\/struct_arg.h@
 -}
 thing_fun_2_ptr = unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_24edf6600396b62a
+{-| __unique:__ @ExampleNothingget_thing_fun_3a_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf" hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf :: IO (FunPtr (CInt ->
                                                                                                                                                            Thing ->
                                                                                                                                                            CDouble ->
@@ -346,6 +360,8 @@ thing_fun_3a_ptr :: FunPtr (CInt -> Thing -> CDouble -> IO Thing)
     __exported by:__ @types\/structs\/struct_arg.h@
 -}
 thing_fun_3a_ptr = unsafePerformIO hs_bindgen_test_typesstructsstruct_arg_29a42b48992cd0bf
+{-| __unique:__ @ExampleNothingget_thing_fun_3b_ptr@
+-}
 foreign import ccall safe "hs_bindgen_test_typesstructsstruct_arg_0d6597dfc03e312f" hs_bindgen_test_typesstructsstruct_arg_0d6597dfc03e312f :: IO (FunPtr (CInt ->
                                                                                                                                                            Thing ->
                                                                                                                                                            CDouble ->

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -86,7 +86,6 @@ library internal
     HsBindgen.Backend.Hs.Origin
     HsBindgen.Backend.Hs.Translation
     HsBindgen.Backend.Hs.Translation.Config
-    HsBindgen.Backend.Hs.Translation.UniqueSymbol
     HsBindgen.Backend.HsModule.Capi
     HsBindgen.Backend.HsModule.Names
     HsBindgen.Backend.HsModule.Render
@@ -96,6 +95,7 @@ library internal
     HsBindgen.Backend.SHs.Simplify
     HsBindgen.Backend.SHs.Translation
     HsBindgen.Backend.TH.Translation
+    HsBindgen.Backend.UniqueSymbol
     HsBindgen.BindingSpec
     HsBindgen.BindingSpec.Gen
     HsBindgen.BindingSpec.Private.Common

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -81,13 +81,10 @@ generateHaddocksWithParams HaddockConfig{..} isField declLoc mHeaderInfo declId 
       -- sure to at least add a comment that will show the function parameter name
       -- if it exists.
       --
-      ( Just
-         HsDoc.Comment {
-           HsDoc.commentTitle      = Nothing
-         , HsDoc.commentOrigin     = commentCName
+      ( Just mempty {
+           HsDoc.commentOrigin     = commentCName
          , HsDoc.commentLocation   = commentLocation
          , HsDoc.commentHeaderInfo = mHeaderInfo
-         , HsDoc.commentChildren   = []
          }
       , map addFunctionParameterComment params)
 generateHaddocksWithParams HaddockConfig{..} isField declLoc mHeaderInfo declId declOrigin (Just CDoc.Comment{..}) params =
@@ -141,12 +138,12 @@ generateHaddocksWithParams HaddockConfig{..} isField declLoc mHeaderInfo declId 
                                 )
                     $ commentChildren'
 
-   in ( Just HsDoc.Comment {
-          commentTitle
-        , commentOrigin     = commentCName
-        , commentLocation   = commentLocation
-        , commentHeaderInfo = mHeaderInfo
-        , commentChildren   = finalChildren
+   in ( Just mempty {
+          HsDoc.commentTitle
+        , HsDoc.commentOrigin     = commentCName
+        , HsDoc.commentLocation   = commentLocation
+        , HsDoc.commentHeaderInfo = mHeaderInfo
+        , HsDoc.commentChildren   = finalChildren
         }
       , updatedParams
       )
@@ -162,14 +159,11 @@ generateHaddocksWithParams HaddockConfig{..} isField declLoc mHeaderInfo declId 
               )
         $ params ->
           let comment =
-                HsDoc.Comment {
-                  commentTitle      = Nothing
-                , commentOrigin     = if Text.null paramCommandName
-                                         then Nothing
-                                         else Just (Text.strip paramCommandName)
-                , commentLocation   = Nothing
-                , commentHeaderInfo = Nothing
-                , commentChildren   = convertBlockContent blockContent
+                mempty {
+                  HsDoc.commentOrigin   = if Text.null paramCommandName
+                                            then Nothing
+                                            else Just (Text.strip paramCommandName)
+                , HsDoc.commentChildren = convertBlockContent blockContent
                 }
            in (comment, paramCommandDirection):filterParamCommands cmds
         | otherwise -> filterParamCommands cmds
@@ -209,12 +203,8 @@ addFunctionParameterComment fp@Hs.FunctionParameter {..} =
         case functionParameterComment of
           Nothing ->
             fp { Hs.functionParameterComment =
-                   Just HsDoc.Comment {
-                          commentTitle      = Nothing
-                        , commentOrigin     = Hs.getName <$> functionParameterName
-                        , commentLocation   = Nothing
-                        , commentHeaderInfo = Nothing
-                        , commentChildren   = []
+                   Just mempty {
+                          HsDoc.commentOrigin = Hs.getName <$> functionParameterName
                         }
                }
           _ -> fp

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Render.hs
@@ -35,6 +35,7 @@ import HsBindgen.Backend.HsModule.Names
 import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Backend.SHs.Translation (translateType)
+import HsBindgen.Backend.UniqueSymbol
 import HsBindgen.Frontend.AST.External qualified as C
 import HsBindgen.Frontend.RootHeader (HashIncludeArg (..))
 import HsBindgen.Imports
@@ -161,6 +162,10 @@ instance Pretty CommentKind where
                       , (\hinfo -> "__exported by:__ @"
                                 >< prettyMainHeaders hinfo
                                 >< "@") <$> commentHeaderInfo
+                      , (\u -> "__unique:__ @"
+                           >< string u.source
+                           >< "@"
+                        ) <$> commentUnique
                       ]
         firstContent =
           case commentTitle of

--- a/hs-bindgen/src-internal/HsBindgen/Backend/UniqueSymbol.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/UniqueSymbol.hs
@@ -1,7 +1,7 @@
 -- | Unique symbols (for use in generated C code)
 --
 -- Intended for unqualified import.
-module HsBindgen.Backend.Hs.Translation.UniqueSymbol (
+module HsBindgen.Backend.UniqueSymbol (
     -- * Generating unique names
     UniqueSymbol(..)
   , getUniqueSymbol
@@ -15,6 +15,7 @@ import Data.List (intercalate)
 import GHC.Unicode (isDigit)
 
 import HsBindgen.Config.Prelims
+import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------
   Generating unique names
@@ -32,6 +33,7 @@ data UniqueSymbol = UniqueSymbol{
       -- if they unexpectedly change).
     , source :: String
     }
+  deriving (Show, Eq, Generic)
 
 -- | Globally unique symbol
 --


### PR DESCRIPTION
This does not yet change the construction of that source, so that the only thing changed in the fixtures is the new comments. In the next commit we'll change the source so that it's a bit more readable.