### PR TITLE
Refactor the `PrettyC` AST

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/CallConv.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/CallConv.hs
@@ -27,10 +27,10 @@ data CWrapper = CWrapper {
   deriving (Show, Generic)
 
 getCWrappersSource :: [CWrapper] -> String
-getCWrappersSource wrappers = unlines $ headers ++ bodies
+getCWrappersSource wrappers = concat headers ++ concat bodies
     where
       getImport :: CWrapper -> String
-      getImport wrapper = "#include <" ++ wrapper.hashIncludeArg.path ++ ">"
+      getImport wrapper = "#include <" ++ wrapper.hashIncludeArg.path ++ ">" ++ "\n"
 
       headers, bodies :: [String]
       -- It is important that we don't include the same header more than once,

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -1322,14 +1322,17 @@ addressStubDecs opts haddockConfig moduleName info ty runnerNameSpec _spec =
     prettyStub :: String
     prettyStub = concat [
           "/* ", stubSymbol.source, " */\n"
-        , PC.prettyDecl stubDecl ""
+        , PC.prettyFunDefn stubDecl ""
         ]
 
-    stubDecl :: PC.Decl
+    stubDecl :: PC.FunDefn
     stubDecl =
         PC.withArgs [] $ \args' ->
-          PC.FunDefn stubSymbol.unique stubType C.HaskellPureFunction args'
-            [PC.Return $ PC.Address $ PC.NamedVar varName]
+          PC.FunDefn stubSymbol.unique stubType C.HaskellPureFunction args' $
+            PC.CSList $
+            PC.CSStatement
+              (PC.ExpressionStatement $ PC.Return $ PC.Address $ PC.NamedVar varName)
+              PC.CSNil
 
     cWrapper :: CWrapper
     cWrapper = CWrapper {


### PR DESCRIPTION
Make it so it's closer to the real C AST. We also add declarations with and without definitions to the AST, because they might be necessary for fixing #1490.