### PR TITLE
CI: Add macOS and Windows jobs to PR test matrix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,6 +33,8 @@ jobs:
       run: |
         { echo 'MATRIX_COMBINATIONS<<EOF'
           echo '{"runner": "ubuntu-latest", "ghc": "9.4", "llvm": "15"},'
+          echo '{"runner": "macos-latest"  , "ghc": "9.4", "llvm": "14"},'
+          echo '{"runner": "windows-latest", "ghc": "9.4", "llvm": "14"},'
           echo EOF
         } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Previously, macOS and Windows CI tests only ran on push to main, making it difficult to catch platform-specific issues early during PR review. This commit adds one macOS and one Windows job to the PR test matrix.

Fixes #1557