### PR TITLE
Do not export UniqueSymbol constructor

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/UniqueSymbol.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/UniqueSymbol.hs
@@ -3,7 +3,7 @@
 -- Intended for unqualified import.
 module HsBindgen.Backend.UniqueSymbol (
     -- * Generating unique names
-    UniqueSymbol(..)
+    UniqueSymbol(unique, source)
   , uniqueCDeclName
   , globallyUnique
   , locallyUnique


### PR DESCRIPTION
Force usage of `globallyUnique` or `locallyUnique`.

I have also audited that use-sites of these functions all have different arguments; that is, we do not generate euqal unique symbols.

Closes #1398.