### PR TITLE
Replace `FieldName`/`ArgumentName` by `ScopedName`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -53,8 +53,8 @@ mkHaddocksFieldInfo config declInfo FieldInfo{..} =
     fst $ mkHaddocksWithArgs config declInfo Args{
         isField     = True
       , loc         = fieldLoc
-      , nameC       = fieldName.nameC.text
-      , nameHsIdent = fieldName.nameHsIdent
+      , nameC       = fieldName.cName.text
+      , nameHsIdent = fieldName.hsName
       , comment     = fieldComment
       , params      = []
       }

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -158,7 +158,7 @@ functionDecs safety opts haddockConfig moduleName info origCFun _spec =
     foreignImportParams :: [Hs.FunctionParameter]
     foreignImportParams = [
            Hs.FunctionParameter
-           { functionParameterName    = fmap C.nameHs mbName
+           { functionParameterName    = fmap (Hs.unsafeHsIdHsName . (.hsName)) mbName
            , functionParameterType    = Type.inContext Type.FunArg (toPrimitiveType (toIsPrimitiveType ty))
            , functionParameterComment = Nothing
            }
@@ -224,7 +224,7 @@ functionDecs safety opts haddockConfig moduleName info origCFun _spec =
       let params :: [Hs.FunctionParameter]
           params = [
                Hs.FunctionParameter
-               { functionParameterName    = fmap C.nameHs mbName
+               { functionParameterName    = fmap (Hs.unsafeHsIdHsName . (.hsName)) mbName
                , functionParameterType    = Type.inContext Type.FunArg (toOrigType (toIsPrimitiveType ty))
                , functionParameterComment = Nothing
                }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -91,11 +91,12 @@ instance (
 
 instance (
       CoercePass Comment p p'
-    , FieldName p ~ FieldName p'
+    , ScopedName p ~ ScopedName p'
     ) => CoercePass FieldInfo p p' where
-  coercePass info = FieldInfo{ fieldComment = fmap coercePass fieldComment
-                             , ..
-                             }
+  coercePass info = FieldInfo{
+        fieldComment = fmap coercePass fieldComment
+      , ..
+      }
     where
       FieldInfo{fieldLoc, fieldName, fieldComment} = info
 
@@ -132,7 +133,7 @@ instance (
 instance (
       CoercePass Type p p'
     , CoercePass Comment p p'
-    , FieldName p ~ FieldName p'
+    , ScopedName p ~ ScopedName p'
     , Ann "StructField" p ~ Ann "StructField" p'
     ) => CoercePass StructField p p' where
   coercePass StructField{..} = StructField {
@@ -156,7 +157,7 @@ instance (
 
 instance (
       CoercePass Type p p'
-    , FieldName p ~ FieldName p'
+    , ScopedName p ~ ScopedName p'
     , CoercePass Comment p p'
     , Ann "UnionField" p ~ Ann "UnionField" p'
     ) => CoercePass UnionField p p' where
@@ -189,7 +190,7 @@ instance (
       }
 
 instance (
-      FieldName p ~ FieldName p'
+      ScopedName p ~ ScopedName p'
     , CoercePass CDoc.Comment (CommentRef p) (CommentRef p')
     ) => CoercePass EnumConstant p p' where
   coercePass EnumConstant{..} = EnumConstant {
@@ -199,7 +200,7 @@ instance (
 
 instance (
       CoercePass Type p p'
-    , ArgumentName p ~ ArgumentName p'
+    , ScopedName p ~ ScopedName p'
     , Ann "Function" p ~ Ann "Function" p'
     ) => CoercePass Function p p' where
   coercePass Function{..} = Function {
@@ -226,7 +227,7 @@ instance (
 
 instance (
       CoercePassId p p'
-    , ArgumentName p ~ ArgumentName p'
+    , ScopedName p ~ ScopedName p'
     , ExtBinding p ~ ExtBinding p'
     ) => CoercePass Type p p' where
   coercePass = \case

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -16,7 +16,7 @@ import HsBindgen.Imports
 
 data Usage p =
     UsedInTypedef ValOrRef
-  | UsedInField ValOrRef (FieldName p)
+  | UsedInField ValOrRef (ScopedName p)
   | UsedInFunction ValOrRef
   | UsedInVar ValOrRef -- ^ Global or constant
 
@@ -68,7 +68,7 @@ depsOfDecl (DeclGlobal ty) =
 
 -- | Dependencies of struct or union field
 depsOfField :: forall a p.
-     (a p -> FieldName p)
+     (a p -> ScopedName p)
   -> (a p -> Type p)
   -> a p -> [(Usage p, Id p)]
 depsOfField getName getType field =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/External.hs
@@ -73,11 +73,6 @@ module HsBindgen.Frontend.AST.External (
   , C.AnonId(..)
   , C.PrelimDeclId(..)
   , C.DeclId(..)
-  , Int.NamePair(..)
-  , Int.nameHs
-  , Int.unsafeNameHsWith
-  , Int.RecordNames(..)
-  , Int.NewtypeNames(..)
   ) where
 
 import Prelude hiding (Enum)
@@ -89,6 +84,7 @@ import Clang.Paths
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.AST.Internal qualified as Int
 import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Pass.MangleNames.IsPass qualified as MangleNames
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass qualified as ResolveBindingSpecs
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
@@ -128,7 +124,7 @@ data DeclInfo = DeclInfo {
 
 data FieldInfo = FieldInfo {
       fieldLoc     :: SingleLoc
-    , fieldName    :: Int.NamePair
+    , fieldName    :: C.ScopedNamePair
     , fieldComment :: Maybe (CDoc.Comment CommentRef)
     }
   deriving stock (Show, Eq, Generic)
@@ -177,7 +173,7 @@ data DeclSpec = DeclSpec {
 
 -- | Definition of a struct
 data Struct = Struct {
-      structNames     :: Int.RecordNames
+      structNames     :: MangleNames.RecordNames
     , structSizeof    :: Int
     , structAlignment :: Int
     , structFields    :: [StructField]
@@ -201,7 +197,7 @@ data StructField = StructField {
 
 -- | Definition of an union
 data Union = Union {
-      unionNames     :: Int.NewtypeNames
+      unionNames     :: MangleNames.NewtypeNames
     , unionSizeof    :: Int
     , unionAlignment :: Int
     , unionFields    :: [UnionField]
@@ -219,7 +215,7 @@ data UnionField = UnionField {
 -------------------------------------------------------------------------------}
 
 data Enum = Enum {
-      enumNames     :: Int.NewtypeNames
+      enumNames     :: MangleNames.NewtypeNames
     , enumType      :: Type
     , enumSizeof    :: Int
     , enumAlignment :: Int
@@ -238,7 +234,7 @@ data EnumConstant = EnumConstant {
 -------------------------------------------------------------------------------}
 
 data Typedef = Typedef {
-      typedefNames :: Int.NewtypeNames
+      typedefNames :: MangleNames.NewtypeNames
     , typedefType  :: Type
     }
   deriving stock (Show, Eq, Generic)
@@ -248,7 +244,7 @@ data Typedef = Typedef {
 -------------------------------------------------------------------------------}
 
 data Function = Function {
-      functionArgs    :: [(Maybe Int.NamePair, Type)]
+      functionArgs    :: [(Maybe C.ScopedNamePair, Type)]
     , functionAttrs   :: Int.FunctionAttributes
     , functionRes     :: Type
     }
@@ -275,7 +271,7 @@ data CheckedMacro =
   deriving stock (Show, Eq, Generic)
 
 data CheckedMacroType = CheckedMacroType {
-      macroTypeNames   :: Int.NewtypeNames
+      macroTypeNames   :: MangleNames.NewtypeNames
     , macroType        :: Type
     }
   deriving stock (Show, Eq, Generic)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
@@ -24,6 +24,9 @@ module HsBindgen.Frontend.Naming (
     -- * DeclIdPair
   , DeclIdPair(..)
 
+    -- * ScopedNamePair
+  , ScopedNamePair(..)
+
     -- * Located
   , Located(..)
   ) where
@@ -154,8 +157,6 @@ checkIsBuiltin curr = do
 
 {-------------------------------------------------------------------------------
   DeclId
-
-  TODO: .Naming module should go.
 -------------------------------------------------------------------------------}
 
 -- | Identifier for a declaration that appears in the C source
@@ -213,6 +214,30 @@ data DeclIdPair = DeclIdPair{
     , hsName :: Hs.Identifier
     }
   deriving stock (Show, Eq, Ord)
+
+{-------------------------------------------------------------------------------
+  ScopedNamePair
+-------------------------------------------------------------------------------}
+
+-- | Pair of a (scoped) C name and the corresponding Haskell name
+--
+-- Invariant: the 'Hs.Identifier' must satisfy the rules for legal Haskell
+-- names, for its intended use (constructor, variable, ..).
+data ScopedNamePair = ScopedNamePair {
+      cName  :: C.ScopedName
+    , hsName :: Hs.Identifier
+    }
+  deriving stock (Show, Eq, Ord, Generic)
+
+-- -- | Extract namespaced Haskell name
+-- --
+-- -- The invariant on 'NamePair' justifies this otherwise unsafe operation.
+-- nameHs :: NamePair -> Hs.Name ns
+-- nameHs = Hs.unsafeHsIdHsName . nameHsIdent
+
+-- -- | Extract and amend namespaced Haskell name
+-- unsafeNameHsWith :: (Hs.Identifier -> Hs.Identifier) -> NamePair -> Hs.Name ns
+-- unsafeNameHsWith f = Hs.unsafeHsIdHsName .  f . nameHsIdent
 
 {-------------------------------------------------------------------------------
   Located

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -34,19 +34,20 @@ class IsPass (p :: Pass) where
   --
   -- This takes various forms during processing:
   --
-  -- 1. After parsing, this is 'DeclId': anonymous structures are assigned an ID
-  --    based on their source location, for everything else we use the C name.
-  -- 2. After 'NameAnon', /everything/ has a C name: we have assigned names to
-  --    anonymous structures.
-  -- 3. After 'NameMangling', this becomes a pair of the C name and the
+  -- 1. After parsing, this is 'PrelimDeclId': anonymous structures are assigned
+  --    an ID based on source location, for everything else we use the C name.
+  -- 2. After 'AssignAnonIds', this is 'DeclId': /everything/ has a name,
+  --    because we have assigned names to anonymous structures.
+  -- 3. After 'MangleNames', this becomes a pair of the C name and the
   --    corresponding Haskell name.
   type Id p :: Star
 
-  -- | Names of fields (structs and unions)
-  type FieldName p :: Star
-
-  -- | Names of arguments (functions)
-  type ArgumentName p :: Star
+  -- | Scoped names
+  --
+  -- This is the name of struct fields, function arguments, etc.; names that
+  -- live in a local scope. This is initially 'C.ScopedName', and becomes
+  -- 'ScopedNamePair' after 'MangleNames'.
+  type ScopedName p :: Star
 
   -- | Macro body
   --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -18,6 +18,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Imports
+import HsBindgen.Language.C qualified as C
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -265,14 +266,14 @@ instance UpdateUseSites C.Function where
         <*> updateUseSites functionRes
     where
       reconstruct ::
-           [(ArgumentName AssignAnonIds, C.Type AssignAnonIds)]
+           [(Maybe (C.ScopedName), C.Type AssignAnonIds)]
         -> C.Type AssignAnonIds
         -> C.Function AssignAnonIds
       reconstruct functionArgs' functionRes' = C.Function {
-          functionArgs = functionArgs'
-        , functionRes  = functionRes'
-        , ..
-        }
+            functionArgs = functionArgs'
+          , functionRes  = functionRes'
+          , ..
+          }
 
 instance UpdateUseSites C.Type where
   updateUseSites = go

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -25,13 +25,12 @@ type family AnnAssignAnonIds ix where
   AnnAssignAnonIds _             = NoAnn
 
 instance IsPass AssignAnonIds where
-  type Id           AssignAnonIds = C.DeclId
-  type FieldName    AssignAnonIds = C.ScopedName
-  type ArgumentName AssignAnonIds = Maybe C.ScopedName
-  type MacroBody    AssignAnonIds = UnparsedMacro
-  type ExtBinding   AssignAnonIds = Void
-  type Ann ix       AssignAnonIds = AnnAssignAnonIds ix
-  type Msg          AssignAnonIds = ImmediateAssignAnonIdsMsg
+  type Id         AssignAnonIds = C.DeclId
+  type ScopedName AssignAnonIds = C.ScopedName
+  type MacroBody  AssignAnonIds = UnparsedMacro
+  type ExtBinding AssignAnonIds = Void
+  type Ann ix     AssignAnonIds = AnnAssignAnonIds ix
+  type Msg        AssignAnonIds = ImmediateAssignAnonIdsMsg
 
 {-------------------------------------------------------------------------------
   Trace messages

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -35,13 +35,12 @@ type family AnnConstructTranslationUnit (ix :: Symbol) :: Star where
   AnnConstructTranslationUnit _                 = NoAnn
 
 instance IsPass ConstructTranslationUnit where
-  type Id           ConstructTranslationUnit = C.DeclId
-  type FieldName    ConstructTranslationUnit = C.ScopedName
-  type ArgumentName ConstructTranslationUnit = Maybe C.ScopedName
-  type MacroBody    ConstructTranslationUnit = UnparsedMacro
-  type ExtBinding   ConstructTranslationUnit = Void
-  type Ann ix       ConstructTranslationUnit = AnnConstructTranslationUnit ix
-  type Msg          ConstructTranslationUnit = ConstructTranslationUnitMsg
+  type Id         ConstructTranslationUnit = C.DeclId
+  type ScopedName ConstructTranslationUnit = C.ScopedName
+  type MacroBody  ConstructTranslationUnit = UnparsedMacro
+  type ExtBinding ConstructTranslationUnit = Void
+  type Ann ix     ConstructTranslationUnit = AnnConstructTranslationUnit ix
+  type Msg        ConstructTranslationUnit = ConstructTranslationUnitMsg
 
 {-------------------------------------------------------------------------------
   Information about the declarations

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/IsPass.hs
@@ -25,13 +25,12 @@ type family AnnHandleMacros (ix :: Symbol) :: Star where
   AnnHandleMacros _                 = NoAnn
 
 instance IsPass HandleMacros where
-  type Id           HandleMacros = C.DeclId
-  type FieldName    HandleMacros = C.ScopedName
-  type ArgumentName HandleMacros = Maybe C.ScopedName
-  type MacroBody    HandleMacros = CheckedMacro HandleMacros
-  type ExtBinding   HandleMacros = Void
-  type Ann ix       HandleMacros = AnnHandleMacros ix
-  type Msg          HandleMacros = HandleMacrosReparseMsg
+  type Id         HandleMacros = C.DeclId
+  type ScopedName HandleMacros = C.ScopedName
+  type MacroBody  HandleMacros = CheckedMacro HandleMacros
+  type ExtBinding HandleMacros = Void
+  type Ann ix     HandleMacros = AnnHandleMacros ix
+  type Msg        HandleMacros = HandleMacrosReparseMsg
 
 {-------------------------------------------------------------------------------
   CoercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -41,13 +41,12 @@ type family AnnParse (ix :: Symbol) :: Star where
   AnnParse _             = NoAnn
 
 instance IsPass Parse where
-  type Id           Parse = C.PrelimDeclId
-  type FieldName    Parse = C.ScopedName
-  type ArgumentName Parse = Maybe C.ScopedName
-  type MacroBody    Parse = UnparsedMacro
-  type ExtBinding   Parse = Void
-  type Ann ix       Parse = AnnParse ix
-  type Msg          Parse = ImmediateParseMsg
+  type Id         Parse = C.PrelimDeclId
+  type ScopedName Parse = C.ScopedName
+  type MacroBody  Parse = UnparsedMacro
+  type ExtBinding Parse = Void
+  type Ann ix     Parse = AnnParse ix
+  type Msg        Parse = ImmediateParseMsg
 
 {-------------------------------------------------------------------------------
   Macros

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -33,6 +33,7 @@ import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Imports
+import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Monad (mapMaybeM)
 
@@ -356,7 +357,7 @@ instance Resolve C.Function where
       <*> resolve ctx functionRes
     where
       reconstruct ::
-           [(ArgumentName ResolveBindingSpecs, C.Type ResolveBindingSpecs)]
+           [(Maybe C.ScopedName, C.Type ResolveBindingSpecs)]
         -> C.Type ResolveBindingSpecs
         -> C.Function ResolveBindingSpecs
       reconstruct functionArgs' functionRes' = C.Function {

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -42,13 +42,12 @@ type family AnnResolveBindingSpecs ix where
   AnnResolveBindingSpecs _                 = NoAnn
 
 instance IsPass ResolveBindingSpecs where
-  type Id           ResolveBindingSpecs = C.DeclId
-  type FieldName    ResolveBindingSpecs = C.ScopedName
-  type ArgumentName ResolveBindingSpecs = Maybe C.ScopedName
-  type MacroBody    ResolveBindingSpecs = CheckedMacro ResolveBindingSpecs
-  type ExtBinding   ResolveBindingSpecs = ResolvedExtBinding
-  type Ann ix       ResolveBindingSpecs = AnnResolveBindingSpecs ix
-  type Msg          ResolveBindingSpecs = ResolveBindingSpecsMsg
+  type Id         ResolveBindingSpecs = C.DeclId
+  type ScopedName ResolveBindingSpecs = C.ScopedName
+  type MacroBody  ResolveBindingSpecs = CheckedMacro ResolveBindingSpecs
+  type ExtBinding ResolveBindingSpecs = ResolvedExtBinding
+  type Ann ix     ResolveBindingSpecs = AnnResolveBindingSpecs ix
+  type Msg        ResolveBindingSpecs = ResolveBindingSpecsMsg
 
 data ResolvedExtBinding = ResolvedExtBinding{
       -- | C declaration for which we are using this binding

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -46,14 +46,13 @@ type family AnnSelect ix where
   AnnSelect _                 = NoAnn
 
 instance IsPass Select where
-  type Id           Select = C.DeclId
-  type FieldName    Select = C.ScopedName
-  type ArgumentName Select = Maybe C.ScopedName
-  type MacroBody    Select = CheckedMacro Select
-  type ExtBinding   Select = ResolvedExtBinding
-  type Ann ix       Select = AnnSelect ix
-  type Config       Select = SelectConfig
-  type Msg          Select = SelectMsg
+  type Id         Select = C.DeclId
+  type ScopedName Select = C.ScopedName
+  type MacroBody  Select = CheckedMacro Select
+  type ExtBinding Select = ResolvedExtBinding
+  type Ann ix     Select = AnnSelect ix
+  type Config     Select = SelectConfig
+  type Msg        Select = SelectMsg
 
 {-------------------------------------------------------------------------------
   Configuration


### PR DESCRIPTION
This finally completes the identifier simplification refactoring.

Closes #1267