### PR TITLE
Add `foreignImportDecs`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -86,6 +86,7 @@ library internal
     HsBindgen.Backend.Hs.Origin
     HsBindgen.Backend.Hs.Translation
     HsBindgen.Backend.Hs.Translation.Config
+    HsBindgen.Backend.Hs.Translation.ForeignImport
     HsBindgen.Backend.Hs.Translation.ToFromFunPtr
     HsBindgen.Backend.Hs.Translation.Type
     HsBindgen.Backend.HsModule.Capi

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -76,7 +76,10 @@ requiredExtensions = \case
 nestedDeriving :: [(Strategy ClosedType, [Global])] -> Set TH.Extension
 nestedDeriving deriv =
        Set.singleton TH.DerivingStrategies
-    <> mconcat (map (strategyExtensions . fst) deriv)
+    <> mconcat [
+          strategyExtensions s <> foldMap globalExtensions gs
+        | (s, gs) <- deriv
+        ]
 
 recordExtensions :: Record -> Set TH.Extension
 recordExtensions r = foldMap fieldExtensions (dataFields r)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
@@ -1,0 +1,39 @@
+-- | Generate Haskell foreign imports
+module HsBindgen.Backend.Hs.Translation.ForeignImport (
+    foreignImportDecs
+  ) where
+
+import HsBindgen.Backend.Hs.AST qualified as Hs
+import HsBindgen.Backend.Hs.AST.Type
+import HsBindgen.Backend.Hs.CallConv
+import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
+import HsBindgen.Backend.Hs.Origin qualified as Origin
+import HsBindgen.Backend.SHs.AST
+import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Language.Haskell qualified as Hs
+
+foreignImportDecs ::
+     Hs.Name 'Hs.NsVar
+  -> HsType
+  -> [Hs.FunctionParameter]
+  -> C.Name
+  -> CallConv
+  -> Origin.ForeignImport
+  -> Maybe HsDoc.Comment
+  -> Safety
+  -> [Hs.Decl]
+foreignImportDecs name resultType parameters origName callConv origin comment safety =
+    [ Hs.DeclForeignImport foreignImportDecl ]
+    -- TODO: prevent the "newtype constructor not in scope" bug. See issue #1282.
+  where
+    foreignImportDecl :: Hs.ForeignImportDecl
+    foreignImportDecl =  Hs.ForeignImportDecl
+        { foreignImportName         = name
+        , foreignImportResultType   = resultType
+        , foreignImportParameters   = parameters
+        , foreignImportOrigName     = origName
+        , foreignImportCallConv     = callConv
+        , foreignImportOrigin       = origin
+        , foreignImportComment      = comment
+        , foreignImportSafety       = safety
+        }


### PR DESCRIPTION
This PR is preparation for issue #1282

This PR is stacked on top of PR #1354, so that one should be merged first.

This function is intended to be a type of smart constructor, even thought it is currently just a shallow wrapper around the `ForeignImportDecl` constructor. This will change as we resolve issue #1282.