### PR TITLE
Skip `CXCursor_DeclRefExpr`

### DIFF
--- a/hs-bindgen/examples/golden/edge-cases/enum_as_array_size.h
+++ b/hs-bindgen/examples/golden/edge-cases/enum_as_array_size.h
@@ -1,0 +1,8 @@
+// https://github.com/well-typed/hs-bindgen/issues/1415
+
+enum test {
+  test_a = 0,
+  test_count
+};
+
+extern const char test_array[test_count];

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example where
+
+import qualified Data.List.NonEmpty
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified HsBindgen.Runtime.CEnum
+import qualified HsBindgen.Runtime.HasBaseForeignType
+import qualified Text.Read
+import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
+
+{-| __C declaration:__ @test@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:3:6@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+newtype Test = Test
+  { un_Test :: FC.CUInt
+  }
+  deriving stock (Eq, Ord)
+  deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
+
+instance F.Storable Test where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure Test
+      <*> F.peekByteOff ptr0 (0 :: Int)
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Test un_Test2 ->
+            F.pokeByteOff ptr0 (0 :: Int) un_Test2
+
+instance HsBindgen.Runtime.CEnum.CEnum Test where
+
+  type CEnumZ Test = FC.CUInt
+
+  toCEnum = Test
+
+  fromCEnum = un_Test
+
+  declaredValues =
+    \_ ->
+      HsBindgen.Runtime.CEnum.declaredValuesFromList [ (0, Data.List.NonEmpty.singleton "Test_a")
+                                                     , (1, Data.List.NonEmpty.singleton "Test_count")
+                                                     ]
+
+  showsUndeclared =
+    HsBindgen.Runtime.CEnum.showsWrappedUndeclared "Test"
+
+  readPrecUndeclared =
+    HsBindgen.Runtime.CEnum.readPrecWrappedUndeclared "Test"
+
+  isDeclared = HsBindgen.Runtime.CEnum.seqIsDeclared
+
+  mkDeclared = HsBindgen.Runtime.CEnum.seqMkDeclared
+
+instance HsBindgen.Runtime.CEnum.SequentialCEnum Test where
+
+  minDeclaredValue = Test_a
+
+  maxDeclaredValue = Test_count
+
+instance Show Test where
+
+  showsPrec = HsBindgen.Runtime.CEnum.showsCEnum
+
+instance Read Test where
+
+  readPrec = HsBindgen.Runtime.CEnum.readPrecCEnum
+
+  readList = Text.Read.readListDefault
+
+  readListPrec = Text.Read.readListPrecDefault
+
+{-| __C declaration:__ @test_a@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:4:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_a :: Test
+pattern Test_a = Test 0
+
+{-| __C declaration:__ @test_count@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:5:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_count :: Test
+pattern Test_count = Test 1

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/FunPtr.hs
@@ -1,0 +1,1 @@
+module Example.FunPtr () where

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Global.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global where
+
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified GHC.IO.Unsafe
+import qualified HsBindgen.Runtime.ConstPtr
+import qualified HsBindgen.Runtime.ConstantArray
+import qualified HsBindgen.Runtime.Prelude
+import Prelude (IO)
+
+$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+  [ "#include <edge-cases/enum_as_array_size.h>"
+  , "/* test_edgecasesenum_as_array_size_Example_get_test_array_ptr */"
+  , "__attribute__ ((const))"
+  , "char const (*hs_bindgen_c86f87bd85936ecd (void))[1]"
+  , "{"
+  , "  return &test_array;"
+  , "}"
+  ]))
+
+-- | __unique:__ @test_edgecasesenum_as_array_size_Example_get_test_array_ptr@
+foreign import ccall unsafe "hs_bindgen_c86f87bd85936ecd" hs_bindgen_c86f87bd85936ecd ::
+     IO (HsBindgen.Runtime.ConstPtr.ConstPtr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CChar))
+
+{-# NOINLINE test_array_ptr #-}
+
+{-| __C declaration:__ @test_array@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:8:19@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+test_array_ptr :: HsBindgen.Runtime.ConstPtr.ConstPtr ((HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CChar)
+test_array_ptr =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_c86f87bd85936ecd
+
+{-# NOINLINE test_array #-}
+
+test_array :: (HsBindgen.Runtime.ConstantArray.ConstantArray 1) FC.CChar
+test_array =
+  GHC.IO.Unsafe.unsafePerformIO (F.peek (HsBindgen.Runtime.ConstPtr.unConstPtr test_array_ptr))

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Safe.hs
@@ -1,0 +1,1 @@
+module Example.Safe () where

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Unsafe.hs
@@ -1,0 +1,1 @@
+module Example.Unsafe () where

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
@@ -1,0 +1,18 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example
+ctypes:
+- headers: edge-cases/enum_as_array_size.h
+  cname: enum test
+  hsname: Test
+hstypes:
+- hsname: Test
+  instances:
+  - Eq
+  - HasBaseForeignType
+  - Ord
+  - Read
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -1,0 +1,99 @@
+-- addDependentFile examples/golden/edge-cases/enum_as_array_size.h
+-- #include <edge-cases/enum_as_array_size.h>
+-- /* test_edgecasesenum_as_array_size_Example_get_test_array_ptr */
+-- __attribute__ ((const))
+-- char const (*hs_bindgen_c86f87bd85936ecd (void))[1]
+-- {
+--   return &test_array;
+-- }
+{-| __C declaration:__ @test@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:3:6@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+newtype Test
+    = Test {un_Test :: CUInt}
+      {- ^ __C declaration:__ @test@
+
+           __defined at:__ @edge-cases\/enum_as_array_size.h:3:6@
+
+           __exported by:__ @edge-cases\/enum_as_array_size.h@
+      -}
+    deriving stock (Eq, Ord)
+    deriving newtype HasBaseForeignType
+instance Storable Test
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure Test <*> peekByteOff ptr_0 (0 :: Int)
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   Test un_Test_3 -> pokeByteOff ptr_1 (0 :: Int) un_Test_3
+instance CEnum Test
+    where type CEnumZ Test = CUInt
+          toCEnum = Test
+          fromCEnum = un_Test
+          declaredValues = \_ -> declaredValuesFromList [(0,
+                                                          singleton "Test_a"),
+                                                         (1, singleton "Test_count")]
+          showsUndeclared = showsWrappedUndeclared "Test"
+          readPrecUndeclared = readPrecWrappedUndeclared "Test"
+          isDeclared = seqIsDeclared
+          mkDeclared = seqMkDeclared
+instance SequentialCEnum Test
+    where minDeclaredValue = Test_a
+          maxDeclaredValue = Test_count
+instance Show Test
+    where showsPrec = showsCEnum
+instance Read Test
+    where readPrec = readPrecCEnum
+          readList = readListDefault
+          readListPrec = readListPrecDefault
+{-| __C declaration:__ @test_a@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:4:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_a :: Test
+{-| __C declaration:__ @test_a@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:4:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_a = Test 0
+{-| __C declaration:__ @test_count@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:5:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_count :: Test
+{-| __C declaration:__ @test_count@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:5:3@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+pattern Test_count = Test 1
+-- | __unique:__ @test_edgecasesenum_as_array_size_Example_get_test_array_ptr@
+foreign import ccall safe "hs_bindgen_c86f87bd85936ecd" hs_bindgen_c86f87bd85936ecd :: IO (ConstPtr (ConstantArray 1
+                                                                                                                   CChar))
+{-# NOINLINE test_array_ptr #-}
+{-| __C declaration:__ @test_array@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:8:19@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+test_array_ptr :: ConstPtr (ConstantArray 1 CChar)
+{-| __C declaration:__ @test_array@
+
+    __defined at:__ @edge-cases\/enum_as_array_size.h:8:19@
+
+    __exported by:__ @edge-cases\/enum_as_array_size.h@
+-}
+test_array_ptr = unsafePerformIO hs_bindgen_c86f87bd85936ecd
+{-# NOINLINE test_array #-}
+test_array :: ConstantArray 1 CChar
+test_array = unsafePerformIO (peek (unConstPtr test_array_ptr))

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -725,6 +725,7 @@ varDecl info = \curr -> do
           -- The only other example I'm currently aware of is characters
           -- ('CXCursor_CharacterLiteral').
           Right CXCursor_UnexposedExpr -> foldContinue
+          Right CXCursor_DeclRefExpr   -> foldContinue
 
           -- @visibility@ attributes, where the value is obtained using
           -- @clang_getCursorVisibility@.

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -267,6 +267,9 @@ test_documentation_data_kind_pragma =
 test_edge_cases_adios :: TestCase
 test_edge_cases_adios = defaultTest "edge-cases/adios"
 
+test_edge_cases_enum_as_array_size :: TestCase
+test_edge_cases_enum_as_array_size = defaultTest "edge-cases/enum_as_array_size"
+
 test_edge_cases_duplicate :: TestCase
 test_edge_cases_duplicate = (defaultTest "edge-cases/duplicate") {
     testOnFrontendConfig = \cfg -> cfg{
@@ -1237,6 +1240,7 @@ testCases = manualTestCases ++ [
     , test_edge_cases_clang_generated_collision
     , test_edge_cases_distilled_lib_1
     , test_edge_cases_duplicate
+    , test_edge_cases_enum_as_array_size
     , test_edge_cases_flam
     , test_edge_cases_headers
     , test_edge_cases_iterator

--- a/scripts/ci/compile-fixtures.sh
+++ b/scripts/ci/compile-fixtures.sh
@@ -31,7 +31,7 @@ KNOWN_FAILURES=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=102
+KNOWN_FIXTURES_COUNT=103
 
 # Default options
 JOBS=4


### PR DESCRIPTION
Fortunately we can just skip this node; `clang` will still tell us the array size.

Closes #1415