### PR TITLE
Builtins are not a different kind of _name_

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -35,7 +35,7 @@ generateHaddocksWithInfo config declInfo =
     fst $ generateHaddocksWithParams config declInfo Args{
         isField     = False
       , loc         = declInfo.declLoc
-      , nameC       = C.declIdName declInfo.declId
+      , nameC       = declInfo.declId.name
       , nameHsIdent = declInfo.declId.haskellId
       , comment     = declInfo.declComment
       , params      = []
@@ -65,7 +65,7 @@ generateHaddocksWithInfoParams config declInfo params =
     generateHaddocksWithParams config declInfo Args{
         isField     = False
       , loc         = declInfo.declLoc
-      , nameC       = C.declIdName declInfo.declId
+      , nameC       = declInfo.declId.name
       , nameHsIdent = declInfo.declId.haskellId
       , comment     = declInfo.declComment
       , params

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -1425,7 +1425,7 @@ functionDecs safety opts haddockConfig moduleName info f _spec = concat [
 
     -- Generation of C wrapper for userland-capi.
     innerName :: String
-    innerName = T.unpack $ C.getName (C.declIdName info.declId)
+    innerName = T.unpack $ C.getName info.declId.name
 
     wrapperName :: UniqueSymbol
     wrapperName = globallyUnique opts.translationUniqueId moduleName $ concat [
@@ -1635,7 +1635,7 @@ addressStubDecs opts haddockConfig moduleName info ty _spec =
           "get_" ++ varName ++ "_ptr"
 
     varName :: String
-    varName = T.unpack $ C.getName (C.declIdName info.declId)
+    varName = T.unpack $ C.getName info.declId.name
 
     stubType :: C.Type
     stubType = C.TypePointer ty

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -258,9 +258,7 @@ getCQualName declId =
           --
           -- TODO <https://github.com/well-typed/hs-bindgen/issues/844>
           -- This is WIP.
-          C.QualName ("@" <> declIdName declId) kind
-        PrelimDeclIdBuiltin cName kind ->
-          C.QualName cName kind
+          C.QualName ("@" <> declId.name) kind
 
 -- TODO strategy
 -- TODO constraints

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/PrettyPrinter.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/PrettyPrinter.hs
@@ -257,9 +257,6 @@ showsOrigId = \case
       . showsCName name
     PrelimDeclIdAnon{} ->
       panicPure "cannot refer to anonymous declaration"
-    PrelimDeclIdBuiltin name kind ->
-        showsNameKind kind
-      . showsCName name
 
 showsNameKind :: NameKind -> ShowS
 showsNameKind = \case

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
@@ -177,7 +177,7 @@ typedefOfDecl typedefId payload useSites
   | shouldSquash
   = let newId :: C.DeclId HandleTypedefs
         newId = C.DeclId{
-            name       = C.DeclIdNamed $ C.declIdName typedefId
+            name       = typedefId.name
           , nameKind   = payload.declId.nameKind
           , origDeclId = typedefId.origDeclId
           , haskellId  = ()
@@ -190,7 +190,7 @@ typedefOfDecl typedefId payload useSites
   | shouldRename
   = let newId :: C.DeclId HandleTypedefs
         newId = C.DeclId{
-            name       = C.DeclIdNamed $ C.declIdName typedefId <> "_Deref"
+            name       = typedefId.name <> "_Deref"
           , nameKind   = payload.declId.nameKind
           , origDeclId = payload.declId.origDeclId
           , haskellId  = ()
@@ -205,13 +205,13 @@ typedefOfDecl typedefId payload useSites
     shouldSquash, shouldRename :: Bool
     shouldSquash = and [
           payload.valOrRef == ByValue
-        , or [ C.declIdName typedefId == C.declIdName payload.declId
+        , or [ typedefId.name == payload.declId.name
              , length useSites == 1
              ]
         ]
     shouldRename = and [
           payload.valOrRef == ByRef
-        , C.declIdName typedefId == C.declIdName payload.declId
+        , typedefId.name == payload.declId.name
         ]
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -287,14 +287,8 @@ processMacro info (UnparsedMacro tokens) = do
     case info.declId of
       C.PrelimDeclIdNamed name _kind ->
         bimap (addInfo name) toDecl <$> parseMacro name tokens
-      C.PrelimDeclIdBuiltin{} ->
-        -- Built-in macros certainly exist, and /in principle/ even have a
-        -- definition, but we currently don't get access to that definition
-        -- <https://github.com/well-typed/libclang/issues/17>.
-        -- We currently therefore always skip them in the parser.
-        panicPure $ "Unexpected: " ++ show info.declId
       C.PrelimDeclIdAnon{} ->
-        -- Anonymous macros cannot exist at all.
+        -- Anonymous macros don't exist
         panicPure $ "Impossible: " ++ show info.declId
   where
     addInfo :: C.Name -> HandleMacrosError -> FailedMacro

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleTypedefs.hs
@@ -68,10 +68,10 @@ handleDecl td decl
   -- We emit a \"rename\" only if we truly are renaming (in some cases we
   -- just change some other properties of the identifier).
   | Just newDeclId <- Map.lookup dId td.rename
-  = ( do guard $ C.declIdName declInfo'.declId /= C.declIdName newDeclId
+  = ( do guard $ declInfo'.declId.name /= newDeclId.name
          Just $ HandleTypedefsRenamedTagged
                   declInfo'
-                  (C.declIdName newDeclId)
+                  newDeclId.name
     , Just . (:[]) $ C.Decl{
            declInfo = declInfo'{C.declId = newDeclId}
          , declKind = handleUseSites td declKind
@@ -124,12 +124,9 @@ introduceAuxFunType td declInfo declAnn args res = [
     derefDecl = C.Decl {
           declInfo = declInfo {
               C.declId = C.DeclId{
-                  name =
-                    C.DeclIdNamed $ C.declIdName declInfo.declId <> "_Deref"
-                , nameKind =
-                    C.NameKindOrdinary
-                , haskellId =
-                    ()
+                  name       = declInfo.declId.name <> "_Deref"
+                , nameKind   = C.NameKindOrdinary
+                , haskellId  = ()
                 , origDeclId =
                     case declInfo.declId.origDeclId of
                       C.OrigDeclId orig    -> C.AuxForDecl orig
@@ -165,7 +162,7 @@ introduceAuxFunType td declInfo declAnn args res = [
           Clang.Paragraph [
               Clang.TextContent "Auxiliary type used by "
             , Clang.InlineRefCommand $
-                C.CommentRef (C.declIdName declInfo.declId) Nothing
+                C.CommentRef declInfo.declId.name Nothing
             ]
         ]
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/NameAnon.hs
@@ -94,7 +94,7 @@ constructDeclId env declId =
      case declId of
        C.PrelimDeclIdNamed name kind ->
          Just $ C.DeclId{
-             name       = C.DeclIdNamed name
+             name       = name
            , nameKind   = kind
            , origDeclId = C.OrigDeclId declId
            , haskellId  = ()
@@ -102,14 +102,7 @@ constructDeclId env declId =
        C.PrelimDeclIdAnon _anonId kind -> do
          useOfAnon <- findNamedUseOf env declId
          Just $ C.DeclId{
-             name       = C.DeclIdNamed (nameForAnon useOfAnon)
-           , nameKind   = kind
-           , origDeclId = C.OrigDeclId declId
-           , haskellId  = ()
-           }
-       C.PrelimDeclIdBuiltin name kind ->
-         Just $ C.DeclId{
-             name       = C.DeclIdBuiltin name
+             name       = nameForAnon useOfAnon
            , nameKind   = kind
            , origDeclId = C.OrigDeclId declId
            , haskellId  = ()

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type/Monad.hs
@@ -105,7 +105,7 @@ data ParseTypeException =
   | UnsupportedLongDouble
 
     -- | Clang built-in declaration
-  | UnsupportedBuiltin C.Name
+  | UnsupportedBuiltin Text
 
     -- | Complex types can only be defined using primitive types, e.g.
     -- @double complex@. @struct Point complex@ is not allowed.
@@ -129,7 +129,7 @@ instance PrettyForTrace ParseTypeException where
       UnsupportedLongDouble ->
           "Unsupported long double"
       UnsupportedBuiltin name ->
-          "Unsupported built-in " >< prettyForTrace name
+          "Unsupported built-in " >< PP.showToCtxDoc name
       UnexpectedComplexType ty ->
           "Unexpected complex type " >< PP.showToCtxDoc ty
       UnsupportedUnderlyingType name err -> PP.hcat [

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -224,8 +224,6 @@ selectDecls
               in parsed && selected
             -- Apply the select predicate to the use site.
             anon@(C.PrelimDeclIdAnon{}) -> matchAnon anon
-            -- Never select builtins.
-            C.PrelimDeclIdBuiltin{} -> False
 
         matchAnon :: DeclId -> Bool
         matchAnon anon =


### PR DESCRIPTION
Built-ins cannot have corresponding declaration (that's what makes them _built-in_ after all), so they cannot appear in the list of decls; built-in _macros_ are a bit of an exception to this, maybe, as they _do_ appear, but without a definition, so we can just skip over them.

For _use sites_, built-ins would not be another name (that is, yet another `TypeRef`), but instead would need to be special-cased, something like

```hs
data Type = ... | TypeBuiltin BuiltinType

data BuiltinType = BuiltinVaList | ...
```

However, we currently don't in fact support any built-in types at all.