### PR TITLE
Use `ConstPtr` for all function result types passed through pointers

### DIFF
--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/CAPI.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/CAPI.hs
@@ -1,11 +1,14 @@
 module HsBindgen.Runtime.CAPI (
     addCSource,
     allocaAndPeek,
+    allocaAndPeekConst,
 ) where
 
 import Foreign (Ptr, Storable, alloca, peek)
 import Language.Haskell.TH (DecsQ)
 import Language.Haskell.TH.Syntax (ForeignSrcLang (LangC), addForeignSource)
+
+import HsBindgen.Runtime.ConstPtr (ConstPtr (ConstPtr))
 
 addCSource :: String -> DecsQ
 addCSource src = do
@@ -14,3 +17,6 @@ addCSource src = do
 
 allocaAndPeek :: Storable a => (Ptr a -> IO ()) -> IO a
 allocaAndPeek kont = alloca $ \ptr -> kont ptr >> peek ptr
+
+allocaAndPeekConst :: Storable a => (ConstPtr a -> IO ()) -> IO a
+allocaAndPeekConst kont = alloca $ \ptr -> kont (ConstPtr ptr) >> peek ptr

--- a/hs-bindgen/examples/golden/types/structs/struct_arg_const.h
+++ b/hs-bindgen/examples/golden/types/structs/struct_arg_const.h
@@ -1,0 +1,9 @@
+// See https://github.com/well-typed/hs-bindgen/issues/1439
+
+struct thing {
+    int x;
+};
+
+void               fun_const_arg   (const struct thing x);
+const struct thing fun_const_result(void);
+const struct thing fun_const       (const struct thing x);

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/Example.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example where
+
+import qualified Data.Primitive.Types
+import qualified Data.Proxy
+import qualified Foreign as F
+import qualified Foreign.C as FC
+import qualified GHC.Ptr as Ptr
+import qualified GHC.Records
+import qualified HsBindgen.Runtime.HasCField
+import HsBindgen.Runtime.TypeEquality (TyEq)
+import Prelude ((<*>), Eq, Int, Show, pure)
+
+{-| __C declaration:__ @struct thing@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:3:8@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+data Thing = Thing
+  { thing_x :: FC.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @types\/structs\/struct_arg_const.h:4:9@
+
+         __exported by:__ @types\/structs\/struct_arg_const.h@
+    -}
+  }
+  deriving stock (Eq, Show)
+
+instance F.Storable Thing where
+
+  sizeOf = \_ -> (4 :: Int)
+
+  alignment = \_ -> (4 :: Int)
+
+  peek =
+    \ptr0 ->
+          pure Thing
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"thing_x") ptr0
+
+  poke =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Thing thing_x2 ->
+            HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"thing_x") ptr0 thing_x2
+
+instance Data.Primitive.Types.Prim Thing where
+
+  sizeOf# = \_ -> (4#)
+
+  alignment# = \_ -> (4#)
+
+  indexByteArray# =
+    \arr0 ->
+      \i1 ->
+        Thing (Data.Primitive.Types.indexByteArray# arr0 i1)
+
+  readByteArray# =
+    \arr0 ->
+      \i1 ->
+        \s2 ->
+          case Data.Primitive.Types.readByteArray# arr0 i1 s2 of
+            (# s3, v4 #) -> (# s3, Thing v4 #)
+
+  writeByteArray# =
+    \arr0 ->
+      \i1 ->
+        \struct2 ->
+          \s3 ->
+            case struct2 of
+              Thing thing_x4 ->
+                Data.Primitive.Types.writeByteArray# arr0 i1 thing_x4 s3
+
+  indexOffAddr# =
+    \addr0 ->
+      \i1 ->
+        Thing (Data.Primitive.Types.indexOffAddr# addr0 i1)
+
+  readOffAddr# =
+    \addr0 ->
+      \i1 ->
+        \s2 ->
+          case Data.Primitive.Types.readOffAddr# addr0 i1 s2 of
+            (# s3, v4 #) -> (# s3, Thing v4 #)
+
+  writeOffAddr# =
+    \addr0 ->
+      \i1 ->
+        \struct2 ->
+          \s3 ->
+            case struct2 of
+              Thing thing_x4 ->
+                Data.Primitive.Types.writeOffAddr# addr0 i1 thing_x4 s3
+
+instance HsBindgen.Runtime.HasCField.HasCField Thing "thing_x" where
+
+  type CFieldType Thing "thing_x" = FC.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Thing) "thing_x")
+         ) => GHC.Records.HasField "thing_x" (Ptr.Ptr Thing) (Ptr.Ptr ty) where
+
+  getField =
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"thing_x")

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/FunPtr.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.FunPtr where
+
+import qualified GHC.IO.Unsafe
+import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.Prelude
+import Example
+import Prelude (IO)
+
+$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+  [ "#include <types/structs/struct_arg_const.h>"
+  , "/* test_typesstructsstruct_arg_const_Example_get_fun_const_arg */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_444a89a1a48acd31 (void)) ("
+  , "  struct thing const arg1"
+  , ")"
+  , "{"
+  , "  return &fun_const_arg;"
+  , "}"
+  , "/* test_typesstructsstruct_arg_const_Example_get_fun_const_result */"
+  , "__attribute__ ((const))"
+  , "struct thing const (*hs_bindgen_3840e50b04084db6 (void)) (void)"
+  , "{"
+  , "  return &fun_const_result;"
+  , "}"
+  , "/* test_typesstructsstruct_arg_const_Example_get_fun_const */"
+  , "__attribute__ ((const))"
+  , "struct thing const (*hs_bindgen_49a195a2b05d425e (void)) ("
+  , "  struct thing const arg1"
+  , ")"
+  , "{"
+  , "  return &fun_const;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const_arg@
+foreign import ccall unsafe "hs_bindgen_444a89a1a48acd31" hs_bindgen_444a89a1a48acd31 ::
+     IO (Ptr.FunPtr (Thing -> IO ()))
+
+{-# NOINLINE fun_const_arg #-}
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg :: Ptr.FunPtr (Thing -> IO ())
+fun_const_arg =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_444a89a1a48acd31
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const_result@
+foreign import ccall unsafe "hs_bindgen_3840e50b04084db6" hs_bindgen_3840e50b04084db6 ::
+     IO (Ptr.FunPtr (IO Thing))
+
+{-# NOINLINE fun_const_result #-}
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: Ptr.FunPtr (IO Thing)
+fun_const_result =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_3840e50b04084db6
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const@
+foreign import ccall unsafe "hs_bindgen_49a195a2b05d425e" hs_bindgen_49a195a2b05d425e ::
+     IO (Ptr.FunPtr (Thing -> IO Thing))
+
+{-# NOINLINE fun_const #-}
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const :: Ptr.FunPtr (Thing -> IO Thing)
+fun_const =
+  GHC.IO.Unsafe.unsafePerformIO hs_bindgen_49a195a2b05d425e

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/Safe.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Safe where
+
+import qualified Foreign as F
+import qualified HsBindgen.Runtime.CAPI
+import qualified HsBindgen.Runtime.ConstPtr
+import qualified HsBindgen.Runtime.Prelude
+import Example
+import Prelude (IO)
+
+$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+  [ "#include <types/structs/struct_arg_const.h>"
+  , "void hs_bindgen_6cb8b51c110839ff ("
+  , "  struct thing const *arg1"
+  , ")"
+  , "{"
+  , "  fun_const_arg(*arg1);"
+  , "}"
+  , "void hs_bindgen_44ee619fd7228cf2 ("
+  , "  struct thing const *arg1"
+  , ")"
+  , "{"
+  , "  *arg1 = fun_const_result();"
+  , "}"
+  , "void hs_bindgen_3794a17277299018 ("
+  , "  struct thing const *arg1,"
+  , "  struct thing const *arg2"
+  , ")"
+  , "{"
+  , "  *arg2 = fun_const(*arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const_arg@
+foreign import ccall safe "hs_bindgen_6cb8b51c110839ff" hs_bindgen_6cb8b51c110839ff ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+fun_const_arg_wrapper = hs_bindgen_6cb8b51c110839ff
+
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg ::
+     Thing
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+fun_const_arg =
+  \x0 ->
+    F.with x0 (\y1 ->
+                 hs_bindgen_6cb8b51c110839ff (HsBindgen.Runtime.ConstPtr.ConstPtr y1))
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const_result@
+foreign import ccall safe "hs_bindgen_44ee619fd7228cf2" hs_bindgen_44ee619fd7228cf2 ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+fun_const_result_wrapper =
+  hs_bindgen_44ee619fd7228cf2
+
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: IO Thing
+fun_const_result =
+  HsBindgen.Runtime.CAPI.allocaAndPeekConst (\z0 ->
+                                               hs_bindgen_44ee619fd7228cf2 z0)
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const@
+foreign import ccall safe "hs_bindgen_3794a17277299018" hs_bindgen_3794a17277299018 ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+     -- ^ __C declaration:__ @x@
+  -> HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+fun_const_wrapper = hs_bindgen_3794a17277299018
+
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const ::
+     Thing
+     -- ^ __C declaration:__ @x@
+  -> IO Thing
+fun_const =
+  \x0 ->
+    F.with x0 (\y1 ->
+                 HsBindgen.Runtime.CAPI.allocaAndPeekConst (\z2 ->
+                                                              hs_bindgen_3794a17277299018 (HsBindgen.Runtime.ConstPtr.ConstPtr y1) z2))

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/Example/Unsafe.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Unsafe where
+
+import qualified Foreign as F
+import qualified HsBindgen.Runtime.CAPI
+import qualified HsBindgen.Runtime.ConstPtr
+import qualified HsBindgen.Runtime.Prelude
+import Example
+import Prelude (IO)
+
+$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+  [ "#include <types/structs/struct_arg_const.h>"
+  , "void hs_bindgen_16645ede9f5730aa ("
+  , "  struct thing const *arg1"
+  , ")"
+  , "{"
+  , "  fun_const_arg(*arg1);"
+  , "}"
+  , "void hs_bindgen_835e1cc568a75ba7 ("
+  , "  struct thing const *arg1"
+  , ")"
+  , "{"
+  , "  *arg1 = fun_const_result();"
+  , "}"
+  , "void hs_bindgen_cf49a7a211a8c12b ("
+  , "  struct thing const *arg1,"
+  , "  struct thing const *arg2"
+  , ")"
+  , "{"
+  , "  *arg2 = fun_const(*arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const_arg@
+foreign import ccall unsafe "hs_bindgen_16645ede9f5730aa" hs_bindgen_16645ede9f5730aa ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+fun_const_arg_wrapper = hs_bindgen_16645ede9f5730aa
+
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg ::
+     Thing
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+fun_const_arg =
+  \x0 ->
+    F.with x0 (\y1 ->
+                 hs_bindgen_16645ede9f5730aa (HsBindgen.Runtime.ConstPtr.ConstPtr y1))
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const_result@
+foreign import ccall unsafe "hs_bindgen_835e1cc568a75ba7" hs_bindgen_835e1cc568a75ba7 ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+fun_const_result_wrapper =
+  hs_bindgen_835e1cc568a75ba7
+
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: IO Thing
+fun_const_result =
+  HsBindgen.Runtime.CAPI.allocaAndPeekConst (\z0 ->
+                                               hs_bindgen_835e1cc568a75ba7 z0)
+
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const@
+foreign import ccall unsafe "hs_bindgen_cf49a7a211a8c12b" hs_bindgen_cf49a7a211a8c12b ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper ::
+     HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+     -- ^ __C declaration:__ @x@
+  -> HsBindgen.Runtime.ConstPtr.ConstPtr Thing
+  -> IO ()
+fun_const_wrapper = hs_bindgen_cf49a7a211a8c12b
+
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const ::
+     Thing
+     -- ^ __C declaration:__ @x@
+  -> IO Thing
+fun_const =
+  \x0 ->
+    F.with x0 (\y1 ->
+                 HsBindgen.Runtime.CAPI.allocaAndPeekConst (\z2 ->
+                                                              hs_bindgen_cf49a7a211a8c12b (HsBindgen.Runtime.ConstPtr.ConstPtr y1) z2))

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/bindingspec.yaml
@@ -1,0 +1,21 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example
+ctypes:
+- headers: types/structs/struct_arg_const.h
+  cname: struct thing
+  hsname: Thing
+hstypes:
+- hsname: Thing
+  representation:
+    record:
+      constructor: Thing
+      fields:
+      - thing_x
+  instances:
+  - Eq
+  - Prim
+  - Show
+  - Storable

--- a/hs-bindgen/fixtures/types/structs/struct_arg_const/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg_const/th.txt
@@ -1,0 +1,301 @@
+-- addDependentFile examples/golden/types/structs/struct_arg_const.h
+-- #include <types/structs/struct_arg_const.h>
+-- void hs_bindgen_6cb8b51c110839ff (
+--   struct thing const *arg1
+-- )
+-- {
+--   fun_const_arg(*arg1);
+-- }
+-- void hs_bindgen_44ee619fd7228cf2 (
+--   struct thing const *arg1
+-- )
+-- {
+--   *arg1 = fun_const_result();
+-- }
+-- void hs_bindgen_3794a17277299018 (
+--   struct thing const *arg1,
+--   struct thing const *arg2
+-- )
+-- {
+--   *arg2 = fun_const(*arg1);
+-- }
+-- void hs_bindgen_16645ede9f5730aa (
+--   struct thing const *arg1
+-- )
+-- {
+--   fun_const_arg(*arg1);
+-- }
+-- void hs_bindgen_835e1cc568a75ba7 (
+--   struct thing const *arg1
+-- )
+-- {
+--   *arg1 = fun_const_result();
+-- }
+-- void hs_bindgen_cf49a7a211a8c12b (
+--   struct thing const *arg1,
+--   struct thing const *arg2
+-- )
+-- {
+--   *arg2 = fun_const(*arg1);
+-- }
+-- /* test_typesstructsstruct_arg_const_Example_get_fun_const_arg */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_444a89a1a48acd31 (void)) (
+--   struct thing const arg1
+-- )
+-- {
+--   return &fun_const_arg;
+-- }
+-- /* test_typesstructsstruct_arg_const_Example_get_fun_const_result */
+-- __attribute__ ((const))
+-- struct thing const (*hs_bindgen_3840e50b04084db6 (void)) (void)
+-- {
+--   return &fun_const_result;
+-- }
+-- /* test_typesstructsstruct_arg_const_Example_get_fun_const */
+-- __attribute__ ((const))
+-- struct thing const (*hs_bindgen_49a195a2b05d425e (void)) (
+--   struct thing const arg1
+-- )
+-- {
+--   return &fun_const;
+-- }
+{-| __C declaration:__ @struct thing@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:3:8@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+data Thing
+    = Thing {thing_x :: CInt
+             {- ^ __C declaration:__ @x@
+
+                  __defined at:__ @types\/structs\/struct_arg_const.h:4:9@
+
+                  __exported by:__ @types\/structs\/struct_arg_const.h@
+             -}}
+      {- ^ __C declaration:__ @struct thing@
+
+           __defined at:__ @types\/structs\/struct_arg_const.h:3:8@
+
+           __exported by:__ @types\/structs\/struct_arg_const.h@
+      -}
+    deriving stock (Eq, Show)
+instance Storable Thing
+    where sizeOf = \_ -> 4 :: Int
+          alignment = \_ -> 4 :: Int
+          peek = \ptr_0 -> pure Thing <*> peekCField (Proxy @"thing_x") ptr_0
+          poke = \ptr_1 -> \s_2 -> case s_2 of
+                                   Thing thing_x_3 -> pokeCField (Proxy @"thing_x") ptr_1 thing_x_3
+instance Prim Thing
+    where sizeOf# = \_ -> 4# :: Int#
+          alignment# = \_ -> 4# :: Int#
+          indexByteArray# = \arr_0 -> \i_1 -> Thing (indexByteArray# arr_0 i_1)
+          readByteArray# = \arr_2 -> \i_3 -> \s_4 -> case readByteArray# arr_2 i_3 s_4 of
+                                                     (# s_5, v_6 #) -> (# s_5, Thing v_6 #)
+          writeByteArray# = \arr_7 -> \i_8 -> \struct_9 -> \s_10 -> case struct_9 of
+                                                                    Thing thing_x_11 -> writeByteArray# arr_7 i_8 thing_x_11 s_10
+          indexOffAddr# = \addr_12 -> \i_13 -> Thing (indexOffAddr# addr_12 i_13)
+          readOffAddr# = \addr_14 -> \i_15 -> \s_16 -> case readOffAddr# addr_14 i_15 s_16 of
+                                                       (# s_17, v_18 #) -> (# s_17, Thing v_18 #)
+          writeOffAddr# = \addr_19 -> \i_20 -> \struct_21 -> \s_22 -> case struct_21 of
+                                                                      Thing thing_x_23 -> writeOffAddr# addr_19 i_20 thing_x_23 s_22
+instance HasCField Thing "thing_x"
+    where type CFieldType Thing "thing_x" = CInt
+          offset# = \_ -> \_ -> 0
+instance TyEq ty (CFieldType Thing "thing_x") =>
+         HasField "thing_x" (Ptr Thing) (Ptr ty)
+    where getField = ptrToCField (Proxy @"thing_x")
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const_arg@
+foreign import ccall safe "hs_bindgen_6cb8b51c110839ff" hs_bindgen_6cb8b51c110839ff :: ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper :: ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper = hs_bindgen_6cb8b51c110839ff
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg :: Thing -> IO Unit
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg = \x_0 -> with x_0 (\y_1 -> hs_bindgen_6cb8b51c110839ff (ConstPtr y_1))
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const_result@
+foreign import ccall safe "hs_bindgen_44ee619fd7228cf2" hs_bindgen_44ee619fd7228cf2 :: ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper :: ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper = hs_bindgen_44ee619fd7228cf2
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: IO Thing
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result = allocaAndPeekConst (\z_0 -> hs_bindgen_44ee619fd7228cf2 z_0)
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Safe_fun_const@
+foreign import ccall safe "hs_bindgen_3794a17277299018" hs_bindgen_3794a17277299018 :: ConstPtr Thing ->
+                                                                                       ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper :: ConstPtr Thing -> ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper = hs_bindgen_3794a17277299018
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const :: Thing -> IO Thing
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const = \x_0 -> with x_0 (\y_1 -> allocaAndPeekConst (\z_2 -> hs_bindgen_3794a17277299018 (ConstPtr y_1) z_2))
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const_arg@
+foreign import ccall safe "hs_bindgen_16645ede9f5730aa" hs_bindgen_16645ede9f5730aa :: ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper :: ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const_arg'
+-}
+fun_const_arg_wrapper = hs_bindgen_16645ede9f5730aa
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg :: Thing -> IO Unit
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg = \x_0 -> with x_0 (\y_1 -> hs_bindgen_16645ede9f5730aa (ConstPtr y_1))
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const_result@
+foreign import ccall safe "hs_bindgen_835e1cc568a75ba7" hs_bindgen_835e1cc568a75ba7 :: ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper :: ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const_result'
+-}
+fun_const_result_wrapper = hs_bindgen_835e1cc568a75ba7
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: IO Thing
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result = allocaAndPeekConst (\z_0 -> hs_bindgen_835e1cc568a75ba7 z_0)
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_Unsafe_fun_const@
+foreign import ccall safe "hs_bindgen_cf49a7a211a8c12b" hs_bindgen_cf49a7a211a8c12b :: ConstPtr Thing ->
+                                                                                       ConstPtr Thing ->
+                                                                                       IO Unit
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper :: ConstPtr Thing -> ConstPtr Thing -> IO Unit
+{-| Pointer-based API for 'fun_const'
+-}
+fun_const_wrapper = hs_bindgen_cf49a7a211a8c12b
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const :: Thing -> IO Thing
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const = \x_0 -> with x_0 (\y_1 -> allocaAndPeekConst (\z_2 -> hs_bindgen_cf49a7a211a8c12b (ConstPtr y_1) z_2))
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const_arg@
+foreign import ccall safe "hs_bindgen_444a89a1a48acd31" hs_bindgen_444a89a1a48acd31 :: IO (FunPtr (Thing ->
+                                                                                                   IO Unit))
+{-# NOINLINE fun_const_arg #-}
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg :: FunPtr (Thing -> IO Unit)
+{-| __C declaration:__ @fun_const_arg@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:7:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_arg = unsafePerformIO hs_bindgen_444a89a1a48acd31
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const_result@
+foreign import ccall safe "hs_bindgen_3840e50b04084db6" hs_bindgen_3840e50b04084db6 :: IO (FunPtr (IO Thing))
+{-# NOINLINE fun_const_result #-}
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result :: FunPtr (IO Thing)
+{-| __C declaration:__ @fun_const_result@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:8:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const_result = unsafePerformIO hs_bindgen_3840e50b04084db6
+-- __unique:__ @test_typesstructsstruct_arg_const_Example_get_fun_const@
+foreign import ccall safe "hs_bindgen_49a195a2b05d425e" hs_bindgen_49a195a2b05d425e :: IO (FunPtr (Thing ->
+                                                                                                   IO Thing))
+{-# NOINLINE fun_const #-}
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const :: FunPtr (Thing -> IO Thing)
+{-| __C declaration:__ @fun_const@
+
+    __defined at:__ @types\/structs\/struct_arg_const.h:9:20@
+
+    __exported by:__ @types\/structs\/struct_arg_const.h@
+-}
+fun_const = unsafePerformIO hs_bindgen_49a195a2b05d425e

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
@@ -305,6 +305,7 @@ resolveGlobal = \case
     CharValue_fromAddr            -> importQ 'CExpr.Runtime.charValueFromAddr
     CAPI_with                     -> importQ 'Foreign.with
     CAPI_allocaAndPeek            -> importQ 'HsBindgen.Runtime.CAPI.allocaAndPeek
+    CAPI_allocaAndPeekConst       -> importQ 'HsBindgen.Runtime.CAPI.allocaAndPeekConst
     ConstantArray_withPtr         -> importQ 'HsBindgen.Runtime.ConstantArray.withPtr
     IncompleteArray_withPtr       -> importQ 'HsBindgen.Runtime.IncompleteArray.withPtr
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
@@ -89,6 +89,7 @@ data Global =
   | ByteArray_getUnionPayload
   | CAPI_with
   | CAPI_allocaAndPeek
+  | CAPI_allocaAndPeekConst
   | ConstantArray_withPtr
   | IncompleteArray_withPtr
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -114,7 +114,8 @@ mkGlobal = \case
       CharValue_constructor  -> 'CExpr.Runtime.CharValue
       CharValue_fromAddr    -> 'CExpr.Runtime.charValueFromAddr
       CAPI_with             -> 'Foreign.with
-      CAPI_allocaAndPeek    -> 'HsBindgen.Runtime.CAPI.allocaAndPeek
+      CAPI_allocaAndPeek      -> 'HsBindgen.Runtime.CAPI.allocaAndPeek
+      CAPI_allocaAndPeekConst -> 'HsBindgen.Runtime.CAPI.allocaAndPeekConst
       ConstantArray_withPtr -> 'HsBindgen.Runtime.ConstantArray.withPtr
       IncompleteArray_withPtr -> 'HsBindgen.Runtime.IncompleteArray.withPtr
 
@@ -386,7 +387,8 @@ mkGlobalExpr n = case n of -- in definition order, no wildcards
     ByteArray_setUnionPayload -> TH.varE name
     ByteArray_getUnionPayload -> TH.varE name
     CAPI_with             -> TH.varE name
-    CAPI_allocaAndPeek    -> TH.varE name
+    CAPI_allocaAndPeek      -> TH.varE name
+    CAPI_allocaAndPeekConst -> TH.varE name
     ConstantArray_withPtr -> TH.varE name
     IncompleteArray_withPtr -> TH.varE name
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -147,6 +147,7 @@ testCases_default = [
     , defaultTest "types/structs/recursive_struct"
     , defaultTest "types/structs/simple_structs"
     , defaultTest "types/structs/struct_arg"
+    , defaultTest "types/structs/struct_arg_const"
     , defaultTest "types/typedefs/multi_level_function_pointer"
     , defaultTest "types/typedefs/typedef_vs_macro"
     , defaultTest "types/typedefs/typenames"

--- a/scripts/ci/compile-fixtures.sh
+++ b/scripts/ci/compile-fixtures.sh
@@ -21,10 +21,11 @@ EOF
 
 # Known failures - these will be skipped unless -f is used
 KNOWN_FAILURES=(
-    edge-cases/iterator          # Makes use of Apple block extension which would require clang (see #913)
-    functions/decls_in_signature # Unusable struct (see #1128)
-    declarations/redeclaration   # Multiple declarations (intentional test case)
-    types/typedefs/typenames     # Multiple declarations (hs-bindgen namespace possible bug/feature)
+    declarations/redeclaration     # Multiple declarations (intentional test case)
+    edge-cases/iterator            # Makes use of Apple block extension which would require clang (see #913)
+    functions/decls_in_signature   # Unusable struct (see #1128)
+    types/structs/struct_arg_const # assignment of read-only location (see issue #1439)
+    types/typedefs/typenames       # Multiple declarations (hs-bindgen namespace possible bug/feature)
 )
 
 # Known fixtures without code - these will be skipped
@@ -51,7 +52,7 @@ KNOWN_EMPTY=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=108
+KNOWN_FIXTURES_COUNT=109
 
 # Default options
 JOBS=4


### PR DESCRIPTION
We had switched to using `ConstPtr` in the function arguments of bindings, but
we were not properly handling yet the case where result types (like structs and
unions) are communicated through a pointer. We add a new `allocaAndPeekConst`
function and we use this instead of `allocaAndPeek` whenever we are dealing with
a pointer to a const struct or union.