### PR TITLE
Identify FLAMs in the parser

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -127,6 +127,7 @@ instance (
         structSizeof
       , structAlignment
       , structFields = map coercePass structFields
+      , structFlam = fmap coercePass structFlam
       , structAnn
       }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -10,8 +10,10 @@ import HsBindgen.Frontend.Pass
 -------------------------------------------------------------------------------}
 
 depsOfDecl :: C.DeclKind p -> [(ValOrRef, Id p)]
-depsOfDecl (C.DeclStruct C.Struct{..}) =
-    concatMap (depsOfField C.structFieldType) structFields
+depsOfDecl (C.DeclStruct C.Struct{..}) = concat [
+      concatMap (depsOfField C.structFieldType) structFields
+    , concatMap (depsOfField C.structFieldType) structFlam
+    ]
 depsOfDecl (C.DeclUnion C.Union{..}) =
     concatMap (depsOfField C.unionFieldType) unionFields
 depsOfDecl (C.DeclEnum _) =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Internal.hs
@@ -161,6 +161,7 @@ data Struct p = Struct {
       structSizeof    :: Int
     , structAlignment :: Int
     , structFields    :: [StructField p]
+    , structFlam      :: Maybe (StructField p) -- ^ FLAM element type, if any
     , structAnn       :: Ann "Struct" p
     }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
@@ -123,8 +123,10 @@ analyseDecl decl =
       C.DeclGlobal   _ -> []
 
 analyseStruct :: C.DeclInfo Parse -> C.Struct Parse -> [(C.AnonId, Context)]
-analyseStruct declInfo struct =
-    concatMap aux struct.structFields
+analyseStruct declInfo struct = concat [
+      concatMap aux struct.structFields
+    , concatMap aux struct.structFlam
+    ]
   where
     aux :: C.StructField Parse -> [(C.AnonId, Context)]
     aux f = analyseType (Field declInfo f.structFieldInfo) f.structFieldType

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -87,12 +87,21 @@ processStruct ::
   -> C.Struct ConstructTranslationUnit
   -> M (C.Decl HandleMacros)
 processStruct info C.Struct{..} =
-    mkDecl <$> mapM processStructField structFields
+    mkDecl
+      <$> mapM processStructField structFields
+      <*> mapM processStructField structFlam
   where
-    mkDecl :: [C.StructField HandleMacros] -> C.Decl HandleMacros
-    mkDecl fields = C.Decl{
+    mkDecl ::
+         [C.StructField HandleMacros]
+      -> Maybe (C.StructField HandleMacros)
+      -> C.Decl HandleMacros
+    mkDecl fields flam = C.Decl{
           declInfo = info
-        , declKind = C.DeclStruct C.Struct{structFields = fields, ..}
+        , declKind = C.DeclStruct C.Struct{
+                         structFields = fields
+                       , structFlam   = flam
+                       , ..
+                       }
         , declAnn  = NoAnn
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -288,15 +288,20 @@ instance Resolve C.DeclKind where
       C.DeclGlobal ty        -> C.DeclGlobal   <$> resolve ctx ty
 
 instance Resolve C.Struct where
-  resolve ctx C.Struct{..} = reconstruct <$> mapM (resolve ctx) structFields
+  resolve ctx C.Struct{..} =
+      reconstruct
+        <$> mapM (resolve ctx) structFields
+        <*> mapM (resolve ctx) structFlam
     where
       reconstruct ::
            [C.StructField ResolveBindingSpecs]
+        -> Maybe (C.StructField ResolveBindingSpecs)
         -> C.Struct ResolveBindingSpecs
-      reconstruct structFields' = C.Struct {
-          structFields = structFields'
-        , ..
-        }
+      reconstruct structFields' structFlam' = C.Struct {
+            structFields = structFields'
+          , structFlam   = structFlam'
+          , ..
+          }
 
 instance Resolve C.StructField where
   resolve ctx C.StructField{..} = reconstruct <$> resolve ctx structFieldType


### PR DESCRIPTION
We were previously doing this at the very end (in `Finalize`); moving this earlier to facilitate the next PR (which will remove `Finalize` altogether, since we are dropping the external AST).

This also makes `MangleNames` a bit consistent (code style wise) with the other passes.