### PR TITLE
Update libclang script

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,7 @@
       "original": {
         "owner": "well-typed",
         "repo": "libclang",
+        "rev": "b8305bd9c3e8e8f63d6f415553388be7f233ef45",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     libclang-bindings-src = {
-      url = "github:well-typed/libclang";
+      url = "github:well-typed/libclang?rev=b8305bd9c3e8e8f63d6f415553388be7f233ef45";
       flake = false;
     };
   };

--- a/scripts/update-libclang.sh
+++ b/scripts/update-libclang.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+nix_flakes_equal_revision() {
+    grep "github:well-typed/libclang" "${NIX_FLAKE}" |
+        grep "${REV_OLD}" \
+            >/dev/null 2>&1
+}
+
+nix_flakes_enabled() {
+    nix config show |
+        grep experimental-features |
+        grep flakes \
+            >/dev/null 2>&1
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+CABAL_PROJECT_BASE="${PROJECT_ROOT}/cabal.project.base"
+NIX_FLAKE="${PROJECT_ROOT}/flake.nix"
+
+REV_OLD=$(grep -C 2 'github.com/well-typed/libclang' "${CABAL_PROJECT_BASE}" |
+    grep 'tag:' |
+    awk '{print $NF}')
+
+if [ -z "$REV_OLD" ]; then
+    echo "Error: Could not find current libclang tag in $CABAL_PROJECT_BASE"
+    exit 1
+fi
+
+if nix_flakes_equal_revision; then
+    echo "Old libclang-bindings revision: ${REV_OLD}"
+else
+    echo "Error: The Cabal and Nix 'libclang-bindings' revision have diverged"
+    exit 1
+fi
+
+REV_NEW=$(git ls-remote https://github.com/well-typed/libclang HEAD | cut -f 1)
+echo "New libclang-bindings revision: ${REV_NEW}"
+
+sed -i 's/'"${REV_OLD}"'/'"${REV_NEW}"'/' "$CABAL_PROJECT_BASE"
+sed -i 's/'"${REV_OLD}"'/'"${REV_NEW}"'/' "$NIX_FLAKE"
+
+if command -v nix >/dev/null 2>&1; then
+    if nix_flakes_enabled; then
+        nix flake update libclang-bindings-src
+    else
+        echo "Warning: Nix Flakes are not enabled"
+        echo "         We advise to pull along the Nix Flake lock file"
+    fi
+else
+    echo "Warning: The command 'nix' is not installed"
+    echo "         We advise to pull along the Nix Flake lock file"
+fi


### PR DESCRIPTION
The script
- Checks if the Cabal and Nix revisions of the libclang bindings are equal.
- If yes, it goes ahead and updates the revisions to the latest ones on the git repository (HEAD).
- If Nix is installed and Flakes are enabled, it updates the lock of `libclang-bindings-src`. If not, it warns the user that this should be done.