### PR TITLE
Remove `.rs` files from `extra-source-files`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -18,7 +18,6 @@ extra-source-files:
   examples/**/*.h
   examples/**/*.yaml
   fixtures/**/*.hs
-  fixtures/**/*.rs
   fixtures/**/*.txt
   fixtures/**/*.yaml
   musl-include/**/*.h


### PR DESCRIPTION
The `.rs` files were recently removed. `cabal sdist` was failing with an error because it couldn't find any `.rs` files. 