### PR TITLE
Runtime: Remove CAPI from Prelude; use HsBindgen.Runtime.CAPI module

### DIFF
--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/CAPI.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/CAPI.hs
@@ -1,8 +1,11 @@
 module HsBindgen.Runtime.CAPI (
-    addCSource,
-    allocaAndPeek,
+    addCSource
+  , allocaAndPeek
+    -- * Auxiliary
+  , Data.List.unlines
 ) where
 
+import Data.List qualified
 import Foreign (Ptr, Storable, alloca, peek)
 import Language.Haskell.TH (DecsQ)
 import Language.Haskell.TH.Syntax (ForeignSrcLang (LangC), addForeignSource)

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Prelude.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Prelude.hs
@@ -12,18 +12,11 @@ module HsBindgen.Runtime.Prelude (
     -- * Constant pointers
   , module HsBindgen.Runtime.ConstPtr
 
-    -- * Userland CAPI
-  , module HsBindgen.Runtime.CAPI
-
     -- * Auxiliary
-  , Data.List.unlines
   , HsBindgenRuntimePreludeIsInScope
   ) where
 
-import Data.List qualified
-
 import HsBindgen.Runtime.Block
-import HsBindgen.Runtime.CAPI
 import HsBindgen.Runtime.ConstPtr
 import HsBindgen.Runtime.LibC
 import HsBindgen.Runtime.SizedByteArray

--- a/hs-bindgen/fixtures/arrays/array/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/FunPtr.hs
@@ -9,15 +9,15 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/array.h>"
   , "/* test_arraysarray_Example_get_fun_1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/arrays/array/Example/Global.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Global.hs
@@ -10,16 +10,16 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/array.h>"
   , "/* test_arraysarray_Example_get_arr0 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/arrays/array/Example/Safe.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Safe.hs
@@ -9,16 +9,16 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/array.h>"
   , "signed int hs_bindgen_a836491d63ff3a2c ("
   , "  signed int arg1,"

--- a/hs-bindgen/fixtures/arrays/array/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example/Unsafe.hs
@@ -9,16 +9,16 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/array.h>"
   , "signed int hs_bindgen_6d07a0b03f884547 ("
   , "  signed int arg1,"

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example/FunPtr.hs
@@ -9,15 +9,15 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/multi_dim.h>"
   , "/* test_arraysmulti_dim_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example/Safe.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example/Safe.hs
@@ -9,14 +9,14 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/multi_dim.h>"
   , "signed int hs_bindgen_57b00b79dd5b838e ("
   , "  signed int (*arg1)[4]"

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example/Unsafe.hs
@@ -9,14 +9,14 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <arrays/multi_dim.h>"
   , "signed int hs_bindgen_3389520bc7419af4 ("
   , "  signed int (*arg1)[4]"

--- a/hs-bindgen/fixtures/attributes/asm/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/asm.h>"
   , "/* test_attributesasm_Example_get_asm_labeled_function */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/attributes/asm/Example/Global.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/asm.h>"
   , "/* test_attributesasm_Example_get_asm_labeled_variable */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/attributes/asm/Example/Safe.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/asm.h>"
   , "signed int hs_bindgen_369133049bfc1e73 ("
   , "  signed int arg1,"

--- a/hs-bindgen/fixtures/attributes/asm/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/attributes/asm/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/asm.h>"
   , "signed int hs_bindgen_3ad6c287a2386382 ("
   , "  signed int arg1,"

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/FunPtr.hs
@@ -7,12 +7,12 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/visibility_attributes.h>"
   , "/* test_attributesvisibility_attribut_Example_get_f0 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Global.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/visibility_attributes.h>"
   , "/* test_attributesvisibility_attribut_Example_get_i0 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Safe.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Safe.hs
@@ -5,11 +5,11 @@
 
 module Example.Safe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/visibility_attributes.h>"
   , "void hs_bindgen_e64a83c5f7f51679 (void)"
   , "{"

--- a/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/attributes/visibility_attributes/Example/Unsafe.hs
@@ -5,11 +5,11 @@
 
 module Example.Unsafe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <attributes/visibility_attributes.h>"
   , "void hs_bindgen_df56d82c9186c794 (void)"
   , "{"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array.h>"
   , "/* test_bindingspecsfun_argmacroar_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/Safe.hs
@@ -7,12 +7,12 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array.h>"
   , "void hs_bindgen_2a6ef3a515232132 ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example/Unsafe.hs
@@ -7,12 +7,12 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array.h>"
   , "void hs_bindgen_969f916bf9590709 ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array_known_size.h>"
   , "/* test_bindingspecsfun_argmacroar_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/Safe.hs
@@ -7,12 +7,12 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array_known_size.h>"
   , "void hs_bindgen_2a6ef3a515232132 ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example/Unsafe.hs
@@ -7,12 +7,12 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/array_known_size.h>"
   , "void hs_bindgen_969f916bf9590709 ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/enum.h>"
   , "/* test_bindingspecsfun_argmacroen_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/Safe.hs
@@ -6,12 +6,12 @@
 module Example.Safe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/enum.h>"
   , "void hs_bindgen_d49a011eb7da5969 ("
   , "  enum MyEnum arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example/Unsafe.hs
@@ -6,12 +6,12 @@
 module Example.Unsafe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/enum.h>"
   , "void hs_bindgen_0e6b98e93cad73ef ("
   , "  enum MyEnum arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function.h>"
   , "/* test_bindingspecsfun_argmacrofu_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/Safe.hs
@@ -8,13 +8,13 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function.h>"
   , "void hs_bindgen_40e15e86e5db36ce ("
   , "  MyFunction *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example/Unsafe.hs
@@ -8,13 +8,13 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function.h>"
   , "void hs_bindgen_fbc2ec26cd297034 ("
   , "  MyFunction *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function_pointer.h>"
   , "/* test_bindingspecsfun_argmacrofu_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/Safe.hs
@@ -6,13 +6,13 @@
 module Example.Safe where
 
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function_pointer.h>"
   , "void hs_bindgen_40e15e86e5db36ce ("
   , "  MyFunctionPointer arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example/Unsafe.hs
@@ -6,13 +6,13 @@
 module Example.Unsafe where
 
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/function_pointer.h>"
   , "void hs_bindgen_fbc2ec26cd297034 ("
   , "  MyFunctionPointer arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/struct.h>"
   , "/* test_bindingspecsfun_argmacrost_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/struct.h>"
   , "void hs_bindgen_f2a9c7d0ba1aaa3b ("
   , "  struct MyStruct *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/struct.h>"
   , "void hs_bindgen_9dbeca9fa307eee9 ("
   , "  struct MyStruct *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/union.h>"
   , "/* test_bindingspecsfun_argmacroun_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/union.h>"
   , "void hs_bindgen_5da9ad143faecbca ("
   , "  union MyUnion *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/macro/union.h>"
   , "void hs_bindgen_f784f3292d76f05c ("
   , "  union MyUnion *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/FunPtr.hs
@@ -8,15 +8,15 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/Safe.hs
@@ -7,12 +7,12 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example/Unsafe.hs
@@ -7,12 +7,12 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/FunPtr.hs
@@ -9,15 +9,15 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array_known_size.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/Safe.hs
@@ -7,12 +7,12 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array_known_size.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example/Unsafe.hs
@@ -7,12 +7,12 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/array_known_size.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  signed int *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/FunPtr.hs
@@ -7,14 +7,14 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/enum.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/Safe.hs
@@ -6,13 +6,13 @@
 module Example.Safe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/enum.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  enum MyEnum arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example/Unsafe.hs
@@ -6,13 +6,13 @@
 module Example.Unsafe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/enum.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  enum MyEnum arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/FunPtr.hs
@@ -8,14 +8,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/Safe.hs
@@ -7,14 +7,14 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  signed int (*arg1) ("

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example/Unsafe.hs
@@ -7,14 +7,14 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  signed int (*arg1) ("

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/FunPtr.hs
@@ -8,14 +8,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function_pointer.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/Safe.hs
@@ -7,14 +7,14 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function_pointer.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  signed int (*arg1) ("

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example/Unsafe.hs
@@ -7,14 +7,14 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/function_pointer.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  signed int (*arg1) ("

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/FunPtr.hs
@@ -7,14 +7,14 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/struct.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/Safe.hs
@@ -7,14 +7,14 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/struct.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  struct MyStruct *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example/Unsafe.hs
@@ -7,14 +7,14 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/struct.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  struct MyStruct *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/FunPtr.hs
@@ -7,14 +7,14 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/union.h>"
   , "/* test_bindingspecsfun_argtypedef_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/Safe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/Safe.hs
@@ -7,14 +7,14 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/union.h>"
   , "void hs_bindgen_99bb90e6d7637d2c ("
   , "  union MyUnion *arg1"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example/Unsafe.hs
@@ -7,14 +7,14 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import qualified M
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <binding-specs/fun_arg/typedef/union.h>"
   , "void hs_bindgen_51195acecf6b880e ("
   , "  union MyUnion *arg1"

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/declarations_required_for_scoping.h>"
   , "/* test_declarationsdeclarations_requ_Example_get_f */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Safe.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Safe.hs
@@ -6,12 +6,12 @@
 module Example.Safe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/declarations_required_for_scoping.h>"
   , "void hs_bindgen_0d1c75136a36e326 ("
   , "  A arg1"

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example/Unsafe.hs
@@ -6,12 +6,12 @@
 module Example.Unsafe where
 
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/declarations_required_for_scoping.h>"
   , "void hs_bindgen_93ed1628a0edf6b0 ("
   , "  A arg1"

--- a/hs-bindgen/fixtures/declarations/definitions/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/definitions.h>"
   , "/* test_declarationsdefinitions_Example_get_foo */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/definitions.h>"
   , "/* test_declarationsdefinitions_Example_get_n */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Safe.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/definitions.h>"
   , "signed int hs_bindgen_9cdc88a6d09442d6 ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/declarations/definitions/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/definitions.h>"
   , "signed int hs_bindgen_07fd5b433f381094 ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/redeclaration.h>"
   , "/* test_declarationsredeclaration_Example_get_x */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/declarations/tentative_definitions/Example/Global.hs
+++ b/hs-bindgen/fixtures/declarations/tentative_definitions/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <declarations/tentative_definitions.h>"
   , "/* test_declarationstentative_definit_Example_get_i1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/FunPtr.hs
@@ -9,6 +9,7 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
@@ -17,7 +18,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <documentation/doxygen_docs.h>"
   , "/* test_documentationdoxygen_docs_Example_get_process_data */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Global.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Global.hs
@@ -8,13 +8,13 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <documentation/doxygen_docs.h>"
   , "/* test_documentationdoxygen_docs_Example_get_global_counter */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Safe.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Safe.hs
@@ -9,6 +9,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
@@ -16,7 +17,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <documentation/doxygen_docs.h>"
   , "signed int hs_bindgen_7eada9f65d982412 ("
   , "  uint8_t const *arg1,"

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example/Unsafe.hs
@@ -9,6 +9,7 @@ import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
@@ -16,7 +17,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <documentation/doxygen_docs.h>"
   , "signed int hs_bindgen_e6085a910ba41ecb ("
   , "  uint8_t const *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/adios.h>"
   , "/* test_edgecasesadios_Example_get_adio\769s_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Global.hs
@@ -9,13 +9,13 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/adios.h>"
   , "/* test_edgecasesadios_Example_get_\978\978 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/adios.h>"
   , "signed int hs_bindgen_2f6d4be143076044 (void)"
   , "{"

--- a/hs-bindgen/fixtures/edge-cases/adios/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/adios.h>"
   , "signed int hs_bindgen_2a3071850c230aa3 (void)"
   , "{"

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/anon_multiple_typedefs.h>"
   , "/* test_edgecasesanon_multiple_typed_Example_get_test */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/anon_multiple_typedefs.h>"
   , "void hs_bindgen_c97a0d4458699ad7 ("
   , "  point2a *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/anon_multiple_typedefs.h>"
   , "void hs_bindgen_f90e97b8d269be4e ("
   , "  point2a *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/FunPtr.hs
@@ -7,6 +7,7 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Prelude
@@ -14,7 +15,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/distilled_lib_1.h>"
   , "/* test_edgecasesdistilled_lib_1_Example_get_some_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Global.hs
@@ -7,13 +7,13 @@ module Example.Global where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/distilled_lib_1.h>"
   , "/* test_edgecasesdistilled_lib_1_Example_get_v */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Safe.hs
@@ -8,13 +8,14 @@ module Example.Safe where
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/distilled_lib_1.h>"
   , "int32_t hs_bindgen_57cb99ed92c001ad ("
   , "  a_type_t *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example/Unsafe.hs
@@ -8,13 +8,14 @@ module Example.Unsafe where
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/distilled_lib_1.h>"
   , "int32_t hs_bindgen_2a91c367a9380a63 ("
   , "  a_type_t *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Global.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example/Global.hs
@@ -10,14 +10,14 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/enum_as_array_size.h>"
   , "/* test_edgecasesenum_as_array_size_Example_get_test_array */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/flam_functions.h>"
   , "/* test_edgecasesflam_functions_Example_get_vector_alloc */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example/Safe.hs
@@ -8,13 +8,13 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/flam_functions.h>"
   , "struct Vector *hs_bindgen_231473be98482b20 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example/Unsafe.hs
@@ -8,13 +8,13 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/flam_functions.h>"
   , "struct Vector *hs_bindgen_66fe57793f0712c2 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/iterator.h>"
   , "/* test_edgecasesiterator_Example_get_makeToggle */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/Safe.hs
@@ -9,13 +9,13 @@ import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/iterator.h>"
   , "Toggle hs_bindgen_9d01035006b66206 ("
   , "  _Bool arg1"

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example/Unsafe.hs
@@ -9,13 +9,13 @@ import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/iterator.h>"
   , "Toggle hs_bindgen_1b7a6a61a9c0da07 ("
   , "  _Bool arg1"

--- a/hs-bindgen/fixtures/edge-cases/names/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/FunPtr.hs
@@ -7,12 +7,12 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/names.h>"
   , "/* test_edgecasesnames_Example_get_by */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/names/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/Safe.hs
@@ -5,11 +5,11 @@
 
 module Example.Safe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/names.h>"
   , "void hs_bindgen_601290db9e101424 (void)"
   , "{"

--- a/hs-bindgen/fixtures/edge-cases/names/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/names/Example/Unsafe.hs
@@ -5,11 +5,11 @@
 
 module Example.Unsafe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/names.h>"
   , "void hs_bindgen_28b998af1f39a743 (void)"
   , "{"

--- a/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/ordinary_anon_parent.h>"
   , "/* test_edgecasesordinary_anon_paren_Example_get__acos */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/Safe.hs
@@ -6,11 +6,11 @@
 module Example.Safe where
 
 import qualified Foreign.C as FC
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/ordinary_anon_parent.h>"
   , "double hs_bindgen_06a412f170b5ff91 ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/ordinary_anon_parent/Example/Unsafe.hs
@@ -6,11 +6,11 @@
 module Example.Unsafe where
 
 import qualified Foreign.C as FC
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/ordinary_anon_parent.h>"
   , "double hs_bindgen_dca60678b5047ee4 ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/FunPtr.hs
@@ -8,14 +8,14 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/spec_examples.h>"
   , "/* test_edgecasesspec_examples_Example_get_resample */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/spec_examples.h>"
   , "void hs_bindgen_8a72aafc705daf44 ("
   , "  int32_T *arg1,"

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <edge-cases/spec_examples.h>"
   , "void hs_bindgen_2311fa9c0d0d6d06 ("
   , "  int32_T *arg1,"

--- a/hs-bindgen/fixtures/functions/callbacks/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/callbacks.h>"
   , "/* test_functionscallbacks_Example_get_readFileWithProcessor */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/callbacks/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/Safe.hs
@@ -8,13 +8,13 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/callbacks.h>"
   , "signed int hs_bindgen_99bda9cd8097b0ea ("
   , "  void (*arg1) ("

--- a/hs-bindgen/fixtures/functions/callbacks/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example/Unsafe.hs
@@ -8,13 +8,13 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/callbacks.h>"
   , "signed int hs_bindgen_d07f3a3e526e7017 ("
   , "  void (*arg1) ("

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/decls_in_signature.h>"
   , "/* test_functionsdecls_in_signature_Example_get_normal */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/decls_in_signature.h>"
   , "void hs_bindgen_920e5c20f770432b ("
   , "  struct opaque *arg1,"

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/decls_in_signature.h>"
   , "void hs_bindgen_247ee31a29b7e5a8 ("
   , "  struct opaque *arg1,"

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/FunPtr.hs
@@ -8,14 +8,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes.h>"
   , "/* test_functionsfun_attributes_Example_get___f1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Global.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes.h>"
   , "/* test_functionsfun_attributes_Example_get_i */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Safe.hs
@@ -8,14 +8,14 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes.h>"
   , "void hs_bindgen_0560fe42a40f777f (void)"
   , "{"

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example/Unsafe.hs
@@ -8,14 +8,14 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes.h>"
   , "void hs_bindgen_52759f125bf2b140 (void)"
   , "{"

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes_conflict.h>"
   , "/* test_functionsfun_attributes_confl_Example_get_square_cp */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes_conflict.h>"
   , "signed int hs_bindgen_5d7162df3a16d8d5 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes_conflict/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/fun_attributes_conflict.h>"
   , "signed int hs_bindgen_648d4f0fd0df4c79 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct.h>"
   , "/* test_functionsheap_typesstruct_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/Safe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct.h>"
   , "void hs_bindgen_a5d53f538e59b1fc ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/Unsafe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct.h>"
   , "void hs_bindgen_c4af6bb824712c6a ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const.h>"
   , "/* test_functionsheap_typesstruct_co_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/Safe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const.h>"
   , "void hs_bindgen_67465eb5641985dc ("
   , "  T const *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example/Unsafe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const.h>"
   , "void hs_bindgen_4351e21e32969011 ("
   , "  T const *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_member.h>"
   , "/* test_functionsheap_typesstruct_co_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/Safe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_member.h>"
   , "void hs_bindgen_67465eb5641985dc ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example/Unsafe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_member.h>"
   , "void hs_bindgen_4351e21e32969011 ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_typedef.h>"
   , "/* test_functionsheap_typesstruct_co_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/Safe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_typedef.h>"
   , "void hs_bindgen_67465eb5641985dc ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example/Unsafe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/struct_const_typedef.h>"
   , "void hs_bindgen_4351e21e32969011 ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union.h>"
   , "/* test_functionsheap_typesunion_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example/Safe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union.h>"
   , "void hs_bindgen_9fc5746860ab93cb ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example/Unsafe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union.h>"
   , "void hs_bindgen_54b038887c811176 ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const.h>"
   , "/* test_functionsheap_typesunion_con_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example/Safe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const.h>"
   , "void hs_bindgen_8a303cd5b4f7787b ("
   , "  T const *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example/Unsafe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const.h>"
   , "void hs_bindgen_4e22c71ca196dc5e ("
   , "  T const *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_member.h>"
   , "/* test_functionsheap_typesunion_con_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/Safe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_member.h>"
   , "void hs_bindgen_8a303cd5b4f7787b ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example/Unsafe.hs
@@ -9,12 +9,11 @@ import qualified Foreign as F
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_member.h>"
   , "void hs_bindgen_4e22c71ca196dc5e ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_typedef.h>"
   , "/* test_functionsheap_typesunion_con_Example_get_fun */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/Safe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_typedef.h>"
   , "void hs_bindgen_8a303cd5b4f7787b ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example/Unsafe.hs
@@ -10,12 +10,11 @@ import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/heap_types/union_const_typedef.h>"
   , "void hs_bindgen_4e22c71ca196dc5e ("
   , "  T *arg1,"

--- a/hs-bindgen/fixtures/functions/simple_func.1.rename/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/simple_func.1.rename/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/simple_func.h>"
   , "/* test_functionssimple_func_1_rename_Example_get_erf */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/simple_func/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/simple_func.h>"
   , "/* test_functionssimple_func_Example_get_erf */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/simple_func/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/simple_func.h>"
   , "double hs_bindgen_1c811bfb80de8f77 ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/functions/simple_func/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/simple_func/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/simple_func.h>"
   , "double hs_bindgen_da5d889180d72efd ("
   , "  double arg1"

--- a/hs-bindgen/fixtures/functions/varargs/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/FunPtr.hs
@@ -7,12 +7,12 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/varargs.h>"
   , "/* test_functionsvarargs_Example_get_h */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/functions/varargs/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/Safe.hs
@@ -5,11 +5,11 @@
 
 module Example.Safe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/varargs.h>"
   , "void hs_bindgen_77a4bac5bbe80f62 (void)"
   , "{"

--- a/hs-bindgen/fixtures/functions/varargs/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/varargs/Example/Unsafe.hs
@@ -5,11 +5,11 @@
 
 module Example.Unsafe where
 
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <functions/varargs.h>"
   , "void hs_bindgen_32ebae80cc3543e1 (void)"
   , "{"

--- a/hs-bindgen/fixtures/globals/globals/Example/Global.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example/Global.hs
@@ -9,6 +9,7 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
@@ -16,7 +17,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <globals/globals.h>"
   , "/* test_globalsglobals_Example_get_simpleGlobal */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/FunPtr.hs
@@ -9,14 +9,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl.h>"
   , "/* test_macrosmacro_in_fundecl_Example_get_quux */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Safe.hs
@@ -9,14 +9,14 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl.h>"
   , "char hs_bindgen_d345c332b6547629 ("
   , "  F arg1,"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example/Unsafe.hs
@@ -9,14 +9,14 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl.h>"
   , "char hs_bindgen_ab9081efcd629826 ("
   , "  F arg1,"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl_vs_typedef.h>"
   , "/* test_macrosmacro_in_fundecl_vs_typ_Example_get_quux1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Safe.hs
@@ -8,13 +8,13 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl_vs_typedef.h>"
   , "char hs_bindgen_02e0e3b28d470fd4 ("
   , "  MC arg1,"

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example/Unsafe.hs
@@ -8,13 +8,13 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/macro_in_fundecl_vs_typedef.h>"
   , "char hs_bindgen_df7e2b8e86de411a ("
   , "  MC arg1,"

--- a/hs-bindgen/fixtures/macros/reparse/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/FunPtr.hs
@@ -10,6 +10,7 @@ import qualified Data.Complex
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
@@ -19,7 +20,7 @@ import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/reparse.h>"
   , "/* test_macrosreparse_Example_get_args_char1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/macros/reparse/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/Safe.hs
@@ -19,7 +19,7 @@ import Data.Void (Void)
 import Example
 import Prelude (Double, Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/reparse.h>"
   , "void hs_bindgen_f15610128336b06a ("
   , "  A arg1,"

--- a/hs-bindgen/fixtures/macros/reparse/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example/Unsafe.hs
@@ -19,7 +19,7 @@ import Data.Void (Void)
 import Example
 import Prelude (Double, Float, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <macros/reparse.h>"
   , "void hs_bindgen_c1716e300ba327c7 ("
   , "  A arg1,"

--- a/hs-bindgen/fixtures/manual/arrays/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/FunPtr.hs
@@ -7,13 +7,13 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/arrays.h>"
   , "/* test_manualarrays_Example_get_transpose */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/arrays/Example/Global.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Global.hs
@@ -9,15 +9,15 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/arrays.h>"
   , "/* test_manualarrays_Example_get_arr1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/arrays/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Safe.hs
@@ -8,15 +8,15 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/arrays.h>"
   , "void hs_bindgen_cba7011c6d25362b ("
   , "  triplet const *arg1,"

--- a/hs-bindgen/fixtures/manual/arrays/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example/Unsafe.hs
@@ -8,15 +8,15 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/arrays.h>"
   , "void hs_bindgen_f9f2776d121db261 ("
   , "  triplet const *arg1,"

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/function_pointers.h>"
   , "/* test_manualfunction_pointers_Example_get_square */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Global.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Global.hs
@@ -9,14 +9,14 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/function_pointers.h>"
   , "/* test_manualfunction_pointers_Example_get_apply1_nopointer_var */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Safe.hs
@@ -8,13 +8,13 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/function_pointers.h>"
   , "signed int hs_bindgen_8c6beff641297a13 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/manual/function_pointers/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example/Unsafe.hs
@@ -8,13 +8,13 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/function_pointers.h>"
   , "signed int hs_bindgen_db669c022bc12e81 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/manual/globals/Example/Global.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example/Global.hs
@@ -10,16 +10,16 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.IncompleteArray
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/globals.h>"
   , "/* test_manualglobals_Example_get_globalConfig */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/FunPtr.hs
@@ -8,14 +8,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/zero_copy.h>"
   , "/* test_manualzero_copy_Example_get_reverse */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/Safe.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/Safe.hs
@@ -8,14 +8,14 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/zero_copy.h>"
   , "signed int hs_bindgen_350cceac1101d344 ("
   , "  struct vector const *arg1,"

--- a/hs-bindgen/fixtures/manual/zero_copy/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example/Unsafe.hs
@@ -8,14 +8,14 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <manual/zero_copy.h>"
   , "signed int hs_bindgen_f9655173d51bbaac ("
   , "  struct vector const *arg1,"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/FunPtr.hs
@@ -7,13 +7,14 @@ module Example.FunPtr where
 
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_selection.h>"
   , "/* test_programanalysisprogram_slici_Example_get_read_file_chunk */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Safe.hs
@@ -8,13 +8,14 @@ module Example.Safe where
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_selection.h>"
   , "enum FileOperationStatus hs_bindgen_b2a91b3b7edf2ad3 ("
   , "  FILE *arg1,"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example/Unsafe.hs
@@ -8,13 +8,14 @@ module Example.Unsafe where
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_selection.h>"
   , "enum FileOperationStatus hs_bindgen_654858ed6a5db417 ("
   , "  FILE *arg1,"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/FunPtr.hs
@@ -9,13 +9,13 @@ import qualified Foreign
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_simple.h>"
   , "/* test_programanalysisprogram_slici_Example_get_bar */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/Safe.hs
@@ -9,12 +9,12 @@ import qualified Foreign
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_simple.h>"
   , "signed int hs_bindgen_48dbbf4b09b5b3c1 ("
   , "  uint64_t arg1,"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example/Unsafe.hs
@@ -9,12 +9,12 @@ import qualified Foreign
 import qualified Foreign.C as FC
 import qualified GHC.Int
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/program_slicing_simple.h>"
   , "signed int hs_bindgen_fe855d53295ba8ab ("
   , "  uint64_t arg1,"

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/selection_matches_c_names.h>"
   , "/* test_programanalysisselection_mat_Example_get_FunctionWithAssignedHaskellNameByNameMangler */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/Safe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/selection_matches_c_names.h>"
   , "signed int hs_bindgen_c9b1dc5577fd8ced (void)"
   , "{"

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <program-analysis/selection_matches_c_names.h>"
   , "signed int hs_bindgen_9a13a53e6a2f2416 (void)"
   , "{"

--- a/hs-bindgen/fixtures/types/complex/complex_non_float_test/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/complex/complex_non_float_test/Example/Global.hs
@@ -9,12 +9,12 @@ import qualified Data.Complex
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/complex_non_float_test.h>"
   , "/* test_typescomplexcomplex_non_floa_Example_get_global_complex_unsigned_short */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/FunPtr.hs
@@ -9,12 +9,12 @@ import qualified Data.Complex
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/hsb_complex_test.h>"
   , "/* test_typescomplexhsb_complex_test_Example_get_multiply_complex_f */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Global.hs
@@ -11,14 +11,14 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/hsb_complex_test.h>"
   , "/* test_typescomplexhsb_complex_test_Example_get_global_complex_float */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Safe.hs
@@ -11,11 +11,10 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/hsb_complex_test.h>"
   , "void hs_bindgen_687af703c95fba0e ("
   , "  float _Complex *arg1,"

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example/Unsafe.hs
@@ -11,11 +11,10 @@ import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/hsb_complex_test.h>"
   , "void hs_bindgen_e5e3172c2163672b ("
   , "  float _Complex *arg1,"

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/vector_test.h>"
   , "/* test_typescomplexvector_test_Example_get_new_vector */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/Safe.hs
@@ -7,13 +7,13 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/vector_test.h>"
   , "vector *hs_bindgen_cd5f566bc96dcba0 ("
   , "  double arg1,"

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example/Unsafe.hs
@@ -7,13 +7,13 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/complex/vector_test.h>"
   , "vector *hs_bindgen_1af353788955c7a2 ("
   , "  double arg1,"

--- a/hs-bindgen/fixtures/types/primitives/bool_c23/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool_c23/Example/Global.hs
@@ -8,12 +8,12 @@ module Example.Global where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/primitives/bool_c23.h>"
   , "/* test_typesprimitivesbool_c23_Example_get_b */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example/Global.hs
@@ -8,14 +8,14 @@ module Example.Global where
 import qualified Foreign as F
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/qualifiers/const_typedefs.h>"
   , "/* test_typesqualifiersconst_typedef_Example_get_i */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/FunPtr.hs
@@ -8,13 +8,14 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/qualifiers/type_qualifiers.h>"
   , "/* test_typesqualifierstype_qualifie_Example_get_list_example */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Global.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Global.hs
@@ -9,13 +9,13 @@ import qualified Foreign as F
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/qualifiers/type_qualifiers.h>"
   , "/* test_typesqualifierstype_qualifie_Example_get_a */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Safe.hs
@@ -8,13 +8,14 @@ module Example.Safe where
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/qualifiers/type_qualifiers.h>"
   , "_Bool hs_bindgen_32187cc02676ee72 ("
   , "  char const **arg1,"

--- a/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/type_qualifiers/Example/Unsafe.hs
@@ -8,13 +8,14 @@ module Example.Unsafe where
 import qualified Foreign.C as FC
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Word
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.ConstPtr
 import qualified HsBindgen.Runtime.HasFFIType
 import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/qualifiers/type_qualifiers.h>"
   , "_Bool hs_bindgen_360934a08f19eaab ("
   , "  char const **arg1,"

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/FunPtr.hs
@@ -8,12 +8,12 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/special/parse_failure_long_double.h>"
   , "/* test_typesspecialparse_failure_lo_Example_get_fun2 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Safe.hs
@@ -7,11 +7,11 @@ module Example.Safe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/special/parse_failure_long_double.h>"
   , "void hs_bindgen_a1252a3becef09a6 ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example/Unsafe.hs
@@ -7,11 +7,11 @@ module Example.Unsafe where
 
 import qualified Foreign.C as FC
 import qualified GHC.Int
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/special/parse_failure_long_double.h>"
   , "void hs_bindgen_61793546aa44e36b ("
   , "  signed int arg1"

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/FunPtr.hs
@@ -8,13 +8,13 @@ module Example.FunPtr where
 import qualified Foreign.C as FC
 import qualified GHC.IO.Unsafe
 import qualified GHC.Ptr as Ptr
+import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/structs/struct_arg.h>"
   , "/* test_typesstructsstruct_arg_Example_get_thing_fun_1 */"
   , "__attribute__ ((const))"

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/Safe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/Safe.hs
@@ -11,12 +11,11 @@ import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/structs/struct_arg.h>"
   , "signed int hs_bindgen_4ad25504590fdd2b ("
   , "  struct thing *arg1"

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example/Unsafe.hs
@@ -11,12 +11,11 @@ import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified HsBindgen.Runtime.CAPI
 import qualified HsBindgen.Runtime.HasFFIType
-import qualified HsBindgen.Runtime.Prelude
 import Data.Void (Void)
 import Example
 import Prelude (Double, IO)
 
-$(HsBindgen.Runtime.Prelude.addCSource (HsBindgen.Runtime.Prelude.unlines
+$(HsBindgen.Runtime.CAPI.addCSource (HsBindgen.Runtime.CAPI.unlines
   [ "#include <types/structs/struct_arg.h>"
   , "signed int hs_bindgen_0bdddf60550fc97b ("
   , "  struct thing *arg1"

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -99,7 +99,7 @@ library internal
     HsBindgen.Backend.Hs.Translation.Structure
     HsBindgen.Backend.Hs.Translation.ToFromFunPtr
     HsBindgen.Backend.Hs.Translation.Type
-    HsBindgen.Backend.HsModule.Capi
+    HsBindgen.Backend.HsModule.CAPI
     HsBindgen.Backend.HsModule.Names
     HsBindgen.Backend.HsModule.Render
     HsBindgen.Backend.HsModule.Translation

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Render.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Render.hs
@@ -34,7 +34,7 @@ import HsBindgen.Backend.Hs.AST.Type (HsPrimType (..))
 import HsBindgen.Backend.Hs.CallConv
 import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Name qualified as Hs
-import HsBindgen.Backend.HsModule.Capi (renderCapiWrapper)
+import HsBindgen.Backend.HsModule.CAPI (renderCapiWrapper)
 import HsBindgen.Backend.HsModule.Names
 import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.Backend.SHs.AST

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
@@ -18,7 +18,7 @@ import HsBindgen.Backend.Category
 import HsBindgen.Backend.Extensions
 import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.Hs.CallConv
-import HsBindgen.Backend.HsModule.Capi (capiImport)
+import HsBindgen.Backend.HsModule.CAPI (capiImport)
 import HsBindgen.Backend.HsModule.Names
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Config.Prelims


### PR DESCRIPTION
## Questions

### Import

```
-- | The CAPI `addCSource` import.
--
-- We import the @hs-bindgen-runtime@ prelude when adding C sources. Foreign
-- imports of these C sources require the _data_ constructors of all involved
-- data types to be in scope. We can only ensure the data constructors to be in
-- scope by tying the CAPI import statement to an import of all C wrapper data
-- types we are using (such as 'Foreign.C.CDouble').
--
-- See also "HsBindgen.Runtime.Prelude".
```

The above seems to be outdated. This PR changes the import to a module-specific one, and all seems to be good. We remove this comment.

### Name

`CAPI` vs `Capi` (at the moment, we use both).

We decided:

```
-- We capitalize module names, but use camelCase/PascalCase in code:
--
-- - in types names:    CapiFoo, FooCapiBar
-- - in variable names: capiFoo, fooCapiBar
```

### Imports of standard types (such as `Word32`)

We seem to use both:

```haskell
-- __unique:__ @test_edgecasesdistilled_lib_1_Example_Safe_some_fun@
foreign import ccall safe "hs_bindgen_57cb99ed92c001ad" hs_bindgen_57cb99ed92c001ad_base ::
     Ptr.Ptr Void
  -> GHC.Word.Word32
  -> Ptr.Ptr Void
  -> IO GHC.Int.Int32

-- __unique:__ @test_edgecasesdistilled_lib_1_Example_Safe_some_fun@
hs_bindgen_57cb99ed92c001ad ::
     Ptr.Ptr A_type_t
  -> HsBindgen.Runtime.Prelude.Word32
  -> Ptr.Ptr HsBindgen.Runtime.Prelude.Word8
  -> IO HsBindgen.Runtime.Prelude.Int32
hs_bindgen_57cb99ed92c001ad =
  HsBindgen.Runtime.HasFFIType.fromFFIType hs_bindgen_57cb99ed92c001ad_base
```

This is not a big deal, but we may want to fix the discrepancy in the future.