### PR TITLE
Run `stylish-haskell` on manual files

### DIFF
--- a/manual/hs/manual/app/Manual.hs
+++ b/manual/hs/manual/app/Manual.hs
@@ -27,26 +27,24 @@ into separate modules corresponding to the manual's structure:
 -}
 module Manual (main) where
 
+import Foreign
 import System.IO.Unsafe
 
-import Example.Unsafe
 import Example
-
-import qualified Manual.BindingSpecifications
-import qualified Manual.Functions.FirstOrder
-import qualified Manual.Functions.HigherOrder
-import qualified Manual.GeneratedNames
-import qualified Manual.Globals
-import qualified Manual.Macros
-import qualified Manual.Types.Arrays
-import qualified Manual.Types.Complex
-import qualified Manual.Types.Enums
-import qualified Manual.Types.Structs
-import qualified Manual.Types.Typedefs
-import qualified Manual.Types.Unions
-import qualified Manual.ZeroCopy
-
-import Foreign
+import Example.Unsafe
+import Manual.BindingSpecifications qualified
+import Manual.Functions.FirstOrder qualified
+import Manual.Functions.HigherOrder qualified
+import Manual.GeneratedNames qualified
+import Manual.Globals qualified
+import Manual.Macros qualified
+import Manual.Types.Arrays qualified
+import Manual.Types.Complex qualified
+import Manual.Types.Enums qualified
+import Manual.Types.Structs qualified
+import Manual.Types.Typedefs qualified
+import Manual.Types.Unions qualified
+import Manual.ZeroCopy qualified
 
 {-------------------------------------------------------------------------------
   Main

--- a/manual/hs/manual/app/Manual/GeneratedNames.hs
+++ b/manual/hs/manual/app/Manual/GeneratedNames.hs
@@ -2,9 +2,8 @@
 
 module Manual.GeneratedNames (examples) where
 
-import Manual.Tools
-
 import Example.Unsafe
+import Manual.Tools
 
 {-------------------------------------------------------------------------------
   Examples

--- a/manual/hs/manual/app/Manual/Macros.hs
+++ b/manual/hs/manual/app/Manual/Macros.hs
@@ -3,10 +3,9 @@ module Manual.Macros (examples) where
 import Foreign as F
 import Foreign.C qualified as FC
 
-import Manual.Tools
-
 import Example
 import Example.Unsafe
+import Manual.Tools
 
 {-------------------------------------------------------------------------------
   Examples

--- a/manual/hs/manual/app/Manual/Types/Typedefs.hs
+++ b/manual/hs/manual/app/Manual/Types/Typedefs.hs
@@ -3,10 +3,9 @@ module Manual.Types.Typedefs (examples) where
 import Foreign as F
 import System.IO.Unsafe
 
-import Manual.Tools
-
 import Example
 import Example.Unsafe
+import Manual.Tools
 
 {-------------------------------------------------------------------------------
   Using typedefs

--- a/manual/hs/manual/app/Manual/Types/Unions.hs
+++ b/manual/hs/manual/app/Manual/Types/Unions.hs
@@ -2,10 +2,9 @@ module Manual.Types.Unions (examples) where
 
 import Foreign as F
 
-import Manual.Tools
-
 import Example
 import Example.Unsafe
+import Manual.Tools
 
 {-------------------------------------------------------------------------------
   Examples

--- a/scripts/ci/check-stylish-ignore
+++ b/scripts/ci/check-stylish-ignore
@@ -5,6 +5,5 @@
 alternatives/**/*.hs
 hs-bindgen/fixtures/*.hs
 hs-bindgen/src-internal/HsBindgen/Frontend/Macro/**/*
-manual/**/*.hs
 c-expr-runtime/**/*.hs
 c-expr-dsl/**/*.hs


### PR DESCRIPTION
The `run-stylish-haskell` script won't run in files that are ignored by git, such as the Haskell files generated using `hs-bindgen` in the manual