### PR TITLE
Minor refactoring of `ResolveBindingSpecs`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -41,13 +41,13 @@ handleMacros ::
   ->  C.TranslationUnit ConstructTranslationUnit
   -> (C.TranslationUnit HandleMacros, [Msg HandleMacros])
 handleMacros standard C.TranslationUnit{unitDecls, unitIncludeGraph, unitAnn} =
-    reassemble $ runM standard .
+    reconstruct $ runM standard .
       fmap partitionEithers $ mapM processDecl unitDecls
   where
-    reassemble ::
+    reconstruct ::
          (([FailedMacro] , [C.Decl HandleMacros]) , [Msg HandleMacros])
       -> (C.TranslationUnit HandleMacros, [Msg HandleMacros])
-    reassemble ((failedMacros, decls'), msgs) =
+    reconstruct ((failedMacros, decls'), msgs) =
       let index' :: DeclIndex
           index' = DeclIndex.registerMacroFailures failedMacros unitAnn.declIndex
 


### PR DESCRIPTION
While working on something else, I noticed that a function `resolveCommentReference` was defined and used where a `coercePass` is sufficient.  This PR removes that function and uses `coercePass`.

While I am at it, I renamed functions `reassemble` to `reconstruct` for consistency with the WIP `AssignAnonIds` terminology.