### PR TITLE
Do not import `GHC.Prim` from `ghc-prim` in our bindings

### DIFF
--- a/hs-bindgen/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/attributes/Example.hs
@@ -20,7 +20,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import Data.Void (Void)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, IO, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
@@ -31,7 +31,7 @@ import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.SizedByteArray
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_both/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_both/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_struct/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_typedef/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/bs_pre_name_squash_typedef/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -42,7 +42,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -38,7 +38,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -21,7 +21,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.FlexibleArrayMember
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
@@ -26,7 +26,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -38,7 +38,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
@@ -25,7 +25,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.SizedByteArray
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -20,7 +20,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Prelude
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
@@ -24,7 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/manual/globals/Example.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example.hs
@@ -26,7 +26,7 @@ import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/manual/zero_copy/Example.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example.hs
@@ -31,7 +31,7 @@ import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.SizedByteArray
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -20,7 +20,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool/Example.hs
@@ -24,7 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
@@ -19,7 +19,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -21,7 +21,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -24,7 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasBaseForeignType
 import qualified HsBindgen.Runtime.HasCField
 import Data.Bits (FiniteBits)
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 

--- a/hs-bindgen/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/unions/Example.hs
@@ -24,7 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ByteArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.SizedByteArray
-import GHC.Prim ((*#), (+#))
+import GHC.Exts ((*#), (+#))
 import HsBindgen.Runtime.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
@@ -172,6 +172,8 @@ moduleOf "Just"     _ = HsImportModule "Data.Maybe" Nothing
 moduleOf ident m0 = case parts of
     ["C","Operator","Classes"]       -> HsImportModule "C.Expr.HostPlatform" (Just "C")
     ["GHC", "Bits"]                  -> HsImportModule "Data.Bits" (Just "Bits")
+    -- See https://gitlab.haskell.org/ghc/ghc/-/issues/23212
+    ["GHC", "Prim"]                  -> HsImportModule "GHC.Exts" Nothing
     ["GHC", "Base"]                  -> iPrelude
     ["GHC", "Classes"]               -> iPrelude
     ["GHC", "Show"]                  -> iPrelude

--- a/hs-bindgen/test/th/Test/TH/Simple.hs
+++ b/hs-bindgen/test/th/Test/TH/Simple.hs
@@ -14,7 +14,7 @@
 
 module Test.TH.Simple where
 
-import GHC.Prim
+import GHC.Exts
 import Optics ((%), (&), (.~))
 
 import HsBindgen.Runtime.Prelude qualified

--- a/manual/hs/hs-vector/hs-vector.cabal
+++ b/manual/hs/hs-vector/hs-vector.cabal
@@ -14,7 +14,6 @@ common lang
 
   build-depends:
     , base                >=4.16 && <5
-    , ghc-prim
     , hs-bindgen-runtime
     , primitive
 

--- a/manual/hs/manual/manual.cabal
+++ b/manual/hs/manual/manual.cabal
@@ -52,7 +52,6 @@ executable run-manual
   -- Internal.
   build-depends:
     , c-expr-runtime
-    , ghc-prim
     , hs-bindgen-runtime
     , hs-game
     , hs-vector


### PR DESCRIPTION
It has a buggy interaction with `-Wunused-packages`. Instead, we import `GHC.Exts` from `base`.

See https://gitlab.haskell.org/ghc/ghc/-/issues/23212 for a description of the bug