### PR TITLE
Final (for now) cleanup of `Frontend.Naming`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Artefact.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Artefact.hs
@@ -27,7 +27,7 @@ import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
 import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Decl qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.ProcessIncludes qualified as ProcessIncludes
 import HsBindgen.Frontend.RootHeader (HashIncludeArg)
@@ -50,8 +50,8 @@ data Artefact (a :: Star) where
   DeclIndex           :: Artefact DeclIndex.DeclIndex
   UseDeclGraph        :: Artefact UseDeclGraph.UseDeclGraph
   DeclUseGraph        :: Artefact DeclUseGraph.DeclUseGraph
-  OmitTypes           :: Artefact [(C.DeclId, SourcePath)]
-  SquashedTypes       :: Artefact [(C.DeclId, (SourcePath, Hs.Identifier))]
+  OmitTypes           :: Artefact [(DeclId, SourcePath)]
+  SquashedTypes       :: Artefact [(DeclId, (SourcePath, Hs.Identifier))]
   ReifiedC            :: Artefact [C.Decl Final]
   Dependencies        :: Artefact [SourcePath]
   -- * Backend

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Haddock/Translation.hs
@@ -22,7 +22,7 @@ import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Errors (panicPure)
 import HsBindgen.Frontend.AST.Decl qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
@@ -39,7 +39,7 @@ mkHaddocks config declInfo name =
       fst $ mkHaddocksWithArgs config declInfo Args{
           isField     = False
         , loc         = declInfo.declLoc
-        , nameC       = C.renderDeclId declInfo.declId.cName
+        , nameC       = renderDeclId declInfo.declId.cName
         , nameHsIdent = declInfo.declId.hsName
         , comment     = declInfo.declComment
         , params      = []
@@ -72,7 +72,7 @@ mkHaddocksDecorateParams config declInfo name params =
     let (mbc, xs) = mkHaddocksWithArgs config declInfo Args{
         isField     = False
       , loc         = declInfo.declLoc
-      , nameC       = C.renderDeclId declInfo.declId.cName
+      , nameC       = renderDeclId declInfo.declId.cName
       , nameHsIdent = declInfo.declId.hsName
       , comment     = declInfo.declComment
       , params

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -45,7 +45,7 @@ import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.IsPass qualified as MangleNames
@@ -146,7 +146,7 @@ isDefinedInCurrentModule :: DeclIndex -> C.Type Final -> Bool
 isDefinedInCurrentModule declIndex =
     any (isInDeclIndex . snd) . C.depsOfType
   where
-    isInDeclIndex :: C.DeclIdPair -> Bool
+    isInDeclIndex :: DeclIdPair -> Bool
     isInDeclIndex declId = isJust $ DeclIndex.lookup declId.cName declIndex
 
 {-------------------------------------------------------------------------------
@@ -1031,7 +1031,7 @@ typedefFunPtrDecs opts haddockConfig origInfo n (args, res) origNames origSpec =
         , declHeaderInfo   = origInfo.declHeaderInfo
         , declComment      = Just auxComment
         , declAvailability = C.Available
-        , declId           = C.DeclIdPair{
+        , declId           = DeclIdPair{
               -- Still refer to the /original/ C decl...?
               cName  = origInfo.declId.cName
             , hsName = auxHsName

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -23,7 +23,7 @@ import HsBindgen.Config.Prelims
 import HsBindgen.Errors
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.RootHeader

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
@@ -24,7 +24,7 @@ import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Errors
 import HsBindgen.Frontend.AST.Type qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass qualified as ResolveBindingSpecs
 import HsBindgen.Language.C qualified as C

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -64,7 +64,7 @@ import HsBindgen.BindingSpec.Private.Stdlib qualified as Stdlib
 import HsBindgen.BindingSpec.Private.V1 qualified as BindingSpec
 import HsBindgen.BindingSpec.Private.Version qualified as Version
 import HsBindgen.Config.ClangArgs qualified as ClangArgs
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Monad
@@ -300,13 +300,13 @@ moduleName = BindingSpec.bindingSpecModule . bindingSpecUnresolved
 -------------------------------------------------------------------------------}
 
 -- | Get the C types in a binding specification
-getCTypes :: BindingSpec -> Map C.DeclId [Set SourcePath]
+getCTypes :: BindingSpec -> Map DeclId [Set SourcePath]
 getCTypes = BindingSpec.getCTypes . bindingSpecResolved
 
 -- | Lookup the @'Common.Omittable' 'BindingSpec.CTypeSpec'@ associated with a C
 -- type
 lookupCTypeSpec ::
-     C.DeclId
+     DeclId
   -> Set SourcePath
   -> BindingSpec
   -> Maybe (Hs.ModuleName, Common.Omittable BindingSpec.CTypeSpec)

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Common.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Common.hs
@@ -42,7 +42,7 @@ import Text.SimplePrettyPrint ((><))
 import Text.SimplePrettyPrint qualified as PP
 
 import HsBindgen.BindingSpec.Private.Version
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
@@ -63,7 +63,7 @@ data BindingSpecReadMsg =
   | BindingSpecReadIncompatibleTarget FilePath
   | BindingSpecReadAnyTargetNotEnforced FilePath
   | BindingSpecReadInvalidCName FilePath Text
-  | BindingSpecReadCTypeConflict FilePath C.DeclId HashIncludeArg
+  | BindingSpecReadCTypeConflict FilePath DeclId HashIncludeArg
   | BindingSpecReadHsIdentifierNoRef FilePath Hs.Identifier
   | BindingSpecReadHsTypeConflict FilePath Hs.Identifier
   | BindingSpecReadHashIncludeArg FilePath HashIncludeArgMsg
@@ -175,7 +175,7 @@ instance PrettyForTrace BindingSpecReadMsg where
 data BindingSpecResolveMsg =
     BindingSpecResolveExternalHeader     ResolveHeaderMsg
   | BindingSpecResolvePrescriptiveHeader ResolveHeaderMsg
-  | BindingSpecResolveTypeDropped        C.DeclId
+  | BindingSpecResolveTypeDropped        DeclId
   deriving stock (Show)
 
 instance IsTrace Level BindingSpecResolveMsg where
@@ -219,7 +219,7 @@ instance PrettyForTrace BindingSpecResolveMsg where
 
 -- | Merge binding specification trace messages
 newtype BindingSpecMergeMsg =
-    BindingSpecMergeConflict C.DeclId
+    BindingSpecMergeConflict DeclId
   deriving stock (Show)
 
 instance IsTrace Level BindingSpecMergeMsg where

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
@@ -21,7 +21,7 @@ import HsBindgen.Runtime.BaseForeignType qualified as BFT
 import HsBindgen.BindingSpec.Private.Common
 import HsBindgen.BindingSpec.Private.V1 qualified as BindingSpec
 import HsBindgen.Errors
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
@@ -225,12 +225,12 @@ bindingSpec = BindingSpec.BindingSpec{..}
 
 -- | Concise alias for the C type 'Map'
 type CTypeMap =
-  Map C.DeclId [(Set HashIncludeArg, Omittable BindingSpec.CTypeSpec)]
+  Map DeclId [(Set HashIncludeArg, Omittable BindingSpec.CTypeSpec)]
 
 -- | Concise alias for the key and value tuple corresponding to an entry in a
 -- 'CTypeMap'
 type CTypeKV =
-  (C.DeclId, [(Set HashIncludeArg, Omittable BindingSpec.CTypeSpec)])
+  (DeclId, [(Set HashIncludeArg, Omittable BindingSpec.CTypeSpec)])
 
 -- | Concise alias for the Haskell type 'Map'
 type HsTypeMap = Map Hs.Identifier BindingSpec.HsTypeSpec
@@ -252,7 +252,7 @@ mkType ::
   -> [FilePath]
   -> (CTypeKV, HsTypeKV)
 mkType t hsIdentifier cTypeRep hsTypeRep insts headers' =
-    case C.parseDeclId t of
+    case parseDeclId t of
       Just cDeclId ->
         ( (cDeclId, [(headers, Require cTypeSpec)])
         , (hsIdentifier, hsTypeSpec)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
@@ -23,7 +23,7 @@ import Data.Set qualified as Set
 import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Type (ValOrRef)
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 
 {-------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ import HsBindgen.Imports
 --
 -- This graph has edges from def sites to use sites.
 newtype DeclUseGraph = Wrap {
-      unwrap :: DynGraph ValOrRef C.DeclId
+      unwrap :: DynGraph ValOrRef DeclId
     }
   deriving stock (Show, Eq)
 
@@ -49,21 +49,21 @@ fromUseDecl = Wrap . DynGraph.reverse . UseDeclGraph.toDynGraph
   Transitive usage
 -------------------------------------------------------------------------------}
 
-getUseSitesTransitively :: DeclUseGraph -> [C.DeclId] -> Set C.DeclId
+getUseSitesTransitively :: DeclUseGraph -> [DeclId] -> Set DeclId
 getUseSitesTransitively = DynGraph.reaches . unwrap
 
 {-------------------------------------------------------------------------------
   Direct usage
 -------------------------------------------------------------------------------}
 
-getUseSites :: DeclUseGraph -> C.DeclId -> [(C.DeclId, ValOrRef)]
+getUseSites :: DeclUseGraph -> DeclId -> [(DeclId, ValOrRef)]
 getUseSites (Wrap graph) = Set.toList . DynGraph.neighbors graph
 
-getUseSitesNoSelfReferences :: DeclUseGraph -> C.DeclId -> [(C.DeclId, ValOrRef)]
+getUseSitesNoSelfReferences :: DeclUseGraph -> DeclId -> [(DeclId, ValOrRef)]
 getUseSitesNoSelfReferences graph qualPrelimDeclId =
   filter (not . isSelfReference) $ getUseSites graph qualPrelimDeclId
     where
-      isSelfReference :: (C.DeclId, ValOrRef) -> Bool
+      isSelfReference :: (DeclId, ValOrRef) -> Bool
       isSelfReference (qualPrelimDeclId', _usage) =
         qualPrelimDeclId == qualPrelimDeclId'
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
@@ -19,7 +19,7 @@ import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.LanguageC.Monad
 import HsBindgen.Frontend.LanguageC.PartialAST
 import HsBindgen.Frontend.LanguageC.PartialAST.ToBindgen
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
@@ -198,7 +198,7 @@ instance Apply (LanC.CTypeSpecifier a) PartialType where
       charSign (Just sign) = C.PrimSignExplicit sign
 
       typeRef :: C.DeclName -> C.Type HandleMacros
-      typeRef name = C.TypeRef $ C.DeclId{name, isAnon = False}
+      typeRef name = C.TypeRef $ DeclId{name, isAnon = False}
 
       checkNotAnon :: Maybe LanC.Ident -> C.TagKind -> FromLanC C.DeclName
       checkNotAnon mName tagKind =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LocationInfo.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LocationInfo.hs
@@ -16,7 +16,7 @@ import Text.SimplePrettyPrint qualified as PP
 import Clang.HighLevel.Types
 
 import HsBindgen.Errors
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId (PrelimDeclId)
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId qualified as PrelimDeclId
 import HsBindgen.Imports
@@ -69,7 +69,7 @@ prelimDeclIdLocationInfo prelimDeclId knownLocs =
       PrelimDeclId.Named name -> LocationDeclNamed name knownLocs
       PrelimDeclId.Anon  anon -> LocationDeclAnon Nothing anon.loc
 
-declIdLocationInfo :: HasCallStack => C.DeclId -> [SingleLoc] -> LocationInfo
+declIdLocationInfo :: HasCallStack => DeclId -> [SingleLoc] -> LocationInfo
 declIdLocationInfo declId knownLocs =
     if not declId.isAnon then
       LocationDeclNamed declId.name knownLocs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Naming.hs
@@ -1,8 +1,12 @@
 -- | C naming and declaration identifiers
 --
--- Intended for qualified import within frontend.
+-- This is such a central module in @hs-bindgen@, it is intended for
+-- /unqualified/ import.
 --
--- > import HsBindgen.Frontend.Naming qualified as C
+-- (Historical note: we used to import this qualified as @C@, but that is
+-- incorrect: these are @hs-bindgen@ concepts, /not/ standard C concepts. In
+-- particular, the names we assign to anonymous declarations is very much
+-- @hs-bindgen@ specific.)
 module HsBindgen.Frontend.Naming (
     -- * DeclId
     DeclId(..)
@@ -10,10 +14,8 @@ module HsBindgen.Frontend.Naming (
   , renderDeclId
   , parseDeclId
 
-    -- * DeclIdPair
+    -- * Pairing C names and Haskell names
   , DeclIdPair(..)
-
-    -- * ScopedNamePair
   , ScopedNamePair(..)
   ) where
 
@@ -30,6 +32,8 @@ import HsBindgen.Util.Tracer (PrettyForTrace (prettyForTrace))
 -------------------------------------------------------------------------------}
 
 -- | Identifier for a declaration that appears in the C source
+--
+-- This is the main ID used throughout @hs-bindgen@ for declarations.
 data DeclId = DeclId{
       -- | Name of the declaration
       --
@@ -77,7 +81,10 @@ instance PrettyForTrace DeclId where
   prettyForTrace = PP.singleQuotes . PP.text . renderDeclId
 
 {-------------------------------------------------------------------------------
-  DeclIdPair
+  Pairing C names and Haskell names
+
+  The Haskell name must satisfy the rules for legal Haskell names for the
+  intended usage (constructor, variable, ..).
 -------------------------------------------------------------------------------}
 
 data DeclIdPair = DeclIdPair{
@@ -86,14 +93,6 @@ data DeclIdPair = DeclIdPair{
     }
   deriving stock (Show, Eq, Ord)
 
-{-------------------------------------------------------------------------------
-  ScopedNamePair
--------------------------------------------------------------------------------}
-
--- | Pair of a (scoped) C name and the corresponding Haskell name
---
--- Invariant: the 'Hs.Identifier' must satisfy the rules for legal Haskell
--- names, for its intended use (constructor, variable, ..).
 data ScopedNamePair = ScopedNamePair {
       cName  :: C.ScopedName
     , hsName :: Hs.Identifier

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -8,7 +8,7 @@ module HsBindgen.Frontend.Pass (
 import Clang.HighLevel.Types
 
 import HsBindgen.Frontend.LocationInfo
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Util.Tracer
@@ -95,7 +95,7 @@ class (
   -- 3. After 'MangleNames', this becomes a pair of the C name and the
   --    corresponding Haskell name.
   type Id p :: Star
-  type Id p = C.DeclId
+  type Id p = DeclId
 
   -- | Scoped names
   --
@@ -135,29 +135,23 @@ class (
 
   -- | Name kind of the C name
   idNameKind :: Proxy p -> Id p -> C.NameKind
-  default idNameKind ::
-       Id p ~ C.DeclId
-    => Proxy p -> Id p -> C.NameKind
+  default idNameKind :: Id p ~ DeclId => Proxy p -> Id p -> C.NameKind
   idNameKind _ = (.name.kind)
 
   -- | Name of the declaration as it appears in the C source, if any
   idSourceName :: Proxy p -> Id p -> Maybe C.DeclName
-  default idSourceName ::
-       Id p ~ C.DeclId
-    => Proxy p -> Id p -> Maybe C.DeclName
-  idSourceName _ = C.declIdSourceName
+  default idSourceName :: Id p ~ DeclId => Proxy p -> Id p -> Maybe C.DeclName
+  idSourceName _ = declIdSourceName
 
   -- | Location information
   idLocationInfo :: Proxy p -> Id p -> [SingleLoc] -> LocationInfo
   default idLocationInfo ::
-       Id p ~ C.DeclId
+       Id p ~ DeclId
     => Proxy p -> Id p -> [SingleLoc] -> LocationInfo
   idLocationInfo _ = declIdLocationInfo
 
   extBindingId :: Proxy p -> ExtBinding p -> Id p
-  default extBindingId ::
-       ExtBinding p ~ Void
-    => Proxy p -> ExtBinding p -> Id p
+  default extBindingId :: ExtBinding p ~ Void => Proxy p -> ExtBinding p -> Id p
   extBindingId _ = absurd
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -11,7 +11,7 @@ import Data.Tuple
 import HsBindgen.Frontend.Analysis.AnonUsage qualified as AnonUsageAnalysis
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.AssignAnonIds.ChooseNames
 import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass
@@ -61,7 +61,7 @@ updateParseResult chosenNames result =
         auxFailure failure <$>
           updateDefSite chosenNames result.declId
   where
-    auxSuccess :: ParseSuccess Parse -> C.DeclId -> ParseResult AssignAnonIds
+    auxSuccess :: ParseSuccess Parse -> DeclId -> ParseResult AssignAnonIds
     auxSuccess ParseSuccess{decl, delayedParseMsgs} declId' =
         case runM chosenNames updated of
           Left (UnusableAnonDecl anonId) -> ParseResult{
@@ -91,7 +91,7 @@ updateParseResult chosenNames result =
 
     auxNotAttempted ::
          ParseNotAttempted
-      -> C.DeclId
+      -> DeclId
       -> ParseResult AssignAnonIds
     auxNotAttempted notAttempted declId' = ParseResult{
           declId         = declId'
@@ -101,7 +101,7 @@ updateParseResult chosenNames result =
 
     auxFailure ::
          ParseFailure
-      -> C.DeclId
+      -> DeclId
       -> ParseResult AssignAnonIds
     auxFailure failure declId' = ParseResult{
           declId         = declId'
@@ -121,7 +121,7 @@ updateDefSite chosenNames =
     first AssignAnonIdsSkippedDecl . fromPrelimDeclId chosenNames
 
 updateDeclInfo ::
-     C.DeclId
+     DeclId
   -> C.DeclInfo Parse
   -> M (C.DeclInfo AssignAnonIds)
 updateDeclInfo declId' info =
@@ -313,7 +313,7 @@ instance UpdateUseSites C.TypedefRef where
         <$> updateDeclId n
         <*> updateUseSites uTy
 
-updateDeclId :: PrelimDeclId -> M C.DeclId
+updateDeclId :: PrelimDeclId -> M DeclId
 updateDeclId prelimDeclId = WrapM $ do
     chosenNames <- ask
     case fromPrelimDeclId chosenNames prelimDeclId of
@@ -358,13 +358,13 @@ instance UpdateUseSites C.CommentRef where
   Internal auxiliary
 -------------------------------------------------------------------------------}
 
--- | Construct 'C.DeclId' from 'C.PrelimDeclId'
+-- | Construct 'DeclId' from 'C.PrelimDeclId'
 --
 -- Returns 'Left' an 'C.AnonId' if the 'C.PrelimDeclId' is anonymous and we have
 -- assigned no name.
-fromPrelimDeclId :: ChosenNames -> PrelimDeclId -> Either AnonId C.DeclId
+fromPrelimDeclId :: ChosenNames -> PrelimDeclId -> Either AnonId DeclId
 fromPrelimDeclId chosenNames = \case
     PrelimDeclId.Named name ->
-      Right C.DeclId{name, isAnon = False}
+      Right DeclId{name, isAnon = False}
     PrelimDeclId.Anon anonId ->
       maybe (Left anonId) Right $ Map.lookup anonId chosenNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -23,7 +23,7 @@ import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.LanguageC qualified as LanC
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.HandleMacros.Error
@@ -436,7 +436,7 @@ parseMacro name tokens  = state     $ \st ->
     updateReparseEnv :: LanC.ReparseEnv -> LanC.ReparseEnv
     updateReparseEnv =
         Map.insert name.text $
-          C.TypeRef $ C.DeclId{name, isAnon = False}
+          C.TypeRef $ DeclId{name, isAnon = False}
 
     dropEval ::
          CExpr.DSL.Quant (CExpr.DSL.FunValue, CExpr.DSL.Type 'CExpr.DSL.Ty)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros/Error.hs
@@ -15,7 +15,7 @@ import Clang.HighLevel.Types
 
 import HsBindgen.Frontend.LanguageC.Error qualified as LanC
 import HsBindgen.Frontend.LocationInfo
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Util.Tracer
@@ -26,7 +26,7 @@ import HsBindgen.Util.Tracer
 
 -- | Macro parse messages; see also 'HandleMacrosReparseMsg'
 data FailedMacro = FailedMacro {
-    name       :: C.DeclId
+    name       :: DeclId
   , loc        :: SingleLoc
   , macroError :: HandleMacrosError
   }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -11,7 +11,7 @@ import Text.SimplePrettyPrint qualified as PP
 
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Frontend.LocationInfo
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
@@ -40,15 +40,15 @@ type family AnnMangleNames ix where
   AnnMangleNames _                  = NoAnn
 
 instance IsPass MangleNames where
-  type Id         MangleNames = C.DeclIdPair
-  type ScopedName MangleNames = C.ScopedNamePair
+  type Id         MangleNames = DeclIdPair
+  type ScopedName MangleNames = ScopedNamePair
   type MacroBody  MangleNames = CheckedMacro MangleNames
   type ExtBinding MangleNames = ResolvedExtBinding
   type Ann ix     MangleNames = AnnMangleNames ix
   type Msg        MangleNames = WithLocationInfo MangleNamesMsg
 
   idNameKind     _ namePair   = namePair.cName.name.kind
-  idSourceName   _ namePair   = C.declIdSourceName namePair.cName
+  idSourceName   _ namePair   = declIdSourceName namePair.cName
   idLocationInfo _ namePair   = declIdLocationInfo namePair.cName
   extBindingId   _ extBinding = extDeclIdPair extBinding
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -10,7 +10,7 @@ import Text.SimplePrettyPrint ((<+>))
 
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.AST.Coerce
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass (DeclMeta)
 import HsBindgen.Frontend.Pass.HandleMacros.IsPass
@@ -67,7 +67,7 @@ data PrescriptiveDeclSpec = PrescriptiveDeclSpec {
 
 data ResolvedExtBinding = ResolvedExtBinding{
       -- | C declaration for which we are using this binding
-      extCDeclId :: C.DeclId
+      extCDeclId :: DeclId
 
       -- | The Haskell type which will be used
     , extHsRef :: Hs.ExtRef
@@ -80,8 +80,8 @@ data ResolvedExtBinding = ResolvedExtBinding{
     }
   deriving stock (Show, Eq, Ord, Generic)
 
-extDeclIdPair :: ResolvedExtBinding -> C.DeclIdPair
-extDeclIdPair ext = C.DeclIdPair{
+extDeclIdPair :: ResolvedExtBinding -> DeclIdPair
+extDeclIdPair ext = DeclIdPair{
       cName  = ext.extCDeclId
     , hsName = ext.extHsRef.extRefIdentifier
     }
@@ -92,15 +92,15 @@ extDeclIdPair ext = C.DeclIdPair{
 
 data ResolveBindingSpecsMsg =
     ResolveBindingSpecsModuleMismatch       Hs.ModuleName Hs.ModuleName
-  | ResolveBindingSpecsExtHsRefNoIdentifier C.DeclId
-  | ResolveBindingSpecsNoHsTypeSpec         C.DeclId
-  | ResolveBindingSpecsNoHsTypeRep          C.DeclId
-  | ResolveBindingSpecsOmittedType          C.DeclId
-  | ResolveBindingSpecsTypeNotUsed          C.DeclId
-  | ResolveBindingSpecsExtDecl              C.DeclId
-  | ResolveBindingSpecsExtType              C.DeclId C.DeclId
-  | ResolveBindingSpecsPrescriptiveRequire  C.DeclId
-  | ResolveBindingSpecsPrescriptiveOmit     C.DeclId
+  | ResolveBindingSpecsExtHsRefNoIdentifier DeclId
+  | ResolveBindingSpecsNoHsTypeSpec         DeclId
+  | ResolveBindingSpecsNoHsTypeRep          DeclId
+  | ResolveBindingSpecsOmittedType          DeclId
+  | ResolveBindingSpecsTypeNotUsed          DeclId
+  | ResolveBindingSpecsExtDecl              DeclId
+  | ResolveBindingSpecsExtType              DeclId DeclId
+  | ResolveBindingSpecsPrescriptiveRequire  DeclId
+  | ResolveBindingSpecsPrescriptiveOmit     DeclId
   deriving stock (Show)
 
 instance PrettyForTrace ResolveBindingSpecsMsg where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -18,7 +18,7 @@ import Clang.HighLevel.Types
 import HsBindgen.Frontend.Analysis.DeclIndex (Unusable (..))
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.LocationInfo
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.HandleMacros.Error
@@ -103,14 +103,14 @@ data SelectMsg =
     -- of its transitive dependencies is 'Unusable'.
   | TransitiveDependencyOfDeclarationUnusable
       SelectReason
-      C.DeclId
+      DeclId
       Unusable
       [SingleLoc]
     -- | The user has selected a declaration that is available but at least one
     -- of its transitive dependencies is not selected.
   | TransitiveDependencyOfDeclarationNotSelected
       SelectReason
-      C.DeclId
+      DeclId
       [SingleLoc]
     -- | The user has selected a deprecated declaration. Maybe they want to
     -- de-select deprecated declaration?

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -28,7 +28,7 @@ import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Analysis.DeclIndex (Unusable (..))
-import HsBindgen.Frontend.Naming qualified as C
+import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId qualified as PrelimDeclId
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.Select.IsPass


### PR DESCRIPTION
Biggest change here is that this is no longer intended for qualified import.