### PR TITLE
Suppress squash notices for hs-bindgen development

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -102,4 +102,6 @@ instance IsTrace Level MangleNamesMsg where
       MangleNamesSquashed{}          -> Notice
 
   getSource  = const HsBindgen
-  getTraceId = const "mangle-names"
+  getTraceId = \case
+    MangleNamesRenamed{}  -> "mangle-names-renamed"
+    MangleNamesSquashed{} -> "mangle-names-squashed"

--- a/hs-bindgen/test/pp/Test/PP/Test01.lhs
+++ b/hs-bindgen/test/pp/Test/PP/Test01.lhs
@@ -1,5 +1,6 @@
 [ "-I", "examples"
 , "--module=Test.PP.Test01"
 , "--unique-id", "com.well-typed.hs-bindgen"
+, "--log-as-info", "mangle-names-squashed"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/Test02.lhs
+++ b/hs-bindgen/test/pp/Test/PP/Test02.lhs
@@ -1,5 +1,6 @@
 [ "-I", "examples"
 , "--module=Test.PP.Test02"
 , "--unique-id", "com.well-typed.hs-bindgen"
+, "--log-as-info", "mangle-names-squashed"
 , "test_02.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/TestPointer.lhs
+++ b/hs-bindgen/test/pp/Test/PP/TestPointer.lhs
@@ -3,5 +3,6 @@
 , "--unique-id", "com.well-typed.hs-bindgen"
 , "--single-file"
 , "--pointer", ""
+, "--log-as-info", "mangle-names-squashed"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/TestSafe.lhs
+++ b/hs-bindgen/test/pp/Test/PP/TestSafe.lhs
@@ -3,5 +3,6 @@
 , "--unique-id", "com.well-typed.hs-bindgen"
 , "--single-file"
 , "--safe", ""
+, "--log-as-info", "mangle-names-squashed"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/TestSafeAndUnsafe.lhs
+++ b/hs-bindgen/test/pp/Test/PP/TestSafeAndUnsafe.lhs
@@ -4,5 +4,6 @@
 , "--single-file"
 , "--safe", "_safe"
 , "--unsafe", "_unsafe"
+, "--log-as-info", "mangle-names-squashed"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/pp/Test/PP/TestUnsafe.lhs
+++ b/hs-bindgen/test/pp/Test/PP/TestUnsafe.lhs
@@ -3,5 +3,6 @@
 , "--unique-id", "com.well-typed.hs-bindgen"
 , "--single-file"
 , "--unsafe", ""
+, "--log-as-info", "mangle-names-squashed"
 , "test_01.h"
 ]

--- a/hs-bindgen/test/th/Test/TH/Simple.hs
+++ b/hs-bindgen/test/th/Test/TH/Simple.hs
@@ -4,11 +4,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Test simple Template Haskell interface.
 
@@ -28,7 +29,7 @@ let cfg :: Config
     cfgTH :: ConfigTH
     cfgTH = def
       & #verbosity       .~ Verbosity Warning
-      & #customLogLevels .~ [EnableMacroWarnings]
+      & #customLogLevels .~ [MakeTrace Info "mangle-names-squashed"]
       & #categoryChoice  .~ useUnsafeCategory
 
  in withHsBindgen cfg cfgTH $

--- a/hs-bindgen/test/th/Test/TH/Test01.hs
+++ b/hs-bindgen/test/th/Test/TH/Test01.hs
@@ -4,11 +4,12 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Test.TH.Test01 where
 
@@ -19,8 +20,10 @@ import HsBindgen.Runtime.Prelude qualified
 import HsBindgen.TH
 
 let cfg :: Config
-    cfg = def & #clang % #extraIncludeDirs .~ [
-              Pkg "examples"
-            ]
- in withHsBindgen cfg def $
+    cfg = def
+      & #clang % #extraIncludeDirs .~ [Pkg "examples"]
+    cfgTh :: ConfigTH
+    cfgTh = def
+      & #customLogLevels .~ [MakeTrace Info "mangle-names-squashed"]
+ in withHsBindgen cfg cfgTh $
       hashInclude "test_01.h"

--- a/hs-bindgen/test/th/Test/TH/Test02.hs
+++ b/hs-bindgen/test/th/Test/TH/Test02.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -16,8 +17,10 @@ import HsBindgen.Runtime.Prelude qualified
 import HsBindgen.TH
 
 let cfg :: Config
-    cfg = def & #clang % #extraIncludeDirs .~ [
-              Pkg "examples"
-            ]
- in withHsBindgen cfg def $
+    cfg = def
+      & #clang % #extraIncludeDirs .~ [Pkg "examples"]
+    cfgTh :: ConfigTH
+    cfgTh = def
+      & #customLogLevels .~ [MakeTrace Info "mangle-names-squashed"]
+ in withHsBindgen cfg cfgTh $
       hashInclude "test_02.h"


### PR DESCRIPTION
This is a quick fix (workaround?) for https://github.com/well-typed/hs-bindgen/issues/1574.

It doesn't implement a dedicated command line option but uses the existing functionality to suppress squash notices in all builds performed by `cabal build all`. (It doesn't touch the manual, which also prints some squash notices).