### PR TITLE
Make sure macro parser can parse `0`

### DIFF
--- a/c-expr-dsl/src/C/Expr/Parse/Infra.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Infra.hs
@@ -4,7 +4,6 @@
 module C.Expr.Parse.Infra (
     -- * Parser type
     Parser
-  , ParserState -- opaque
   , runParser
     -- * Parse errors
   , MacroParseError(..)
@@ -39,12 +38,7 @@ import Clang.Paths
   Parser type
 -------------------------------------------------------------------------------}
 
-type Parser = Parsec [Token TokenSpelling] ParserState
-
-data ParserState = ParserState
-
-initParserState :: ParserState
-initParserState = ParserState
+type Parser = Parsec [Token TokenSpelling] ()
 
 runParser ::
      HasCallStack
@@ -52,7 +46,7 @@ runParser ::
   -> [Token TokenSpelling]
   -> Either MacroParseError a
 runParser p tokens =
-    first unrecognized $ Parsec.runParser p initParserState sourcePath tokens
+    first unrecognized $ Parsec.runParser p () sourcePath tokens
   where
     sourcePath :: FilePath
     sourcePath =

--- a/examples/botan/hs-project/botan.cabal
+++ b/examples/botan/hs-project/botan.cabal
@@ -38,6 +38,7 @@ library
 
   build-depends:
     , base
+    , c-expr-runtime
     , hs-bindgen-runtime
     , vector
 

--- a/examples/botan/hs-project/cabal.project
+++ b/examples/botan/hs-project/cabal.project
@@ -1,4 +1,5 @@
 import: ../../../cabal.project.base
 
 packages: .
-          ../../../hs-bindgen-runtime
+          ../../../hs-bindgen-runtime,
+          ../../../c-expr-runtime

--- a/hs-bindgen/examples/golden/macros/issue_890.h
+++ b/hs-bindgen/examples/golden/macros/issue_890.h
@@ -1,0 +1,5 @@
+#define A 0
+#define B(x) (x + 1)
+#define C B(0)
+#define D B(A)
+#define E B(1)

--- a/hs-bindgen/fixtures/macros/issue_890/Example.hs
+++ b/hs-bindgen/fixtures/macros/issue_890/Example.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Example where
+
+import qualified C.Expr.HostPlatform as C
+import qualified Foreign.C as FC
+
+{-| __C declaration:__ @A@
+
+    __defined at:__ @macros\/issue_890.h:1:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+a :: FC.CInt
+a = (0 :: FC.CInt)
+
+{-| __C declaration:__ @B@
+
+    __defined at:__ @macros\/issue_890.h:2:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+b :: forall a0. (C.Add a0) FC.CInt => a0 -> (C.AddRes a0) FC.CInt
+b = \x0 -> (C.+) x0 (1 :: FC.CInt)
+
+{-| __C declaration:__ @C@
+
+    __defined at:__ @macros\/issue_890.h:3:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+c :: FC.CInt
+c = b (0 :: FC.CInt)
+
+{-| __C declaration:__ @D@
+
+    __defined at:__ @macros\/issue_890.h:4:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+d :: FC.CInt
+d = b a
+
+{-| __C declaration:__ @E@
+
+    __defined at:__ @macros\/issue_890.h:5:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+e :: FC.CInt
+e = b (1 :: FC.CInt)

--- a/hs-bindgen/fixtures/macros/issue_890/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/issue_890/Example/FunPtr.hs
@@ -1,0 +1,1 @@
+module Example.FunPtr () where

--- a/hs-bindgen/fixtures/macros/issue_890/Example/Global.hs
+++ b/hs-bindgen/fixtures/macros/issue_890/Example/Global.hs
@@ -1,0 +1,1 @@
+module Example.Global () where

--- a/hs-bindgen/fixtures/macros/issue_890/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/issue_890/Example/Safe.hs
@@ -1,0 +1,1 @@
+module Example.Safe () where

--- a/hs-bindgen/fixtures/macros/issue_890/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/issue_890/Example/Unsafe.hs
@@ -1,0 +1,1 @@
+module Example.Unsafe () where

--- a/hs-bindgen/fixtures/macros/issue_890/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/issue_890/bindingspec.yaml
@@ -1,0 +1,5 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example

--- a/hs-bindgen/fixtures/macros/issue_890/th.txt
+++ b/hs-bindgen/fixtures/macros/issue_890/th.txt
@@ -1,0 +1,71 @@
+-- addDependentFile examples/golden/macros/issue_890.h
+{-| __C declaration:__ @A@
+
+    __defined at:__ @macros\/issue_890.h:1:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+a :: CInt
+{-| __C declaration:__ @A@
+
+    __defined at:__ @macros\/issue_890.h:1:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+a = 0 :: CInt
+{-| __C declaration:__ @B@
+
+    __defined at:__ @macros\/issue_890.h:2:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+b :: forall a_0 . Add a_0 CInt => a_0 -> AddRes a_0 CInt
+{-| __C declaration:__ @B@
+
+    __defined at:__ @macros\/issue_890.h:2:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+b = \x_0 -> (+) x_0 (1 :: CInt)
+{-| __C declaration:__ @C@
+
+    __defined at:__ @macros\/issue_890.h:3:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+c :: CInt
+{-| __C declaration:__ @C@
+
+    __defined at:__ @macros\/issue_890.h:3:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+c = b (0 :: CInt)
+{-| __C declaration:__ @D@
+
+    __defined at:__ @macros\/issue_890.h:4:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+d :: CInt
+{-| __C declaration:__ @D@
+
+    __defined at:__ @macros\/issue_890.h:4:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+d = b a
+{-| __C declaration:__ @E@
+
+    __defined at:__ @macros\/issue_890.h:5:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+e :: CInt
+{-| __C declaration:__ @E@
+
+    __defined at:__ @macros\/issue_890.h:5:9@
+
+    __exported by:__ @macros\/issue_890.h@
+-}
+e = b (1 :: CInt)

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -485,6 +485,10 @@ test_macros_macro_redefines_global =
     _otherwise ->
       Nothing
 
+test_macros_issue_890 :: TestCase
+test_macros_issue_890 =
+  defaultTest "macros/issue_890"
+
 test_types_special_parse_failure_long_double :: TestCase
 test_types_special_parse_failure_long_double =
   testTraceCustom "types/special/parse_failure_long_double" ["fun1", "struct1"] $ \case
@@ -1192,6 +1196,7 @@ testCases = manualTestCases ++ [
     , test_functions_simple_func
     , test_functions_varargs
     , test_globals_globals
+    , test_macros_issue_890
     , test_macros_macro_functions
     , test_macros_macro_in_fundecl
     , test_macros_macro_in_fundecl_vs_typedef

--- a/scripts/ci/compile-fixtures.sh
+++ b/scripts/ci/compile-fixtures.sh
@@ -31,7 +31,7 @@ KNOWN_FAILURES=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=87
+KNOWN_FIXTURES_COUNT=88
 
 # Default options
 JOBS=4


### PR DESCRIPTION
The `0` was being interpreted as the prefix for octal (as in `010` meaning `8` in decimal).

Closes #890