### PR TITLE
Use `_Aux` instead of `_Deref`

### DIFF
--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -231,38 +231,38 @@ __defined at:__ @documentation\/doxygen_docs.h:225:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
-newtype Event_callback_t_Deref = Event_callback_t_Deref
-  { un_Event_callback_t_Deref :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
+newtype Event_callback_t_Aux = Event_callback_t_Aux
+  { un_Event_callback_t_Aux :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toEvent_callback_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_0f8e2c78e0583f5e ::
-     Event_callback_t_Deref
-  -> IO (Ptr.FunPtr Event_callback_t_Deref)
+-- __unique:__ @toEvent_callback_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_111918b0aee2a7fb ::
+     Event_callback_t_Aux
+  -> IO (Ptr.FunPtr Event_callback_t_Aux)
 
--- __unique:__ @fromEvent_callback_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_9dbdfc6c37a7780f ::
-     Ptr.FunPtr Event_callback_t_Deref
-  -> Event_callback_t_Deref
+-- __unique:__ @fromEvent_callback_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_9e9d478c2d75628c ::
+     Ptr.FunPtr Event_callback_t_Aux
+  -> Event_callback_t_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Event_callback_t_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Event_callback_t_Aux where
 
-  toFunPtr = hs_bindgen_0f8e2c78e0583f5e
+  toFunPtr = hs_bindgen_111918b0aee2a7fb
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Event_callback_t_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Event_callback_t_Aux where
 
-  fromFunPtr = hs_bindgen_9dbdfc6c37a7780f
+  fromFunPtr = hs_bindgen_9e9d478c2d75628c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Event_callback_t_Deref) "un_Event_callback_t_Deref")
-         ) => GHC.Records.HasField "un_Event_callback_t_Deref" (Ptr.Ptr Event_callback_t_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Event_callback_t_Aux) "un_Event_callback_t_Aux")
+         ) => GHC.Records.HasField "un_Event_callback_t_Aux" (Ptr.Ptr Event_callback_t_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Event_callback_t_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Event_callback_t_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Event_callback_t_Deref "un_Event_callback_t_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Event_callback_t_Aux "un_Event_callback_t_Aux" where
 
-  type CFieldType Event_callback_t_Deref "un_Event_callback_t_Deref" =
+  type CFieldType Event_callback_t_Aux "un_Event_callback_t_Aux" =
     FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
 
   offset# = \_ -> \_ -> 0
@@ -284,7 +284,7 @@ __defined at:__ @documentation\/doxygen_docs.h:225:15@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 newtype Event_callback_t = Event_callback_t
-  { un_Event_callback_t :: Ptr.FunPtr Event_callback_t_Deref
+  { un_Event_callback_t :: Ptr.FunPtr Event_callback_t_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -298,7 +298,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Event_callback_t) "u
 instance HsBindgen.Runtime.HasCField.HasCField Event_callback_t "un_Event_callback_t" where
 
   type CFieldType Event_callback_t "un_Event_callback_t" =
-    Ptr.FunPtr Event_callback_t_Deref
+    Ptr.FunPtr Event_callback_t_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1119,38 +1119,38 @@ __defined at:__ @documentation\/doxygen_docs.h:317:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
-newtype Processor_fn_t_Deref = Processor_fn_t_Deref
-  { un_Processor_fn_t_Deref :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
+newtype Processor_fn_t_Aux = Processor_fn_t_Aux
+  { un_Processor_fn_t_Aux :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toProcessor_fn_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_5f7a57f9f2b19661 ::
-     Processor_fn_t_Deref
-  -> IO (Ptr.FunPtr Processor_fn_t_Deref)
+-- __unique:__ @toProcessor_fn_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_d4e16471c82d5df0 ::
+     Processor_fn_t_Aux
+  -> IO (Ptr.FunPtr Processor_fn_t_Aux)
 
--- __unique:__ @fromProcessor_fn_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_a894574bbd080808 ::
-     Ptr.FunPtr Processor_fn_t_Deref
-  -> Processor_fn_t_Deref
+-- __unique:__ @fromProcessor_fn_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_0d4b3d0461629423 ::
+     Ptr.FunPtr Processor_fn_t_Aux
+  -> Processor_fn_t_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Processor_fn_t_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Processor_fn_t_Aux where
 
-  toFunPtr = hs_bindgen_5f7a57f9f2b19661
+  toFunPtr = hs_bindgen_d4e16471c82d5df0
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Processor_fn_t_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Processor_fn_t_Aux where
 
-  fromFunPtr = hs_bindgen_a894574bbd080808
+  fromFunPtr = hs_bindgen_0d4b3d0461629423
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_fn_t_Deref) "un_Processor_fn_t_Deref")
-         ) => GHC.Records.HasField "un_Processor_fn_t_Deref" (Ptr.Ptr Processor_fn_t_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_fn_t_Aux) "un_Processor_fn_t_Aux")
+         ) => GHC.Records.HasField "un_Processor_fn_t_Aux" (Ptr.Ptr Processor_fn_t_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Processor_fn_t_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Processor_fn_t_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Processor_fn_t_Deref "un_Processor_fn_t_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Processor_fn_t_Aux "un_Processor_fn_t_Aux" where
 
-  type CFieldType Processor_fn_t_Deref "un_Processor_fn_t_Deref" =
+  type CFieldType Processor_fn_t_Aux "un_Processor_fn_t_Aux" =
     FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
 
   offset# = \_ -> \_ -> 0
@@ -1174,7 +1174,7 @@ __defined at:__ @documentation\/doxygen_docs.h:317:15@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 newtype Processor_fn_t = Processor_fn_t
-  { un_Processor_fn_t :: Ptr.FunPtr Processor_fn_t_Deref
+  { un_Processor_fn_t :: Ptr.FunPtr Processor_fn_t_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1188,7 +1188,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_fn_t) "un_
 instance HsBindgen.Runtime.HasCField.HasCField Processor_fn_t "un_Processor_fn_t" where
 
   type CFieldType Processor_fn_t "un_Processor_fn_t" =
-    Ptr.FunPtr Processor_fn_t_Deref
+    Ptr.FunPtr Processor_fn_t_Aux
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -542,9 +542,9 @@ __defined at:__ @documentation\/doxygen_docs.h:225:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
-newtype Event_callback_t_Deref
-    = Event_callback_t_Deref {un_Event_callback_t_Deref :: (CInt ->
-                                                            Ptr Void -> IO CInt)}
+newtype Event_callback_t_Aux
+    = Event_callback_t_Aux {un_Event_callback_t_Aux :: (CInt ->
+                                                        Ptr Void -> IO CInt)}
       {- ^ Auxiliary type used by 'Event_callback_t'
 
       __C declaration:__ @event_callback_t@
@@ -554,26 +554,25 @@ newtype Event_callback_t_Deref
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toEvent_callback_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_0f8e2c78e0583f5e :: Event_callback_t_Deref ->
-                                                                   IO (FunPtr Event_callback_t_Deref)
--- __unique:__ @fromEvent_callback_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_9dbdfc6c37a7780f :: FunPtr Event_callback_t_Deref ->
-                                                                   Event_callback_t_Deref
-instance ToFunPtr Event_callback_t_Deref
-    where toFunPtr = hs_bindgen_0f8e2c78e0583f5e
-instance FromFunPtr Event_callback_t_Deref
-    where fromFunPtr = hs_bindgen_9dbdfc6c37a7780f
+-- __unique:__ @toEvent_callback_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_111918b0aee2a7fb :: Event_callback_t_Aux ->
+                                                                   IO (FunPtr Event_callback_t_Aux)
+-- __unique:__ @fromEvent_callback_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_9e9d478c2d75628c :: FunPtr Event_callback_t_Aux ->
+                                                                   Event_callback_t_Aux
+instance ToFunPtr Event_callback_t_Aux
+    where toFunPtr = hs_bindgen_111918b0aee2a7fb
+instance FromFunPtr Event_callback_t_Aux
+    where fromFunPtr = hs_bindgen_9e9d478c2d75628c
 instance TyEq ty
-              (CFieldType Event_callback_t_Deref "un_Event_callback_t_Deref") =>
-         HasField "un_Event_callback_t_Deref"
-                  (Ptr Event_callback_t_Deref)
+              (CFieldType Event_callback_t_Aux "un_Event_callback_t_Aux") =>
+         HasField "un_Event_callback_t_Aux"
+                  (Ptr Event_callback_t_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Event_callback_t_Deref")
-instance HasCField Event_callback_t_Deref
-                   "un_Event_callback_t_Deref"
-    where type CFieldType Event_callback_t_Deref
-                          "un_Event_callback_t_Deref" = CInt -> Ptr Void -> IO CInt
+    where getField = ptrToCField (Proxy @"un_Event_callback_t_Aux")
+instance HasCField Event_callback_t_Aux "un_Event_callback_t_Aux"
+    where type CFieldType Event_callback_t_Aux
+                          "un_Event_callback_t_Aux" = CInt -> Ptr Void -> IO CInt
           offset# = \_ -> \_ -> 0
 {-|
 
@@ -592,7 +591,7 @@ __defined at:__ @documentation\/doxygen_docs.h:225:15@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 newtype Event_callback_t
-    = Event_callback_t {un_Event_callback_t :: (FunPtr Event_callback_t_Deref)}
+    = Event_callback_t {un_Event_callback_t :: (FunPtr Event_callback_t_Aux)}
       {- ^
 
          Callback function type
@@ -617,7 +616,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Event_callback_t")
 instance HasCField Event_callback_t "un_Event_callback_t"
     where type CFieldType Event_callback_t
-                          "un_Event_callback_t" = FunPtr Event_callback_t_Deref
+                          "un_Event_callback_t" = FunPtr Event_callback_t_Aux
           offset# = \_ -> \_ -> 0
 {-|
 
@@ -1371,9 +1370,9 @@ __defined at:__ @documentation\/doxygen_docs.h:317:15@
 
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
-newtype Processor_fn_t_Deref
-    = Processor_fn_t_Deref {un_Processor_fn_t_Deref :: (CInt ->
-                                                        Ptr Void -> IO CInt)}
+newtype Processor_fn_t_Aux
+    = Processor_fn_t_Aux {un_Processor_fn_t_Aux :: (CInt ->
+                                                    Ptr Void -> IO CInt)}
       {- ^ Auxiliary type used by 'Processor_fn_t'
 
       __C declaration:__ @processor_fn_t@
@@ -1383,25 +1382,23 @@ newtype Processor_fn_t_Deref
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toProcessor_fn_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_5f7a57f9f2b19661 :: Processor_fn_t_Deref ->
-                                                                   IO (FunPtr Processor_fn_t_Deref)
--- __unique:__ @fromProcessor_fn_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_a894574bbd080808 :: FunPtr Processor_fn_t_Deref ->
-                                                                   Processor_fn_t_Deref
-instance ToFunPtr Processor_fn_t_Deref
-    where toFunPtr = hs_bindgen_5f7a57f9f2b19661
-instance FromFunPtr Processor_fn_t_Deref
-    where fromFunPtr = hs_bindgen_a894574bbd080808
+-- __unique:__ @toProcessor_fn_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_d4e16471c82d5df0 :: Processor_fn_t_Aux ->
+                                                                   IO (FunPtr Processor_fn_t_Aux)
+-- __unique:__ @fromProcessor_fn_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_0d4b3d0461629423 :: FunPtr Processor_fn_t_Aux ->
+                                                                   Processor_fn_t_Aux
+instance ToFunPtr Processor_fn_t_Aux
+    where toFunPtr = hs_bindgen_d4e16471c82d5df0
+instance FromFunPtr Processor_fn_t_Aux
+    where fromFunPtr = hs_bindgen_0d4b3d0461629423
 instance TyEq ty
-              (CFieldType Processor_fn_t_Deref "un_Processor_fn_t_Deref") =>
-         HasField "un_Processor_fn_t_Deref"
-                  (Ptr Processor_fn_t_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Processor_fn_t_Deref")
-instance HasCField Processor_fn_t_Deref "un_Processor_fn_t_Deref"
-    where type CFieldType Processor_fn_t_Deref
-                          "un_Processor_fn_t_Deref" = CInt -> Ptr Void -> IO CInt
+              (CFieldType Processor_fn_t_Aux "un_Processor_fn_t_Aux") =>
+         HasField "un_Processor_fn_t_Aux" (Ptr Processor_fn_t_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Processor_fn_t_Aux")
+instance HasCField Processor_fn_t_Aux "un_Processor_fn_t_Aux"
+    where type CFieldType Processor_fn_t_Aux
+                          "un_Processor_fn_t_Aux" = CInt -> Ptr Void -> IO CInt
           offset# = \_ -> \_ -> 0
 {-|
 
@@ -1422,7 +1419,7 @@ __defined at:__ @documentation\/doxygen_docs.h:317:15@
 __exported by:__ @documentation\/doxygen_docs.h@
 -}
 newtype Processor_fn_t
-    = Processor_fn_t {un_Processor_fn_t :: (FunPtr Processor_fn_t_Deref)}
+    = Processor_fn_t {un_Processor_fn_t :: (FunPtr Processor_fn_t_Aux)}
       {- ^
 
          > processor_fn_t
@@ -1448,7 +1445,7 @@ instance TyEq ty (CFieldType Processor_fn_t "un_Processor_fn_t") =>
     where getField = ptrToCField (Proxy @"un_Processor_fn_t")
 instance HasCField Processor_fn_t "un_Processor_fn_t"
     where type CFieldType Processor_fn_t
-                          "un_Processor_fn_t" = FunPtr Processor_fn_t_Deref
+                          "un_Processor_fn_t" = FunPtr Processor_fn_t_Aux
           offset# = \_ -> \_ -> 0
 {-|
 

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -776,38 +776,38 @@ __defined at:__ @edge-cases\/distilled_lib_1.h:77:19@
 
 __exported by:__ @edge-cases\/distilled_lib_1.h@
 -}
-newtype Callback_t_Deref = Callback_t_Deref
-  { un_Callback_t_Deref :: (Ptr.Ptr Void) -> HsBindgen.Runtime.Prelude.Word32 -> IO HsBindgen.Runtime.Prelude.Word32
+newtype Callback_t_Aux = Callback_t_Aux
+  { un_Callback_t_Aux :: (Ptr.Ptr Void) -> HsBindgen.Runtime.Prelude.Word32 -> IO HsBindgen.Runtime.Prelude.Word32
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toCallback_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_24eac512dce926e9 ::
-     Callback_t_Deref
-  -> IO (Ptr.FunPtr Callback_t_Deref)
+-- __unique:__ @toCallback_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b6b6922e35047658 ::
+     Callback_t_Aux
+  -> IO (Ptr.FunPtr Callback_t_Aux)
 
--- __unique:__ @fromCallback_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_893b8fa3b3f09882 ::
-     Ptr.FunPtr Callback_t_Deref
-  -> Callback_t_Deref
+-- __unique:__ @fromCallback_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_d6debb4b8d5bb869 ::
+     Ptr.FunPtr Callback_t_Aux
+  -> Callback_t_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Callback_t_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Callback_t_Aux where
 
-  toFunPtr = hs_bindgen_24eac512dce926e9
+  toFunPtr = hs_bindgen_b6b6922e35047658
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Callback_t_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Callback_t_Aux where
 
-  fromFunPtr = hs_bindgen_893b8fa3b3f09882
+  fromFunPtr = hs_bindgen_d6debb4b8d5bb869
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Callback_t_Deref) "un_Callback_t_Deref")
-         ) => GHC.Records.HasField "un_Callback_t_Deref" (Ptr.Ptr Callback_t_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Callback_t_Aux) "un_Callback_t_Aux")
+         ) => GHC.Records.HasField "un_Callback_t_Aux" (Ptr.Ptr Callback_t_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Callback_t_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Callback_t_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Callback_t_Deref "un_Callback_t_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Callback_t_Aux "un_Callback_t_Aux" where
 
-  type CFieldType Callback_t_Deref "un_Callback_t_Deref" =
+  type CFieldType Callback_t_Aux "un_Callback_t_Aux" =
     (Ptr.Ptr Void) -> HsBindgen.Runtime.Prelude.Word32 -> IO HsBindgen.Runtime.Prelude.Word32
 
   offset# = \_ -> \_ -> 0
@@ -819,7 +819,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Callback_t_Deref "un_Callback_t_D
     __exported by:__ @edge-cases\/distilled_lib_1.h@
 -}
 newtype Callback_t = Callback_t
-  { un_Callback_t :: Ptr.FunPtr Callback_t_Deref
+  { un_Callback_t :: Ptr.FunPtr Callback_t_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -833,6 +833,6 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Callback_t) "un_Call
 instance HsBindgen.Runtime.HasCField.HasCField Callback_t "un_Callback_t" where
 
   type CFieldType Callback_t "un_Callback_t" =
-    Ptr.FunPtr Callback_t_Deref
+    Ptr.FunPtr Callback_t_Aux
 
   offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -685,10 +685,10 @@ __defined at:__ @edge-cases\/distilled_lib_1.h:77:19@
 
 __exported by:__ @edge-cases\/distilled_lib_1.h@
 -}
-newtype Callback_t_Deref
-    = Callback_t_Deref {un_Callback_t_Deref :: (Ptr Void ->
-                                                HsBindgen.Runtime.Prelude.Word32 ->
-                                                IO HsBindgen.Runtime.Prelude.Word32)}
+newtype Callback_t_Aux
+    = Callback_t_Aux {un_Callback_t_Aux :: (Ptr Void ->
+                                            HsBindgen.Runtime.Prelude.Word32 ->
+                                            IO HsBindgen.Runtime.Prelude.Word32)}
       {- ^ Auxiliary type used by 'Callback_t'
 
       __C declaration:__ @callback_t@
@@ -698,25 +698,24 @@ newtype Callback_t_Deref
       __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toCallback_t_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_24eac512dce926e9 :: Callback_t_Deref ->
-                                                                   IO (FunPtr Callback_t_Deref)
--- __unique:__ @fromCallback_t_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_893b8fa3b3f09882 :: FunPtr Callback_t_Deref ->
-                                                                   Callback_t_Deref
-instance ToFunPtr Callback_t_Deref
-    where toFunPtr = hs_bindgen_24eac512dce926e9
-instance FromFunPtr Callback_t_Deref
-    where fromFunPtr = hs_bindgen_893b8fa3b3f09882
-instance TyEq ty
-              (CFieldType Callback_t_Deref "un_Callback_t_Deref") =>
-         HasField "un_Callback_t_Deref" (Ptr Callback_t_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Callback_t_Deref")
-instance HasCField Callback_t_Deref "un_Callback_t_Deref"
-    where type CFieldType Callback_t_Deref
-                          "un_Callback_t_Deref" = Ptr Void ->
-                                                  HsBindgen.Runtime.Prelude.Word32 ->
-                                                  IO HsBindgen.Runtime.Prelude.Word32
+-- __unique:__ @toCallback_t_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b6b6922e35047658 :: Callback_t_Aux ->
+                                                                   IO (FunPtr Callback_t_Aux)
+-- __unique:__ @fromCallback_t_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_d6debb4b8d5bb869 :: FunPtr Callback_t_Aux ->
+                                                                   Callback_t_Aux
+instance ToFunPtr Callback_t_Aux
+    where toFunPtr = hs_bindgen_b6b6922e35047658
+instance FromFunPtr Callback_t_Aux
+    where fromFunPtr = hs_bindgen_d6debb4b8d5bb869
+instance TyEq ty (CFieldType Callback_t_Aux "un_Callback_t_Aux") =>
+         HasField "un_Callback_t_Aux" (Ptr Callback_t_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Callback_t_Aux")
+instance HasCField Callback_t_Aux "un_Callback_t_Aux"
+    where type CFieldType Callback_t_Aux
+                          "un_Callback_t_Aux" = Ptr Void ->
+                                                HsBindgen.Runtime.Prelude.Word32 ->
+                                                IO HsBindgen.Runtime.Prelude.Word32
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @callback_t@
 
@@ -725,7 +724,7 @@ instance HasCField Callback_t_Deref "un_Callback_t_Deref"
     __exported by:__ @edge-cases\/distilled_lib_1.h@
 -}
 newtype Callback_t
-    = Callback_t {un_Callback_t :: (FunPtr Callback_t_Deref)}
+    = Callback_t {un_Callback_t :: (FunPtr Callback_t_Aux)}
       {- ^ __C declaration:__ @callback_t@
 
            __defined at:__ @edge-cases\/distilled_lib_1.h:77:19@
@@ -739,7 +738,7 @@ instance TyEq ty (CFieldType Callback_t "un_Callback_t") =>
     where getField = ptrToCField (Proxy @"un_Callback_t")
 instance HasCField Callback_t "un_Callback_t"
     where type CFieldType Callback_t
-                          "un_Callback_t" = FunPtr Callback_t_Deref
+                          "un_Callback_t" = FunPtr Callback_t_Aux
           offset# = \_ -> \_ -> 0
 -- __unique:__ @test_edgecasesdistilled_lib_1_Example_Safe_some_fun@
 foreign import ccall safe "hs_bindgen_57cb99ed92c001ad" hs_bindgen_57cb99ed92c001ad :: Ptr A_type_t ->

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -48,38 +48,38 @@ __defined at:__ @functions\/callbacks.h:10:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype FileOpenedNotification_Deref = FileOpenedNotification_Deref
-  { un_FileOpenedNotification_Deref :: IO ()
+newtype FileOpenedNotification_Aux = FileOpenedNotification_Aux
+  { un_FileOpenedNotification_Aux :: IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFileOpenedNotification_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_71c9954059c4eb57 ::
-     FileOpenedNotification_Deref
-  -> IO (Ptr.FunPtr FileOpenedNotification_Deref)
+-- __unique:__ @toFileOpenedNotification_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b3b8b1fad168671a ::
+     FileOpenedNotification_Aux
+  -> IO (Ptr.FunPtr FileOpenedNotification_Aux)
 
--- __unique:__ @fromFileOpenedNotification_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5197d76026e68499 ::
-     Ptr.FunPtr FileOpenedNotification_Deref
-  -> FileOpenedNotification_Deref
+-- __unique:__ @fromFileOpenedNotification_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_f3ba5920f34c7f6a ::
+     Ptr.FunPtr FileOpenedNotification_Aux
+  -> FileOpenedNotification_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr FileOpenedNotification_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr FileOpenedNotification_Aux where
 
-  toFunPtr = hs_bindgen_71c9954059c4eb57
+  toFunPtr = hs_bindgen_b3b8b1fad168671a
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr FileOpenedNotification_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr FileOpenedNotification_Aux where
 
-  fromFunPtr = hs_bindgen_5197d76026e68499
+  fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOpenedNotification_Deref) "un_FileOpenedNotification_Deref")
-         ) => GHC.Records.HasField "un_FileOpenedNotification_Deref" (Ptr.Ptr FileOpenedNotification_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOpenedNotification_Aux) "un_FileOpenedNotification_Aux")
+         ) => GHC.Records.HasField "un_FileOpenedNotification_Aux" (Ptr.Ptr FileOpenedNotification_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_FileOpenedNotification_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_FileOpenedNotification_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification_Deref "un_FileOpenedNotification_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification_Aux "un_FileOpenedNotification_Aux" where
 
-  type CFieldType FileOpenedNotification_Deref "un_FileOpenedNotification_Deref" =
+  type CFieldType FileOpenedNotification_Aux "un_FileOpenedNotification_Aux" =
     IO ()
 
   offset# = \_ -> \_ -> 0
@@ -91,7 +91,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification_Deref "un_
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype FileOpenedNotification = FileOpenedNotification
-  { un_FileOpenedNotification :: Ptr.FunPtr FileOpenedNotification_Deref
+  { un_FileOpenedNotification :: Ptr.FunPtr FileOpenedNotification_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -105,7 +105,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOpenedNotificati
 instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification "un_FileOpenedNotification" where
 
   type CFieldType FileOpenedNotification "un_FileOpenedNotification" =
-    Ptr.FunPtr FileOpenedNotification_Deref
+    Ptr.FunPtr FileOpenedNotification_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -117,38 +117,38 @@ __defined at:__ @functions\/callbacks.h:11:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype ProgressUpdate_Deref = ProgressUpdate_Deref
-  { un_ProgressUpdate_Deref :: FC.CInt -> IO ()
+newtype ProgressUpdate_Aux = ProgressUpdate_Aux
+  { un_ProgressUpdate_Aux :: FC.CInt -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toProgressUpdate_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_dd7cdf530e3d4c8d ::
-     ProgressUpdate_Deref
-  -> IO (Ptr.FunPtr ProgressUpdate_Deref)
+-- __unique:__ @toProgressUpdate_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_d551f31556ffa727 ::
+     ProgressUpdate_Aux
+  -> IO (Ptr.FunPtr ProgressUpdate_Aux)
 
--- __unique:__ @fromProgressUpdate_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_3d2189b9fad82fae ::
-     Ptr.FunPtr ProgressUpdate_Deref
-  -> ProgressUpdate_Deref
+-- __unique:__ @fromProgressUpdate_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ccf7f4b62a839a04 ::
+     Ptr.FunPtr ProgressUpdate_Aux
+  -> ProgressUpdate_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr ProgressUpdate_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr ProgressUpdate_Aux where
 
-  toFunPtr = hs_bindgen_dd7cdf530e3d4c8d
+  toFunPtr = hs_bindgen_d551f31556ffa727
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr ProgressUpdate_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr ProgressUpdate_Aux where
 
-  fromFunPtr = hs_bindgen_3d2189b9fad82fae
+  fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProgressUpdate_Deref) "un_ProgressUpdate_Deref")
-         ) => GHC.Records.HasField "un_ProgressUpdate_Deref" (Ptr.Ptr ProgressUpdate_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProgressUpdate_Aux) "un_ProgressUpdate_Aux")
+         ) => GHC.Records.HasField "un_ProgressUpdate_Aux" (Ptr.Ptr ProgressUpdate_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_ProgressUpdate_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_ProgressUpdate_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate_Deref "un_ProgressUpdate_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate_Aux "un_ProgressUpdate_Aux" where
 
-  type CFieldType ProgressUpdate_Deref "un_ProgressUpdate_Deref" =
+  type CFieldType ProgressUpdate_Aux "un_ProgressUpdate_Aux" =
     FC.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -160,7 +160,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate_Deref "un_Progress
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype ProgressUpdate = ProgressUpdate
-  { un_ProgressUpdate :: Ptr.FunPtr ProgressUpdate_Deref
+  { un_ProgressUpdate :: Ptr.FunPtr ProgressUpdate_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -174,7 +174,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProgressUpdate) "un_
 instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate "un_ProgressUpdate" where
 
   type CFieldType ProgressUpdate "un_ProgressUpdate" =
-    Ptr.FunPtr ProgressUpdate_Deref
+    Ptr.FunPtr ProgressUpdate_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -186,38 +186,38 @@ __defined at:__ @functions\/callbacks.h:12:15@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype DataValidator_Deref = DataValidator_Deref
-  { un_DataValidator_Deref :: FC.CInt -> IO FC.CInt
+newtype DataValidator_Aux = DataValidator_Aux
+  { un_DataValidator_Aux :: FC.CInt -> IO FC.CInt
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toDataValidator_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_2dd1c35b0255a24e ::
-     DataValidator_Deref
-  -> IO (Ptr.FunPtr DataValidator_Deref)
+-- __unique:__ @toDataValidator_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c656ca21e63343d6 ::
+     DataValidator_Aux
+  -> IO (Ptr.FunPtr DataValidator_Aux)
 
--- __unique:__ @fromDataValidator_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_d128eab55aa429fc ::
-     Ptr.FunPtr DataValidator_Deref
-  -> DataValidator_Deref
+-- __unique:__ @fromDataValidator_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_c1e79a4c11ca4033 ::
+     Ptr.FunPtr DataValidator_Aux
+  -> DataValidator_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr DataValidator_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr DataValidator_Aux where
 
-  toFunPtr = hs_bindgen_2dd1c35b0255a24e
+  toFunPtr = hs_bindgen_c656ca21e63343d6
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr DataValidator_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr DataValidator_Aux where
 
-  fromFunPtr = hs_bindgen_d128eab55aa429fc
+  fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataValidator_Deref) "un_DataValidator_Deref")
-         ) => GHC.Records.HasField "un_DataValidator_Deref" (Ptr.Ptr DataValidator_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataValidator_Aux) "un_DataValidator_Aux")
+         ) => GHC.Records.HasField "un_DataValidator_Aux" (Ptr.Ptr DataValidator_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_DataValidator_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_DataValidator_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField DataValidator_Deref "un_DataValidator_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField DataValidator_Aux "un_DataValidator_Aux" where
 
-  type CFieldType DataValidator_Deref "un_DataValidator_Deref" =
+  type CFieldType DataValidator_Aux "un_DataValidator_Aux" =
     FC.CInt -> IO FC.CInt
 
   offset# = \_ -> \_ -> 0
@@ -229,7 +229,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataValidator_Deref "un_DataValid
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype DataValidator = DataValidator
-  { un_DataValidator :: Ptr.FunPtr DataValidator_Deref
+  { un_DataValidator :: Ptr.FunPtr DataValidator_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -243,7 +243,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataValidator) "un_D
 instance HsBindgen.Runtime.HasCField.HasCField DataValidator "un_DataValidator" where
 
   type CFieldType DataValidator "un_DataValidator" =
-    Ptr.FunPtr DataValidator_Deref
+    Ptr.FunPtr DataValidator_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -381,38 +381,38 @@ __defined at:__ @functions\/callbacks.h:26:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype MeasurementReceived_Deref = MeasurementReceived_Deref
-  { un_MeasurementReceived_Deref :: (Ptr.Ptr Measurement) -> IO ()
+newtype MeasurementReceived_Aux = MeasurementReceived_Aux
+  { un_MeasurementReceived_Aux :: (Ptr.Ptr Measurement) -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toMeasurementReceived_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_d9413d8e35ffe643 ::
-     MeasurementReceived_Deref
-  -> IO (Ptr.FunPtr MeasurementReceived_Deref)
+-- __unique:__ @toMeasurementReceived_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_9259654df9d40f5b ::
+     MeasurementReceived_Aux
+  -> IO (Ptr.FunPtr MeasurementReceived_Aux)
 
--- __unique:__ @fromMeasurementReceived_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_8af7f320063ba46e ::
-     Ptr.FunPtr MeasurementReceived_Deref
-  -> MeasurementReceived_Deref
+-- __unique:__ @fromMeasurementReceived_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_383c36bb22947621 ::
+     Ptr.FunPtr MeasurementReceived_Aux
+  -> MeasurementReceived_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr MeasurementReceived_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr MeasurementReceived_Aux where
 
-  toFunPtr = hs_bindgen_d9413d8e35ffe643
+  toFunPtr = hs_bindgen_9259654df9d40f5b
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr MeasurementReceived_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr MeasurementReceived_Aux where
 
-  fromFunPtr = hs_bindgen_8af7f320063ba46e
+  fromFunPtr = hs_bindgen_383c36bb22947621
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived_Deref) "un_MeasurementReceived_Deref")
-         ) => GHC.Records.HasField "un_MeasurementReceived_Deref" (Ptr.Ptr MeasurementReceived_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived_Aux) "un_MeasurementReceived_Aux")
+         ) => GHC.Records.HasField "un_MeasurementReceived_Aux" (Ptr.Ptr MeasurementReceived_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_MeasurementReceived_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_MeasurementReceived_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived_Deref "un_MeasurementReceived_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived_Aux "un_MeasurementReceived_Aux" where
 
-  type CFieldType MeasurementReceived_Deref "un_MeasurementReceived_Deref" =
+  type CFieldType MeasurementReceived_Aux "un_MeasurementReceived_Aux" =
     (Ptr.Ptr Measurement) -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -424,7 +424,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived_Deref "un_Mea
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype MeasurementReceived = MeasurementReceived
-  { un_MeasurementReceived :: Ptr.FunPtr MeasurementReceived_Deref
+  { un_MeasurementReceived :: Ptr.FunPtr MeasurementReceived_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -438,7 +438,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived)
 instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived "un_MeasurementReceived" where
 
   type CFieldType MeasurementReceived "un_MeasurementReceived" =
-    Ptr.FunPtr MeasurementReceived_Deref
+    Ptr.FunPtr MeasurementReceived_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -450,19 +450,19 @@ __defined at:__ @functions\/callbacks.h:29:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype MeasurementReceived2_Deref = MeasurementReceived2_Deref
-  { un_MeasurementReceived2_Deref :: Measurement -> IO ()
+newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
+  { un_MeasurementReceived2_Aux :: Measurement -> IO ()
   }
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2_Deref) "un_MeasurementReceived2_Deref")
-         ) => GHC.Records.HasField "un_MeasurementReceived2_Deref" (Ptr.Ptr MeasurementReceived2_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2_Aux) "un_MeasurementReceived2_Aux")
+         ) => GHC.Records.HasField "un_MeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_MeasurementReceived2_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_MeasurementReceived2_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2_Deref "un_MeasurementReceived2_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2_Aux "un_MeasurementReceived2_Aux" where
 
-  type CFieldType MeasurementReceived2_Deref "un_MeasurementReceived2_Deref" =
+  type CFieldType MeasurementReceived2_Aux "un_MeasurementReceived2_Aux" =
     Measurement -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -474,7 +474,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2_Deref "un_Me
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype MeasurementReceived2 = MeasurementReceived2
-  { un_MeasurementReceived2 :: Ptr.FunPtr MeasurementReceived2_Deref
+  { un_MeasurementReceived2 :: Ptr.FunPtr MeasurementReceived2_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -488,7 +488,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2
 instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2 "un_MeasurementReceived2" where
 
   type CFieldType MeasurementReceived2 "un_MeasurementReceived2" =
-    Ptr.FunPtr MeasurementReceived2_Deref
+    Ptr.FunPtr MeasurementReceived2_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -500,19 +500,19 @@ __defined at:__ @functions\/callbacks.h:32:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype SampleBufferFull_Deref = SampleBufferFull_Deref
-  { un_SampleBufferFull_Deref :: ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ()
+newtype SampleBufferFull_Aux = SampleBufferFull_Aux
+  { un_SampleBufferFull_Aux :: ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ()
   }
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull_Deref) "un_SampleBufferFull_Deref")
-         ) => GHC.Records.HasField "un_SampleBufferFull_Deref" (Ptr.Ptr SampleBufferFull_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull_Aux) "un_SampleBufferFull_Aux")
+         ) => GHC.Records.HasField "un_SampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_SampleBufferFull_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_SampleBufferFull_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull_Deref "un_SampleBufferFull_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull_Aux "un_SampleBufferFull_Aux" where
 
-  type CFieldType SampleBufferFull_Deref "un_SampleBufferFull_Deref" =
+  type CFieldType SampleBufferFull_Aux "un_SampleBufferFull_Aux" =
     ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -524,7 +524,7 @@ instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull_Deref "un_Sample
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype SampleBufferFull = SampleBufferFull
-  { un_SampleBufferFull :: Ptr.FunPtr SampleBufferFull_Deref
+  { un_SampleBufferFull :: Ptr.FunPtr SampleBufferFull_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -538,7 +538,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull) "u
 instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull "un_SampleBufferFull" where
 
   type CFieldType SampleBufferFull "un_SampleBufferFull" =
-    Ptr.FunPtr SampleBufferFull_Deref
+    Ptr.FunPtr SampleBufferFull_Aux
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -430,8 +430,8 @@ __defined at:__ @functions\/callbacks.h:10:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype FileOpenedNotification_Deref
-    = FileOpenedNotification_Deref {un_FileOpenedNotification_Deref :: (IO Unit)}
+newtype FileOpenedNotification_Aux
+    = FileOpenedNotification_Aux {un_FileOpenedNotification_Aux :: (IO Unit)}
       {- ^ Auxiliary type used by 'FileOpenedNotification'
 
       __C declaration:__ @FileOpenedNotification@
@@ -441,27 +441,27 @@ newtype FileOpenedNotification_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFileOpenedNotification_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_71c9954059c4eb57 :: FileOpenedNotification_Deref ->
-                                                                   IO (FunPtr FileOpenedNotification_Deref)
--- __unique:__ @fromFileOpenedNotification_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5197d76026e68499 :: FunPtr FileOpenedNotification_Deref ->
-                                                                   FileOpenedNotification_Deref
-instance ToFunPtr FileOpenedNotification_Deref
-    where toFunPtr = hs_bindgen_71c9954059c4eb57
-instance FromFunPtr FileOpenedNotification_Deref
-    where fromFunPtr = hs_bindgen_5197d76026e68499
+-- __unique:__ @toFileOpenedNotification_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b3b8b1fad168671a :: FileOpenedNotification_Aux ->
+                                                                   IO (FunPtr FileOpenedNotification_Aux)
+-- __unique:__ @fromFileOpenedNotification_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_f3ba5920f34c7f6a :: FunPtr FileOpenedNotification_Aux ->
+                                                                   FileOpenedNotification_Aux
+instance ToFunPtr FileOpenedNotification_Aux
+    where toFunPtr = hs_bindgen_b3b8b1fad168671a
+instance FromFunPtr FileOpenedNotification_Aux
+    where fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 instance TyEq ty
-              (CFieldType FileOpenedNotification_Deref
-                          "un_FileOpenedNotification_Deref") =>
-         HasField "un_FileOpenedNotification_Deref"
-                  (Ptr FileOpenedNotification_Deref)
+              (CFieldType FileOpenedNotification_Aux
+                          "un_FileOpenedNotification_Aux") =>
+         HasField "un_FileOpenedNotification_Aux"
+                  (Ptr FileOpenedNotification_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_FileOpenedNotification_Deref")
-instance HasCField FileOpenedNotification_Deref
-                   "un_FileOpenedNotification_Deref"
-    where type CFieldType FileOpenedNotification_Deref
-                          "un_FileOpenedNotification_Deref" = IO Unit
+    where getField = ptrToCField (Proxy @"un_FileOpenedNotification_Aux")
+instance HasCField FileOpenedNotification_Aux
+                   "un_FileOpenedNotification_Aux"
+    where type CFieldType FileOpenedNotification_Aux
+                          "un_FileOpenedNotification_Aux" = IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @FileOpenedNotification@
 
@@ -470,7 +470,7 @@ instance HasCField FileOpenedNotification_Deref
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype FileOpenedNotification
-    = FileOpenedNotification {un_FileOpenedNotification :: (FunPtr FileOpenedNotification_Deref)}
+    = FileOpenedNotification {un_FileOpenedNotification :: (FunPtr FileOpenedNotification_Aux)}
       {- ^ __C declaration:__ @FileOpenedNotification@
 
            __defined at:__ @functions\/callbacks.h:10:16@
@@ -488,7 +488,7 @@ instance TyEq ty
 instance HasCField FileOpenedNotification
                    "un_FileOpenedNotification"
     where type CFieldType FileOpenedNotification
-                          "un_FileOpenedNotification" = FunPtr FileOpenedNotification_Deref
+                          "un_FileOpenedNotification" = FunPtr FileOpenedNotification_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'ProgressUpdate'
 
@@ -498,9 +498,8 @@ __defined at:__ @functions\/callbacks.h:11:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype ProgressUpdate_Deref
-    = ProgressUpdate_Deref {un_ProgressUpdate_Deref :: (CInt ->
-                                                        IO Unit)}
+newtype ProgressUpdate_Aux
+    = ProgressUpdate_Aux {un_ProgressUpdate_Aux :: (CInt -> IO Unit)}
       {- ^ Auxiliary type used by 'ProgressUpdate'
 
       __C declaration:__ @ProgressUpdate@
@@ -510,25 +509,23 @@ newtype ProgressUpdate_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toProgressUpdate_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_dd7cdf530e3d4c8d :: ProgressUpdate_Deref ->
-                                                                   IO (FunPtr ProgressUpdate_Deref)
--- __unique:__ @fromProgressUpdate_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_3d2189b9fad82fae :: FunPtr ProgressUpdate_Deref ->
-                                                                   ProgressUpdate_Deref
-instance ToFunPtr ProgressUpdate_Deref
-    where toFunPtr = hs_bindgen_dd7cdf530e3d4c8d
-instance FromFunPtr ProgressUpdate_Deref
-    where fromFunPtr = hs_bindgen_3d2189b9fad82fae
+-- __unique:__ @toProgressUpdate_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_d551f31556ffa727 :: ProgressUpdate_Aux ->
+                                                                   IO (FunPtr ProgressUpdate_Aux)
+-- __unique:__ @fromProgressUpdate_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ccf7f4b62a839a04 :: FunPtr ProgressUpdate_Aux ->
+                                                                   ProgressUpdate_Aux
+instance ToFunPtr ProgressUpdate_Aux
+    where toFunPtr = hs_bindgen_d551f31556ffa727
+instance FromFunPtr ProgressUpdate_Aux
+    where fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 instance TyEq ty
-              (CFieldType ProgressUpdate_Deref "un_ProgressUpdate_Deref") =>
-         HasField "un_ProgressUpdate_Deref"
-                  (Ptr ProgressUpdate_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_ProgressUpdate_Deref")
-instance HasCField ProgressUpdate_Deref "un_ProgressUpdate_Deref"
-    where type CFieldType ProgressUpdate_Deref
-                          "un_ProgressUpdate_Deref" = CInt -> IO Unit
+              (CFieldType ProgressUpdate_Aux "un_ProgressUpdate_Aux") =>
+         HasField "un_ProgressUpdate_Aux" (Ptr ProgressUpdate_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_ProgressUpdate_Aux")
+instance HasCField ProgressUpdate_Aux "un_ProgressUpdate_Aux"
+    where type CFieldType ProgressUpdate_Aux
+                          "un_ProgressUpdate_Aux" = CInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @ProgressUpdate@
 
@@ -537,7 +534,7 @@ instance HasCField ProgressUpdate_Deref "un_ProgressUpdate_Deref"
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype ProgressUpdate
-    = ProgressUpdate {un_ProgressUpdate :: (FunPtr ProgressUpdate_Deref)}
+    = ProgressUpdate {un_ProgressUpdate :: (FunPtr ProgressUpdate_Aux)}
       {- ^ __C declaration:__ @ProgressUpdate@
 
            __defined at:__ @functions\/callbacks.h:11:16@
@@ -551,7 +548,7 @@ instance TyEq ty (CFieldType ProgressUpdate "un_ProgressUpdate") =>
     where getField = ptrToCField (Proxy @"un_ProgressUpdate")
 instance HasCField ProgressUpdate "un_ProgressUpdate"
     where type CFieldType ProgressUpdate
-                          "un_ProgressUpdate" = FunPtr ProgressUpdate_Deref
+                          "un_ProgressUpdate" = FunPtr ProgressUpdate_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'DataValidator'
 
@@ -561,8 +558,8 @@ __defined at:__ @functions\/callbacks.h:12:15@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype DataValidator_Deref
-    = DataValidator_Deref {un_DataValidator_Deref :: (CInt -> IO CInt)}
+newtype DataValidator_Aux
+    = DataValidator_Aux {un_DataValidator_Aux :: (CInt -> IO CInt)}
       {- ^ Auxiliary type used by 'DataValidator'
 
       __C declaration:__ @DataValidator@
@@ -572,25 +569,23 @@ newtype DataValidator_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toDataValidator_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_2dd1c35b0255a24e :: DataValidator_Deref ->
-                                                                   IO (FunPtr DataValidator_Deref)
--- __unique:__ @fromDataValidator_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_d128eab55aa429fc :: FunPtr DataValidator_Deref ->
-                                                                   DataValidator_Deref
-instance ToFunPtr DataValidator_Deref
-    where toFunPtr = hs_bindgen_2dd1c35b0255a24e
-instance FromFunPtr DataValidator_Deref
-    where fromFunPtr = hs_bindgen_d128eab55aa429fc
+-- __unique:__ @toDataValidator_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c656ca21e63343d6 :: DataValidator_Aux ->
+                                                                   IO (FunPtr DataValidator_Aux)
+-- __unique:__ @fromDataValidator_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_c1e79a4c11ca4033 :: FunPtr DataValidator_Aux ->
+                                                                   DataValidator_Aux
+instance ToFunPtr DataValidator_Aux
+    where toFunPtr = hs_bindgen_c656ca21e63343d6
+instance FromFunPtr DataValidator_Aux
+    where fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 instance TyEq ty
-              (CFieldType DataValidator_Deref "un_DataValidator_Deref") =>
-         HasField "un_DataValidator_Deref"
-                  (Ptr DataValidator_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_DataValidator_Deref")
-instance HasCField DataValidator_Deref "un_DataValidator_Deref"
-    where type CFieldType DataValidator_Deref
-                          "un_DataValidator_Deref" = CInt -> IO CInt
+              (CFieldType DataValidator_Aux "un_DataValidator_Aux") =>
+         HasField "un_DataValidator_Aux" (Ptr DataValidator_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_DataValidator_Aux")
+instance HasCField DataValidator_Aux "un_DataValidator_Aux"
+    where type CFieldType DataValidator_Aux
+                          "un_DataValidator_Aux" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @DataValidator@
 
@@ -599,7 +594,7 @@ instance HasCField DataValidator_Deref "un_DataValidator_Deref"
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype DataValidator
-    = DataValidator {un_DataValidator :: (FunPtr DataValidator_Deref)}
+    = DataValidator {un_DataValidator :: (FunPtr DataValidator_Aux)}
       {- ^ __C declaration:__ @DataValidator@
 
            __defined at:__ @functions\/callbacks.h:12:15@
@@ -613,7 +608,7 @@ instance TyEq ty (CFieldType DataValidator "un_DataValidator") =>
     where getField = ptrToCField (Proxy @"un_DataValidator")
 instance HasCField DataValidator "un_DataValidator"
     where type CFieldType DataValidator
-                          "un_DataValidator" = FunPtr DataValidator_Deref
+                          "un_DataValidator" = FunPtr DataValidator_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct Measurement@
 
@@ -694,9 +689,9 @@ __defined at:__ @functions\/callbacks.h:26:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype MeasurementReceived_Deref
-    = MeasurementReceived_Deref {un_MeasurementReceived_Deref :: (Ptr Measurement ->
-                                                                  IO Unit)}
+newtype MeasurementReceived_Aux
+    = MeasurementReceived_Aux {un_MeasurementReceived_Aux :: (Ptr Measurement ->
+                                                              IO Unit)}
       {- ^ Auxiliary type used by 'MeasurementReceived'
 
       __C declaration:__ @MeasurementReceived@
@@ -706,27 +701,27 @@ newtype MeasurementReceived_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toMeasurementReceived_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_d9413d8e35ffe643 :: MeasurementReceived_Deref ->
-                                                                   IO (FunPtr MeasurementReceived_Deref)
--- __unique:__ @fromMeasurementReceived_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_8af7f320063ba46e :: FunPtr MeasurementReceived_Deref ->
-                                                                   MeasurementReceived_Deref
-instance ToFunPtr MeasurementReceived_Deref
-    where toFunPtr = hs_bindgen_d9413d8e35ffe643
-instance FromFunPtr MeasurementReceived_Deref
-    where fromFunPtr = hs_bindgen_8af7f320063ba46e
+-- __unique:__ @toMeasurementReceived_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_9259654df9d40f5b :: MeasurementReceived_Aux ->
+                                                                   IO (FunPtr MeasurementReceived_Aux)
+-- __unique:__ @fromMeasurementReceived_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_383c36bb22947621 :: FunPtr MeasurementReceived_Aux ->
+                                                                   MeasurementReceived_Aux
+instance ToFunPtr MeasurementReceived_Aux
+    where toFunPtr = hs_bindgen_9259654df9d40f5b
+instance FromFunPtr MeasurementReceived_Aux
+    where fromFunPtr = hs_bindgen_383c36bb22947621
 instance TyEq ty
-              (CFieldType MeasurementReceived_Deref
-                          "un_MeasurementReceived_Deref") =>
-         HasField "un_MeasurementReceived_Deref"
-                  (Ptr MeasurementReceived_Deref)
+              (CFieldType MeasurementReceived_Aux
+                          "un_MeasurementReceived_Aux") =>
+         HasField "un_MeasurementReceived_Aux"
+                  (Ptr MeasurementReceived_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_MeasurementReceived_Deref")
-instance HasCField MeasurementReceived_Deref
-                   "un_MeasurementReceived_Deref"
-    where type CFieldType MeasurementReceived_Deref
-                          "un_MeasurementReceived_Deref" = Ptr Measurement -> IO Unit
+    where getField = ptrToCField (Proxy @"un_MeasurementReceived_Aux")
+instance HasCField MeasurementReceived_Aux
+                   "un_MeasurementReceived_Aux"
+    where type CFieldType MeasurementReceived_Aux
+                          "un_MeasurementReceived_Aux" = Ptr Measurement -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @MeasurementReceived@
 
@@ -735,7 +730,7 @@ instance HasCField MeasurementReceived_Deref
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype MeasurementReceived
-    = MeasurementReceived {un_MeasurementReceived :: (FunPtr MeasurementReceived_Deref)}
+    = MeasurementReceived {un_MeasurementReceived :: (FunPtr MeasurementReceived_Aux)}
       {- ^ __C declaration:__ @MeasurementReceived@
 
            __defined at:__ @functions\/callbacks.h:26:16@
@@ -752,7 +747,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_MeasurementReceived")
 instance HasCField MeasurementReceived "un_MeasurementReceived"
     where type CFieldType MeasurementReceived
-                          "un_MeasurementReceived" = FunPtr MeasurementReceived_Deref
+                          "un_MeasurementReceived" = FunPtr MeasurementReceived_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'MeasurementReceived2'
 
@@ -762,9 +757,9 @@ __defined at:__ @functions\/callbacks.h:29:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype MeasurementReceived2_Deref
-    = MeasurementReceived2_Deref {un_MeasurementReceived2_Deref :: (Measurement ->
-                                                                    IO Unit)}
+newtype MeasurementReceived2_Aux
+    = MeasurementReceived2_Aux {un_MeasurementReceived2_Aux :: (Measurement ->
+                                                                IO Unit)}
       {- ^ Auxiliary type used by 'MeasurementReceived2'
 
       __C declaration:__ @MeasurementReceived2@
@@ -774,16 +769,16 @@ newtype MeasurementReceived2_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
 instance TyEq ty
-              (CFieldType MeasurementReceived2_Deref
-                          "un_MeasurementReceived2_Deref") =>
-         HasField "un_MeasurementReceived2_Deref"
-                  (Ptr MeasurementReceived2_Deref)
+              (CFieldType MeasurementReceived2_Aux
+                          "un_MeasurementReceived2_Aux") =>
+         HasField "un_MeasurementReceived2_Aux"
+                  (Ptr MeasurementReceived2_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_MeasurementReceived2_Deref")
-instance HasCField MeasurementReceived2_Deref
-                   "un_MeasurementReceived2_Deref"
-    where type CFieldType MeasurementReceived2_Deref
-                          "un_MeasurementReceived2_Deref" = Measurement -> IO Unit
+    where getField = ptrToCField (Proxy @"un_MeasurementReceived2_Aux")
+instance HasCField MeasurementReceived2_Aux
+                   "un_MeasurementReceived2_Aux"
+    where type CFieldType MeasurementReceived2_Aux
+                          "un_MeasurementReceived2_Aux" = Measurement -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @MeasurementReceived2@
 
@@ -792,7 +787,7 @@ instance HasCField MeasurementReceived2_Deref
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype MeasurementReceived2
-    = MeasurementReceived2 {un_MeasurementReceived2 :: (FunPtr MeasurementReceived2_Deref)}
+    = MeasurementReceived2 {un_MeasurementReceived2 :: (FunPtr MeasurementReceived2_Aux)}
       {- ^ __C declaration:__ @MeasurementReceived2@
 
            __defined at:__ @functions\/callbacks.h:29:16@
@@ -809,7 +804,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_MeasurementReceived2")
 instance HasCField MeasurementReceived2 "un_MeasurementReceived2"
     where type CFieldType MeasurementReceived2
-                          "un_MeasurementReceived2" = FunPtr MeasurementReceived2_Deref
+                          "un_MeasurementReceived2" = FunPtr MeasurementReceived2_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'SampleBufferFull'
 
@@ -819,10 +814,10 @@ __defined at:__ @functions\/callbacks.h:32:16@
 
 __exported by:__ @functions\/callbacks.h@
 -}
-newtype SampleBufferFull_Deref
-    = SampleBufferFull_Deref {un_SampleBufferFull_Deref :: (ConstantArray 10
-                                                                          CInt ->
-                                                            IO Unit)}
+newtype SampleBufferFull_Aux
+    = SampleBufferFull_Aux {un_SampleBufferFull_Aux :: (ConstantArray 10
+                                                                      CInt ->
+                                                        IO Unit)}
       {- ^ Auxiliary type used by 'SampleBufferFull'
 
       __C declaration:__ @SampleBufferFull@
@@ -832,15 +827,14 @@ newtype SampleBufferFull_Deref
       __exported by:__ @functions\/callbacks.h@
       -}
 instance TyEq ty
-              (CFieldType SampleBufferFull_Deref "un_SampleBufferFull_Deref") =>
-         HasField "un_SampleBufferFull_Deref"
-                  (Ptr SampleBufferFull_Deref)
+              (CFieldType SampleBufferFull_Aux "un_SampleBufferFull_Aux") =>
+         HasField "un_SampleBufferFull_Aux"
+                  (Ptr SampleBufferFull_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_SampleBufferFull_Deref")
-instance HasCField SampleBufferFull_Deref
-                   "un_SampleBufferFull_Deref"
-    where type CFieldType SampleBufferFull_Deref
-                          "un_SampleBufferFull_Deref" = ConstantArray 10 CInt -> IO Unit
+    where getField = ptrToCField (Proxy @"un_SampleBufferFull_Aux")
+instance HasCField SampleBufferFull_Aux "un_SampleBufferFull_Aux"
+    where type CFieldType SampleBufferFull_Aux
+                          "un_SampleBufferFull_Aux" = ConstantArray 10 CInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @SampleBufferFull@
 
@@ -849,7 +843,7 @@ instance HasCField SampleBufferFull_Deref
     __exported by:__ @functions\/callbacks.h@
 -}
 newtype SampleBufferFull
-    = SampleBufferFull {un_SampleBufferFull :: (FunPtr SampleBufferFull_Deref)}
+    = SampleBufferFull {un_SampleBufferFull :: (FunPtr SampleBufferFull_Aux)}
       {- ^ __C declaration:__ @SampleBufferFull@
 
            __defined at:__ @functions\/callbacks.h:32:16@
@@ -864,7 +858,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_SampleBufferFull")
 instance HasCField SampleBufferFull "un_SampleBufferFull"
     where type CFieldType SampleBufferFull
-                          "un_SampleBufferFull" = FunPtr SampleBufferFull_Deref
+                          "un_SampleBufferFull" = FunPtr SampleBufferFull_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct MeasurementHandler@
 

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
@@ -31,38 +31,38 @@ __defined at:__ @functions\/circular_dependency_fun.h:3:16@
 
 __exported by:__ @functions\/circular_dependency_fun.h@
 -}
-newtype Fun_ptr_Deref = Fun_ptr_Deref
-  { un_Fun_ptr_Deref :: (Ptr.Ptr Forward_declaration) -> IO ()
+newtype Fun_ptr_Aux = Fun_ptr_Aux
+  { un_Fun_ptr_Aux :: (Ptr.Ptr Forward_declaration) -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFun_ptr_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_83e60b3bb02cd08d ::
-     Fun_ptr_Deref
-  -> IO (Ptr.FunPtr Fun_ptr_Deref)
+-- __unique:__ @toFun_ptr_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_5964bbadb359ee4a ::
+     Fun_ptr_Aux
+  -> IO (Ptr.FunPtr Fun_ptr_Aux)
 
--- __unique:__ @fromFun_ptr_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_66799ec68b619f2a ::
-     Ptr.FunPtr Fun_ptr_Deref
-  -> Fun_ptr_Deref
+-- __unique:__ @fromFun_ptr_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_f8391e85af67fcb6 ::
+     Ptr.FunPtr Fun_ptr_Aux
+  -> Fun_ptr_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Fun_ptr_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Fun_ptr_Aux where
 
-  toFunPtr = hs_bindgen_83e60b3bb02cd08d
+  toFunPtr = hs_bindgen_5964bbadb359ee4a
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Fun_ptr_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Fun_ptr_Aux where
 
-  fromFunPtr = hs_bindgen_66799ec68b619f2a
+  fromFunPtr = hs_bindgen_f8391e85af67fcb6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Fun_ptr_Deref) "un_Fun_ptr_Deref")
-         ) => GHC.Records.HasField "un_Fun_ptr_Deref" (Ptr.Ptr Fun_ptr_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Fun_ptr_Aux) "un_Fun_ptr_Aux")
+         ) => GHC.Records.HasField "un_Fun_ptr_Aux" (Ptr.Ptr Fun_ptr_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Fun_ptr_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Fun_ptr_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr_Deref "un_Fun_ptr_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr_Aux "un_Fun_ptr_Aux" where
 
-  type CFieldType Fun_ptr_Deref "un_Fun_ptr_Deref" =
+  type CFieldType Fun_ptr_Aux "un_Fun_ptr_Aux" =
     (Ptr.Ptr Forward_declaration) -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -74,7 +74,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr_Deref "un_Fun_ptr_Deref" 
     __exported by:__ @functions\/circular_dependency_fun.h@
 -}
 newtype Fun_ptr = Fun_ptr
-  { un_Fun_ptr :: Ptr.FunPtr Fun_ptr_Deref
+  { un_Fun_ptr :: Ptr.FunPtr Fun_ptr_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -88,7 +88,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Fun_ptr) "un_Fun_ptr
 instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr "un_Fun_ptr" where
 
   type CFieldType Fun_ptr "un_Fun_ptr" =
-    Ptr.FunPtr Fun_ptr_Deref
+    Ptr.FunPtr Fun_ptr_Aux
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
@@ -7,9 +7,9 @@ __defined at:__ @functions\/circular_dependency_fun.h:3:16@
 
 __exported by:__ @functions\/circular_dependency_fun.h@
 -}
-newtype Fun_ptr_Deref
-    = Fun_ptr_Deref {un_Fun_ptr_Deref :: (Ptr Forward_declaration ->
-                                          IO Unit)}
+newtype Fun_ptr_Aux
+    = Fun_ptr_Aux {un_Fun_ptr_Aux :: (Ptr Forward_declaration ->
+                                      IO Unit)}
       {- ^ Auxiliary type used by 'Fun_ptr'
 
       __C declaration:__ @fun_ptr@
@@ -19,22 +19,22 @@ newtype Fun_ptr_Deref
       __exported by:__ @functions\/circular_dependency_fun.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFun_ptr_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_83e60b3bb02cd08d :: Fun_ptr_Deref ->
-                                                                   IO (FunPtr Fun_ptr_Deref)
--- __unique:__ @fromFun_ptr_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_66799ec68b619f2a :: FunPtr Fun_ptr_Deref ->
-                                                                   Fun_ptr_Deref
-instance ToFunPtr Fun_ptr_Deref
-    where toFunPtr = hs_bindgen_83e60b3bb02cd08d
-instance FromFunPtr Fun_ptr_Deref
-    where fromFunPtr = hs_bindgen_66799ec68b619f2a
-instance TyEq ty (CFieldType Fun_ptr_Deref "un_Fun_ptr_Deref") =>
-         HasField "un_Fun_ptr_Deref" (Ptr Fun_ptr_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Fun_ptr_Deref")
-instance HasCField Fun_ptr_Deref "un_Fun_ptr_Deref"
-    where type CFieldType Fun_ptr_Deref
-                          "un_Fun_ptr_Deref" = Ptr Forward_declaration -> IO Unit
+-- __unique:__ @toFun_ptr_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_5964bbadb359ee4a :: Fun_ptr_Aux ->
+                                                                   IO (FunPtr Fun_ptr_Aux)
+-- __unique:__ @fromFun_ptr_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_f8391e85af67fcb6 :: FunPtr Fun_ptr_Aux ->
+                                                                   Fun_ptr_Aux
+instance ToFunPtr Fun_ptr_Aux
+    where toFunPtr = hs_bindgen_5964bbadb359ee4a
+instance FromFunPtr Fun_ptr_Aux
+    where fromFunPtr = hs_bindgen_f8391e85af67fcb6
+instance TyEq ty (CFieldType Fun_ptr_Aux "un_Fun_ptr_Aux") =>
+         HasField "un_Fun_ptr_Aux" (Ptr Fun_ptr_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Fun_ptr_Aux")
+instance HasCField Fun_ptr_Aux "un_Fun_ptr_Aux"
+    where type CFieldType Fun_ptr_Aux
+                          "un_Fun_ptr_Aux" = Ptr Forward_declaration -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @fun_ptr@
 
@@ -43,7 +43,7 @@ instance HasCField Fun_ptr_Deref "un_Fun_ptr_Deref"
     __exported by:__ @functions\/circular_dependency_fun.h@
 -}
 newtype Fun_ptr
-    = Fun_ptr {un_Fun_ptr :: (FunPtr Fun_ptr_Deref)}
+    = Fun_ptr {un_Fun_ptr :: (FunPtr Fun_ptr_Aux)}
       {- ^ __C declaration:__ @fun_ptr@
 
            __defined at:__ @functions\/circular_dependency_fun.h:3:16@
@@ -56,7 +56,7 @@ instance TyEq ty (CFieldType Fun_ptr "un_Fun_ptr") =>
          HasField "un_Fun_ptr" (Ptr Fun_ptr) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_Fun_ptr")
 instance HasCField Fun_ptr "un_Fun_ptr"
-    where type CFieldType Fun_ptr "un_Fun_ptr" = FunPtr Fun_ptr_Deref
+    where type CFieldType Fun_ptr "un_Fun_ptr" = FunPtr Fun_ptr_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct forward_declaration@
 

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -384,38 +384,38 @@ __defined at:__ @macros\/reparse.h:132:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef1_Deref = Funptr_typedef1_Deref
-  { un_Funptr_typedef1_Deref :: IO A
+newtype Funptr_typedef1_Aux = Funptr_typedef1_Aux
+  { un_Funptr_typedef1_Aux :: IO A
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunptr_typedef1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_22b246c3d4e2e9b4 ::
-     Funptr_typedef1_Deref
-  -> IO (Ptr.FunPtr Funptr_typedef1_Deref)
+-- __unique:__ @toFunptr_typedef1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c584d0f839fd43de ::
+     Funptr_typedef1_Aux
+  -> IO (Ptr.FunPtr Funptr_typedef1_Aux)
 
--- __unique:__ @fromFunptr_typedef1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_be8d1e35ae3ce7ea ::
-     Ptr.FunPtr Funptr_typedef1_Deref
-  -> Funptr_typedef1_Deref
+-- __unique:__ @fromFunptr_typedef1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_806a46dc418a062c ::
+     Ptr.FunPtr Funptr_typedef1_Aux
+  -> Funptr_typedef1_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef1_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef1_Aux where
 
-  toFunPtr = hs_bindgen_22b246c3d4e2e9b4
+  toFunPtr = hs_bindgen_c584d0f839fd43de
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef1_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef1_Aux where
 
-  fromFunPtr = hs_bindgen_be8d1e35ae3ce7ea
+  fromFunPtr = hs_bindgen_806a46dc418a062c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef1_Deref) "un_Funptr_typedef1_Deref")
-         ) => GHC.Records.HasField "un_Funptr_typedef1_Deref" (Ptr.Ptr Funptr_typedef1_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef1_Aux) "un_Funptr_typedef1_Aux")
+         ) => GHC.Records.HasField "un_Funptr_typedef1_Aux" (Ptr.Ptr Funptr_typedef1_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef1_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef1_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1_Deref "un_Funptr_typedef1_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1_Aux "un_Funptr_typedef1_Aux" where
 
-  type CFieldType Funptr_typedef1_Deref "un_Funptr_typedef1_Deref" =
+  type CFieldType Funptr_typedef1_Aux "un_Funptr_typedef1_Aux" =
     IO A
 
   offset# = \_ -> \_ -> 0
@@ -427,7 +427,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1_Deref "un_Funptr_
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef1 = Funptr_typedef1
-  { un_Funptr_typedef1 :: Ptr.FunPtr Funptr_typedef1_Deref
+  { un_Funptr_typedef1 :: Ptr.FunPtr Funptr_typedef1_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -441,7 +441,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef1) "un
 instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1 "un_Funptr_typedef1" where
 
   type CFieldType Funptr_typedef1 "un_Funptr_typedef1" =
-    Ptr.FunPtr Funptr_typedef1_Deref
+    Ptr.FunPtr Funptr_typedef1_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -453,38 +453,38 @@ __defined at:__ @macros\/reparse.h:133:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef2_Deref = Funptr_typedef2_Deref
-  { un_Funptr_typedef2_Deref :: IO (Ptr.Ptr A)
+newtype Funptr_typedef2_Aux = Funptr_typedef2_Aux
+  { un_Funptr_typedef2_Aux :: IO (Ptr.Ptr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunptr_typedef2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_64096afe55f670f8 ::
-     Funptr_typedef2_Deref
-  -> IO (Ptr.FunPtr Funptr_typedef2_Deref)
+-- __unique:__ @toFunptr_typedef2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_f174457a161ac5a0 ::
+     Funptr_typedef2_Aux
+  -> IO (Ptr.FunPtr Funptr_typedef2_Aux)
 
--- __unique:__ @fromFunptr_typedef2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_f3ef05bacf30e067 ::
-     Ptr.FunPtr Funptr_typedef2_Deref
-  -> Funptr_typedef2_Deref
+-- __unique:__ @fromFunptr_typedef2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_323d07dff85b802c ::
+     Ptr.FunPtr Funptr_typedef2_Aux
+  -> Funptr_typedef2_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef2_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef2_Aux where
 
-  toFunPtr = hs_bindgen_64096afe55f670f8
+  toFunPtr = hs_bindgen_f174457a161ac5a0
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef2_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef2_Aux where
 
-  fromFunPtr = hs_bindgen_f3ef05bacf30e067
+  fromFunPtr = hs_bindgen_323d07dff85b802c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef2_Deref) "un_Funptr_typedef2_Deref")
-         ) => GHC.Records.HasField "un_Funptr_typedef2_Deref" (Ptr.Ptr Funptr_typedef2_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef2_Aux) "un_Funptr_typedef2_Aux")
+         ) => GHC.Records.HasField "un_Funptr_typedef2_Aux" (Ptr.Ptr Funptr_typedef2_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef2_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef2_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2_Deref "un_Funptr_typedef2_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2_Aux "un_Funptr_typedef2_Aux" where
 
-  type CFieldType Funptr_typedef2_Deref "un_Funptr_typedef2_Deref" =
+  type CFieldType Funptr_typedef2_Aux "un_Funptr_typedef2_Aux" =
     IO (Ptr.Ptr A)
 
   offset# = \_ -> \_ -> 0
@@ -496,7 +496,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2_Deref "un_Funptr_
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef2 = Funptr_typedef2
-  { un_Funptr_typedef2 :: Ptr.FunPtr Funptr_typedef2_Deref
+  { un_Funptr_typedef2 :: Ptr.FunPtr Funptr_typedef2_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -510,7 +510,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef2) "un
 instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2 "un_Funptr_typedef2" where
 
   type CFieldType Funptr_typedef2 "un_Funptr_typedef2" =
-    Ptr.FunPtr Funptr_typedef2_Deref
+    Ptr.FunPtr Funptr_typedef2_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -522,38 +522,38 @@ __defined at:__ @macros\/reparse.h:134:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef3_Deref = Funptr_typedef3_Deref
-  { un_Funptr_typedef3_Deref :: IO (Ptr.Ptr (Ptr.Ptr A))
+newtype Funptr_typedef3_Aux = Funptr_typedef3_Aux
+  { un_Funptr_typedef3_Aux :: IO (Ptr.Ptr (Ptr.Ptr A))
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunptr_typedef3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_eccb0ab7322077fa ::
-     Funptr_typedef3_Deref
-  -> IO (Ptr.FunPtr Funptr_typedef3_Deref)
+-- __unique:__ @toFunptr_typedef3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_031d1a7decd790d8 ::
+     Funptr_typedef3_Aux
+  -> IO (Ptr.FunPtr Funptr_typedef3_Aux)
 
--- __unique:__ @fromFunptr_typedef3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_6babaeadc50dea72 ::
-     Ptr.FunPtr Funptr_typedef3_Deref
-  -> Funptr_typedef3_Deref
+-- __unique:__ @fromFunptr_typedef3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_82dc7b932974117e ::
+     Ptr.FunPtr Funptr_typedef3_Aux
+  -> Funptr_typedef3_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef3_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef3_Aux where
 
-  toFunPtr = hs_bindgen_eccb0ab7322077fa
+  toFunPtr = hs_bindgen_031d1a7decd790d8
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef3_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef3_Aux where
 
-  fromFunPtr = hs_bindgen_6babaeadc50dea72
+  fromFunPtr = hs_bindgen_82dc7b932974117e
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef3_Deref) "un_Funptr_typedef3_Deref")
-         ) => GHC.Records.HasField "un_Funptr_typedef3_Deref" (Ptr.Ptr Funptr_typedef3_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef3_Aux) "un_Funptr_typedef3_Aux")
+         ) => GHC.Records.HasField "un_Funptr_typedef3_Aux" (Ptr.Ptr Funptr_typedef3_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef3_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef3_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3_Deref "un_Funptr_typedef3_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3_Aux "un_Funptr_typedef3_Aux" where
 
-  type CFieldType Funptr_typedef3_Deref "un_Funptr_typedef3_Deref" =
+  type CFieldType Funptr_typedef3_Aux "un_Funptr_typedef3_Aux" =
     IO (Ptr.Ptr (Ptr.Ptr A))
 
   offset# = \_ -> \_ -> 0
@@ -565,7 +565,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3_Deref "un_Funptr_
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef3 = Funptr_typedef3
-  { un_Funptr_typedef3 :: Ptr.FunPtr Funptr_typedef3_Deref
+  { un_Funptr_typedef3 :: Ptr.FunPtr Funptr_typedef3_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -579,7 +579,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef3) "un
 instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3 "un_Funptr_typedef3" where
 
   type CFieldType Funptr_typedef3 "un_Funptr_typedef3" =
-    Ptr.FunPtr Funptr_typedef3_Deref
+    Ptr.FunPtr Funptr_typedef3_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -591,38 +591,38 @@ __defined at:__ @macros\/reparse.h:135:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef4_Deref = Funptr_typedef4_Deref
-  { un_Funptr_typedef4_Deref :: FC.CInt -> FC.CDouble -> IO A
+newtype Funptr_typedef4_Aux = Funptr_typedef4_Aux
+  { un_Funptr_typedef4_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunptr_typedef4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_725ad1ac194d67b4 ::
-     Funptr_typedef4_Deref
-  -> IO (Ptr.FunPtr Funptr_typedef4_Deref)
+-- __unique:__ @toFunptr_typedef4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_da2336d254667386 ::
+     Funptr_typedef4_Aux
+  -> IO (Ptr.FunPtr Funptr_typedef4_Aux)
 
--- __unique:__ @fromFunptr_typedef4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_1153f16e6073820c ::
-     Ptr.FunPtr Funptr_typedef4_Deref
-  -> Funptr_typedef4_Deref
+-- __unique:__ @fromFunptr_typedef4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_d4a97954476da161 ::
+     Ptr.FunPtr Funptr_typedef4_Aux
+  -> Funptr_typedef4_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef4_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef4_Aux where
 
-  toFunPtr = hs_bindgen_725ad1ac194d67b4
+  toFunPtr = hs_bindgen_da2336d254667386
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef4_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef4_Aux where
 
-  fromFunPtr = hs_bindgen_1153f16e6073820c
+  fromFunPtr = hs_bindgen_d4a97954476da161
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef4_Deref) "un_Funptr_typedef4_Deref")
-         ) => GHC.Records.HasField "un_Funptr_typedef4_Deref" (Ptr.Ptr Funptr_typedef4_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef4_Aux) "un_Funptr_typedef4_Aux")
+         ) => GHC.Records.HasField "un_Funptr_typedef4_Aux" (Ptr.Ptr Funptr_typedef4_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef4_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef4_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4_Deref "un_Funptr_typedef4_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4_Aux "un_Funptr_typedef4_Aux" where
 
-  type CFieldType Funptr_typedef4_Deref "un_Funptr_typedef4_Deref" =
+  type CFieldType Funptr_typedef4_Aux "un_Funptr_typedef4_Aux" =
     FC.CInt -> FC.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
@@ -634,7 +634,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4_Deref "un_Funptr_
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef4 = Funptr_typedef4
-  { un_Funptr_typedef4 :: Ptr.FunPtr Funptr_typedef4_Deref
+  { un_Funptr_typedef4 :: Ptr.FunPtr Funptr_typedef4_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -648,7 +648,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef4) "un
 instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4 "un_Funptr_typedef4" where
 
   type CFieldType Funptr_typedef4 "un_Funptr_typedef4" =
-    Ptr.FunPtr Funptr_typedef4_Deref
+    Ptr.FunPtr Funptr_typedef4_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -660,38 +660,38 @@ __defined at:__ @macros\/reparse.h:136:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef5_Deref = Funptr_typedef5_Deref
-  { un_Funptr_typedef5_Deref :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
+newtype Funptr_typedef5_Aux = Funptr_typedef5_Aux
+  { un_Funptr_typedef5_Aux :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunptr_typedef5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_c44517d5483831b6 ::
-     Funptr_typedef5_Deref
-  -> IO (Ptr.FunPtr Funptr_typedef5_Deref)
+-- __unique:__ @toFunptr_typedef5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_1f45632f07742a46 ::
+     Funptr_typedef5_Aux
+  -> IO (Ptr.FunPtr Funptr_typedef5_Aux)
 
--- __unique:__ @fromFunptr_typedef5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4d292c43d3e48a9a ::
-     Ptr.FunPtr Funptr_typedef5_Deref
-  -> Funptr_typedef5_Deref
+-- __unique:__ @fromFunptr_typedef5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_0bd1877eaaba0d3e ::
+     Ptr.FunPtr Funptr_typedef5_Aux
+  -> Funptr_typedef5_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef5_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Funptr_typedef5_Aux where
 
-  toFunPtr = hs_bindgen_c44517d5483831b6
+  toFunPtr = hs_bindgen_1f45632f07742a46
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef5_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Funptr_typedef5_Aux where
 
-  fromFunPtr = hs_bindgen_4d292c43d3e48a9a
+  fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef5_Deref) "un_Funptr_typedef5_Deref")
-         ) => GHC.Records.HasField "un_Funptr_typedef5_Deref" (Ptr.Ptr Funptr_typedef5_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef5_Aux) "un_Funptr_typedef5_Aux")
+         ) => GHC.Records.HasField "un_Funptr_typedef5_Aux" (Ptr.Ptr Funptr_typedef5_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef5_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Funptr_typedef5_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5_Deref "un_Funptr_typedef5_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5_Aux "un_Funptr_typedef5_Aux" where
 
-  type CFieldType Funptr_typedef5_Deref "un_Funptr_typedef5_Deref" =
+  type CFieldType Funptr_typedef5_Aux "un_Funptr_typedef5_Aux" =
     FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
 
   offset# = \_ -> \_ -> 0
@@ -703,7 +703,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5_Deref "un_Funptr_
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef5 = Funptr_typedef5
-  { un_Funptr_typedef5 :: Ptr.FunPtr Funptr_typedef5_Deref
+  { un_Funptr_typedef5 :: Ptr.FunPtr Funptr_typedef5_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -717,7 +717,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef5) "un
 instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5 "un_Funptr_typedef5" where
 
   type CFieldType Funptr_typedef5 "un_Funptr_typedef5" =
-    Ptr.FunPtr Funptr_typedef5_Deref
+    Ptr.FunPtr Funptr_typedef5_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1212,38 +1212,38 @@ __defined at:__ @macros\/reparse.h:238:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr1_Deref = Const_funptr1_Deref
-  { un_Const_funptr1_Deref :: FC.CInt -> FC.CDouble -> IO A
+newtype Const_funptr1_Aux = Const_funptr1_Aux
+  { un_Const_funptr1_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_38db40c67c079dce ::
-     Const_funptr1_Deref
-  -> IO (Ptr.FunPtr Const_funptr1_Deref)
+-- __unique:__ @toConst_funptr1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_7f125e20a9d4075b ::
+     Const_funptr1_Aux
+  -> IO (Ptr.FunPtr Const_funptr1_Aux)
 
--- __unique:__ @fromConst_funptr1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4148fab066315a44 ::
-     Ptr.FunPtr Const_funptr1_Deref
-  -> Const_funptr1_Deref
+-- __unique:__ @fromConst_funptr1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ac4bd8d789bba94b ::
+     Ptr.FunPtr Const_funptr1_Aux
+  -> Const_funptr1_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr1_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr1_Aux where
 
-  toFunPtr = hs_bindgen_38db40c67c079dce
+  toFunPtr = hs_bindgen_7f125e20a9d4075b
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr1_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr1_Aux where
 
-  fromFunPtr = hs_bindgen_4148fab066315a44
+  fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr1_Deref) "un_Const_funptr1_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr1_Deref" (Ptr.Ptr Const_funptr1_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr1_Aux) "un_Const_funptr1_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr1_Aux" (Ptr.Ptr Const_funptr1_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr1_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr1_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1_Deref "un_Const_funptr1_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1_Aux "un_Const_funptr1_Aux" where
 
-  type CFieldType Const_funptr1_Deref "un_Const_funptr1_Deref" =
+  type CFieldType Const_funptr1_Aux "un_Const_funptr1_Aux" =
     FC.CInt -> FC.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
@@ -1255,7 +1255,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr1 = Const_funptr1
-  { un_Const_funptr1 :: Ptr.FunPtr Const_funptr1_Deref
+  { un_Const_funptr1 :: Ptr.FunPtr Const_funptr1_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1269,7 +1269,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr1) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1 "un_Const_funptr1" where
 
   type CFieldType Const_funptr1 "un_Const_funptr1" =
-    Ptr.FunPtr Const_funptr1_Deref
+    Ptr.FunPtr Const_funptr1_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1281,38 +1281,38 @@ __defined at:__ @macros\/reparse.h:239:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr2_Deref = Const_funptr2_Deref
-  { un_Const_funptr2_Deref :: FC.CInt -> FC.CDouble -> IO A
+newtype Const_funptr2_Aux = Const_funptr2_Aux
+  { un_Const_funptr2_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_01ba6a06fa3eac1f ::
-     Const_funptr2_Deref
-  -> IO (Ptr.FunPtr Const_funptr2_Deref)
+-- __unique:__ @toConst_funptr2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c7b1e36d845634fb ::
+     Const_funptr2_Aux
+  -> IO (Ptr.FunPtr Const_funptr2_Aux)
 
--- __unique:__ @fromConst_funptr2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_d567b5c5455b37a2 ::
-     Ptr.FunPtr Const_funptr2_Deref
-  -> Const_funptr2_Deref
+-- __unique:__ @fromConst_funptr2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_352cebf463125ca9 ::
+     Ptr.FunPtr Const_funptr2_Aux
+  -> Const_funptr2_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr2_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr2_Aux where
 
-  toFunPtr = hs_bindgen_01ba6a06fa3eac1f
+  toFunPtr = hs_bindgen_c7b1e36d845634fb
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr2_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr2_Aux where
 
-  fromFunPtr = hs_bindgen_d567b5c5455b37a2
+  fromFunPtr = hs_bindgen_352cebf463125ca9
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr2_Deref) "un_Const_funptr2_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr2_Deref" (Ptr.Ptr Const_funptr2_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr2_Aux) "un_Const_funptr2_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr2_Aux" (Ptr.Ptr Const_funptr2_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr2_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr2_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2_Deref "un_Const_funptr2_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2_Aux "un_Const_funptr2_Aux" where
 
-  type CFieldType Const_funptr2_Deref "un_Const_funptr2_Deref" =
+  type CFieldType Const_funptr2_Aux "un_Const_funptr2_Aux" =
     FC.CInt -> FC.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
@@ -1324,7 +1324,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr2 = Const_funptr2
-  { un_Const_funptr2 :: Ptr.FunPtr Const_funptr2_Deref
+  { un_Const_funptr2 :: Ptr.FunPtr Const_funptr2_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1338,7 +1338,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr2) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2 "un_Const_funptr2" where
 
   type CFieldType Const_funptr2 "un_Const_funptr2" =
-    Ptr.FunPtr Const_funptr2_Deref
+    Ptr.FunPtr Const_funptr2_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1350,38 +1350,38 @@ __defined at:__ @macros\/reparse.h:240:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr3_Deref = Const_funptr3_Deref
-  { un_Const_funptr3_Deref :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
+newtype Const_funptr3_Aux = Const_funptr3_Aux
+  { un_Const_funptr3_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_3d1e077286c03261 ::
-     Const_funptr3_Deref
-  -> IO (Ptr.FunPtr Const_funptr3_Deref)
+-- __unique:__ @toConst_funptr3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_2dcbfe1c2502178c ::
+     Const_funptr3_Aux
+  -> IO (Ptr.FunPtr Const_funptr3_Aux)
 
--- __unique:__ @fromConst_funptr3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_e08dd4a4255b48ad ::
-     Ptr.FunPtr Const_funptr3_Deref
-  -> Const_funptr3_Deref
+-- __unique:__ @fromConst_funptr3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_86738dcfd7c9d33c ::
+     Ptr.FunPtr Const_funptr3_Aux
+  -> Const_funptr3_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr3_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr3_Aux where
 
-  toFunPtr = hs_bindgen_3d1e077286c03261
+  toFunPtr = hs_bindgen_2dcbfe1c2502178c
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr3_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr3_Aux where
 
-  fromFunPtr = hs_bindgen_e08dd4a4255b48ad
+  fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr3_Deref) "un_Const_funptr3_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr3_Deref" (Ptr.Ptr Const_funptr3_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr3_Aux) "un_Const_funptr3_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr3_Aux" (Ptr.Ptr Const_funptr3_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr3_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr3_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3_Deref "un_Const_funptr3_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3_Aux "un_Const_funptr3_Aux" where
 
-  type CFieldType Const_funptr3_Deref "un_Const_funptr3_Deref" =
+  type CFieldType Const_funptr3_Aux "un_Const_funptr3_Aux" =
     FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
 
   offset# = \_ -> \_ -> 0
@@ -1393,7 +1393,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr3 = Const_funptr3
-  { un_Const_funptr3 :: Ptr.FunPtr Const_funptr3_Deref
+  { un_Const_funptr3 :: Ptr.FunPtr Const_funptr3_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1407,7 +1407,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr3) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3 "un_Const_funptr3" where
 
   type CFieldType Const_funptr3 "un_Const_funptr3" =
-    Ptr.FunPtr Const_funptr3_Deref
+    Ptr.FunPtr Const_funptr3_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1419,38 +1419,38 @@ __defined at:__ @macros\/reparse.h:241:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr4_Deref = Const_funptr4_Deref
-  { un_Const_funptr4_Deref :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
+newtype Const_funptr4_Aux = Const_funptr4_Aux
+  { un_Const_funptr4_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_6805b127d1868888 ::
-     Const_funptr4_Deref
-  -> IO (Ptr.FunPtr Const_funptr4_Deref)
+-- __unique:__ @toConst_funptr4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_5461deeda491de0b ::
+     Const_funptr4_Aux
+  -> IO (Ptr.FunPtr Const_funptr4_Aux)
 
--- __unique:__ @fromConst_funptr4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_3f51966963120db7 ::
-     Ptr.FunPtr Const_funptr4_Deref
-  -> Const_funptr4_Deref
+-- __unique:__ @fromConst_funptr4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_de7846fca3bfd1b6 ::
+     Ptr.FunPtr Const_funptr4_Aux
+  -> Const_funptr4_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr4_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr4_Aux where
 
-  toFunPtr = hs_bindgen_6805b127d1868888
+  toFunPtr = hs_bindgen_5461deeda491de0b
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr4_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr4_Aux where
 
-  fromFunPtr = hs_bindgen_3f51966963120db7
+  fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr4_Deref) "un_Const_funptr4_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr4_Deref" (Ptr.Ptr Const_funptr4_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr4_Aux) "un_Const_funptr4_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr4_Aux" (Ptr.Ptr Const_funptr4_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr4_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr4_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4_Deref "un_Const_funptr4_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4_Aux "un_Const_funptr4_Aux" where
 
-  type CFieldType Const_funptr4_Deref "un_Const_funptr4_Deref" =
+  type CFieldType Const_funptr4_Aux "un_Const_funptr4_Aux" =
     FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
 
   offset# = \_ -> \_ -> 0
@@ -1462,7 +1462,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr4 = Const_funptr4
-  { un_Const_funptr4 :: Ptr.FunPtr Const_funptr4_Deref
+  { un_Const_funptr4 :: Ptr.FunPtr Const_funptr4_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1476,7 +1476,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr4) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4 "un_Const_funptr4" where
 
   type CFieldType Const_funptr4 "un_Const_funptr4" =
-    Ptr.FunPtr Const_funptr4_Deref
+    Ptr.FunPtr Const_funptr4_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1488,38 +1488,38 @@ __defined at:__ @macros\/reparse.h:242:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr5_Deref = Const_funptr5_Deref
-  { un_Const_funptr5_Deref :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
+newtype Const_funptr5_Aux = Const_funptr5_Aux
+  { un_Const_funptr5_Aux :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_c73c2e895703862e ::
-     Const_funptr5_Deref
-  -> IO (Ptr.FunPtr Const_funptr5_Deref)
+-- __unique:__ @toConst_funptr5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_7b0174fc978a1ce1 ::
+     Const_funptr5_Aux
+  -> IO (Ptr.FunPtr Const_funptr5_Aux)
 
--- __unique:__ @fromConst_funptr5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_b83160aff8536dd5 ::
-     Ptr.FunPtr Const_funptr5_Deref
-  -> Const_funptr5_Deref
+-- __unique:__ @fromConst_funptr5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_38a21d84bb7115b5 ::
+     Ptr.FunPtr Const_funptr5_Aux
+  -> Const_funptr5_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr5_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr5_Aux where
 
-  toFunPtr = hs_bindgen_c73c2e895703862e
+  toFunPtr = hs_bindgen_7b0174fc978a1ce1
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr5_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr5_Aux where
 
-  fromFunPtr = hs_bindgen_b83160aff8536dd5
+  fromFunPtr = hs_bindgen_38a21d84bb7115b5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr5_Deref) "un_Const_funptr5_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr5_Deref" (Ptr.Ptr Const_funptr5_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr5_Aux) "un_Const_funptr5_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr5_Aux" (Ptr.Ptr Const_funptr5_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr5_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr5_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5_Deref "un_Const_funptr5_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5_Aux "un_Const_funptr5_Aux" where
 
-  type CFieldType Const_funptr5_Deref "un_Const_funptr5_Deref" =
+  type CFieldType Const_funptr5_Aux "un_Const_funptr5_Aux" =
     FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
 
   offset# = \_ -> \_ -> 0
@@ -1531,7 +1531,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr5 = Const_funptr5
-  { un_Const_funptr5 :: Ptr.FunPtr Const_funptr5_Deref
+  { un_Const_funptr5 :: Ptr.FunPtr Const_funptr5_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1545,7 +1545,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr5) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5 "un_Const_funptr5" where
 
   type CFieldType Const_funptr5 "un_Const_funptr5" =
-    Ptr.FunPtr Const_funptr5_Deref
+    Ptr.FunPtr Const_funptr5_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1557,38 +1557,38 @@ __defined at:__ @macros\/reparse.h:243:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr6_Deref = Const_funptr6_Deref
-  { un_Const_funptr6_Deref :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
+newtype Const_funptr6_Aux = Const_funptr6_Aux
+  { un_Const_funptr6_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr6_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_575363929f0351c3 ::
-     Const_funptr6_Deref
-  -> IO (Ptr.FunPtr Const_funptr6_Deref)
+-- __unique:__ @toConst_funptr6_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_4e32721222f4df9f ::
+     Const_funptr6_Aux
+  -> IO (Ptr.FunPtr Const_funptr6_Aux)
 
--- __unique:__ @fromConst_funptr6_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_ac228f1c81628334 ::
-     Ptr.FunPtr Const_funptr6_Deref
-  -> Const_funptr6_Deref
+-- __unique:__ @fromConst_funptr6_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_45251216b04aa8b5 ::
+     Ptr.FunPtr Const_funptr6_Aux
+  -> Const_funptr6_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr6_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr6_Aux where
 
-  toFunPtr = hs_bindgen_575363929f0351c3
+  toFunPtr = hs_bindgen_4e32721222f4df9f
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr6_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr6_Aux where
 
-  fromFunPtr = hs_bindgen_ac228f1c81628334
+  fromFunPtr = hs_bindgen_45251216b04aa8b5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr6_Deref) "un_Const_funptr6_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr6_Deref" (Ptr.Ptr Const_funptr6_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr6_Aux) "un_Const_funptr6_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr6_Aux" (Ptr.Ptr Const_funptr6_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr6_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr6_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6_Deref "un_Const_funptr6_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6_Aux "un_Const_funptr6_Aux" where
 
-  type CFieldType Const_funptr6_Deref "un_Const_funptr6_Deref" =
+  type CFieldType Const_funptr6_Aux "un_Const_funptr6_Aux" =
     FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
 
   offset# = \_ -> \_ -> 0
@@ -1600,7 +1600,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr6 = Const_funptr6
-  { un_Const_funptr6 :: Ptr.FunPtr Const_funptr6_Deref
+  { un_Const_funptr6 :: Ptr.FunPtr Const_funptr6_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1614,7 +1614,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr6) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6 "un_Const_funptr6" where
 
   type CFieldType Const_funptr6 "un_Const_funptr6" =
-    Ptr.FunPtr Const_funptr6_Deref
+    Ptr.FunPtr Const_funptr6_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -1626,38 +1626,38 @@ __defined at:__ @macros\/reparse.h:244:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr7_Deref = Const_funptr7_Deref
-  { un_Const_funptr7_Deref :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
+newtype Const_funptr7_Aux = Const_funptr7_Aux
+  { un_Const_funptr7_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toConst_funptr7_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_3a96aa40b7ee206f ::
-     Const_funptr7_Deref
-  -> IO (Ptr.FunPtr Const_funptr7_Deref)
+-- __unique:__ @toConst_funptr7_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_0d04fc96ffb9de06 ::
+     Const_funptr7_Aux
+  -> IO (Ptr.FunPtr Const_funptr7_Aux)
 
--- __unique:__ @fromConst_funptr7_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_340e3ab91473372f ::
-     Ptr.FunPtr Const_funptr7_Deref
-  -> Const_funptr7_Deref
+-- __unique:__ @fromConst_funptr7_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_42fbcebf75a973ba ::
+     Ptr.FunPtr Const_funptr7_Aux
+  -> Const_funptr7_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr7_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr Const_funptr7_Aux where
 
-  toFunPtr = hs_bindgen_3a96aa40b7ee206f
+  toFunPtr = hs_bindgen_0d04fc96ffb9de06
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr7_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr Const_funptr7_Aux where
 
-  fromFunPtr = hs_bindgen_340e3ab91473372f
+  fromFunPtr = hs_bindgen_42fbcebf75a973ba
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr7_Deref) "un_Const_funptr7_Deref")
-         ) => GHC.Records.HasField "un_Const_funptr7_Deref" (Ptr.Ptr Const_funptr7_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr7_Aux) "un_Const_funptr7_Aux")
+         ) => GHC.Records.HasField "un_Const_funptr7_Aux" (Ptr.Ptr Const_funptr7_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr7_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_Const_funptr7_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7_Deref "un_Const_funptr7_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7_Aux "un_Const_funptr7_Aux" where
 
-  type CFieldType Const_funptr7_Deref "un_Const_funptr7_Deref" =
+  type CFieldType Const_funptr7_Aux "un_Const_funptr7_Aux" =
     FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.ConstPtr.ConstPtr A)
 
   offset# = \_ -> \_ -> 0
@@ -1669,7 +1669,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7_Deref "un_Const_fun
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr7 = Const_funptr7
-  { un_Const_funptr7 :: Ptr.FunPtr Const_funptr7_Deref
+  { un_Const_funptr7 :: Ptr.FunPtr Const_funptr7_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1683,7 +1683,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr7) "un_C
 instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7 "un_Const_funptr7" where
 
   type CFieldType Const_funptr7 "un_Const_funptr7" =
-    Ptr.FunPtr Const_funptr7_Deref
+    Ptr.FunPtr Const_funptr7_Aux
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2782,8 +2782,8 @@ __defined at:__ @macros\/reparse.h:132:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef1_Deref
-    = Funptr_typedef1_Deref {un_Funptr_typedef1_Deref :: (IO A)}
+newtype Funptr_typedef1_Aux
+    = Funptr_typedef1_Aux {un_Funptr_typedef1_Aux :: (IO A)}
       {- ^ Auxiliary type used by 'Funptr_typedef1'
 
       __C declaration:__ @funptr_typedef1@
@@ -2793,25 +2793,25 @@ newtype Funptr_typedef1_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunptr_typedef1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_22b246c3d4e2e9b4 :: Funptr_typedef1_Deref ->
-                                                                   IO (FunPtr Funptr_typedef1_Deref)
--- __unique:__ @fromFunptr_typedef1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_be8d1e35ae3ce7ea :: FunPtr Funptr_typedef1_Deref ->
-                                                                   Funptr_typedef1_Deref
-instance ToFunPtr Funptr_typedef1_Deref
-    where toFunPtr = hs_bindgen_22b246c3d4e2e9b4
-instance FromFunPtr Funptr_typedef1_Deref
-    where fromFunPtr = hs_bindgen_be8d1e35ae3ce7ea
+-- __unique:__ @toFunptr_typedef1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c584d0f839fd43de :: Funptr_typedef1_Aux ->
+                                                                   IO (FunPtr Funptr_typedef1_Aux)
+-- __unique:__ @fromFunptr_typedef1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_806a46dc418a062c :: FunPtr Funptr_typedef1_Aux ->
+                                                                   Funptr_typedef1_Aux
+instance ToFunPtr Funptr_typedef1_Aux
+    where toFunPtr = hs_bindgen_c584d0f839fd43de
+instance FromFunPtr Funptr_typedef1_Aux
+    where fromFunPtr = hs_bindgen_806a46dc418a062c
 instance TyEq ty
-              (CFieldType Funptr_typedef1_Deref "un_Funptr_typedef1_Deref") =>
-         HasField "un_Funptr_typedef1_Deref"
-                  (Ptr Funptr_typedef1_Deref)
+              (CFieldType Funptr_typedef1_Aux "un_Funptr_typedef1_Aux") =>
+         HasField "un_Funptr_typedef1_Aux"
+                  (Ptr Funptr_typedef1_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Funptr_typedef1_Deref")
-instance HasCField Funptr_typedef1_Deref "un_Funptr_typedef1_Deref"
-    where type CFieldType Funptr_typedef1_Deref
-                          "un_Funptr_typedef1_Deref" = IO A
+    where getField = ptrToCField (Proxy @"un_Funptr_typedef1_Aux")
+instance HasCField Funptr_typedef1_Aux "un_Funptr_typedef1_Aux"
+    where type CFieldType Funptr_typedef1_Aux
+                          "un_Funptr_typedef1_Aux" = IO A
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @funptr_typedef1@
 
@@ -2820,7 +2820,7 @@ instance HasCField Funptr_typedef1_Deref "un_Funptr_typedef1_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef1
-    = Funptr_typedef1 {un_Funptr_typedef1 :: (FunPtr Funptr_typedef1_Deref)}
+    = Funptr_typedef1 {un_Funptr_typedef1 :: (FunPtr Funptr_typedef1_Aux)}
       {- ^ __C declaration:__ @funptr_typedef1@
 
            __defined at:__ @macros\/reparse.h:132:16@
@@ -2835,7 +2835,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Funptr_typedef1")
 instance HasCField Funptr_typedef1 "un_Funptr_typedef1"
     where type CFieldType Funptr_typedef1
-                          "un_Funptr_typedef1" = FunPtr Funptr_typedef1_Deref
+                          "un_Funptr_typedef1" = FunPtr Funptr_typedef1_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Funptr_typedef2'
 
@@ -2845,8 +2845,8 @@ __defined at:__ @macros\/reparse.h:133:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef2_Deref
-    = Funptr_typedef2_Deref {un_Funptr_typedef2_Deref :: (IO (Ptr A))}
+newtype Funptr_typedef2_Aux
+    = Funptr_typedef2_Aux {un_Funptr_typedef2_Aux :: (IO (Ptr A))}
       {- ^ Auxiliary type used by 'Funptr_typedef2'
 
       __C declaration:__ @funptr_typedef2@
@@ -2856,25 +2856,25 @@ newtype Funptr_typedef2_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunptr_typedef2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_64096afe55f670f8 :: Funptr_typedef2_Deref ->
-                                                                   IO (FunPtr Funptr_typedef2_Deref)
--- __unique:__ @fromFunptr_typedef2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_f3ef05bacf30e067 :: FunPtr Funptr_typedef2_Deref ->
-                                                                   Funptr_typedef2_Deref
-instance ToFunPtr Funptr_typedef2_Deref
-    where toFunPtr = hs_bindgen_64096afe55f670f8
-instance FromFunPtr Funptr_typedef2_Deref
-    where fromFunPtr = hs_bindgen_f3ef05bacf30e067
+-- __unique:__ @toFunptr_typedef2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_f174457a161ac5a0 :: Funptr_typedef2_Aux ->
+                                                                   IO (FunPtr Funptr_typedef2_Aux)
+-- __unique:__ @fromFunptr_typedef2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_323d07dff85b802c :: FunPtr Funptr_typedef2_Aux ->
+                                                                   Funptr_typedef2_Aux
+instance ToFunPtr Funptr_typedef2_Aux
+    where toFunPtr = hs_bindgen_f174457a161ac5a0
+instance FromFunPtr Funptr_typedef2_Aux
+    where fromFunPtr = hs_bindgen_323d07dff85b802c
 instance TyEq ty
-              (CFieldType Funptr_typedef2_Deref "un_Funptr_typedef2_Deref") =>
-         HasField "un_Funptr_typedef2_Deref"
-                  (Ptr Funptr_typedef2_Deref)
+              (CFieldType Funptr_typedef2_Aux "un_Funptr_typedef2_Aux") =>
+         HasField "un_Funptr_typedef2_Aux"
+                  (Ptr Funptr_typedef2_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Funptr_typedef2_Deref")
-instance HasCField Funptr_typedef2_Deref "un_Funptr_typedef2_Deref"
-    where type CFieldType Funptr_typedef2_Deref
-                          "un_Funptr_typedef2_Deref" = IO (Ptr A)
+    where getField = ptrToCField (Proxy @"un_Funptr_typedef2_Aux")
+instance HasCField Funptr_typedef2_Aux "un_Funptr_typedef2_Aux"
+    where type CFieldType Funptr_typedef2_Aux
+                          "un_Funptr_typedef2_Aux" = IO (Ptr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @funptr_typedef2@
 
@@ -2883,7 +2883,7 @@ instance HasCField Funptr_typedef2_Deref "un_Funptr_typedef2_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef2
-    = Funptr_typedef2 {un_Funptr_typedef2 :: (FunPtr Funptr_typedef2_Deref)}
+    = Funptr_typedef2 {un_Funptr_typedef2 :: (FunPtr Funptr_typedef2_Aux)}
       {- ^ __C declaration:__ @funptr_typedef2@
 
            __defined at:__ @macros\/reparse.h:133:16@
@@ -2898,7 +2898,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Funptr_typedef2")
 instance HasCField Funptr_typedef2 "un_Funptr_typedef2"
     where type CFieldType Funptr_typedef2
-                          "un_Funptr_typedef2" = FunPtr Funptr_typedef2_Deref
+                          "un_Funptr_typedef2" = FunPtr Funptr_typedef2_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Funptr_typedef3'
 
@@ -2908,8 +2908,8 @@ __defined at:__ @macros\/reparse.h:134:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef3_Deref
-    = Funptr_typedef3_Deref {un_Funptr_typedef3_Deref :: (IO (Ptr (Ptr A)))}
+newtype Funptr_typedef3_Aux
+    = Funptr_typedef3_Aux {un_Funptr_typedef3_Aux :: (IO (Ptr (Ptr A)))}
       {- ^ Auxiliary type used by 'Funptr_typedef3'
 
       __C declaration:__ @funptr_typedef3@
@@ -2919,25 +2919,25 @@ newtype Funptr_typedef3_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunptr_typedef3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_eccb0ab7322077fa :: Funptr_typedef3_Deref ->
-                                                                   IO (FunPtr Funptr_typedef3_Deref)
--- __unique:__ @fromFunptr_typedef3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_6babaeadc50dea72 :: FunPtr Funptr_typedef3_Deref ->
-                                                                   Funptr_typedef3_Deref
-instance ToFunPtr Funptr_typedef3_Deref
-    where toFunPtr = hs_bindgen_eccb0ab7322077fa
-instance FromFunPtr Funptr_typedef3_Deref
-    where fromFunPtr = hs_bindgen_6babaeadc50dea72
+-- __unique:__ @toFunptr_typedef3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_031d1a7decd790d8 :: Funptr_typedef3_Aux ->
+                                                                   IO (FunPtr Funptr_typedef3_Aux)
+-- __unique:__ @fromFunptr_typedef3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_82dc7b932974117e :: FunPtr Funptr_typedef3_Aux ->
+                                                                   Funptr_typedef3_Aux
+instance ToFunPtr Funptr_typedef3_Aux
+    where toFunPtr = hs_bindgen_031d1a7decd790d8
+instance FromFunPtr Funptr_typedef3_Aux
+    where fromFunPtr = hs_bindgen_82dc7b932974117e
 instance TyEq ty
-              (CFieldType Funptr_typedef3_Deref "un_Funptr_typedef3_Deref") =>
-         HasField "un_Funptr_typedef3_Deref"
-                  (Ptr Funptr_typedef3_Deref)
+              (CFieldType Funptr_typedef3_Aux "un_Funptr_typedef3_Aux") =>
+         HasField "un_Funptr_typedef3_Aux"
+                  (Ptr Funptr_typedef3_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Funptr_typedef3_Deref")
-instance HasCField Funptr_typedef3_Deref "un_Funptr_typedef3_Deref"
-    where type CFieldType Funptr_typedef3_Deref
-                          "un_Funptr_typedef3_Deref" = IO (Ptr (Ptr A))
+    where getField = ptrToCField (Proxy @"un_Funptr_typedef3_Aux")
+instance HasCField Funptr_typedef3_Aux "un_Funptr_typedef3_Aux"
+    where type CFieldType Funptr_typedef3_Aux
+                          "un_Funptr_typedef3_Aux" = IO (Ptr (Ptr A))
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @funptr_typedef3@
 
@@ -2946,7 +2946,7 @@ instance HasCField Funptr_typedef3_Deref "un_Funptr_typedef3_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef3
-    = Funptr_typedef3 {un_Funptr_typedef3 :: (FunPtr Funptr_typedef3_Deref)}
+    = Funptr_typedef3 {un_Funptr_typedef3 :: (FunPtr Funptr_typedef3_Aux)}
       {- ^ __C declaration:__ @funptr_typedef3@
 
            __defined at:__ @macros\/reparse.h:134:16@
@@ -2961,7 +2961,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Funptr_typedef3")
 instance HasCField Funptr_typedef3 "un_Funptr_typedef3"
     where type CFieldType Funptr_typedef3
-                          "un_Funptr_typedef3" = FunPtr Funptr_typedef3_Deref
+                          "un_Funptr_typedef3" = FunPtr Funptr_typedef3_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Funptr_typedef4'
 
@@ -2971,9 +2971,9 @@ __defined at:__ @macros\/reparse.h:135:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef4_Deref
-    = Funptr_typedef4_Deref {un_Funptr_typedef4_Deref :: (CInt ->
-                                                          CDouble -> IO A)}
+newtype Funptr_typedef4_Aux
+    = Funptr_typedef4_Aux {un_Funptr_typedef4_Aux :: (CInt ->
+                                                      CDouble -> IO A)}
       {- ^ Auxiliary type used by 'Funptr_typedef4'
 
       __C declaration:__ @funptr_typedef4@
@@ -2983,25 +2983,25 @@ newtype Funptr_typedef4_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunptr_typedef4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_725ad1ac194d67b4 :: Funptr_typedef4_Deref ->
-                                                                   IO (FunPtr Funptr_typedef4_Deref)
--- __unique:__ @fromFunptr_typedef4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_1153f16e6073820c :: FunPtr Funptr_typedef4_Deref ->
-                                                                   Funptr_typedef4_Deref
-instance ToFunPtr Funptr_typedef4_Deref
-    where toFunPtr = hs_bindgen_725ad1ac194d67b4
-instance FromFunPtr Funptr_typedef4_Deref
-    where fromFunPtr = hs_bindgen_1153f16e6073820c
+-- __unique:__ @toFunptr_typedef4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_da2336d254667386 :: Funptr_typedef4_Aux ->
+                                                                   IO (FunPtr Funptr_typedef4_Aux)
+-- __unique:__ @fromFunptr_typedef4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_d4a97954476da161 :: FunPtr Funptr_typedef4_Aux ->
+                                                                   Funptr_typedef4_Aux
+instance ToFunPtr Funptr_typedef4_Aux
+    where toFunPtr = hs_bindgen_da2336d254667386
+instance FromFunPtr Funptr_typedef4_Aux
+    where fromFunPtr = hs_bindgen_d4a97954476da161
 instance TyEq ty
-              (CFieldType Funptr_typedef4_Deref "un_Funptr_typedef4_Deref") =>
-         HasField "un_Funptr_typedef4_Deref"
-                  (Ptr Funptr_typedef4_Deref)
+              (CFieldType Funptr_typedef4_Aux "un_Funptr_typedef4_Aux") =>
+         HasField "un_Funptr_typedef4_Aux"
+                  (Ptr Funptr_typedef4_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Funptr_typedef4_Deref")
-instance HasCField Funptr_typedef4_Deref "un_Funptr_typedef4_Deref"
-    where type CFieldType Funptr_typedef4_Deref
-                          "un_Funptr_typedef4_Deref" = CInt -> CDouble -> IO A
+    where getField = ptrToCField (Proxy @"un_Funptr_typedef4_Aux")
+instance HasCField Funptr_typedef4_Aux "un_Funptr_typedef4_Aux"
+    where type CFieldType Funptr_typedef4_Aux
+                          "un_Funptr_typedef4_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @funptr_typedef4@
 
@@ -3010,7 +3010,7 @@ instance HasCField Funptr_typedef4_Deref "un_Funptr_typedef4_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef4
-    = Funptr_typedef4 {un_Funptr_typedef4 :: (FunPtr Funptr_typedef4_Deref)}
+    = Funptr_typedef4 {un_Funptr_typedef4 :: (FunPtr Funptr_typedef4_Aux)}
       {- ^ __C declaration:__ @funptr_typedef4@
 
            __defined at:__ @macros\/reparse.h:135:16@
@@ -3025,7 +3025,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Funptr_typedef4")
 instance HasCField Funptr_typedef4 "un_Funptr_typedef4"
     where type CFieldType Funptr_typedef4
-                          "un_Funptr_typedef4" = FunPtr Funptr_typedef4_Deref
+                          "un_Funptr_typedef4" = FunPtr Funptr_typedef4_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Funptr_typedef5'
 
@@ -3035,9 +3035,9 @@ __defined at:__ @macros\/reparse.h:136:16@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Funptr_typedef5_Deref
-    = Funptr_typedef5_Deref {un_Funptr_typedef5_Deref :: (CInt ->
-                                                          CDouble -> IO (Ptr A))}
+newtype Funptr_typedef5_Aux
+    = Funptr_typedef5_Aux {un_Funptr_typedef5_Aux :: (CInt ->
+                                                      CDouble -> IO (Ptr A))}
       {- ^ Auxiliary type used by 'Funptr_typedef5'
 
       __C declaration:__ @funptr_typedef5@
@@ -3047,25 +3047,25 @@ newtype Funptr_typedef5_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunptr_typedef5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_c44517d5483831b6 :: Funptr_typedef5_Deref ->
-                                                                   IO (FunPtr Funptr_typedef5_Deref)
--- __unique:__ @fromFunptr_typedef5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4d292c43d3e48a9a :: FunPtr Funptr_typedef5_Deref ->
-                                                                   Funptr_typedef5_Deref
-instance ToFunPtr Funptr_typedef5_Deref
-    where toFunPtr = hs_bindgen_c44517d5483831b6
-instance FromFunPtr Funptr_typedef5_Deref
-    where fromFunPtr = hs_bindgen_4d292c43d3e48a9a
+-- __unique:__ @toFunptr_typedef5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_1f45632f07742a46 :: Funptr_typedef5_Aux ->
+                                                                   IO (FunPtr Funptr_typedef5_Aux)
+-- __unique:__ @fromFunptr_typedef5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_0bd1877eaaba0d3e :: FunPtr Funptr_typedef5_Aux ->
+                                                                   Funptr_typedef5_Aux
+instance ToFunPtr Funptr_typedef5_Aux
+    where toFunPtr = hs_bindgen_1f45632f07742a46
+instance FromFunPtr Funptr_typedef5_Aux
+    where fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 instance TyEq ty
-              (CFieldType Funptr_typedef5_Deref "un_Funptr_typedef5_Deref") =>
-         HasField "un_Funptr_typedef5_Deref"
-                  (Ptr Funptr_typedef5_Deref)
+              (CFieldType Funptr_typedef5_Aux "un_Funptr_typedef5_Aux") =>
+         HasField "un_Funptr_typedef5_Aux"
+                  (Ptr Funptr_typedef5_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Funptr_typedef5_Deref")
-instance HasCField Funptr_typedef5_Deref "un_Funptr_typedef5_Deref"
-    where type CFieldType Funptr_typedef5_Deref
-                          "un_Funptr_typedef5_Deref" = CInt -> CDouble -> IO (Ptr A)
+    where getField = ptrToCField (Proxy @"un_Funptr_typedef5_Aux")
+instance HasCField Funptr_typedef5_Aux "un_Funptr_typedef5_Aux"
+    where type CFieldType Funptr_typedef5_Aux
+                          "un_Funptr_typedef5_Aux" = CInt -> CDouble -> IO (Ptr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @funptr_typedef5@
 
@@ -3074,7 +3074,7 @@ instance HasCField Funptr_typedef5_Deref "un_Funptr_typedef5_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Funptr_typedef5
-    = Funptr_typedef5 {un_Funptr_typedef5 :: (FunPtr Funptr_typedef5_Deref)}
+    = Funptr_typedef5 {un_Funptr_typedef5 :: (FunPtr Funptr_typedef5_Aux)}
       {- ^ __C declaration:__ @funptr_typedef5@
 
            __defined at:__ @macros\/reparse.h:136:16@
@@ -3089,7 +3089,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"un_Funptr_typedef5")
 instance HasCField Funptr_typedef5 "un_Funptr_typedef5"
     where type CFieldType Funptr_typedef5
-                          "un_Funptr_typedef5" = FunPtr Funptr_typedef5_Deref
+                          "un_Funptr_typedef5" = FunPtr Funptr_typedef5_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @comments2@
 
@@ -3538,9 +3538,9 @@ __defined at:__ @macros\/reparse.h:238:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr1_Deref
-    = Const_funptr1_Deref {un_Const_funptr1_Deref :: (CInt ->
-                                                      CDouble -> IO A)}
+newtype Const_funptr1_Aux
+    = Const_funptr1_Aux {un_Const_funptr1_Aux :: (CInt ->
+                                                  CDouble -> IO A)}
       {- ^ Auxiliary type used by 'Const_funptr1'
 
       __C declaration:__ @const_funptr1@
@@ -3550,25 +3550,23 @@ newtype Const_funptr1_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_38db40c67c079dce :: Const_funptr1_Deref ->
-                                                                   IO (FunPtr Const_funptr1_Deref)
--- __unique:__ @fromConst_funptr1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4148fab066315a44 :: FunPtr Const_funptr1_Deref ->
-                                                                   Const_funptr1_Deref
-instance ToFunPtr Const_funptr1_Deref
-    where toFunPtr = hs_bindgen_38db40c67c079dce
-instance FromFunPtr Const_funptr1_Deref
-    where fromFunPtr = hs_bindgen_4148fab066315a44
+-- __unique:__ @toConst_funptr1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_7f125e20a9d4075b :: Const_funptr1_Aux ->
+                                                                   IO (FunPtr Const_funptr1_Aux)
+-- __unique:__ @fromConst_funptr1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ac4bd8d789bba94b :: FunPtr Const_funptr1_Aux ->
+                                                                   Const_funptr1_Aux
+instance ToFunPtr Const_funptr1_Aux
+    where toFunPtr = hs_bindgen_7f125e20a9d4075b
+instance FromFunPtr Const_funptr1_Aux
+    where fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 instance TyEq ty
-              (CFieldType Const_funptr1_Deref "un_Const_funptr1_Deref") =>
-         HasField "un_Const_funptr1_Deref"
-                  (Ptr Const_funptr1_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr1_Deref")
-instance HasCField Const_funptr1_Deref "un_Const_funptr1_Deref"
-    where type CFieldType Const_funptr1_Deref
-                          "un_Const_funptr1_Deref" = CInt -> CDouble -> IO A
+              (CFieldType Const_funptr1_Aux "un_Const_funptr1_Aux") =>
+         HasField "un_Const_funptr1_Aux" (Ptr Const_funptr1_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr1_Aux")
+instance HasCField Const_funptr1_Aux "un_Const_funptr1_Aux"
+    where type CFieldType Const_funptr1_Aux
+                          "un_Const_funptr1_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr1@
 
@@ -3577,7 +3575,7 @@ instance HasCField Const_funptr1_Deref "un_Const_funptr1_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr1
-    = Const_funptr1 {un_Const_funptr1 :: (FunPtr Const_funptr1_Deref)}
+    = Const_funptr1 {un_Const_funptr1 :: (FunPtr Const_funptr1_Aux)}
       {- ^ __C declaration:__ @const_funptr1@
 
            __defined at:__ @macros\/reparse.h:238:27@
@@ -3591,7 +3589,7 @@ instance TyEq ty (CFieldType Const_funptr1 "un_Const_funptr1") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr1")
 instance HasCField Const_funptr1 "un_Const_funptr1"
     where type CFieldType Const_funptr1
-                          "un_Const_funptr1" = FunPtr Const_funptr1_Deref
+                          "un_Const_funptr1" = FunPtr Const_funptr1_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr2'
 
@@ -3601,9 +3599,9 @@ __defined at:__ @macros\/reparse.h:239:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr2_Deref
-    = Const_funptr2_Deref {un_Const_funptr2_Deref :: (CInt ->
-                                                      CDouble -> IO A)}
+newtype Const_funptr2_Aux
+    = Const_funptr2_Aux {un_Const_funptr2_Aux :: (CInt ->
+                                                  CDouble -> IO A)}
       {- ^ Auxiliary type used by 'Const_funptr2'
 
       __C declaration:__ @const_funptr2@
@@ -3613,25 +3611,23 @@ newtype Const_funptr2_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_01ba6a06fa3eac1f :: Const_funptr2_Deref ->
-                                                                   IO (FunPtr Const_funptr2_Deref)
--- __unique:__ @fromConst_funptr2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_d567b5c5455b37a2 :: FunPtr Const_funptr2_Deref ->
-                                                                   Const_funptr2_Deref
-instance ToFunPtr Const_funptr2_Deref
-    where toFunPtr = hs_bindgen_01ba6a06fa3eac1f
-instance FromFunPtr Const_funptr2_Deref
-    where fromFunPtr = hs_bindgen_d567b5c5455b37a2
+-- __unique:__ @toConst_funptr2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c7b1e36d845634fb :: Const_funptr2_Aux ->
+                                                                   IO (FunPtr Const_funptr2_Aux)
+-- __unique:__ @fromConst_funptr2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_352cebf463125ca9 :: FunPtr Const_funptr2_Aux ->
+                                                                   Const_funptr2_Aux
+instance ToFunPtr Const_funptr2_Aux
+    where toFunPtr = hs_bindgen_c7b1e36d845634fb
+instance FromFunPtr Const_funptr2_Aux
+    where fromFunPtr = hs_bindgen_352cebf463125ca9
 instance TyEq ty
-              (CFieldType Const_funptr2_Deref "un_Const_funptr2_Deref") =>
-         HasField "un_Const_funptr2_Deref"
-                  (Ptr Const_funptr2_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr2_Deref")
-instance HasCField Const_funptr2_Deref "un_Const_funptr2_Deref"
-    where type CFieldType Const_funptr2_Deref
-                          "un_Const_funptr2_Deref" = CInt -> CDouble -> IO A
+              (CFieldType Const_funptr2_Aux "un_Const_funptr2_Aux") =>
+         HasField "un_Const_funptr2_Aux" (Ptr Const_funptr2_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr2_Aux")
+instance HasCField Const_funptr2_Aux "un_Const_funptr2_Aux"
+    where type CFieldType Const_funptr2_Aux
+                          "un_Const_funptr2_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr2@
 
@@ -3640,7 +3636,7 @@ instance HasCField Const_funptr2_Deref "un_Const_funptr2_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr2
-    = Const_funptr2 {un_Const_funptr2 :: (FunPtr Const_funptr2_Deref)}
+    = Const_funptr2 {un_Const_funptr2 :: (FunPtr Const_funptr2_Aux)}
       {- ^ __C declaration:__ @const_funptr2@
 
            __defined at:__ @macros\/reparse.h:239:27@
@@ -3654,7 +3650,7 @@ instance TyEq ty (CFieldType Const_funptr2 "un_Const_funptr2") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr2")
 instance HasCField Const_funptr2 "un_Const_funptr2"
     where type CFieldType Const_funptr2
-                          "un_Const_funptr2" = FunPtr Const_funptr2_Deref
+                          "un_Const_funptr2" = FunPtr Const_funptr2_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr3'
 
@@ -3664,9 +3660,9 @@ __defined at:__ @macros\/reparse.h:240:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr3_Deref
-    = Const_funptr3_Deref {un_Const_funptr3_Deref :: (CInt ->
-                                                      CDouble -> IO (ConstPtr A))}
+newtype Const_funptr3_Aux
+    = Const_funptr3_Aux {un_Const_funptr3_Aux :: (CInt ->
+                                                  CDouble -> IO (ConstPtr A))}
       {- ^ Auxiliary type used by 'Const_funptr3'
 
       __C declaration:__ @const_funptr3@
@@ -3676,25 +3672,23 @@ newtype Const_funptr3_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_3d1e077286c03261 :: Const_funptr3_Deref ->
-                                                                   IO (FunPtr Const_funptr3_Deref)
--- __unique:__ @fromConst_funptr3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_e08dd4a4255b48ad :: FunPtr Const_funptr3_Deref ->
-                                                                   Const_funptr3_Deref
-instance ToFunPtr Const_funptr3_Deref
-    where toFunPtr = hs_bindgen_3d1e077286c03261
-instance FromFunPtr Const_funptr3_Deref
-    where fromFunPtr = hs_bindgen_e08dd4a4255b48ad
+-- __unique:__ @toConst_funptr3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_2dcbfe1c2502178c :: Const_funptr3_Aux ->
+                                                                   IO (FunPtr Const_funptr3_Aux)
+-- __unique:__ @fromConst_funptr3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_86738dcfd7c9d33c :: FunPtr Const_funptr3_Aux ->
+                                                                   Const_funptr3_Aux
+instance ToFunPtr Const_funptr3_Aux
+    where toFunPtr = hs_bindgen_2dcbfe1c2502178c
+instance FromFunPtr Const_funptr3_Aux
+    where fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 instance TyEq ty
-              (CFieldType Const_funptr3_Deref "un_Const_funptr3_Deref") =>
-         HasField "un_Const_funptr3_Deref"
-                  (Ptr Const_funptr3_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr3_Deref")
-instance HasCField Const_funptr3_Deref "un_Const_funptr3_Deref"
-    where type CFieldType Const_funptr3_Deref
-                          "un_Const_funptr3_Deref" = CInt -> CDouble -> IO (ConstPtr A)
+              (CFieldType Const_funptr3_Aux "un_Const_funptr3_Aux") =>
+         HasField "un_Const_funptr3_Aux" (Ptr Const_funptr3_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr3_Aux")
+instance HasCField Const_funptr3_Aux "un_Const_funptr3_Aux"
+    where type CFieldType Const_funptr3_Aux
+                          "un_Const_funptr3_Aux" = CInt -> CDouble -> IO (ConstPtr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr3@
 
@@ -3703,7 +3697,7 @@ instance HasCField Const_funptr3_Deref "un_Const_funptr3_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr3
-    = Const_funptr3 {un_Const_funptr3 :: (FunPtr Const_funptr3_Deref)}
+    = Const_funptr3 {un_Const_funptr3 :: (FunPtr Const_funptr3_Aux)}
       {- ^ __C declaration:__ @const_funptr3@
 
            __defined at:__ @macros\/reparse.h:240:27@
@@ -3717,7 +3711,7 @@ instance TyEq ty (CFieldType Const_funptr3 "un_Const_funptr3") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr3")
 instance HasCField Const_funptr3 "un_Const_funptr3"
     where type CFieldType Const_funptr3
-                          "un_Const_funptr3" = FunPtr Const_funptr3_Deref
+                          "un_Const_funptr3" = FunPtr Const_funptr3_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr4'
 
@@ -3727,9 +3721,9 @@ __defined at:__ @macros\/reparse.h:241:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr4_Deref
-    = Const_funptr4_Deref {un_Const_funptr4_Deref :: (CInt ->
-                                                      CDouble -> IO (ConstPtr A))}
+newtype Const_funptr4_Aux
+    = Const_funptr4_Aux {un_Const_funptr4_Aux :: (CInt ->
+                                                  CDouble -> IO (ConstPtr A))}
       {- ^ Auxiliary type used by 'Const_funptr4'
 
       __C declaration:__ @const_funptr4@
@@ -3739,25 +3733,23 @@ newtype Const_funptr4_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_6805b127d1868888 :: Const_funptr4_Deref ->
-                                                                   IO (FunPtr Const_funptr4_Deref)
--- __unique:__ @fromConst_funptr4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_3f51966963120db7 :: FunPtr Const_funptr4_Deref ->
-                                                                   Const_funptr4_Deref
-instance ToFunPtr Const_funptr4_Deref
-    where toFunPtr = hs_bindgen_6805b127d1868888
-instance FromFunPtr Const_funptr4_Deref
-    where fromFunPtr = hs_bindgen_3f51966963120db7
+-- __unique:__ @toConst_funptr4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_5461deeda491de0b :: Const_funptr4_Aux ->
+                                                                   IO (FunPtr Const_funptr4_Aux)
+-- __unique:__ @fromConst_funptr4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_de7846fca3bfd1b6 :: FunPtr Const_funptr4_Aux ->
+                                                                   Const_funptr4_Aux
+instance ToFunPtr Const_funptr4_Aux
+    where toFunPtr = hs_bindgen_5461deeda491de0b
+instance FromFunPtr Const_funptr4_Aux
+    where fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 instance TyEq ty
-              (CFieldType Const_funptr4_Deref "un_Const_funptr4_Deref") =>
-         HasField "un_Const_funptr4_Deref"
-                  (Ptr Const_funptr4_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr4_Deref")
-instance HasCField Const_funptr4_Deref "un_Const_funptr4_Deref"
-    where type CFieldType Const_funptr4_Deref
-                          "un_Const_funptr4_Deref" = CInt -> CDouble -> IO (ConstPtr A)
+              (CFieldType Const_funptr4_Aux "un_Const_funptr4_Aux") =>
+         HasField "un_Const_funptr4_Aux" (Ptr Const_funptr4_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr4_Aux")
+instance HasCField Const_funptr4_Aux "un_Const_funptr4_Aux"
+    where type CFieldType Const_funptr4_Aux
+                          "un_Const_funptr4_Aux" = CInt -> CDouble -> IO (ConstPtr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr4@
 
@@ -3766,7 +3758,7 @@ instance HasCField Const_funptr4_Deref "un_Const_funptr4_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr4
-    = Const_funptr4 {un_Const_funptr4 :: (FunPtr Const_funptr4_Deref)}
+    = Const_funptr4 {un_Const_funptr4 :: (FunPtr Const_funptr4_Aux)}
       {- ^ __C declaration:__ @const_funptr4@
 
            __defined at:__ @macros\/reparse.h:241:27@
@@ -3780,7 +3772,7 @@ instance TyEq ty (CFieldType Const_funptr4 "un_Const_funptr4") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr4")
 instance HasCField Const_funptr4 "un_Const_funptr4"
     where type CFieldType Const_funptr4
-                          "un_Const_funptr4" = FunPtr Const_funptr4_Deref
+                          "un_Const_funptr4" = FunPtr Const_funptr4_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr5'
 
@@ -3790,9 +3782,9 @@ __defined at:__ @macros\/reparse.h:242:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr5_Deref
-    = Const_funptr5_Deref {un_Const_funptr5_Deref :: (CInt ->
-                                                      CDouble -> IO (Ptr A))}
+newtype Const_funptr5_Aux
+    = Const_funptr5_Aux {un_Const_funptr5_Aux :: (CInt ->
+                                                  CDouble -> IO (Ptr A))}
       {- ^ Auxiliary type used by 'Const_funptr5'
 
       __C declaration:__ @const_funptr5@
@@ -3802,25 +3794,23 @@ newtype Const_funptr5_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_c73c2e895703862e :: Const_funptr5_Deref ->
-                                                                   IO (FunPtr Const_funptr5_Deref)
--- __unique:__ @fromConst_funptr5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_b83160aff8536dd5 :: FunPtr Const_funptr5_Deref ->
-                                                                   Const_funptr5_Deref
-instance ToFunPtr Const_funptr5_Deref
-    where toFunPtr = hs_bindgen_c73c2e895703862e
-instance FromFunPtr Const_funptr5_Deref
-    where fromFunPtr = hs_bindgen_b83160aff8536dd5
+-- __unique:__ @toConst_funptr5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_7b0174fc978a1ce1 :: Const_funptr5_Aux ->
+                                                                   IO (FunPtr Const_funptr5_Aux)
+-- __unique:__ @fromConst_funptr5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_38a21d84bb7115b5 :: FunPtr Const_funptr5_Aux ->
+                                                                   Const_funptr5_Aux
+instance ToFunPtr Const_funptr5_Aux
+    where toFunPtr = hs_bindgen_7b0174fc978a1ce1
+instance FromFunPtr Const_funptr5_Aux
+    where fromFunPtr = hs_bindgen_38a21d84bb7115b5
 instance TyEq ty
-              (CFieldType Const_funptr5_Deref "un_Const_funptr5_Deref") =>
-         HasField "un_Const_funptr5_Deref"
-                  (Ptr Const_funptr5_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr5_Deref")
-instance HasCField Const_funptr5_Deref "un_Const_funptr5_Deref"
-    where type CFieldType Const_funptr5_Deref
-                          "un_Const_funptr5_Deref" = CInt -> CDouble -> IO (Ptr A)
+              (CFieldType Const_funptr5_Aux "un_Const_funptr5_Aux") =>
+         HasField "un_Const_funptr5_Aux" (Ptr Const_funptr5_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr5_Aux")
+instance HasCField Const_funptr5_Aux "un_Const_funptr5_Aux"
+    where type CFieldType Const_funptr5_Aux
+                          "un_Const_funptr5_Aux" = CInt -> CDouble -> IO (Ptr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr5@
 
@@ -3829,7 +3819,7 @@ instance HasCField Const_funptr5_Deref "un_Const_funptr5_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr5
-    = Const_funptr5 {un_Const_funptr5 :: (FunPtr Const_funptr5_Deref)}
+    = Const_funptr5 {un_Const_funptr5 :: (FunPtr Const_funptr5_Aux)}
       {- ^ __C declaration:__ @const_funptr5@
 
            __defined at:__ @macros\/reparse.h:242:27@
@@ -3843,7 +3833,7 @@ instance TyEq ty (CFieldType Const_funptr5 "un_Const_funptr5") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr5")
 instance HasCField Const_funptr5 "un_Const_funptr5"
     where type CFieldType Const_funptr5
-                          "un_Const_funptr5" = FunPtr Const_funptr5_Deref
+                          "un_Const_funptr5" = FunPtr Const_funptr5_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr6'
 
@@ -3853,9 +3843,9 @@ __defined at:__ @macros\/reparse.h:243:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr6_Deref
-    = Const_funptr6_Deref {un_Const_funptr6_Deref :: (CInt ->
-                                                      CDouble -> IO (ConstPtr A))}
+newtype Const_funptr6_Aux
+    = Const_funptr6_Aux {un_Const_funptr6_Aux :: (CInt ->
+                                                  CDouble -> IO (ConstPtr A))}
       {- ^ Auxiliary type used by 'Const_funptr6'
 
       __C declaration:__ @const_funptr6@
@@ -3865,25 +3855,23 @@ newtype Const_funptr6_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr6_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_575363929f0351c3 :: Const_funptr6_Deref ->
-                                                                   IO (FunPtr Const_funptr6_Deref)
--- __unique:__ @fromConst_funptr6_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_ac228f1c81628334 :: FunPtr Const_funptr6_Deref ->
-                                                                   Const_funptr6_Deref
-instance ToFunPtr Const_funptr6_Deref
-    where toFunPtr = hs_bindgen_575363929f0351c3
-instance FromFunPtr Const_funptr6_Deref
-    where fromFunPtr = hs_bindgen_ac228f1c81628334
+-- __unique:__ @toConst_funptr6_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_4e32721222f4df9f :: Const_funptr6_Aux ->
+                                                                   IO (FunPtr Const_funptr6_Aux)
+-- __unique:__ @fromConst_funptr6_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_45251216b04aa8b5 :: FunPtr Const_funptr6_Aux ->
+                                                                   Const_funptr6_Aux
+instance ToFunPtr Const_funptr6_Aux
+    where toFunPtr = hs_bindgen_4e32721222f4df9f
+instance FromFunPtr Const_funptr6_Aux
+    where fromFunPtr = hs_bindgen_45251216b04aa8b5
 instance TyEq ty
-              (CFieldType Const_funptr6_Deref "un_Const_funptr6_Deref") =>
-         HasField "un_Const_funptr6_Deref"
-                  (Ptr Const_funptr6_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr6_Deref")
-instance HasCField Const_funptr6_Deref "un_Const_funptr6_Deref"
-    where type CFieldType Const_funptr6_Deref
-                          "un_Const_funptr6_Deref" = CInt -> CDouble -> IO (ConstPtr A)
+              (CFieldType Const_funptr6_Aux "un_Const_funptr6_Aux") =>
+         HasField "un_Const_funptr6_Aux" (Ptr Const_funptr6_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr6_Aux")
+instance HasCField Const_funptr6_Aux "un_Const_funptr6_Aux"
+    where type CFieldType Const_funptr6_Aux
+                          "un_Const_funptr6_Aux" = CInt -> CDouble -> IO (ConstPtr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr6@
 
@@ -3892,7 +3880,7 @@ instance HasCField Const_funptr6_Deref "un_Const_funptr6_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr6
-    = Const_funptr6 {un_Const_funptr6 :: (FunPtr Const_funptr6_Deref)}
+    = Const_funptr6 {un_Const_funptr6 :: (FunPtr Const_funptr6_Aux)}
       {- ^ __C declaration:__ @const_funptr6@
 
            __defined at:__ @macros\/reparse.h:243:27@
@@ -3906,7 +3894,7 @@ instance TyEq ty (CFieldType Const_funptr6 "un_Const_funptr6") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr6")
 instance HasCField Const_funptr6 "un_Const_funptr6"
     where type CFieldType Const_funptr6
-                          "un_Const_funptr6" = FunPtr Const_funptr6_Deref
+                          "un_Const_funptr6" = FunPtr Const_funptr6_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Const_funptr7'
 
@@ -3916,9 +3904,9 @@ __defined at:__ @macros\/reparse.h:244:27@
 
 __exported by:__ @macros\/reparse.h@
 -}
-newtype Const_funptr7_Deref
-    = Const_funptr7_Deref {un_Const_funptr7_Deref :: (CInt ->
-                                                      CDouble -> IO (ConstPtr A))}
+newtype Const_funptr7_Aux
+    = Const_funptr7_Aux {un_Const_funptr7_Aux :: (CInt ->
+                                                  CDouble -> IO (ConstPtr A))}
       {- ^ Auxiliary type used by 'Const_funptr7'
 
       __C declaration:__ @const_funptr7@
@@ -3928,25 +3916,23 @@ newtype Const_funptr7_Deref
       __exported by:__ @macros\/reparse.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toConst_funptr7_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_3a96aa40b7ee206f :: Const_funptr7_Deref ->
-                                                                   IO (FunPtr Const_funptr7_Deref)
--- __unique:__ @fromConst_funptr7_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_340e3ab91473372f :: FunPtr Const_funptr7_Deref ->
-                                                                   Const_funptr7_Deref
-instance ToFunPtr Const_funptr7_Deref
-    where toFunPtr = hs_bindgen_3a96aa40b7ee206f
-instance FromFunPtr Const_funptr7_Deref
-    where fromFunPtr = hs_bindgen_340e3ab91473372f
+-- __unique:__ @toConst_funptr7_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_0d04fc96ffb9de06 :: Const_funptr7_Aux ->
+                                                                   IO (FunPtr Const_funptr7_Aux)
+-- __unique:__ @fromConst_funptr7_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_42fbcebf75a973ba :: FunPtr Const_funptr7_Aux ->
+                                                                   Const_funptr7_Aux
+instance ToFunPtr Const_funptr7_Aux
+    where toFunPtr = hs_bindgen_0d04fc96ffb9de06
+instance FromFunPtr Const_funptr7_Aux
+    where fromFunPtr = hs_bindgen_42fbcebf75a973ba
 instance TyEq ty
-              (CFieldType Const_funptr7_Deref "un_Const_funptr7_Deref") =>
-         HasField "un_Const_funptr7_Deref"
-                  (Ptr Const_funptr7_Deref)
-                  (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_Const_funptr7_Deref")
-instance HasCField Const_funptr7_Deref "un_Const_funptr7_Deref"
-    where type CFieldType Const_funptr7_Deref
-                          "un_Const_funptr7_Deref" = CInt -> CDouble -> IO (ConstPtr A)
+              (CFieldType Const_funptr7_Aux "un_Const_funptr7_Aux") =>
+         HasField "un_Const_funptr7_Aux" (Ptr Const_funptr7_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_Const_funptr7_Aux")
+instance HasCField Const_funptr7_Aux "un_Const_funptr7_Aux"
+    where type CFieldType Const_funptr7_Aux
+                          "un_Const_funptr7_Aux" = CInt -> CDouble -> IO (ConstPtr A)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @const_funptr7@
 
@@ -3955,7 +3941,7 @@ instance HasCField Const_funptr7_Deref "un_Const_funptr7_Deref"
     __exported by:__ @macros\/reparse.h@
 -}
 newtype Const_funptr7
-    = Const_funptr7 {un_Const_funptr7 :: (FunPtr Const_funptr7_Deref)}
+    = Const_funptr7 {un_Const_funptr7 :: (FunPtr Const_funptr7_Aux)}
       {- ^ __C declaration:__ @const_funptr7@
 
            __defined at:__ @macros\/reparse.h:244:27@
@@ -3969,7 +3955,7 @@ instance TyEq ty (CFieldType Const_funptr7 "un_Const_funptr7") =>
     where getField = ptrToCField (Proxy @"un_Const_funptr7")
 instance HasCField Const_funptr7 "un_Const_funptr7"
     where type CFieldType Const_funptr7
-                          "un_Const_funptr7" = FunPtr Const_funptr7_Deref
+                          "un_Const_funptr7" = FunPtr Const_funptr7_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @BOOL@
 

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -734,21 +734,21 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S6) "s6_b")
   getField =
     HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s6_b")
 
-{-| __C declaration:__ @struct \@S7a_Deref@
+{-| __C declaration:__ @struct \@S7a_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h:34:9@
 
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
-data S7a_Deref = S7a_Deref
-  { s7a_Deref_a :: FC.CChar
+data S7a_Aux = S7a_Aux
+  { s7a_Aux_a :: FC.CChar
     {- ^ __C declaration:__ @a@
 
          __defined at:__ @types\/structs\/simple_structs.h:34:23@
 
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
-  , s7a_Deref_b :: FC.CInt
+  , s7a_Aux_b :: FC.CInt
     {- ^ __C declaration:__ @b@
 
          __defined at:__ @types\/structs\/simple_structs.h:34:30@
@@ -758,7 +758,7 @@ data S7a_Deref = S7a_Deref
   }
   deriving stock (Eq, Show)
 
-instance F.Storable S7a_Deref where
+instance F.Storable S7a_Aux where
 
   sizeOf = \_ -> (8 :: Int)
 
@@ -766,19 +766,19 @@ instance F.Storable S7a_Deref where
 
   peek =
     \ptr0 ->
-          pure S7a_Deref
-      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7a_Deref_a") ptr0
-      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7a_Deref_b") ptr0
+          pure S7a_Aux
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7a_Aux_a") ptr0
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7a_Aux_b") ptr0
 
   poke =
     \ptr0 ->
       \s1 ->
         case s1 of
-          S7a_Deref s7a_Deref_a2 s7a_Deref_b3 ->
-               HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7a_Deref_a") ptr0 s7a_Deref_a2
-            >> HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7a_Deref_b") ptr0 s7a_Deref_b3
+          S7a_Aux s7a_Aux_a2 s7a_Aux_b3 ->
+               HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7a_Aux_a") ptr0 s7a_Aux_a2
+            >> HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7a_Aux_b") ptr0 s7a_Aux_b3
 
-instance Data.Primitive.Types.Prim S7a_Deref where
+instance Data.Primitive.Types.Prim S7a_Aux where
 
   sizeOf# = \_ -> (8#)
 
@@ -787,7 +787,7 @@ instance Data.Primitive.Types.Prim S7a_Deref where
   indexByteArray# =
     \arr0 ->
       \i1 ->
-        S7a_Deref (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)))
+        S7a_Aux (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)))
 
   readByteArray# =
     \arr0 ->
@@ -796,7 +796,7 @@ instance Data.Primitive.Types.Prim S7a_Deref where
           case Data.Primitive.Types.readByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s2 of
             (# s3, v4 #) ->
               case Data.Primitive.Types.readByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s3 of
-                (# s5, v6 #) -> (# s5, S7a_Deref v4 v6 #)
+                (# s5, v6 #) -> (# s5, S7a_Aux v4 v6 #)
 
   writeByteArray# =
     \arr0 ->
@@ -804,15 +804,15 @@ instance Data.Primitive.Types.Prim S7a_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              S7a_Deref s7a_Deref_a4 s7a_Deref_b5 ->
-                case Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s7a_Deref_a4 s3 of
+              S7a_Aux s7a_Aux_a4 s7a_Aux_b5 ->
+                case Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s7a_Aux_a4 s3 of
                   s6 ->
-                    Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s7a_Deref_b5 s6
+                    Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s7a_Aux_b5 s6
 
   indexOffAddr# =
     \addr0 ->
       \i1 ->
-        S7a_Deref (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)))
+        S7a_Aux (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)))
 
   readOffAddr# =
     \addr0 ->
@@ -821,7 +821,7 @@ instance Data.Primitive.Types.Prim S7a_Deref where
           case Data.Primitive.Types.readOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s2 of
             (# s3, v4 #) ->
               case Data.Primitive.Types.readOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s3 of
-                (# s5, v6 #) -> (# s5, S7a_Deref v4 v6 #)
+                (# s5, v6 #) -> (# s5, S7a_Aux v4 v6 #)
 
   writeOffAddr# =
     \addr0 ->
@@ -829,34 +829,34 @@ instance Data.Primitive.Types.Prim S7a_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              S7a_Deref s7a_Deref_a4 s7a_Deref_b5 ->
-                case Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s7a_Deref_a4 s3 of
+              S7a_Aux s7a_Aux_a4 s7a_Aux_b5 ->
+                case Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s7a_Aux_a4 s3 of
                   s6 ->
-                    Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s7a_Deref_b5 s6
+                    Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s7a_Aux_b5 s6
 
-instance HsBindgen.Runtime.HasCField.HasCField S7a_Deref "s7a_Deref_a" where
+instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
-  type CFieldType S7a_Deref "s7a_Deref_a" = FC.CChar
+  type CFieldType S7a_Aux "s7a_Aux_a" = FC.CChar
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Deref) "s7a_Deref_a")
-         ) => GHC.Records.HasField "s7a_Deref_a" (Ptr.Ptr S7a_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "s7a_Aux_a")
+         ) => GHC.Records.HasField "s7a_Aux_a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7a_Deref_a")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7a_Aux_a")
 
-instance HsBindgen.Runtime.HasCField.HasCField S7a_Deref "s7a_Deref_b" where
+instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_b" where
 
-  type CFieldType S7a_Deref "s7a_Deref_b" = FC.CInt
+  type CFieldType S7a_Aux "s7a_Aux_b" = FC.CInt
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Deref) "s7a_Deref_b")
-         ) => GHC.Records.HasField "s7a_Deref_b" (Ptr.Ptr S7a_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "s7a_Aux_b")
+         ) => GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7a_Deref_b")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7a_Aux_b")
 
 {-| __C declaration:__ @S7a@
 
@@ -865,7 +865,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Deref) "s7a_Dere
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
 newtype S7a = S7a
-  { un_S7a :: Ptr.Ptr S7a_Deref
+  { un_S7a :: Ptr.Ptr S7a_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -878,25 +878,25 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a) "un_S7a")
 
 instance HsBindgen.Runtime.HasCField.HasCField S7a "un_S7a" where
 
-  type CFieldType S7a "un_S7a" = Ptr.Ptr S7a_Deref
+  type CFieldType S7a "un_S7a" = Ptr.Ptr S7a_Aux
 
   offset# = \_ -> \_ -> 0
 
-{-| __C declaration:__ @struct \@S7b_Deref@
+{-| __C declaration:__ @struct \@S7b_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h:35:9@
 
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
-data S7b_Deref = S7b_Deref
-  { s7b_Deref_a :: FC.CChar
+data S7b_Aux = S7b_Aux
+  { s7b_Aux_a :: FC.CChar
     {- ^ __C declaration:__ @a@
 
          __defined at:__ @types\/structs\/simple_structs.h:35:23@
 
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
-  , s7b_Deref_b :: FC.CInt
+  , s7b_Aux_b :: FC.CInt
     {- ^ __C declaration:__ @b@
 
          __defined at:__ @types\/structs\/simple_structs.h:35:30@
@@ -906,7 +906,7 @@ data S7b_Deref = S7b_Deref
   }
   deriving stock (Eq, Show)
 
-instance F.Storable S7b_Deref where
+instance F.Storable S7b_Aux where
 
   sizeOf = \_ -> (8 :: Int)
 
@@ -914,19 +914,19 @@ instance F.Storable S7b_Deref where
 
   peek =
     \ptr0 ->
-          pure S7b_Deref
-      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7b_Deref_a") ptr0
-      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7b_Deref_b") ptr0
+          pure S7b_Aux
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7b_Aux_a") ptr0
+      <*> HsBindgen.Runtime.HasCField.peekCField (Data.Proxy.Proxy @"s7b_Aux_b") ptr0
 
   poke =
     \ptr0 ->
       \s1 ->
         case s1 of
-          S7b_Deref s7b_Deref_a2 s7b_Deref_b3 ->
-               HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7b_Deref_a") ptr0 s7b_Deref_a2
-            >> HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7b_Deref_b") ptr0 s7b_Deref_b3
+          S7b_Aux s7b_Aux_a2 s7b_Aux_b3 ->
+               HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7b_Aux_a") ptr0 s7b_Aux_a2
+            >> HsBindgen.Runtime.HasCField.pokeCField (Data.Proxy.Proxy @"s7b_Aux_b") ptr0 s7b_Aux_b3
 
-instance Data.Primitive.Types.Prim S7b_Deref where
+instance Data.Primitive.Types.Prim S7b_Aux where
 
   sizeOf# = \_ -> (8#)
 
@@ -935,7 +935,7 @@ instance Data.Primitive.Types.Prim S7b_Deref where
   indexByteArray# =
     \arr0 ->
       \i1 ->
-        S7b_Deref (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)))
+        S7b_Aux (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)))
 
   readByteArray# =
     \arr0 ->
@@ -944,7 +944,7 @@ instance Data.Primitive.Types.Prim S7b_Deref where
           case Data.Primitive.Types.readByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s2 of
             (# s3, v4 #) ->
               case Data.Primitive.Types.readByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s3 of
-                (# s5, v6 #) -> (# s5, S7b_Deref v4 v6 #)
+                (# s5, v6 #) -> (# s5, S7b_Aux v4 v6 #)
 
   writeByteArray# =
     \arr0 ->
@@ -952,15 +952,15 @@ instance Data.Primitive.Types.Prim S7b_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              S7b_Deref s7b_Deref_a4 s7b_Deref_b5 ->
-                case Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s7b_Deref_a4 s3 of
+              S7b_Aux s7b_Aux_a4 s7b_Aux_b5 ->
+                case Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (0#)) s7b_Aux_a4 s3 of
                   s6 ->
-                    Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s7b_Deref_b5 s6
+                    Data.Primitive.Types.writeByteArray# arr0 ((+#) ((*#) (2#) i1) (1#)) s7b_Aux_b5 s6
 
   indexOffAddr# =
     \addr0 ->
       \i1 ->
-        S7b_Deref (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)))
+        S7b_Aux (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#))) (Data.Primitive.Types.indexOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)))
 
   readOffAddr# =
     \addr0 ->
@@ -969,7 +969,7 @@ instance Data.Primitive.Types.Prim S7b_Deref where
           case Data.Primitive.Types.readOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s2 of
             (# s3, v4 #) ->
               case Data.Primitive.Types.readOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s3 of
-                (# s5, v6 #) -> (# s5, S7b_Deref v4 v6 #)
+                (# s5, v6 #) -> (# s5, S7b_Aux v4 v6 #)
 
   writeOffAddr# =
     \addr0 ->
@@ -977,34 +977,34 @@ instance Data.Primitive.Types.Prim S7b_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              S7b_Deref s7b_Deref_a4 s7b_Deref_b5 ->
-                case Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s7b_Deref_a4 s3 of
+              S7b_Aux s7b_Aux_a4 s7b_Aux_b5 ->
+                case Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (0#)) s7b_Aux_a4 s3 of
                   s6 ->
-                    Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s7b_Deref_b5 s6
+                    Data.Primitive.Types.writeOffAddr# addr0 ((+#) ((*#) (2#) i1) (1#)) s7b_Aux_b5 s6
 
-instance HsBindgen.Runtime.HasCField.HasCField S7b_Deref "s7b_Deref_a" where
+instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
-  type CFieldType S7b_Deref "s7b_Deref_a" = FC.CChar
+  type CFieldType S7b_Aux "s7b_Aux_a" = FC.CChar
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Deref) "s7b_Deref_a")
-         ) => GHC.Records.HasField "s7b_Deref_a" (Ptr.Ptr S7b_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "s7b_Aux_a")
+         ) => GHC.Records.HasField "s7b_Aux_a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7b_Deref_a")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7b_Aux_a")
 
-instance HsBindgen.Runtime.HasCField.HasCField S7b_Deref "s7b_Deref_b" where
+instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_b" where
 
-  type CFieldType S7b_Deref "s7b_Deref_b" = FC.CInt
+  type CFieldType S7b_Aux "s7b_Aux_b" = FC.CInt
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Deref) "s7b_Deref_b")
-         ) => GHC.Records.HasField "s7b_Deref_b" (Ptr.Ptr S7b_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "s7b_Aux_b")
+         ) => GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7b_Deref_b")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"s7b_Aux_b")
 
 {-| __C declaration:__ @S7b@
 
@@ -1013,7 +1013,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Deref) "s7b_Dere
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
 newtype S7b = S7b
-  { un_S7b :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Deref))
+  { un_S7b :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -1027,6 +1027,6 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b) "un_S7b")
 instance HsBindgen.Runtime.HasCField.HasCField S7b "un_S7b" where
 
   type CFieldType S7b "un_S7b" =
-    Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Deref))
+    Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
 
   offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/types/structs/simple_structs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/bindingspec.yaml
@@ -35,14 +35,14 @@ ctypes:
   cname: S6
   hsname: S6
 - headers: types/structs/simple_structs.h
-  cname: struct @S7a_Deref
-  hsname: S7a_Deref
+  cname: struct @S7a_Aux
+  hsname: S7a_Aux
 - headers: types/structs/simple_structs.h
   cname: S7a
   hsname: S7a
 - headers: types/structs/simple_structs.h
-  cname: struct @S7b_Deref
-  hsname: S7b_Deref
+  cname: struct @S7b_Aux
+  hsname: S7b_Aux
 - headers: types/structs/simple_structs.h
   cname: S7b
   hsname: S7b
@@ -132,13 +132,13 @@ hstypes:
   - Ord
   - Show
   - Storable
-- hsname: S7a_Deref
+- hsname: S7a_Aux
   representation:
     record:
-      constructor: S7a_Deref
+      constructor: S7a_Aux
       fields:
-      - s7a_Deref_a
-      - s7a_Deref_b
+      - s7a_Aux_a
+      - s7a_Aux_b
   instances:
   - Eq
   - Prim
@@ -157,13 +157,13 @@ hstypes:
   - Ord
   - Show
   - Storable
-- hsname: S7b_Deref
+- hsname: S7b_Aux
   representation:
     record:
-      constructor: S7b_Deref
+      constructor: S7b_Aux
       fields:
-      - s7b_Deref_a
-      - s7b_Deref_b
+      - s7b_Aux_a
+      - s7b_Aux_b
   instances:
   - Eq
   - Prim

--- a/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
@@ -410,76 +410,76 @@ instance HasCField S6 "s6_b"
 instance TyEq ty (CFieldType S6 "s6_b") =>
          HasField "s6_b" (Ptr S6) (Ptr ty)
     where getField = ptrToCField (Proxy @"s6_b")
-{-| __C declaration:__ @struct \@S7a_Deref@
+{-| __C declaration:__ @struct \@S7a_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h:34:9@
 
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
-data S7a_Deref
-    = S7a_Deref {s7a_Deref_a :: CChar
-                 {- ^ __C declaration:__ @a@
+data S7a_Aux
+    = S7a_Aux {s7a_Aux_a :: CChar
+               {- ^ __C declaration:__ @a@
 
-                      __defined at:__ @types\/structs\/simple_structs.h:34:23@
+                    __defined at:__ @types\/structs\/simple_structs.h:34:23@
 
-                      __exported by:__ @types\/structs\/simple_structs.h@
-                 -},
-                 s7a_Deref_b :: CInt
-                 {- ^ __C declaration:__ @b@
+                    __exported by:__ @types\/structs\/simple_structs.h@
+               -},
+               s7a_Aux_b :: CInt
+               {- ^ __C declaration:__ @b@
 
-                      __defined at:__ @types\/structs\/simple_structs.h:34:30@
+                    __defined at:__ @types\/structs\/simple_structs.h:34:30@
 
-                      __exported by:__ @types\/structs\/simple_structs.h@
-                 -}}
-      {- ^ __C declaration:__ @struct \@S7a_Deref@
+                    __exported by:__ @types\/structs\/simple_structs.h@
+               -}}
+      {- ^ __C declaration:__ @struct \@S7a_Aux@
 
            __defined at:__ @types\/structs\/simple_structs.h:34:9@
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
     deriving stock (Eq, Show)
-instance Storable S7a_Deref
+instance Storable S7a_Aux
     where sizeOf = \_ -> 8 :: Int
           alignment = \_ -> 4 :: Int
-          peek = \ptr_0 -> (pure S7a_Deref <*> peekCField (Proxy @"s7a_Deref_a") ptr_0) <*> peekCField (Proxy @"s7a_Deref_b") ptr_0
+          peek = \ptr_0 -> (pure S7a_Aux <*> peekCField (Proxy @"s7a_Aux_a") ptr_0) <*> peekCField (Proxy @"s7a_Aux_b") ptr_0
           poke = \ptr_1 -> \s_2 -> case s_2 of
-                                   S7a_Deref s7a_Deref_a_3
-                                             s7a_Deref_b_4 -> pokeCField (Proxy @"s7a_Deref_a") ptr_1 s7a_Deref_a_3 >> pokeCField (Proxy @"s7a_Deref_b") ptr_1 s7a_Deref_b_4
-instance Prim S7a_Deref
+                                   S7a_Aux s7a_Aux_a_3
+                                           s7a_Aux_b_4 -> pokeCField (Proxy @"s7a_Aux_a") ptr_1 s7a_Aux_a_3 >> pokeCField (Proxy @"s7a_Aux_b") ptr_1 s7a_Aux_b_4
+instance Prim S7a_Aux
     where sizeOf# = \_ -> 8# :: Int#
           alignment# = \_ -> 4# :: Int#
-          indexByteArray# = \arr_0 -> \i_1 -> S7a_Deref (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (0# :: Int#))) (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (1# :: Int#)))
+          indexByteArray# = \arr_0 -> \i_1 -> S7a_Aux (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (0# :: Int#))) (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (1# :: Int#)))
           readByteArray# = \arr_2 -> \i_3 -> \s_4 -> case readByteArray# arr_2 ((+#) ((*#) (2# :: Int#) i_3) (0# :: Int#)) s_4 of
                                                      (# s_5,
                                                         v_6 #) -> case readByteArray# arr_2 ((+#) ((*#) (2# :: Int#) i_3) (1# :: Int#)) s_5 of
                                                                   (# s_7, v_8 #) -> (# s_7,
-                                                                                       S7a_Deref v_6 v_8 #)
+                                                                                       S7a_Aux v_6 v_8 #)
           writeByteArray# = \arr_9 -> \i_10 -> \struct_11 -> \s_12 -> case struct_11 of
-                                                                      S7a_Deref s7a_Deref_a_13
-                                                                                s7a_Deref_b_14 -> case writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (0# :: Int#)) s7a_Deref_a_13 s_12 of
-                                                                                                  s_15 -> writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (1# :: Int#)) s7a_Deref_b_14 s_15
-          indexOffAddr# = \addr_16 -> \i_17 -> S7a_Deref (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (0# :: Int#))) (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (1# :: Int#)))
+                                                                      S7a_Aux s7a_Aux_a_13
+                                                                              s7a_Aux_b_14 -> case writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (0# :: Int#)) s7a_Aux_a_13 s_12 of
+                                                                                              s_15 -> writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (1# :: Int#)) s7a_Aux_b_14 s_15
+          indexOffAddr# = \addr_16 -> \i_17 -> S7a_Aux (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (0# :: Int#))) (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (1# :: Int#)))
           readOffAddr# = \addr_18 -> \i_19 -> \s_20 -> case readOffAddr# addr_18 ((+#) ((*#) (2# :: Int#) i_19) (0# :: Int#)) s_20 of
                                                        (# s_21,
                                                           v_22 #) -> case readOffAddr# addr_18 ((+#) ((*#) (2# :: Int#) i_19) (1# :: Int#)) s_21 of
                                                                      (# s_23, v_24 #) -> (# s_23,
-                                                                                            S7a_Deref v_22 v_24 #)
+                                                                                            S7a_Aux v_22 v_24 #)
           writeOffAddr# = \addr_25 -> \i_26 -> \struct_27 -> \s_28 -> case struct_27 of
-                                                                      S7a_Deref s7a_Deref_a_29
-                                                                                s7a_Deref_b_30 -> case writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (0# :: Int#)) s7a_Deref_a_29 s_28 of
-                                                                                                  s_31 -> writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (1# :: Int#)) s7a_Deref_b_30 s_31
-instance HasCField S7a_Deref "s7a_Deref_a"
-    where type CFieldType S7a_Deref "s7a_Deref_a" = CChar
+                                                                      S7a_Aux s7a_Aux_a_29
+                                                                              s7a_Aux_b_30 -> case writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (0# :: Int#)) s7a_Aux_a_29 s_28 of
+                                                                                              s_31 -> writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (1# :: Int#)) s7a_Aux_b_30 s_31
+instance HasCField S7a_Aux "s7a_Aux_a"
+    where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7a_Deref "s7a_Deref_a") =>
-         HasField "s7a_Deref_a" (Ptr S7a_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"s7a_Deref_a")
-instance HasCField S7a_Deref "s7a_Deref_b"
-    where type CFieldType S7a_Deref "s7a_Deref_b" = CInt
+instance TyEq ty (CFieldType S7a_Aux "s7a_Aux_a") =>
+         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"s7a_Aux_a")
+instance HasCField S7a_Aux "s7a_Aux_b"
+    where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7a_Deref "s7a_Deref_b") =>
-         HasField "s7a_Deref_b" (Ptr S7a_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"s7a_Deref_b")
+instance TyEq ty (CFieldType S7a_Aux "s7a_Aux_b") =>
+         HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"s7a_Aux_b")
 {-| __C declaration:__ @S7a@
 
     __defined at:__ @types\/structs\/simple_structs.h:34:36@
@@ -487,7 +487,7 @@ instance TyEq ty (CFieldType S7a_Deref "s7a_Deref_b") =>
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
 newtype S7a
-    = S7a {un_S7a :: (Ptr S7a_Deref)}
+    = S7a {un_S7a :: (Ptr S7a_Aux)}
       {- ^ __C declaration:__ @S7a@
 
            __defined at:__ @types\/structs\/simple_structs.h:34:36@
@@ -500,78 +500,78 @@ instance TyEq ty (CFieldType S7a "un_S7a") =>
          HasField "un_S7a" (Ptr S7a) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_S7a")
 instance HasCField S7a "un_S7a"
-    where type CFieldType S7a "un_S7a" = Ptr S7a_Deref
+    where type CFieldType S7a "un_S7a" = Ptr S7a_Aux
           offset# = \_ -> \_ -> 0
-{-| __C declaration:__ @struct \@S7b_Deref@
+{-| __C declaration:__ @struct \@S7b_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h:35:9@
 
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
-data S7b_Deref
-    = S7b_Deref {s7b_Deref_a :: CChar
-                 {- ^ __C declaration:__ @a@
+data S7b_Aux
+    = S7b_Aux {s7b_Aux_a :: CChar
+               {- ^ __C declaration:__ @a@
 
-                      __defined at:__ @types\/structs\/simple_structs.h:35:23@
+                    __defined at:__ @types\/structs\/simple_structs.h:35:23@
 
-                      __exported by:__ @types\/structs\/simple_structs.h@
-                 -},
-                 s7b_Deref_b :: CInt
-                 {- ^ __C declaration:__ @b@
+                    __exported by:__ @types\/structs\/simple_structs.h@
+               -},
+               s7b_Aux_b :: CInt
+               {- ^ __C declaration:__ @b@
 
-                      __defined at:__ @types\/structs\/simple_structs.h:35:30@
+                    __defined at:__ @types\/structs\/simple_structs.h:35:30@
 
-                      __exported by:__ @types\/structs\/simple_structs.h@
-                 -}}
-      {- ^ __C declaration:__ @struct \@S7b_Deref@
+                    __exported by:__ @types\/structs\/simple_structs.h@
+               -}}
+      {- ^ __C declaration:__ @struct \@S7b_Aux@
 
            __defined at:__ @types\/structs\/simple_structs.h:35:9@
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
     deriving stock (Eq, Show)
-instance Storable S7b_Deref
+instance Storable S7b_Aux
     where sizeOf = \_ -> 8 :: Int
           alignment = \_ -> 4 :: Int
-          peek = \ptr_0 -> (pure S7b_Deref <*> peekCField (Proxy @"s7b_Deref_a") ptr_0) <*> peekCField (Proxy @"s7b_Deref_b") ptr_0
+          peek = \ptr_0 -> (pure S7b_Aux <*> peekCField (Proxy @"s7b_Aux_a") ptr_0) <*> peekCField (Proxy @"s7b_Aux_b") ptr_0
           poke = \ptr_1 -> \s_2 -> case s_2 of
-                                   S7b_Deref s7b_Deref_a_3
-                                             s7b_Deref_b_4 -> pokeCField (Proxy @"s7b_Deref_a") ptr_1 s7b_Deref_a_3 >> pokeCField (Proxy @"s7b_Deref_b") ptr_1 s7b_Deref_b_4
-instance Prim S7b_Deref
+                                   S7b_Aux s7b_Aux_a_3
+                                           s7b_Aux_b_4 -> pokeCField (Proxy @"s7b_Aux_a") ptr_1 s7b_Aux_a_3 >> pokeCField (Proxy @"s7b_Aux_b") ptr_1 s7b_Aux_b_4
+instance Prim S7b_Aux
     where sizeOf# = \_ -> 8# :: Int#
           alignment# = \_ -> 4# :: Int#
-          indexByteArray# = \arr_0 -> \i_1 -> S7b_Deref (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (0# :: Int#))) (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (1# :: Int#)))
+          indexByteArray# = \arr_0 -> \i_1 -> S7b_Aux (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (0# :: Int#))) (indexByteArray# arr_0 ((+#) ((*#) (2# :: Int#) i_1) (1# :: Int#)))
           readByteArray# = \arr_2 -> \i_3 -> \s_4 -> case readByteArray# arr_2 ((+#) ((*#) (2# :: Int#) i_3) (0# :: Int#)) s_4 of
                                                      (# s_5,
                                                         v_6 #) -> case readByteArray# arr_2 ((+#) ((*#) (2# :: Int#) i_3) (1# :: Int#)) s_5 of
                                                                   (# s_7, v_8 #) -> (# s_7,
-                                                                                       S7b_Deref v_6 v_8 #)
+                                                                                       S7b_Aux v_6 v_8 #)
           writeByteArray# = \arr_9 -> \i_10 -> \struct_11 -> \s_12 -> case struct_11 of
-                                                                      S7b_Deref s7b_Deref_a_13
-                                                                                s7b_Deref_b_14 -> case writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (0# :: Int#)) s7b_Deref_a_13 s_12 of
-                                                                                                  s_15 -> writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (1# :: Int#)) s7b_Deref_b_14 s_15
-          indexOffAddr# = \addr_16 -> \i_17 -> S7b_Deref (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (0# :: Int#))) (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (1# :: Int#)))
+                                                                      S7b_Aux s7b_Aux_a_13
+                                                                              s7b_Aux_b_14 -> case writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (0# :: Int#)) s7b_Aux_a_13 s_12 of
+                                                                                              s_15 -> writeByteArray# arr_9 ((+#) ((*#) (2# :: Int#) i_10) (1# :: Int#)) s7b_Aux_b_14 s_15
+          indexOffAddr# = \addr_16 -> \i_17 -> S7b_Aux (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (0# :: Int#))) (indexOffAddr# addr_16 ((+#) ((*#) (2# :: Int#) i_17) (1# :: Int#)))
           readOffAddr# = \addr_18 -> \i_19 -> \s_20 -> case readOffAddr# addr_18 ((+#) ((*#) (2# :: Int#) i_19) (0# :: Int#)) s_20 of
                                                        (# s_21,
                                                           v_22 #) -> case readOffAddr# addr_18 ((+#) ((*#) (2# :: Int#) i_19) (1# :: Int#)) s_21 of
                                                                      (# s_23, v_24 #) -> (# s_23,
-                                                                                            S7b_Deref v_22 v_24 #)
+                                                                                            S7b_Aux v_22 v_24 #)
           writeOffAddr# = \addr_25 -> \i_26 -> \struct_27 -> \s_28 -> case struct_27 of
-                                                                      S7b_Deref s7b_Deref_a_29
-                                                                                s7b_Deref_b_30 -> case writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (0# :: Int#)) s7b_Deref_a_29 s_28 of
-                                                                                                  s_31 -> writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (1# :: Int#)) s7b_Deref_b_30 s_31
-instance HasCField S7b_Deref "s7b_Deref_a"
-    where type CFieldType S7b_Deref "s7b_Deref_a" = CChar
+                                                                      S7b_Aux s7b_Aux_a_29
+                                                                              s7b_Aux_b_30 -> case writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (0# :: Int#)) s7b_Aux_a_29 s_28 of
+                                                                                              s_31 -> writeOffAddr# addr_25 ((+#) ((*#) (2# :: Int#) i_26) (1# :: Int#)) s7b_Aux_b_30 s_31
+instance HasCField S7b_Aux "s7b_Aux_a"
+    where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7b_Deref "s7b_Deref_a") =>
-         HasField "s7b_Deref_a" (Ptr S7b_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"s7b_Deref_a")
-instance HasCField S7b_Deref "s7b_Deref_b"
-    where type CFieldType S7b_Deref "s7b_Deref_b" = CInt
+instance TyEq ty (CFieldType S7b_Aux "s7b_Aux_a") =>
+         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"s7b_Aux_a")
+instance HasCField S7b_Aux "s7b_Aux_b"
+    where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7b_Deref "s7b_Deref_b") =>
-         HasField "s7b_Deref_b" (Ptr S7b_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"s7b_Deref_b")
+instance TyEq ty (CFieldType S7b_Aux "s7b_Aux_b") =>
+         HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"s7b_Aux_b")
 {-| __C declaration:__ @S7b@
 
     __defined at:__ @types\/structs\/simple_structs.h:35:38@
@@ -579,7 +579,7 @@ instance TyEq ty (CFieldType S7b_Deref "s7b_Deref_b") =>
     __exported by:__ @types\/structs\/simple_structs.h@
 -}
 newtype S7b
-    = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Deref)))}
+    = S7b {un_S7b :: (Ptr (Ptr (Ptr S7b_Aux)))}
       {- ^ __C declaration:__ @S7b@
 
            __defined at:__ @types\/structs\/simple_structs.h:35:38@
@@ -592,5 +592,5 @@ instance TyEq ty (CFieldType S7b "un_S7b") =>
          HasField "un_S7b" (Ptr S7b) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_S7b")
 instance HasCField S7b "un_S7b"
-    where type CFieldType S7b "un_S7b" = Ptr (Ptr (Ptr S7b_Deref))
+    where type CFieldType S7b "un_S7b" = Ptr (Ptr (Ptr S7b_Aux))
           offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -37,38 +37,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:7:16@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F1_Deref = F1_Deref
-  { un_F1_Deref :: FC.CInt -> FC.CInt -> IO ()
+newtype F1_Aux = F1_Aux
+  { un_F1_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_fa93becf814ab275 ::
-     F1_Deref
-  -> IO (Ptr.FunPtr F1_Deref)
+-- __unique:__ @toF1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c ::
+     F1_Aux
+  -> IO (Ptr.FunPtr F1_Aux)
 
--- __unique:__ @fromF1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5a971083f7b8024b ::
-     Ptr.FunPtr F1_Deref
-  -> F1_Deref
+-- __unique:__ @fromF1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ddeb5206e8192425 ::
+     Ptr.FunPtr F1_Aux
+  -> F1_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F1_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F1_Aux where
 
-  toFunPtr = hs_bindgen_fa93becf814ab275
+  toFunPtr = hs_bindgen_00d16e666202ed6c
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F1_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F1_Aux where
 
-  fromFunPtr = hs_bindgen_5a971083f7b8024b
+  fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Deref) "un_F1_Deref")
-         ) => GHC.Records.HasField "un_F1_Deref" (Ptr.Ptr F1_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Aux) "un_F1_Aux")
+         ) => GHC.Records.HasField "un_F1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F1_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F1_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F1_Deref "un_F1_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "un_F1_Aux" where
 
-  type CFieldType F1_Deref "un_F1_Deref" =
+  type CFieldType F1_Aux "un_F1_Aux" =
     FC.CInt -> FC.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -80,7 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Deref "un_F1_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F1 = F1
-  { un_F1 :: Ptr.FunPtr F1_Deref
+  { un_F1 :: Ptr.FunPtr F1_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -93,7 +93,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1) "un_F1")
 
 instance HsBindgen.Runtime.HasCField.HasCField F1 "un_F1" where
 
-  type CFieldType F1 "un_F1" = Ptr.FunPtr F1_Deref
+  type CFieldType F1 "un_F1" = Ptr.FunPtr F1_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -105,38 +105,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:10:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F2_Deref = F2_Deref
-  { un_F2_Deref :: FC.CInt -> FC.CInt -> IO ()
+newtype F2_Aux = F2_Aux
+  { un_F2_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_8741614e72e842ed ::
-     F2_Deref
-  -> IO (Ptr.FunPtr F2_Deref)
+-- __unique:__ @toF2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c39d7524b75b54e8 ::
+     F2_Aux
+  -> IO (Ptr.FunPtr F2_Aux)
 
--- __unique:__ @fromF2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4b21dd5f07b53aa8 ::
-     Ptr.FunPtr F2_Deref
-  -> F2_Deref
+-- __unique:__ @fromF2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_e15bcd26f1ed1df7 ::
+     Ptr.FunPtr F2_Aux
+  -> F2_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F2_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F2_Aux where
 
-  toFunPtr = hs_bindgen_8741614e72e842ed
+  toFunPtr = hs_bindgen_c39d7524b75b54e8
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F2_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F2_Aux where
 
-  fromFunPtr = hs_bindgen_4b21dd5f07b53aa8
+  fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F2_Deref) "un_F2_Deref")
-         ) => GHC.Records.HasField "un_F2_Deref" (Ptr.Ptr F2_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F2_Aux) "un_F2_Aux")
+         ) => GHC.Records.HasField "un_F2_Aux" (Ptr.Ptr F2_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F2_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F2_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F2_Deref "un_F2_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F2_Aux "un_F2_Aux" where
 
-  type CFieldType F2_Deref "un_F2_Deref" =
+  type CFieldType F2_Aux "un_F2_Aux" =
     FC.CInt -> FC.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -148,7 +148,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F2_Deref "un_F2_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F2 = F2
-  { un_F2 :: Ptr.Ptr (Ptr.FunPtr F2_Deref)
+  { un_F2 :: Ptr.Ptr (Ptr.FunPtr F2_Aux)
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -162,7 +162,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F2) "un_F2")
 instance HsBindgen.Runtime.HasCField.HasCField F2 "un_F2" where
 
   type CFieldType F2 "un_F2" =
-    Ptr.Ptr (Ptr.FunPtr F2_Deref)
+    Ptr.Ptr (Ptr.FunPtr F2_Aux)
 
   offset# = \_ -> \_ -> 0
 
@@ -174,38 +174,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:13:18@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F3_Deref = F3_Deref
-  { un_F3_Deref :: FC.CInt -> FC.CInt -> IO ()
+newtype F3_Aux = F3_Aux
+  { un_F3_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_04d39f91c5c62278 ::
-     F3_Deref
-  -> IO (Ptr.FunPtr F3_Deref)
+-- __unique:__ @toF3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_4a960721e7d1dcef ::
+     F3_Aux
+  -> IO (Ptr.FunPtr F3_Aux)
 
--- __unique:__ @fromF3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_aee01b3475cc645c ::
-     Ptr.FunPtr F3_Deref
-  -> F3_Deref
+-- __unique:__ @fromF3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_66460422a7197535 ::
+     Ptr.FunPtr F3_Aux
+  -> F3_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F3_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F3_Aux where
 
-  toFunPtr = hs_bindgen_04d39f91c5c62278
+  toFunPtr = hs_bindgen_4a960721e7d1dcef
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F3_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F3_Aux where
 
-  fromFunPtr = hs_bindgen_aee01b3475cc645c
+  fromFunPtr = hs_bindgen_66460422a7197535
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F3_Deref) "un_F3_Deref")
-         ) => GHC.Records.HasField "un_F3_Deref" (Ptr.Ptr F3_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F3_Aux) "un_F3_Aux")
+         ) => GHC.Records.HasField "un_F3_Aux" (Ptr.Ptr F3_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F3_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F3_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F3_Deref "un_F3_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F3_Aux "un_F3_Aux" where
 
-  type CFieldType F3_Deref "un_F3_Deref" =
+  type CFieldType F3_Aux "un_F3_Aux" =
     FC.CInt -> FC.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
@@ -217,7 +217,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F3_Deref "un_F3_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F3 = F3
-  { un_F3 :: Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Deref))
+  { un_F3 :: Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux))
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -231,7 +231,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F3) "un_F3")
 instance HsBindgen.Runtime.HasCField.HasCField F3 "un_F3" where
 
   type CFieldType F3 "un_F3" =
-    Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Deref))
+    Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux))
 
   offset# = \_ -> \_ -> 0
 
@@ -243,38 +243,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:16:16@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F4_Deref = F4_Deref
-  { un_F4_Deref :: IO FC.CInt
+newtype F4_Aux = F4_Aux
+  { un_F4_Aux :: IO FC.CInt
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_b1dc6cdfd1046f6c ::
-     F4_Deref
-  -> IO (Ptr.FunPtr F4_Deref)
+-- __unique:__ @toF4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_83bcff023b3bc648 ::
+     F4_Aux
+  -> IO (Ptr.FunPtr F4_Aux)
 
--- __unique:__ @fromF4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_bf80b45e357edad9 ::
-     Ptr.FunPtr F4_Deref
-  -> F4_Deref
+-- __unique:__ @fromF4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_40f9a8d432b9eb97 ::
+     Ptr.FunPtr F4_Aux
+  -> F4_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F4_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F4_Aux where
 
-  toFunPtr = hs_bindgen_b1dc6cdfd1046f6c
+  toFunPtr = hs_bindgen_83bcff023b3bc648
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F4_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F4_Aux where
 
-  fromFunPtr = hs_bindgen_bf80b45e357edad9
+  fromFunPtr = hs_bindgen_40f9a8d432b9eb97
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F4_Deref) "un_F4_Deref")
-         ) => GHC.Records.HasField "un_F4_Deref" (Ptr.Ptr F4_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F4_Aux) "un_F4_Aux")
+         ) => GHC.Records.HasField "un_F4_Aux" (Ptr.Ptr F4_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F4_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F4_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F4_Deref "un_F4_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F4_Aux "un_F4_Aux" where
 
-  type CFieldType F4_Deref "un_F4_Deref" = IO FC.CInt
+  type CFieldType F4_Aux "un_F4_Aux" = IO FC.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -285,7 +285,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F4_Deref "un_F4_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F4 = F4
-  { un_F4 :: Ptr.Ptr (Ptr.FunPtr F4_Deref)
+  { un_F4 :: Ptr.Ptr (Ptr.FunPtr F4_Aux)
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -299,7 +299,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F4) "un_F4")
 instance HsBindgen.Runtime.HasCField.HasCField F4 "un_F4" where
 
   type CFieldType F4 "un_F4" =
-    Ptr.Ptr (Ptr.FunPtr F4_Deref)
+    Ptr.Ptr (Ptr.FunPtr F4_Aux)
 
   offset# = \_ -> \_ -> 0
 
@@ -311,38 +311,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:19:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F5_Deref = F5_Deref
-  { un_F5_Deref :: IO ()
+newtype F5_Aux = F5_Aux
+  { un_F5_Aux :: IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_82c23fe0d26463bd ::
-     F5_Deref
-  -> IO (Ptr.FunPtr F5_Deref)
+-- __unique:__ @toF5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_6891cbd81d6f42b9 ::
+     F5_Aux
+  -> IO (Ptr.FunPtr F5_Aux)
 
--- __unique:__ @fromF5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_9e30690aa537cac5 ::
-     Ptr.FunPtr F5_Deref
-  -> F5_Deref
+-- __unique:__ @fromF5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_586f6635c057975f ::
+     Ptr.FunPtr F5_Aux
+  -> F5_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F5_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F5_Aux where
 
-  toFunPtr = hs_bindgen_82c23fe0d26463bd
+  toFunPtr = hs_bindgen_6891cbd81d6f42b9
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F5_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F5_Aux where
 
-  fromFunPtr = hs_bindgen_9e30690aa537cac5
+  fromFunPtr = hs_bindgen_586f6635c057975f
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F5_Deref) "un_F5_Deref")
-         ) => GHC.Records.HasField "un_F5_Deref" (Ptr.Ptr F5_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F5_Aux) "un_F5_Aux")
+         ) => GHC.Records.HasField "un_F5_Aux" (Ptr.Ptr F5_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F5_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F5_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F5_Deref "un_F5_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F5_Aux "un_F5_Aux" where
 
-  type CFieldType F5_Deref "un_F5_Deref" = IO ()
+  type CFieldType F5_Aux "un_F5_Aux" = IO ()
 
   offset# = \_ -> \_ -> 0
 
@@ -353,7 +353,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F5_Deref "un_F5_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F5 = F5
-  { un_F5 :: Ptr.Ptr (Ptr.FunPtr F5_Deref)
+  { un_F5 :: Ptr.Ptr (Ptr.FunPtr F5_Aux)
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -367,7 +367,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F5) "un_F5")
 instance HsBindgen.Runtime.HasCField.HasCField F5 "un_F5" where
 
   type CFieldType F5 "un_F5" =
-    Ptr.Ptr (Ptr.FunPtr F5_Deref)
+    Ptr.Ptr (Ptr.FunPtr F5_Aux)
 
   offset# = \_ -> \_ -> 0
 
@@ -403,39 +403,38 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:23:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F6_Deref = F6_Deref
-  { un_F6_Deref :: MyInt -> IO ()
+newtype F6_Aux = F6_Aux
+  { un_F6_Aux :: MyInt -> IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF6_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_8c739a057f4c416d ::
-     F6_Deref
-  -> IO (Ptr.FunPtr F6_Deref)
+-- __unique:__ @toF6_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c1baf73f98614f45 ::
+     F6_Aux
+  -> IO (Ptr.FunPtr F6_Aux)
 
--- __unique:__ @fromF6_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_95e55fee8d4c2b5b ::
-     Ptr.FunPtr F6_Deref
-  -> F6_Deref
+-- __unique:__ @fromF6_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_a887947b26e58f0c ::
+     Ptr.FunPtr F6_Aux
+  -> F6_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F6_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F6_Aux where
 
-  toFunPtr = hs_bindgen_8c739a057f4c416d
+  toFunPtr = hs_bindgen_c1baf73f98614f45
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F6_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F6_Aux where
 
-  fromFunPtr = hs_bindgen_95e55fee8d4c2b5b
+  fromFunPtr = hs_bindgen_a887947b26e58f0c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F6_Deref) "un_F6_Deref")
-         ) => GHC.Records.HasField "un_F6_Deref" (Ptr.Ptr F6_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F6_Aux) "un_F6_Aux")
+         ) => GHC.Records.HasField "un_F6_Aux" (Ptr.Ptr F6_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F6_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F6_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F6_Deref "un_F6_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F6_Aux "un_F6_Aux" where
 
-  type CFieldType F6_Deref "un_F6_Deref" =
-    MyInt -> IO ()
+  type CFieldType F6_Aux "un_F6_Aux" = MyInt -> IO ()
 
   offset# = \_ -> \_ -> 0
 
@@ -446,7 +445,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F6_Deref "un_F6_Deref" where
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F6 = F6
-  { un_F6 :: Ptr.Ptr (Ptr.FunPtr F6_Deref)
+  { un_F6 :: Ptr.Ptr (Ptr.FunPtr F6_Aux)
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -460,6 +459,6 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F6) "un_F6")
 instance HsBindgen.Runtime.HasCField.HasCField F6 "un_F6" where
 
   type CFieldType F6 "un_F6" =
-    Ptr.Ptr (Ptr.FunPtr F6_Deref)
+    Ptr.Ptr (Ptr.FunPtr F6_Aux)
 
   offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -7,8 +7,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:7:16@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F1_Deref
-    = F1_Deref {un_F1_Deref :: (CInt -> CInt -> IO Unit)}
+newtype F1_Aux
+    = F1_Aux {un_F1_Aux :: (CInt -> CInt -> IO Unit)}
       {- ^ Auxiliary type used by 'F1'
 
       __C declaration:__ @f1@
@@ -18,22 +18,21 @@ newtype F1_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_fa93becf814ab275 :: F1_Deref ->
-                                                                   IO (FunPtr F1_Deref)
--- __unique:__ @fromF1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5a971083f7b8024b :: FunPtr F1_Deref ->
-                                                                   F1_Deref
-instance ToFunPtr F1_Deref
-    where toFunPtr = hs_bindgen_fa93becf814ab275
-instance FromFunPtr F1_Deref
-    where fromFunPtr = hs_bindgen_5a971083f7b8024b
-instance TyEq ty (CFieldType F1_Deref "un_F1_Deref") =>
-         HasField "un_F1_Deref" (Ptr F1_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F1_Deref")
-instance HasCField F1_Deref "un_F1_Deref"
-    where type CFieldType F1_Deref "un_F1_Deref" = CInt ->
-                                                   CInt -> IO Unit
+-- __unique:__ @toF1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c :: F1_Aux ->
+                                                                   IO (FunPtr F1_Aux)
+-- __unique:__ @fromF1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ddeb5206e8192425 :: FunPtr F1_Aux ->
+                                                                   F1_Aux
+instance ToFunPtr F1_Aux
+    where toFunPtr = hs_bindgen_00d16e666202ed6c
+instance FromFunPtr F1_Aux
+    where fromFunPtr = hs_bindgen_ddeb5206e8192425
+instance TyEq ty (CFieldType F1_Aux "un_F1_Aux") =>
+         HasField "un_F1_Aux" (Ptr F1_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F1_Aux")
+instance HasCField F1_Aux "un_F1_Aux"
+    where type CFieldType F1_Aux "un_F1_Aux" = CInt -> CInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f1@
 
@@ -42,7 +41,7 @@ instance HasCField F1_Deref "un_F1_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F1
-    = F1 {un_F1 :: (FunPtr F1_Deref)}
+    = F1 {un_F1 :: (FunPtr F1_Aux)}
       {- ^ __C declaration:__ @f1@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:7:16@
@@ -55,7 +54,7 @@ instance TyEq ty (CFieldType F1 "un_F1") =>
          HasField "un_F1" (Ptr F1) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F1")
 instance HasCField F1 "un_F1"
-    where type CFieldType F1 "un_F1" = FunPtr F1_Deref
+    where type CFieldType F1 "un_F1" = FunPtr F1_Aux
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'F2'
 
@@ -65,8 +64,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:10:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F2_Deref
-    = F2_Deref {un_F2_Deref :: (CInt -> CInt -> IO Unit)}
+newtype F2_Aux
+    = F2_Aux {un_F2_Aux :: (CInt -> CInt -> IO Unit)}
       {- ^ Auxiliary type used by 'F2'
 
       __C declaration:__ @f2@
@@ -76,22 +75,21 @@ newtype F2_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF2_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_8741614e72e842ed :: F2_Deref ->
-                                                                   IO (FunPtr F2_Deref)
--- __unique:__ @fromF2_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_4b21dd5f07b53aa8 :: FunPtr F2_Deref ->
-                                                                   F2_Deref
-instance ToFunPtr F2_Deref
-    where toFunPtr = hs_bindgen_8741614e72e842ed
-instance FromFunPtr F2_Deref
-    where fromFunPtr = hs_bindgen_4b21dd5f07b53aa8
-instance TyEq ty (CFieldType F2_Deref "un_F2_Deref") =>
-         HasField "un_F2_Deref" (Ptr F2_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F2_Deref")
-instance HasCField F2_Deref "un_F2_Deref"
-    where type CFieldType F2_Deref "un_F2_Deref" = CInt ->
-                                                   CInt -> IO Unit
+-- __unique:__ @toF2_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c39d7524b75b54e8 :: F2_Aux ->
+                                                                   IO (FunPtr F2_Aux)
+-- __unique:__ @fromF2_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_e15bcd26f1ed1df7 :: FunPtr F2_Aux ->
+                                                                   F2_Aux
+instance ToFunPtr F2_Aux
+    where toFunPtr = hs_bindgen_c39d7524b75b54e8
+instance FromFunPtr F2_Aux
+    where fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
+instance TyEq ty (CFieldType F2_Aux "un_F2_Aux") =>
+         HasField "un_F2_Aux" (Ptr F2_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F2_Aux")
+instance HasCField F2_Aux "un_F2_Aux"
+    where type CFieldType F2_Aux "un_F2_Aux" = CInt -> CInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f2@
 
@@ -100,7 +98,7 @@ instance HasCField F2_Deref "un_F2_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F2
-    = F2 {un_F2 :: (Ptr (FunPtr F2_Deref))}
+    = F2 {un_F2 :: (Ptr (FunPtr F2_Aux))}
       {- ^ __C declaration:__ @f2@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:10:17@
@@ -113,7 +111,7 @@ instance TyEq ty (CFieldType F2 "un_F2") =>
          HasField "un_F2" (Ptr F2) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F2")
 instance HasCField F2 "un_F2"
-    where type CFieldType F2 "un_F2" = Ptr (FunPtr F2_Deref)
+    where type CFieldType F2 "un_F2" = Ptr (FunPtr F2_Aux)
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'F3'
 
@@ -123,8 +121,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:13:18@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F3_Deref
-    = F3_Deref {un_F3_Deref :: (CInt -> CInt -> IO Unit)}
+newtype F3_Aux
+    = F3_Aux {un_F3_Aux :: (CInt -> CInt -> IO Unit)}
       {- ^ Auxiliary type used by 'F3'
 
       __C declaration:__ @f3@
@@ -134,22 +132,21 @@ newtype F3_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF3_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_04d39f91c5c62278 :: F3_Deref ->
-                                                                   IO (FunPtr F3_Deref)
--- __unique:__ @fromF3_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_aee01b3475cc645c :: FunPtr F3_Deref ->
-                                                                   F3_Deref
-instance ToFunPtr F3_Deref
-    where toFunPtr = hs_bindgen_04d39f91c5c62278
-instance FromFunPtr F3_Deref
-    where fromFunPtr = hs_bindgen_aee01b3475cc645c
-instance TyEq ty (CFieldType F3_Deref "un_F3_Deref") =>
-         HasField "un_F3_Deref" (Ptr F3_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F3_Deref")
-instance HasCField F3_Deref "un_F3_Deref"
-    where type CFieldType F3_Deref "un_F3_Deref" = CInt ->
-                                                   CInt -> IO Unit
+-- __unique:__ @toF3_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_4a960721e7d1dcef :: F3_Aux ->
+                                                                   IO (FunPtr F3_Aux)
+-- __unique:__ @fromF3_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_66460422a7197535 :: FunPtr F3_Aux ->
+                                                                   F3_Aux
+instance ToFunPtr F3_Aux
+    where toFunPtr = hs_bindgen_4a960721e7d1dcef
+instance FromFunPtr F3_Aux
+    where fromFunPtr = hs_bindgen_66460422a7197535
+instance TyEq ty (CFieldType F3_Aux "un_F3_Aux") =>
+         HasField "un_F3_Aux" (Ptr F3_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F3_Aux")
+instance HasCField F3_Aux "un_F3_Aux"
+    where type CFieldType F3_Aux "un_F3_Aux" = CInt -> CInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f3@
 
@@ -158,7 +155,7 @@ instance HasCField F3_Deref "un_F3_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F3
-    = F3 {un_F3 :: (Ptr (Ptr (FunPtr F3_Deref)))}
+    = F3 {un_F3 :: (Ptr (Ptr (FunPtr F3_Aux)))}
       {- ^ __C declaration:__ @f3@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:13:18@
@@ -171,7 +168,7 @@ instance TyEq ty (CFieldType F3 "un_F3") =>
          HasField "un_F3" (Ptr F3) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F3")
 instance HasCField F3 "un_F3"
-    where type CFieldType F3 "un_F3" = Ptr (Ptr (FunPtr F3_Deref))
+    where type CFieldType F3 "un_F3" = Ptr (Ptr (FunPtr F3_Aux))
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'F4'
 
@@ -181,8 +178,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:16:16@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F4_Deref
-    = F4_Deref {un_F4_Deref :: (IO CInt)}
+newtype F4_Aux
+    = F4_Aux {un_F4_Aux :: (IO CInt)}
       {- ^ Auxiliary type used by 'F4'
 
       __C declaration:__ @f4@
@@ -192,21 +189,21 @@ newtype F4_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF4_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_b1dc6cdfd1046f6c :: F4_Deref ->
-                                                                   IO (FunPtr F4_Deref)
--- __unique:__ @fromF4_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_bf80b45e357edad9 :: FunPtr F4_Deref ->
-                                                                   F4_Deref
-instance ToFunPtr F4_Deref
-    where toFunPtr = hs_bindgen_b1dc6cdfd1046f6c
-instance FromFunPtr F4_Deref
-    where fromFunPtr = hs_bindgen_bf80b45e357edad9
-instance TyEq ty (CFieldType F4_Deref "un_F4_Deref") =>
-         HasField "un_F4_Deref" (Ptr F4_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F4_Deref")
-instance HasCField F4_Deref "un_F4_Deref"
-    where type CFieldType F4_Deref "un_F4_Deref" = IO CInt
+-- __unique:__ @toF4_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_83bcff023b3bc648 :: F4_Aux ->
+                                                                   IO (FunPtr F4_Aux)
+-- __unique:__ @fromF4_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_40f9a8d432b9eb97 :: FunPtr F4_Aux ->
+                                                                   F4_Aux
+instance ToFunPtr F4_Aux
+    where toFunPtr = hs_bindgen_83bcff023b3bc648
+instance FromFunPtr F4_Aux
+    where fromFunPtr = hs_bindgen_40f9a8d432b9eb97
+instance TyEq ty (CFieldType F4_Aux "un_F4_Aux") =>
+         HasField "un_F4_Aux" (Ptr F4_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F4_Aux")
+instance HasCField F4_Aux "un_F4_Aux"
+    where type CFieldType F4_Aux "un_F4_Aux" = IO CInt
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f4@
 
@@ -215,7 +212,7 @@ instance HasCField F4_Deref "un_F4_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F4
-    = F4 {un_F4 :: (Ptr (FunPtr F4_Deref))}
+    = F4 {un_F4 :: (Ptr (FunPtr F4_Aux))}
       {- ^ __C declaration:__ @f4@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:16:16@
@@ -228,7 +225,7 @@ instance TyEq ty (CFieldType F4 "un_F4") =>
          HasField "un_F4" (Ptr F4) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F4")
 instance HasCField F4 "un_F4"
-    where type CFieldType F4 "un_F4" = Ptr (FunPtr F4_Deref)
+    where type CFieldType F4 "un_F4" = Ptr (FunPtr F4_Aux)
           offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'F5'
 
@@ -238,8 +235,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:19:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F5_Deref
-    = F5_Deref {un_F5_Deref :: (IO Unit)}
+newtype F5_Aux
+    = F5_Aux {un_F5_Aux :: (IO Unit)}
       {- ^ Auxiliary type used by 'F5'
 
       __C declaration:__ @f5@
@@ -249,21 +246,21 @@ newtype F5_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF5_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_82c23fe0d26463bd :: F5_Deref ->
-                                                                   IO (FunPtr F5_Deref)
--- __unique:__ @fromF5_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_9e30690aa537cac5 :: FunPtr F5_Deref ->
-                                                                   F5_Deref
-instance ToFunPtr F5_Deref
-    where toFunPtr = hs_bindgen_82c23fe0d26463bd
-instance FromFunPtr F5_Deref
-    where fromFunPtr = hs_bindgen_9e30690aa537cac5
-instance TyEq ty (CFieldType F5_Deref "un_F5_Deref") =>
-         HasField "un_F5_Deref" (Ptr F5_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F5_Deref")
-instance HasCField F5_Deref "un_F5_Deref"
-    where type CFieldType F5_Deref "un_F5_Deref" = IO Unit
+-- __unique:__ @toF5_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_6891cbd81d6f42b9 :: F5_Aux ->
+                                                                   IO (FunPtr F5_Aux)
+-- __unique:__ @fromF5_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_586f6635c057975f :: FunPtr F5_Aux ->
+                                                                   F5_Aux
+instance ToFunPtr F5_Aux
+    where toFunPtr = hs_bindgen_6891cbd81d6f42b9
+instance FromFunPtr F5_Aux
+    where fromFunPtr = hs_bindgen_586f6635c057975f
+instance TyEq ty (CFieldType F5_Aux "un_F5_Aux") =>
+         HasField "un_F5_Aux" (Ptr F5_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F5_Aux")
+instance HasCField F5_Aux "un_F5_Aux"
+    where type CFieldType F5_Aux "un_F5_Aux" = IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f5@
 
@@ -272,7 +269,7 @@ instance HasCField F5_Deref "un_F5_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F5
-    = F5 {un_F5 :: (Ptr (FunPtr F5_Deref))}
+    = F5 {un_F5 :: (Ptr (FunPtr F5_Aux))}
       {- ^ __C declaration:__ @f5@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:19:17@
@@ -285,7 +282,7 @@ instance TyEq ty (CFieldType F5 "un_F5") =>
          HasField "un_F5" (Ptr F5) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F5")
 instance HasCField F5 "un_F5"
-    where type CFieldType F5 "un_F5" = Ptr (FunPtr F5_Deref)
+    where type CFieldType F5 "un_F5" = Ptr (FunPtr F5_Aux)
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @MyInt@
 
@@ -327,8 +324,8 @@ __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:23:17@
 
 __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
-newtype F6_Deref
-    = F6_Deref {un_F6_Deref :: (MyInt -> IO Unit)}
+newtype F6_Aux
+    = F6_Aux {un_F6_Aux :: (MyInt -> IO Unit)}
       {- ^ Auxiliary type used by 'F6'
 
       __C declaration:__ @f6@
@@ -338,21 +335,21 @@ newtype F6_Deref
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF6_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_8c739a057f4c416d :: F6_Deref ->
-                                                                   IO (FunPtr F6_Deref)
--- __unique:__ @fromF6_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_95e55fee8d4c2b5b :: FunPtr F6_Deref ->
-                                                                   F6_Deref
-instance ToFunPtr F6_Deref
-    where toFunPtr = hs_bindgen_8c739a057f4c416d
-instance FromFunPtr F6_Deref
-    where fromFunPtr = hs_bindgen_95e55fee8d4c2b5b
-instance TyEq ty (CFieldType F6_Deref "un_F6_Deref") =>
-         HasField "un_F6_Deref" (Ptr F6_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F6_Deref")
-instance HasCField F6_Deref "un_F6_Deref"
-    where type CFieldType F6_Deref "un_F6_Deref" = MyInt -> IO Unit
+-- __unique:__ @toF6_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_c1baf73f98614f45 :: F6_Aux ->
+                                                                   IO (FunPtr F6_Aux)
+-- __unique:__ @fromF6_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_a887947b26e58f0c :: FunPtr F6_Aux ->
+                                                                   F6_Aux
+instance ToFunPtr F6_Aux
+    where toFunPtr = hs_bindgen_c1baf73f98614f45
+instance FromFunPtr F6_Aux
+    where fromFunPtr = hs_bindgen_a887947b26e58f0c
+instance TyEq ty (CFieldType F6_Aux "un_F6_Aux") =>
+         HasField "un_F6_Aux" (Ptr F6_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F6_Aux")
+instance HasCField F6_Aux "un_F6_Aux"
+    where type CFieldType F6_Aux "un_F6_Aux" = MyInt -> IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f6@
 
@@ -361,7 +358,7 @@ instance HasCField F6_Deref "un_F6_Deref"
     __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 -}
 newtype F6
-    = F6 {un_F6 :: (Ptr (FunPtr F6_Deref))}
+    = F6 {un_F6 :: (Ptr (FunPtr F6_Aux))}
       {- ^ __C declaration:__ @f6@
 
            __defined at:__ @types\/typedefs\/multi_level_function_pointer.h:23:17@
@@ -374,5 +371,5 @@ instance TyEq ty (CFieldType F6 "un_F6") =>
          HasField "un_F6" (Ptr F6) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F6")
 instance HasCField F6 "un_F6"
-    where type CFieldType F6 "un_F6" = Ptr (FunPtr F6_Deref)
+    where type CFieldType F6 "un_F6" = Ptr (FunPtr F6_Aux)
           offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/types/typedefs/typedef_analysis/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_analysis/Example.hs
@@ -242,34 +242,34 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct5_t "un_Struct5_t" where
 
     __exported by:__ @types\/typedefs\/typedef_analysis.h@
 -}
-data Struct6_Deref = Struct6_Deref
+data Struct6_Aux = Struct6_Aux
   {}
   deriving stock (Eq, Show)
 
-instance F.Storable Struct6_Deref where
+instance F.Storable Struct6_Aux where
 
   sizeOf = \_ -> (0 :: Int)
 
   alignment = \_ -> (1 :: Int)
 
-  peek = \ptr0 -> pure Struct6_Deref
+  peek = \ptr0 -> pure Struct6_Aux
 
   poke =
     \ptr0 ->
       \s1 ->
         case s1 of
-          Struct6_Deref -> return ()
+          Struct6_Aux -> return ()
 
-instance Data.Primitive.Types.Prim Struct6_Deref where
+instance Data.Primitive.Types.Prim Struct6_Aux where
 
   sizeOf# = \_ -> (0#)
 
   alignment# = \_ -> (1#)
 
-  indexByteArray# = \arr0 -> \i1 -> Struct6_Deref
+  indexByteArray# = \arr0 -> \i1 -> Struct6_Aux
 
   readByteArray# =
-    \arr0 -> \i1 -> \s2 -> (# s2, Struct6_Deref #)
+    \arr0 -> \i1 -> \s2 -> (# s2, Struct6_Aux #)
 
   writeByteArray# =
     \arr0 ->
@@ -277,12 +277,12 @@ instance Data.Primitive.Types.Prim Struct6_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              Struct6_Deref -> s3
+              Struct6_Aux -> s3
 
-  indexOffAddr# = \addr0 -> \i1 -> Struct6_Deref
+  indexOffAddr# = \addr0 -> \i1 -> Struct6_Aux
 
   readOffAddr# =
-    \addr0 -> \i1 -> \s2 -> (# s2, Struct6_Deref #)
+    \addr0 -> \i1 -> \s2 -> (# s2, Struct6_Aux #)
 
   writeOffAddr# =
     \addr0 ->
@@ -290,7 +290,7 @@ instance Data.Primitive.Types.Prim Struct6_Deref where
         \struct2 ->
           \s3 ->
             case struct2 of
-              Struct6_Deref -> s3
+              Struct6_Aux -> s3
 
 {-| __C declaration:__ @struct6@
 
@@ -299,7 +299,7 @@ instance Data.Primitive.Types.Prim Struct6_Deref where
     __exported by:__ @types\/typedefs\/typedef_analysis.h@
 -}
 newtype Struct6 = Struct6
-  { un_Struct6 :: Ptr.Ptr Struct6_Deref
+  { un_Struct6 :: Ptr.Ptr Struct6_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -313,7 +313,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct6) "un_Struct6
 instance HsBindgen.Runtime.HasCField.HasCField Struct6 "un_Struct6" where
 
   type CFieldType Struct6 "un_Struct6" =
-    Ptr.Ptr Struct6_Deref
+    Ptr.Ptr Struct6_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -849,7 +849,7 @@ data Use_sites = Use_sites
 
          __exported by:__ @types\/typedefs\/typedef_analysis.h@
     -}
-  , use_sites_useStruct_struct6 :: Struct6_Deref
+  , use_sites_useStruct_struct6 :: Struct6_Aux
     {- ^ __C declaration:__ @useStruct_struct6@
 
          __defined at:__ @types\/typedefs\/typedef_analysis.h:82:18@
@@ -1087,7 +1087,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_site
 instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useStruct_struct6" where
 
   type CFieldType Use_sites "use_sites_useStruct_struct6" =
-    Struct6_Deref
+    Struct6_Aux
 
   offset# = \_ -> \_ -> 24
 

--- a/hs-bindgen/fixtures/types/typedefs/typedef_analysis/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_analysis/bindingspec.yaml
@@ -36,7 +36,7 @@ ctypes:
   hsname: Struct5_t
 - headers: types/typedefs/typedef_analysis.h
   cname: struct struct6
-  hsname: Struct6_Deref
+  hsname: Struct6_Aux
 - headers: types/typedefs/typedef_analysis.h
   cname: struct6
   hsname: Struct6
@@ -195,10 +195,10 @@ hstypes:
   - Ord
   - Show
   - Storable
-- hsname: Struct6_Deref
+- hsname: Struct6_Aux
   representation:
     record:
-      constructor: Struct6_Deref
+      constructor: Struct6_Aux
       fields: []
   instances:
   - Eq

--- a/hs-bindgen/fixtures/types/typedefs/typedef_analysis/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_analysis/th.txt
@@ -141,8 +141,8 @@ instance HasCField Struct5_t "un_Struct5_t"
 
     __exported by:__ @types\/typedefs\/typedef_analysis.h@
 -}
-data Struct6_Deref
-    = Struct6_Deref {}
+data Struct6_Aux
+    = Struct6_Aux {}
       {- ^ __C declaration:__ @struct struct6@
 
            __defined at:__ @types\/typedefs\/typedef_analysis.h:25:16@
@@ -150,24 +150,24 @@ data Struct6_Deref
            __exported by:__ @types\/typedefs\/typedef_analysis.h@
       -}
     deriving stock (Eq, Show)
-instance Storable Struct6_Deref
+instance Storable Struct6_Aux
     where sizeOf = \_ -> 0 :: Int
           alignment = \_ -> 1 :: Int
-          peek = \ptr_0 -> pure Struct6_Deref
+          peek = \ptr_0 -> pure Struct6_Aux
           poke = \ptr_1 -> \s_2 -> case s_2 of
-                                   Struct6_Deref -> return ()
-instance Prim Struct6_Deref
+                                   Struct6_Aux -> return ()
+instance Prim Struct6_Aux
     where sizeOf# = \_ -> 0# :: Int#
           alignment# = \_ -> 1# :: Int#
-          indexByteArray# = \arr_0 -> \i_1 -> Struct6_Deref
-          readByteArray# = \arr_2 -> \i_3 -> \s_4 -> (# s_4, Struct6_Deref #)
+          indexByteArray# = \arr_0 -> \i_1 -> Struct6_Aux
+          readByteArray# = \arr_2 -> \i_3 -> \s_4 -> (# s_4, Struct6_Aux #)
           writeByteArray# = \arr_5 -> \i_6 -> \struct_7 -> \s_8 -> case struct_7 of
-                                                                   Struct6_Deref -> s_8
-          indexOffAddr# = \addr_9 -> \i_10 -> Struct6_Deref
+                                                                   Struct6_Aux -> s_8
+          indexOffAddr# = \addr_9 -> \i_10 -> Struct6_Aux
           readOffAddr# = \addr_11 -> \i_12 -> \s_13 -> (# s_13,
-                                                          Struct6_Deref #)
+                                                          Struct6_Aux #)
           writeOffAddr# = \addr_14 -> \i_15 -> \struct_16 -> \s_17 -> case struct_16 of
-                                                                      Struct6_Deref -> s_17
+                                                                      Struct6_Aux -> s_17
 {-| __C declaration:__ @struct6@
 
     __defined at:__ @types\/typedefs\/typedef_analysis.h:25:28@
@@ -175,7 +175,7 @@ instance Prim Struct6_Deref
     __exported by:__ @types\/typedefs\/typedef_analysis.h@
 -}
 newtype Struct6
-    = Struct6 {un_Struct6 :: (Ptr Struct6_Deref)}
+    = Struct6 {un_Struct6 :: (Ptr Struct6_Aux)}
       {- ^ __C declaration:__ @struct6@
 
            __defined at:__ @types\/typedefs\/typedef_analysis.h:25:28@
@@ -188,7 +188,7 @@ instance TyEq ty (CFieldType Struct6 "un_Struct6") =>
          HasField "un_Struct6" (Ptr Struct6) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_Struct6")
 instance HasCField Struct6 "un_Struct6"
-    where type CFieldType Struct6 "un_Struct6" = Ptr Struct6_Deref
+    where type CFieldType Struct6 "un_Struct6" = Ptr Struct6_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct7@
 
@@ -571,7 +571,7 @@ data Use_sites
 
                       __exported by:__ @types\/typedefs\/typedef_analysis.h@
                  -},
-                 use_sites_useStruct_struct6 :: Struct6_Deref
+                 use_sites_useStruct_struct6 :: Struct6_Aux
                  {- ^ __C declaration:__ @useStruct_struct6@
 
                       __defined at:__ @types\/typedefs\/typedef_analysis.h:82:18@
@@ -735,7 +735,7 @@ instance TyEq ty
     where getField = ptrToCField (Proxy @"use_sites_useTypedef_struct5_t")
 instance HasCField Use_sites "use_sites_useStruct_struct6"
     where type CFieldType Use_sites
-                          "use_sites_useStruct_struct6" = Struct6_Deref
+                          "use_sites_useStruct_struct6" = Struct6_Aux
           offset# = \_ -> \_ -> 24
 instance TyEq ty
               (CFieldType Use_sites "use_sites_useStruct_struct6") =>

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
@@ -127,38 +127,38 @@ __defined at:__ @types\/typedefs\/typedefs.h:8:16@
 
 __exported by:__ @types\/typedefs\/typedefs.h@
 -}
-newtype FunctionPointer_Function_Deref = FunctionPointer_Function_Deref
-  { un_FunctionPointer_Function_Deref :: IO ()
+newtype FunctionPointer_Function_Aux = FunctionPointer_Function_Aux
+  { un_FunctionPointer_Function_Aux :: IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toFunctionPointer_Function_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_ee75ebb8a19735c1 ::
-     FunctionPointer_Function_Deref
-  -> IO (Ptr.FunPtr FunctionPointer_Function_Deref)
+-- __unique:__ @toFunctionPointer_Function_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b171c028cdc0781d ::
+     FunctionPointer_Function_Aux
+  -> IO (Ptr.FunPtr FunctionPointer_Function_Aux)
 
--- __unique:__ @fromFunctionPointer_Function_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_82a2a7d3ed6faa26 ::
-     Ptr.FunPtr FunctionPointer_Function_Deref
-  -> FunctionPointer_Function_Deref
+-- __unique:__ @fromFunctionPointer_Function_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_4c3da8240a31e036 ::
+     Ptr.FunPtr FunctionPointer_Function_Aux
+  -> FunctionPointer_Function_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr FunctionPointer_Function_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr FunctionPointer_Function_Aux where
 
-  toFunPtr = hs_bindgen_ee75ebb8a19735c1
+  toFunPtr = hs_bindgen_b171c028cdc0781d
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr FunctionPointer_Function_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr FunctionPointer_Function_Aux where
 
-  fromFunPtr = hs_bindgen_82a2a7d3ed6faa26
+  fromFunPtr = hs_bindgen_4c3da8240a31e036
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FunctionPointer_Function_Deref) "un_FunctionPointer_Function_Deref")
-         ) => GHC.Records.HasField "un_FunctionPointer_Function_Deref" (Ptr.Ptr FunctionPointer_Function_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FunctionPointer_Function_Aux) "un_FunctionPointer_Function_Aux")
+         ) => GHC.Records.HasField "un_FunctionPointer_Function_Aux" (Ptr.Ptr FunctionPointer_Function_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_FunctionPointer_Function_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_FunctionPointer_Function_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function_Deref "un_FunctionPointer_Function_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function_Aux "un_FunctionPointer_Function_Aux" where
 
-  type CFieldType FunctionPointer_Function_Deref "un_FunctionPointer_Function_Deref" =
+  type CFieldType FunctionPointer_Function_Aux "un_FunctionPointer_Function_Aux" =
     IO ()
 
   offset# = \_ -> \_ -> 0
@@ -170,7 +170,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function_Deref "u
     __exported by:__ @types\/typedefs\/typedefs.h@
 -}
 newtype FunctionPointer_Function = FunctionPointer_Function
-  { un_FunctionPointer_Function :: Ptr.FunPtr FunctionPointer_Function_Deref
+  { un_FunctionPointer_Function :: Ptr.FunPtr FunctionPointer_Function_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -184,7 +184,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FunctionPointer_Func
 instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function "un_FunctionPointer_Function" where
 
   type CFieldType FunctionPointer_Function "un_FunctionPointer_Function" =
-    Ptr.FunPtr FunctionPointer_Function_Deref
+    Ptr.FunPtr FunctionPointer_Function_Aux
 
   offset# = \_ -> \_ -> 0
 
@@ -238,38 +238,38 @@ __defined at:__ @types\/typedefs\/typedefs.h:11:16@
 
 __exported by:__ @types\/typedefs\/typedefs.h@
 -}
-newtype F1_Deref = F1_Deref
-  { un_F1_Deref :: IO ()
+newtype F1_Aux = F1_Aux
+  { un_F1_Aux :: IO ()
   }
   deriving newtype (HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
 
--- __unique:__ @toF1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_fa93becf814ab275 ::
-     F1_Deref
-  -> IO (Ptr.FunPtr F1_Deref)
+-- __unique:__ @toF1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c ::
+     F1_Aux
+  -> IO (Ptr.FunPtr F1_Aux)
 
--- __unique:__ @fromF1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5a971083f7b8024b ::
-     Ptr.FunPtr F1_Deref
-  -> F1_Deref
+-- __unique:__ @fromF1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ddeb5206e8192425 ::
+     Ptr.FunPtr F1_Aux
+  -> F1_Aux
 
-instance HsBindgen.Runtime.FunPtr.ToFunPtr F1_Deref where
+instance HsBindgen.Runtime.FunPtr.ToFunPtr F1_Aux where
 
-  toFunPtr = hs_bindgen_fa93becf814ab275
+  toFunPtr = hs_bindgen_00d16e666202ed6c
 
-instance HsBindgen.Runtime.FunPtr.FromFunPtr F1_Deref where
+instance HsBindgen.Runtime.FunPtr.FromFunPtr F1_Aux where
 
-  fromFunPtr = hs_bindgen_5a971083f7b8024b
+  fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Deref) "un_F1_Deref")
-         ) => GHC.Records.HasField "un_F1_Deref" (Ptr.Ptr F1_Deref) (Ptr.Ptr ty) where
+instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Aux) "un_F1_Aux")
+         ) => GHC.Records.HasField "un_F1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
 
   getField =
-    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F1_Deref")
+    HsBindgen.Runtime.HasCField.ptrToCField (Data.Proxy.Proxy @"un_F1_Aux")
 
-instance HsBindgen.Runtime.HasCField.HasCField F1_Deref "un_F1_Deref" where
+instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "un_F1_Aux" where
 
-  type CFieldType F1_Deref "un_F1_Deref" = IO ()
+  type CFieldType F1_Aux "un_F1_Aux" = IO ()
 
   offset# = \_ -> \_ -> 0
 
@@ -280,7 +280,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Deref "un_F1_Deref" where
     __exported by:__ @types\/typedefs\/typedefs.h@
 -}
 newtype F1 = F1
-  { un_F1 :: Ptr.FunPtr F1_Deref
+  { un_F1 :: Ptr.FunPtr F1_Aux
   }
   deriving stock (Eq, Ord, Show)
   deriving newtype (F.Storable, HsBindgen.Runtime.HasBaseForeignType.HasBaseForeignType)
@@ -293,7 +293,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1) "un_F1")
 
 instance HsBindgen.Runtime.HasCField.HasCField F1 "un_F1" where
 
-  type CFieldType F1 "un_F1" = Ptr.FunPtr F1_Deref
+  type CFieldType F1 "un_F1" = Ptr.FunPtr F1_Aux
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
@@ -92,8 +92,8 @@ __defined at:__ @types\/typedefs\/typedefs.h:8:16@
 
 __exported by:__ @types\/typedefs\/typedefs.h@
 -}
-newtype FunctionPointer_Function_Deref
-    = FunctionPointer_Function_Deref {un_FunctionPointer_Function_Deref :: (IO Unit)}
+newtype FunctionPointer_Function_Aux
+    = FunctionPointer_Function_Aux {un_FunctionPointer_Function_Aux :: (IO Unit)}
       {- ^ Auxiliary type used by 'FunctionPointer_Function'
 
       __C declaration:__ @FunctionPointer_Function@
@@ -103,27 +103,27 @@ newtype FunctionPointer_Function_Deref
       __exported by:__ @types\/typedefs\/typedefs.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toFunctionPointer_Function_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_ee75ebb8a19735c1 :: FunctionPointer_Function_Deref ->
-                                                                   IO (FunPtr FunctionPointer_Function_Deref)
--- __unique:__ @fromFunctionPointer_Function_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_82a2a7d3ed6faa26 :: FunPtr FunctionPointer_Function_Deref ->
-                                                                   FunctionPointer_Function_Deref
-instance ToFunPtr FunctionPointer_Function_Deref
-    where toFunPtr = hs_bindgen_ee75ebb8a19735c1
-instance FromFunPtr FunctionPointer_Function_Deref
-    where fromFunPtr = hs_bindgen_82a2a7d3ed6faa26
+-- __unique:__ @toFunctionPointer_Function_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_b171c028cdc0781d :: FunctionPointer_Function_Aux ->
+                                                                   IO (FunPtr FunctionPointer_Function_Aux)
+-- __unique:__ @fromFunctionPointer_Function_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_4c3da8240a31e036 :: FunPtr FunctionPointer_Function_Aux ->
+                                                                   FunctionPointer_Function_Aux
+instance ToFunPtr FunctionPointer_Function_Aux
+    where toFunPtr = hs_bindgen_b171c028cdc0781d
+instance FromFunPtr FunctionPointer_Function_Aux
+    where fromFunPtr = hs_bindgen_4c3da8240a31e036
 instance TyEq ty
-              (CFieldType FunctionPointer_Function_Deref
-                          "un_FunctionPointer_Function_Deref") =>
-         HasField "un_FunctionPointer_Function_Deref"
-                  (Ptr FunctionPointer_Function_Deref)
+              (CFieldType FunctionPointer_Function_Aux
+                          "un_FunctionPointer_Function_Aux") =>
+         HasField "un_FunctionPointer_Function_Aux"
+                  (Ptr FunctionPointer_Function_Aux)
                   (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_FunctionPointer_Function_Deref")
-instance HasCField FunctionPointer_Function_Deref
-                   "un_FunctionPointer_Function_Deref"
-    where type CFieldType FunctionPointer_Function_Deref
-                          "un_FunctionPointer_Function_Deref" = IO Unit
+    where getField = ptrToCField (Proxy @"un_FunctionPointer_Function_Aux")
+instance HasCField FunctionPointer_Function_Aux
+                   "un_FunctionPointer_Function_Aux"
+    where type CFieldType FunctionPointer_Function_Aux
+                          "un_FunctionPointer_Function_Aux" = IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @FunctionPointer_Function@
 
@@ -132,7 +132,7 @@ instance HasCField FunctionPointer_Function_Deref
     __exported by:__ @types\/typedefs\/typedefs.h@
 -}
 newtype FunctionPointer_Function
-    = FunctionPointer_Function {un_FunctionPointer_Function :: (FunPtr FunctionPointer_Function_Deref)}
+    = FunctionPointer_Function {un_FunctionPointer_Function :: (FunPtr FunctionPointer_Function_Aux)}
       {- ^ __C declaration:__ @FunctionPointer_Function@
 
            __defined at:__ @types\/typedefs\/typedefs.h:8:16@
@@ -151,7 +151,7 @@ instance TyEq ty
 instance HasCField FunctionPointer_Function
                    "un_FunctionPointer_Function"
     where type CFieldType FunctionPointer_Function
-                          "un_FunctionPointer_Function" = FunPtr FunctionPointer_Function_Deref
+                          "un_FunctionPointer_Function" = FunPtr FunctionPointer_Function_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @NonFunctionPointer_Function@
 
@@ -199,8 +199,8 @@ __defined at:__ @types\/typedefs\/typedefs.h:11:16@
 
 __exported by:__ @types\/typedefs\/typedefs.h@
 -}
-newtype F1_Deref
-    = F1_Deref {un_F1_Deref :: (IO Unit)}
+newtype F1_Aux
+    = F1_Aux {un_F1_Aux :: (IO Unit)}
       {- ^ Auxiliary type used by 'F1'
 
       __C declaration:__ @f1@
@@ -210,21 +210,21 @@ newtype F1_Deref
       __exported by:__ @types\/typedefs\/typedefs.h@
       -}
     deriving newtype HasBaseForeignType
--- __unique:__ @toF1_Deref@
-foreign import ccall safe "wrapper" hs_bindgen_fa93becf814ab275 :: F1_Deref ->
-                                                                   IO (FunPtr F1_Deref)
--- __unique:__ @fromF1_Deref@
-foreign import ccall safe "dynamic" hs_bindgen_5a971083f7b8024b :: FunPtr F1_Deref ->
-                                                                   F1_Deref
-instance ToFunPtr F1_Deref
-    where toFunPtr = hs_bindgen_fa93becf814ab275
-instance FromFunPtr F1_Deref
-    where fromFunPtr = hs_bindgen_5a971083f7b8024b
-instance TyEq ty (CFieldType F1_Deref "un_F1_Deref") =>
-         HasField "un_F1_Deref" (Ptr F1_Deref) (Ptr ty)
-    where getField = ptrToCField (Proxy @"un_F1_Deref")
-instance HasCField F1_Deref "un_F1_Deref"
-    where type CFieldType F1_Deref "un_F1_Deref" = IO Unit
+-- __unique:__ @toF1_Aux@
+foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c :: F1_Aux ->
+                                                                   IO (FunPtr F1_Aux)
+-- __unique:__ @fromF1_Aux@
+foreign import ccall safe "dynamic" hs_bindgen_ddeb5206e8192425 :: FunPtr F1_Aux ->
+                                                                   F1_Aux
+instance ToFunPtr F1_Aux
+    where toFunPtr = hs_bindgen_00d16e666202ed6c
+instance FromFunPtr F1_Aux
+    where fromFunPtr = hs_bindgen_ddeb5206e8192425
+instance TyEq ty (CFieldType F1_Aux "un_F1_Aux") =>
+         HasField "un_F1_Aux" (Ptr F1_Aux) (Ptr ty)
+    where getField = ptrToCField (Proxy @"un_F1_Aux")
+instance HasCField F1_Aux "un_F1_Aux"
+    where type CFieldType F1_Aux "un_F1_Aux" = IO Unit
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @f1@
 
@@ -233,7 +233,7 @@ instance HasCField F1_Deref "un_F1_Deref"
     __exported by:__ @types\/typedefs\/typedefs.h@
 -}
 newtype F1
-    = F1 {un_F1 :: (FunPtr F1_Deref)}
+    = F1 {un_F1 :: (FunPtr F1_Aux)}
       {- ^ __C declaration:__ @f1@
 
            __defined at:__ @types\/typedefs\/typedefs.h:11:16@
@@ -246,7 +246,7 @@ instance TyEq ty (CFieldType F1 "un_F1") =>
          HasField "un_F1" (Ptr F1) (Ptr ty)
     where getField = ptrToCField (Proxy @"un_F1")
 instance HasCField F1 "un_F1"
-    where type CFieldType F1 "un_F1" = FunPtr F1_Deref
+    where type CFieldType F1 "un_F1" = FunPtr F1_Aux
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @g1@
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -967,7 +967,7 @@ typedefFieldDecls hsNewType = [
 -- We want to generate /two/ types:
 --
 -- > newtype F_Aux = F_Aux (FC.CInt -> FC.CInt -> IO ())
--- > newtype F     = F (Ptr.FunPtr F_Deref)
+-- > newtype F     = F (Ptr.FunPtr F_Aux)
 --
 -- so that @F_Aux@ can be given @ToFunPtr@/@FromFunPtr@ instances.
 typedefFunPtrDecs ::
@@ -991,11 +991,8 @@ typedefFunPtrDecs opts haddockConfig origInfo n (args, res) origNames origSpec =
 
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1379>
     -- The name of this auxiliary type should be configurable.
-    --
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1427>
-    -- This should be called "_Aux" instead.
     auxHsName :: Hs.Identifier
-    auxHsName = origInfo.id.hsName <> "_Deref"
+    auxHsName = origInfo.id.hsName <> "_Aux"
 
     auxInfo :: C.DeclInfo Final
     auxInfo = C.DeclInfo {

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
@@ -61,7 +61,7 @@ data Context =
     -- We distinguish this from 'TypedefDirect' because in the case of
     -- 'TypedefDirect' we use the name of typedef as the name of the struct
     -- (indeed, @clang >= 16@ already does this out of the box), but in the case
-    -- of 'TypedefIndirect' we add a @_Deref@ suffix, because now the two types
+    -- of 'TypedefIndirect' we add a @_Aux@ suffix, because now the two types
     -- are meaningfully different (and @clang@ assigns no name at all).
   | TypedefIndirect (C.DeclInfo Parse)
   deriving stock (Show)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
@@ -166,10 +166,8 @@ typedefOfTagged typedefInfo payload useSites
       , conclude payload.id $ Rename (UseNameOf typedefInfo.id)
       ]
 
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1427>
-    -- Use "_Aux" instead.
   | shouldRename
-  = conclude payload.id $ Rename (AddSuffix "_Deref")
+  = conclude payload.id $ Rename (AddSuffix "_Aux")
 
   | otherwise
   = mempty

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/ChooseNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/ChooseNames.hs
@@ -91,16 +91,11 @@ chooseNames (AnonUsageAnalysis usageAnalysis) =
     -- Fortunately, clang does not assign a name to the struct in this situation
     -- (or rather, it assigns a name such as "(unnamed struct at ..)", so we can
     -- detect this case.
-    --
-    -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1427>
-    -- This should not really be called @_Deref@, but maybe something like
-    -- @_Aux@: it's not just pointer dereferencing, but also other uses. (Here
-    -- as well as in 'HandleTypedefs').
     nameForTypedefIndirect :: AnonId -> DeclId -> DeclId
     nameForTypedefIndirect anonId typedef = DeclId{
           isAnon = True
         , name   = C.DeclName{
-              text = typedef.name.text <> "_" <> "Deref"
+              text = typedef.name.text <> "_Aux"
             , kind = anonId.kind
             }
         }

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -1270,7 +1270,7 @@ test_types_typedefs_typedef_analysis =
         , ("struct3_t"       , Nothing)
         , ("struct struct4"  , Just "Struct4_t")
         , ("struct4_t"       , Nothing)
-        , ("struct struct6"  , Just "Struct6_Deref")
+        , ("struct struct6"  , Just "Struct6_Aux")
         , ("struct8"         , Nothing)
         , ("struct9"         , Nothing)
         , ("struct struct10" , Just "Struct10_t")

--- a/manual/hs/manual/app/Manual/Functions/HigherOrder.hs
+++ b/manual/hs/manual/app/Manual/Functions/HigherOrder.hs
@@ -42,17 +42,17 @@ examples :: IO ()
 examples = do
     section "Callbacks (Passing Haskell functions to C callbacks)"
 
-    withToFunPtr (FileOpenedNotification_Deref $ putStrLn "")
+    withToFunPtr (FileOpenedNotification_Aux $ putStrLn "")
                  (onFileOpened . FileOpenedNotification)
 
     putStrLn ""
     withToFunPtr
-        (ProgressUpdate_Deref $ \progress -> putStrLn $ "Progress: " ++ show progress ++ "%")
+        (ProgressUpdate_Aux $ \progress -> putStrLn $ "Progress: " ++ show progress ++ "%")
         (onProgressChanged . ProgressUpdate)
 
     putStrLn ""
     withToFunPtr
-      (DataValidator_Deref $ \value -> do
+      (DataValidator_Aux $ \value -> do
         putStrLn $ "Validating: " ++ show value
         return $ if value > 0 then 1 else 0)
       $ (\validator -> do
@@ -63,7 +63,7 @@ examples = do
 
     putStrLn ""
     withToFunPtr
-      (MeasurementReceived_Deref $ peek >=> print)
+      (MeasurementReceived_Aux $ peek >=> print)
       (onNewMeasurement . MeasurementReceived)
 
     putStrLn ""
@@ -104,7 +104,7 @@ examples = do
                 ++ ", priority=" ++ show priority
         if un_FileOpenedNotification notify /= F.nullFunPtr
           then do
-            let (FileOpenedNotification_Deref notifyFn) = fromFunPtr (un_FileOpenedNotification notify)
+            let (FileOpenedNotification_Aux notifyFn) = fromFunPtr (un_FileOpenedNotification notify)
             notifyFn
           else putStrLn "  (Notification callback was NULL)"
 


### PR DESCRIPTION
This is more accurate, because we were not necessarily _dereferencing_ to get the underlying type (the parent type might not be a pointer to the child type, but might be something else).

Closes #1427