### PR TITLE
Suggested changes to overwrite files and output directory policies

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -138,7 +138,7 @@ writeBindingsMultiple :: FilePath -> Artefact ()
 writeBindingsMultiple hsOutputDir = do
     moduleBaseName     <- FinalModuleBaseName
     bindingsByCategory <- getBindingsMultiple
-    writeByCategory "bindings" hsOutputDir moduleBaseName bindingsByCategory
+    writeByCategory "Bindings" hsOutputDir moduleBaseName bindingsByCategory
 
 -- | Write binding specifications to file.
 writeBindingSpec :: FilePath -> Artefact ()
@@ -156,7 +156,7 @@ writeBindingSpec path = do
           getMainHeaders
           omitTypes
           (fromMaybe [] (Map.lookup BType $ unByCategory hsDecls))
-  FileWrite "binding specifications" path (BindingSpecContent bindingSpec)
+  FileWrite "Binding specifications" path (BindingSpecContent bindingSpec)
 
 -- | Create test suite in directory.
 writeTests :: FilePath -> Artefact ()


### PR DESCRIPTION
- Use `StateT` instead of writer, like so we can access the actions before exiting the monad stack.
- Stay in `ExceptT` so we can use `throwError` instead of the implicit `Either` early return.
- Separate "check adherence to policy" from "execute file action".

Edit:
- [x] I am still fixing the tracer; somehow the safe tracer is not used anymore.