### PR TITLE
Refactor C standard

### DIFF
--- a/c-expr-runtime/test/Main.hs
+++ b/c-expr-runtime/test/Main.hs
@@ -11,8 +11,6 @@ module Main where
 -- base
 import Control.Arrow
   ( first )
-import Control.Exception
-  ( throwIO )
 import Data.List
   ( isPrefixOf )
 import Data.String
@@ -108,9 +106,8 @@ main = do
       , "The test-suite will use whichever C header files it finds on your system."
       ]
 
-  stdClangArg <- either throwIO return $
-    Clang.getStdClangArg Clang.C23 Clang.DisableGnu
-  let platform = hostPlatform
+  let stdClangArg = "-std=c17"  -- C23 arg depends on libclang version
+      platform = hostPlatform
       clangArgs = Clang.ClangArgs $ stdClangArg :
         case platformOS hostPlatform of
           Windows -> ["-target", "x86_64-pc-windows"]

--- a/cabal.project.base
+++ b/cabal.project.base
@@ -5,4 +5,4 @@ index-state: 2025-12-19T00:00:00Z
 source-repository-package
     type: git
     location: https://github.com/well-typed/libclang
-    tag: 363bc3593b18670b497c36f29d11ad49df9eea4d
+    tag: 27f20c2e320f779314175ee3e82072fec61b8391

--- a/examples/blocktest/generate-and-run.sh
+++ b/examples/blocktest/generate-and-run.sh
@@ -29,7 +29,7 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     --hs-output-dir hs-project/generated \
     --unique-id blocksdemo.well-typed.com \
     --module Iterator \
-    --standard c23 \
+    --clang-option '-std=c2x' \
     --enable-blocks \
     iterator.h
 

--- a/examples/libpcap/generate.sh
+++ b/examples/libpcap/generate.sh
@@ -19,7 +19,7 @@ module_flags=(
 libclang_flags=(
     # Enable GNU extensions. GNU extensions define types, such as `u_int`, which
     # `libpcap` requires.
-    --gnu
+    --clang-option '-std=gnu17'
 )
 
 # `hs-bindgen` parses the C header files using `libclang` and interprets/reifies

--- a/flake.lock
+++ b/flake.lock
@@ -21,17 +21,17 @@
     "libclang-bindings-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768172012,
-        "narHash": "sha256-HgrqgUdJN1A7bZF5oIchicMo9dKDDJmJImHynH5hZfM=",
+        "lastModified": 1768982090,
+        "narHash": "sha256-EgM9ZJvbM0+SQ8f9P27Rnx4dY8Q1fWtGVXsRl5f0Vfk=",
         "owner": "well-typed",
         "repo": "libclang",
-        "rev": "363bc3593b18670b497c36f29d11ad49df9eea4d",
+        "rev": "27f20c2e320f779314175ee3e82072fec61b8391",
         "type": "github"
       },
       "original": {
         "owner": "well-typed",
         "repo": "libclang",
-        "rev": "363bc3593b18670b497c36f29d11ad49df9eea4d",
+        "rev": "27f20c2e320f779314175ee3e82072fec61b8391",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     libclang-bindings-src = {
-      url = "github:well-typed/libclang?rev=363bc3593b18670b497c36f29d11ad49df9eea4d";
+      url = "github:well-typed/libclang?rev=27f20c2e320f779314175ee3e82072fec61b8391";
       flake = false;
     };
   };

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -33,7 +33,6 @@ module HsBindgen.App (
 import Data.Char qualified as Char
 import Data.Default (Default (..))
 import Data.Either (partitionEithers)
-import Data.List qualified as List
 import Data.Maybe (catMaybes)
 import Options.Applicative
 import Options.Applicative.Extra (helperWith)
@@ -247,8 +246,6 @@ parseClangArgsConfig = do
     -- ApplicativeDo to be able to reorder arguments for --help, and to use
     -- record construction (i.e., to avoid bool or string/path blindness)
     -- instead of positional one.
-    cStandard        <- parseCStandard
-    gnu              <- parseGnu
     enableBlocks     <- parseEnableBlocks
     builtinIncDir    <- parseBuiltinIncDirConfig
     extraIncludeDirs <- many parseIncludeDir
@@ -257,9 +254,7 @@ parseClangArgsConfig = do
     argsInner        <- many parseClangOptionInner
     argsAfter        <- many parseClangOptionAfter
     pure $ ClangArgsConfig{
-        cStandard        = cStandard
-      , gnu              = gnu
-      , enableBlocks     = enableBlocks
+        enableBlocks     = enableBlocks
       , builtinIncDir    = builtinIncDir
       , extraIncludeDirs = extraIncludeDirs
       , defineMacros     = defineMacros
@@ -267,43 +262,6 @@ parseClangArgsConfig = do
       , argsInner        = argsInner
       , argsAfter        = argsAfter
       }
-
-parseCStandard :: Parser CStandard
-parseCStandard = option (eitherReader readCStandard) $ mconcat [
-      long "standard"
-    , metavar "STANDARD"
-    , value defaultCStandard
-    , help $ concat [
-          "C standard (default: "
-        , renderCStandard defaultCStandard
-        , "; supported: "
-        , List.intercalate ", " (map fst cStandards)
-        , ")"
-        ]
-    ]
-  where
-    defaultCStandard :: CStandard
-    defaultCStandard = C17
-
-    renderCStandard :: CStandard -> String
-    renderCStandard = map Char.toLower . show
-
-    cStandards :: [(String, CStandard)]
-    cStandards = [
-        (renderCStandard cStandard, cStandard)
-      | cStandard <- [minBound ..]
-      ]
-
-    readCStandard :: String -> Either String CStandard
-    readCStandard s = case List.lookup s cStandards of
-      Just cStandard -> Right cStandard
-      Nothing -> Left $ "unknown C standard: " ++ s
-
-parseGnu :: Parser Gnu
-parseGnu = flag DisableGnu EnableGnu $ mconcat [
-      long "gnu"
-    , help "Enable GNU extensions"
-    ]
 
 -- TODO: Perhaps we should mimick Clang's @-f@ parameter?
 parseEnableBlocks :: Parser Bool

--- a/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/BindingSpec/StdLib.hs
@@ -61,11 +61,11 @@ parseOpts =
 exec :: GlobalOpts -> Opts -> IO ()
 exec global opts = do
     mSpec <- withTracer global.unsafe $ \tracer -> do
-        clangArgs <-
-          getClangArgs (contramap TraceBoot tracer) opts.clangArgsConfig
-        getStdlibBindingSpec
-          (contramap (TraceBoot . BootBindingSpec) tracer)
-          clangArgs
+      clangArgs <- (.clangArgs) <$>
+        getClangArtefacts (contramap TraceBoot tracer) opts.clangArgsConfig
+      getStdlibBindingSpec
+        (contramap (TraceBoot . BootBindingSpec) tracer)
+        clangArgs
     case mSpec of
       Left _ -> do
         putStrLn $ "An error happened (see above)"

--- a/hs-bindgen/app/HsBindgen/Cli/Info/BuiltinMacros.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/BuiltinMacros.hs
@@ -68,7 +68,8 @@ exec global opts =
     void . withTracer global.unsafe $ \tracer -> do
       let tracerBoot  = contramap TraceBoot tracer
           tracerClang = contramap (TraceFrontend . FrontendClang) tracer
-      clangArgs <- getClangArgs tracerBoot opts.clangArgsConfig
+      clangArgs <-
+        (.clangArgs) <$> getClangArtefacts tracerBoot opts.clangArgsConfig
       -- 1. Get the names of the builtin macros
       names <- getBuiltinMacroNames tracerClang clangArgs
       -- 2. Try to get stringified values for all macros

--- a/hs-bindgen/app/HsBindgen/Cli/Info/Libclang.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/Libclang.hs
@@ -57,8 +57,8 @@ parseOpts = Opts <$> parseClangArgsConfig
 exec :: GlobalOpts -> Opts -> IO ()
 exec global opts = do
     eRes <- withTracer tracerConfigWithoutASTReadError $ \tracer -> do
-      clangArgs <-
-        getClangArgs (contramap TraceBoot tracer) opts.clangArgsConfig
+      clangArgs <- (.clangArgs) <$>
+        getClangArtefacts (contramap TraceBoot tracer) opts.clangArgsConfig
       let hasNoUserOptions = hasNoUserClangOptions opts.clangArgsConfig
           setup = defaultClangSetup clangArgs $
             ClangInputMemory "hs-bindgen-nop.h" ""

--- a/hs-bindgen/app/HsBindgen/Cli/Info/ResolveHeader.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/ResolveHeader.hs
@@ -58,8 +58,8 @@ exec :: GlobalOpts -> Opts -> IO ()
 exec global opts = do
     eErr <- withTracer tracerConfig' $ \tracer -> do
       hashIncludeArgs <- checkInputs tracer opts.inputs
-      clangArgs <-
-        getClangArgs (contramap TraceBoot tracer) opts.clangArgsConfig
+      clangArgs <- (.clangArgs) <$>
+        getClangArtefacts (contramap TraceBoot tracer) opts.clangArgsConfig
       includes <-
         resolveHeaders
           (contramap TraceResolveHeader tracer)

--- a/hs-bindgen/clang-ast-dump/Main.hs
+++ b/hs-bindgen/clang-ast-dump/Main.hs
@@ -77,13 +77,13 @@ clangAstDump opts = do
     putStrLn ""
 
     eitherRes <- withTracer tracerConf $ \tracer -> do
-      cArgs <- either throwIO return $ clangArgsConfigToClangArgs cArgsConfig
-      let tracerResolve = contramap DumpTraceResolveHeader tracer
+      let clangArgs     = clangArgsConfigToClangArgs cArgsConfig
+          tracerResolve = contramap DumpTraceResolveHeader tracer
           tracerClang   = contramap DumpTraceClang         tracer
       src <- maybe (throwIO HeaderNotFound) return . Map.lookup opts.file
-          =<< resolveHeaders tracerResolve cArgs (Set.singleton opts.file)
+          =<< resolveHeaders tracerResolve clangArgs (Set.singleton opts.file)
       let setup :: ClangSetup
-          setup = (defaultClangSetup cArgs $ ClangInputFile src) {
+          setup = (defaultClangSetup clangArgs $ ClangInputFile src) {
                 flags = cOpts
               }
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -121,6 +121,7 @@ library internal
     HsBindgen.Clang
     HsBindgen.Clang.BuiltinIncDir
     HsBindgen.Clang.CompareVersions
+    HsBindgen.Clang.CStandard
     HsBindgen.Clang.ExtraClangArgs
     HsBindgen.Config.ClangArgs
     HsBindgen.Config.FixCandidate

--- a/hs-bindgen/src-internal/HsBindgen/Clang/CStandard.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/CStandard.hs
@@ -1,0 +1,5 @@
+module HsBindgen.Clang.CStandard (
+    module Clang.CStandard
+  ) where
+
+import Clang.CStandard

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -206,8 +206,9 @@ runFrontend tracer config boot = do
 
     handleMacrosPass <- cache "handleMacros" $ do
       afterConstructTranslationUnit <- constructTranslationUnitPass
+      std <- boot.cStandard
       let (afterHandleMacros, msgsHandleMacros) =
-            handleMacros boot.cStandard afterConstructTranslationUnit
+            handleMacros std afterConstructTranslationUnit
       forM_ msgsHandleMacros $ traceWith tracer . FrontendHandleMacros
       pure afterHandleMacros
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC.hs
@@ -26,12 +26,12 @@ import Data.Tuple (swap)
 import Language.C qualified as LanC
 import Language.C.Data.Position qualified as LanC
 
-import Clang.Args (CStandard (..))
 import Clang.Enum.Simple qualified as Clang
 import Clang.HighLevel.Types qualified as Clang
 import Clang.LowLevel.Core qualified as Clang
 import Clang.Paths qualified as Clang
 
+import HsBindgen.Clang.CStandard
 import HsBindgen.Errors
 import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.LanguageC.Error
@@ -209,22 +209,22 @@ prependToken token rest = concat [
 -- | Initial 'ReparseTypeEnv'
 --
 -- This is not quite empty: it contains some "built in" types.
-initReparseEnv :: CStandard -> ReparseEnv
+initReparseEnv :: ClangCStandard -> ReparseEnv
 initReparseEnv standard = Map.fromList (bespokeTypes standard)
 
 -- | \"Primitive\" we expect the reparser to recognize
 --
 -- The language-c parser does not support these explicitly.
-bespokeTypes :: CStandard -> [(CName, C.Type HandleMacros)]
+bespokeTypes :: ClangCStandard -> [(CName, C.Type HandleMacros)]
 bespokeTypes = \case
-   -- Make sure that we really only replace keywords lacking definitions.
-   --
-   -- If we add entries for types to `bespokeTypes` which are not keywords
-   -- (i.e., are not part of the standard), we will pretend to know what these
-   -- types are, but the actual type must come from a header, and we actually do
-   -- not know what that defintion is.
-   C23 -> [("bool", C.TypePrim C.PrimBool)]
-   _otherwise -> []
+    -- Make sure that we really only replace keywords lacking definitions.
+    --
+    -- If we add entries for types to `bespokeTypes` which are not keywords
+    -- (i.e., are not part of the standard), we will pretend to know what these
+    -- types are, but the actual type must come from a header, and we actually
+    -- do not know what that defintion is.
+    ClangCStandard C23 _gnu -> [("bool", C.TypePrim C.PrimBool)]
+    _otherwise -> []
 
 {-------------------------------------------------------------------------------
   Auxiliary language-c: working with the unique name supply

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -13,9 +13,9 @@ import C.Expr.Syntax qualified as CExpr.DSL
 import C.Expr.Typecheck.Expr qualified as CExpr.DSL
 import C.Expr.Typecheck.Type qualified as CExpr.DSL
 
-import Clang.Args (CStandard)
 import Clang.HighLevel.Types
 
+import HsBindgen.Clang.CStandard (ClangCStandard)
 import HsBindgen.Errors
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.AST.Coerce
@@ -37,7 +37,7 @@ import HsBindgen.Language.C qualified as C
 
 -- | Sort and typecheck macros, and reparse declarations
 handleMacros ::
-      CStandard
+      ClangCStandard
   ->  C.TranslationUnit ConstructTranslationUnit
   -> (C.TranslationUnit HandleMacros, [Msg HandleMacros])
 handleMacros standard unit =
@@ -406,14 +406,14 @@ data MacroState = MacroState {
     }
   deriving stock (Generic)
 
-initMacroState :: CStandard -> MacroState
+initMacroState :: ClangCStandard -> MacroState
 initMacroState standard = MacroState{
       errors     = []
     , macroEnv   = Map.empty
     , reparseEnv = LanC.initReparseEnv standard
     }
 
-runM :: CStandard -> M a -> (a, [Msg HandleMacros])
+runM :: ClangCStandard -> M a -> (a, [Msg HandleMacros])
 runM standard (WrapM ma) = (.errors) <$> runState ma (initMacroState standard)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -15,8 +15,6 @@ module HsBindgen.TH (
 
     -- ** Clang arguments
   , ClangArgs.ClangArgsConfig(..)
-  , ClangArgs.CStandard(..)
-  , ClangArgs.Gnu(..)
   , ClangArgs.BuiltinIncDirConfig(..)
   , TH.IncludeDir(..)
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -5,7 +5,6 @@ import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
 import Test.Tasty
 
-import Clang.Args
 import Clang.LowLevel.Core
 import Clang.Version
 
@@ -356,7 +355,8 @@ testCases_bespoke_attributes = [
 test_attributes_asm :: TestCase
 test_attributes_asm =
     defaultTest "attributes/asm"
-      & #onBoot .~ ( #clangArgs % #gnu .~ EnableGnu )
+      & #clangVersion .~ Just (>= (18, 0, 0))
+      & #onBoot       .~ ( #clangArgs % #argsBefore .~ ["-std=gnu2x"] )
 
 test_attributes_attributes :: TestCase
 test_attributes_attributes =

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/ClangArgs.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/ClangArgs.hs
@@ -8,7 +8,6 @@ import Clang.LowLevel.Core
 import HsBindgen.Clang
 import HsBindgen.Clang.ExtraClangArgs (splitArguments)
 import HsBindgen.Config.ClangArgs
-import HsBindgen.Errors
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer
 
@@ -32,10 +31,7 @@ tests testResources = testGroup "Test.HsBindgen.Unit.ClangArgs" [
 testGetTargetTriple :: IO TestResources -> Assertion
 testGetTargetTriple testResources = do
     clangArgsConfig <- getTestDefaultClangArgsConfig testResources []
-    clangArgs <- either (panicIO . show) return $
-      clangArgsConfigToClangArgs clangArgsConfig
-
-    let setup :: ClangSetup
+    let clangArgs = clangArgsConfigToClangArgs clangArgsConfig
         setup = defaultClangSetup clangArgs $
                   ClangInputMemory "hs-bindgen-triple.h" ""
 

--- a/manual/LowLevel/Usage/03-ClangOptions.md
+++ b/manual/LowLevel/Usage/03-ClangOptions.md
@@ -25,7 +25,7 @@ the environment variable `BINDGEN_EXTRA_CLANG_ARGS`.
 Options are passed to Clang in the following order:
 
 1. `--clang-option-before` options
-2. Clang options managed by `hs-bindgen` (C standard, include directories, etc.)
+2. Clang options managed by `hs-bindgen` (include directories, etc.)
 3. `--clang-option` options
 4. `BINDGEN_EXTRA_CLANG_ARGS` options (see below)
 5. `--clang-option-after` options
@@ -37,9 +37,8 @@ Example:
 
 ```console
 hs-bindgen-cli preprocess \
-  --standard c23 \
   -I include \
-  --clang-option="-idirafter/opt/acme-0.1.0/include" \
+  --clang-option="-std=gnu23" \
   --module Foo \
   --hs-output-dir src \
   foo.h

--- a/manual/LowLevel/Usage/04-Includes.md
+++ b/manual/LowLevel/Usage/04-Includes.md
@@ -204,8 +204,8 @@ of the bracket C include search path.
 
 ```console
 hs-bindgen-cli preprocess \
-  --standard c23 \
   -I include \
+  --clang-option="-std=gnu23" \
   --clang-option="-idirafter/opt/acme-0.1.0/include" \
   --module Foo \
   --hs-output-dir src \


### PR DESCRIPTION
We decided to always get the C standard from `libclang`.  Users may specify a Clang standard via Clang arguments.

Clang standards specify *both* the C standard and use of GNU extensions. New type `ClangCStandard` is the product of `CStandard` and `Gnu`. While these types should generally be specified together, but it is convenient to case match them separately.  See the `libclang` commit for details.

This commit removes `cStandard` and `gnu` from `ClangArgsConfig`. `Boot` is refactored to get the C standard using `libclang`.  Various refactoring is done to work with these changes.

The `--standard` and `--gnu` options are removed from the CLI.

The C standard types are removed from the `TH` interface.  New module `HsBindgen.Clang.CStandard` re-exports `Clang.CStandard`, so we can make the module public or re-export types in the `TH` interface if desired, but it is no longer configurable.

The `c-expr-runtime` test is changed to use C17, since the Clang argument for it is not dependent on the LLVM/Clang version.

The `hs-bindgen` tests use `c23` or `c2x` depending on the LLVM/Clang version.  This will soon be refactored!