### PR TITLE
Delete `HaskellId` type family (just use `Id`)

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -392,8 +392,8 @@ convertInlineContent = \case
 
   CDoc.InlineRefCommand (CommentRef c mHsIdent) -> [
       case mHsIdent of
-        Just hs -> HsDoc.Identifier hs.text
-        Nothing -> HsDoc.Monospace [HsDoc.TextContent c]
+        Just namePair -> HsDoc.Identifier namePair.hsName.text
+        Nothing       -> HsDoc.Monospace [HsDoc.TextContent c]
     ]
 
   -- HTML is not currently supported

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -1032,8 +1032,6 @@ typedefFunPtrDecs opts haddockConfig origInfo n (args, res) origNames origSpec =
             }
         }
 
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1433>
-    -- We should use @typedefInfo.declId@ instead of @typedefName.text@.
     auxComment :: Clang.Comment C.CommentRef
     auxComment = Clang.Comment [
           Clang.Paragraph [
@@ -1041,7 +1039,7 @@ typedefFunPtrDecs opts haddockConfig origInfo n (args, res) origNames origSpec =
             , Clang.InlineRefCommand $
                 C.CommentRef
                   origInfo.declId.cName.name.text
-                  (Just origInfo.declId.hsName)
+                  (Just origInfo.declId)
             ]
         ]
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -1,7 +1,6 @@
 module HsBindgen.Frontend.AST.Coerce (
     CoercePass(..)
   , CoercePassId(..)
-  , CoercePassHaskellId(..)
   , CoercePassMacroBody(..)
   ) where
 
@@ -24,14 +23,6 @@ class CoercePassId (p :: Pass) (p' :: Pass) where
        (Id p ~ Id p')
     => Proxy '(p, p') -> Id p -> Id p'
   coercePassId _ = id
-
-class CoercePassHaskellId (p :: Pass) (p' :: Pass) where
-  coercePassHaskellId :: Proxy '(p, p') -> HaskellId p -> HaskellId p'
-
-  default coercePassHaskellId ::
-       (HaskellId p ~ HaskellId p')
-    => Proxy '(p, p') -> HaskellId p -> HaskellId p'
-  coercePassHaskellId _ = id
 
 class CoercePassMacroBody (p :: Pass) (p' :: Pass) where
   coercePassMacroBody :: Proxy '(p, p') -> MacroBody p -> MacroBody p'
@@ -59,13 +50,13 @@ instance (
       }
 
 instance (
-      CoercePassHaskellId p p'
+      CoercePassId p p'
     ) => CoercePass CommentRef p p' where
   coercePass (CommentRef c hs) =
-      CommentRef c (coercePassHaskellId (Proxy @'(p, p')) <$> hs)
+      CommentRef c (coercePassId (Proxy @'(p, p')) <$> hs)
 
 instance (
-      CoercePassHaskellId p p'
+      CoercePassId p p'
     ) => CoercePass CDoc.Comment (CommentRef p) (CommentRef p') where
   coercePass comment = fmap coercePass comment
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
@@ -92,7 +92,6 @@ import HsBindgen.Frontend.Naming qualified as C
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass qualified as ResolveBindingSpecs
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
-import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -263,7 +262,7 @@ data Function = Function {
 --
 -- The Haskell identifier might not be known (if the reference is to a
 -- declaration not in the current translation unit).
-data CommentRef = CommentRef Text (Maybe Hs.Identifier)
+data CommentRef = CommentRef Text (Maybe C.DeclIdPair)
   deriving stock (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -335,9 +335,9 @@ newtype Comment p =
 --
 -- Doxygen references are just strings; in particular, they do not distinguish
 -- between namespaces (i.e., @struct foo@ is simply referred to as @foo@). In
--- 'MangleNames' we will /search/ for a matching name and set the @HaskellId@
+-- 'MangleNames' we will /search/ for a matching name and set the 'Id'
 -- accordingly, so that we can generate an approprate reference in the Haddocks.
-data CommentRef p = CommentRef Text (Maybe (HaskellId p))
+data CommentRef p = CommentRef Text (Maybe (Id p))
 
 {-------------------------------------------------------------------------------
   Macros
@@ -523,7 +523,6 @@ class ( IsPass p
       , Show (ArgumentName p)
       , Show (ExtBinding   p)
       , Show (FieldName    p)
-      , Show (HaskellId    p)
       , Show (Id           p)
       , Show (MacroBody    p)
 
@@ -552,7 +551,6 @@ class ( IsPass p
 
       , Eq (ArgumentName p)
       , Eq (ExtBinding   p)
-      , Eq (HaskellId    p)
       , Eq (MacroBody    p)
 
       , Eq (Ann "CheckedMacroType" p)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -48,15 +48,6 @@ class IsPass (p :: Pass) where
   -- | Names of arguments (functions)
   type ArgumentName p :: Star
 
-  -- | Haskell identifier given to a declaration
-  --
-  -- This does not get instantiated until the 'MangleNames' pass.
-  --
-  -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1267>
-  -- This is part of a larger refactoring, and its usage will still change.
-  type HaskellId p :: Star
-  type HaskellId p = ()
-
   -- | Macro body
   --
   -- Parsing macros is non-trivial, and requires knowledge of other macros in

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -5,7 +5,6 @@ module HsBindgen.Frontend.Pass.AssignAnonIds.IsPass (
 
 import Text.SimplePrettyPrint qualified as PP
 
-import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Internal
 import HsBindgen.Frontend.Naming qualified as C
 import HsBindgen.Frontend.Pass
@@ -60,10 +59,3 @@ instance IsTrace Level ImmediateAssignAnonIdsMsg where
 
   getSource  = const HsBindgen
   getTraceId = const "assign-anon-ids"
-
-{-------------------------------------------------------------------------------
-  CoercePass
--------------------------------------------------------------------------------}
-
-instance CoercePassHaskellId Parse AssignAnonIds where
-  coercePassHaskellId _ = id

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -73,6 +73,5 @@ instance IsTrace Level ConstructTranslationUnitMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassHaskellId AssignAnonIds ConstructTranslationUnit
 instance CoercePassMacroBody AssignAnonIds ConstructTranslationUnit
 instance CoercePassId        AssignAnonIds ConstructTranslationUnit

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -37,5 +37,4 @@ instance IsPass HandleMacros where
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassId        ConstructTranslationUnit HandleMacros
-instance CoercePassHaskellId ConstructTranslationUnit HandleMacros
+instance CoercePassId ConstructTranslationUnit HandleMacros

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -41,7 +41,6 @@ instance IsPass MangleNames where
   type Id           MangleNames = C.DeclIdPair
   type FieldName    MangleNames = C.NamePair
   type ArgumentName MangleNames = Maybe C.NamePair
-  type HaskellId    MangleNames = Hs.Identifier
   type MacroBody    MangleNames = C.CheckedMacro MangleNames
   type ExtBinding   MangleNames = ResolvedExtBinding
   type Ann ix       MangleNames = AnnMangleNames ix

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -138,5 +138,4 @@ instance IsTrace Level ResolveBindingSpecsMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassHaskellId HandleMacros ResolveBindingSpecs
-instance CoercePassId        HandleMacros ResolveBindingSpecs
+instance CoercePassId HandleMacros ResolveBindingSpecs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -227,8 +227,7 @@ instance IsTrace Level SelectMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassHaskellId ResolveBindingSpecs Select
-instance CoercePassId        ResolveBindingSpecs Select
+instance CoercePassId ResolveBindingSpecs Select
 
 instance CoercePassMacroBody ResolveBindingSpecs Select where
   coercePassMacroBody _ = coercePass


### PR DESCRIPTION
This was _only_ used for `Comment`, where we can simply use `Id` instead. Indeed, using `Id` is better: it means that we can use a `DeclId` if we have one.

Closes #1433