### PR TITLE
Collect selection failures due to transitive dependencies

### DIFF
--- a/hs-bindgen/examples/golden/program-analysis/selection_merge_traces.h
+++ b/hs-bindgen/examples/golden/program-analysis/selection_merge_traces.h
@@ -1,0 +1,11 @@
+struct X {
+  int x;
+};
+
+struct Y {
+  int y;
+};
+
+/* If we do not select X and Y, we want to get a _single_ trace: Could not
+   select `f` because ... (in contrast to getting two traces) */
+void dependsOnXAndY(struct X sx, struct Y sy);

--- a/hs-bindgen/fixtures/program-analysis/selection_merge_traces/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_merge_traces/bindingspec.yaml
@@ -1,0 +1,5 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+target: x86_64-pc-linux-musl
+hsmodule: Example

--- a/hs-bindgen/fixtures/program-analysis/selection_merge_traces/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_merge_traces/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile examples/golden/program-analysis/selection_merge_traces.h

--- a/scripts/ci/compile-fixtures.sh
+++ b/scripts/ci/compile-fixtures.sh
@@ -21,16 +21,16 @@ EOF
 
 # Known failures - these will be skipped unless -f is used
 KNOWN_FAILURES=(
-    declarations/redeclaration     # Multiple declarations (intentional test case)
-    edge-cases/iterator            # Makes use of Apple block extension which would require clang (see #913)
-    functions/decls_in_signature   # Unusable struct (see #1128)
+    declarations/redeclaration                # Multiple declarations (intentional test case)
+    edge-cases/iterator                       # Makes use of Apple block extension which would require clang (see #913)
+    functions/decls_in_signature              # Unusable struct (see #1128)
     functions/heap_types/struct_const_member  # Issue #1490
     functions/heap_types/struct_const_typedef # Issue #1490
     functions/heap_types/struct_const         # Issue #1490
     functions/heap_types/union_const_member   # Issue #1490
     functions/heap_types/union_const_typedef  # Issue #1490
     functions/heap_types/union_const          # Issue #1490
-    types/typedefs/typenames       # Multiple declarations (hs-bindgen namespace possible bug/feature)
+    types/typedefs/typenames                  # Multiple declarations (hs-bindgen namespace possible bug/feature)
 )
 
 # Known fixtures without code - these will be skipped
@@ -46,6 +46,7 @@ KNOWN_EMPTY=(
     macros/macro_type_void
     program-analysis/delay_traces
     program-analysis/selection_foo
+    program-analysis/selection_merge_traces
     program-analysis/selection_omit_prescriptive
     types/special/long_double
     types/structs/implicit_fields_struct
@@ -57,7 +58,7 @@ KNOWN_EMPTY=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=117
+KNOWN_FIXTURES_COUNT=118
 
 # Default options
 JOBS=4


### PR DESCRIPTION
Only emit one trace message.

Closes #1383.

Output:
```console
$ ./scripts/run-golden-test.sh program-analysis/selection_merge_traces.h --select-except-by-decl-name "struct X" --select-except-by-decl-name "struct Y"
Temporary output directory: /tmp/tmp.u7nh2RLJdA
[Warning] [HsBindgen] [unique-id] empty unique identifier ('UniqueId', '--unique-id'):
  C uses a global namespace.
  We encourage using a unique identifier to avoid duplicate symbol names.
  For example, use and adapt 'com.example.package'.
[Warning] [HsBindgen] [select] 'dependsOnXAndY'  at  "./hs-bindgen/examples/golden/program-analysis/selection_merge_traces.h:11:6"
  Could not select declaration (direct select predicate match):
    Transitive dependency not selected:
      'struct X'  at  "./hs-bindgen/examples/golden/program-analysis/selection_merge_traces.h:1:8"
      Consider adjusting the select predicate
    Transitive dependency not selected:
      'struct Y'  at  "./hs-bindgen/examples/golden/program-analysis/selection_merge_traces.h:5:8"
      Consider adjusting the select predicate
[Notice ] [HsBindgen] [artefact-no-bindings-multiple] All binding categories with base module name "Example" are empty
```