### PR TITLE
Derive `Generic` for all generated types

### DIFF
--- a/hs-bindgen/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -35,6 +37,7 @@ import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -65,6 +68,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype List = List
   { unwrapList :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType List) "unwrapList")
@@ -89,6 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField List "unwrapList" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -119,6 +124,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Matrix "unwrapMatrix" where
 newtype Tripletlist = Tripletlist
   { unwrapTripletlist :: HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tripletlist) "unwrapTripletlist")
@@ -156,6 +162,7 @@ data Example = Example
          __exported by:__ @arrays\/array.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example where
@@ -221,6 +228,7 @@ __exported by:__ @arrays\/array.h@
 newtype Sudoku = Sudoku
   { unwrapSudoku :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/fixtures/arrays/array/th.txt
@@ -665,6 +665,7 @@ newtype Triplet
 
            __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
@@ -688,6 +689,7 @@ newtype List
 
            __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType List "unwrapList") =>
          HasField "unwrapList" (Ptr List) (Ptr ty)
@@ -709,6 +711,7 @@ newtype Matrix
 
            __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
@@ -733,6 +736,7 @@ newtype Tripletlist
 
            __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType Tripletlist "unwrapTripletlist") =>
          HasField "unwrapTripletlist" (Ptr Tripletlist) (Ptr ty)
@@ -768,6 +772,7 @@ data Example
 
            __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Example
     where staticSizeOf = \_ -> 48 :: Int
@@ -811,6 +816,7 @@ newtype Sudoku
 
       __exported by:__ @arrays\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Sudoku "unwrapSudoku") =>

--- a/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -33,6 +35,7 @@ import Prelude (Eq, Show)
 newtype S = S
   { unwrapS :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "unwrapS")
@@ -57,6 +60,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S "unwrapS" where
 newtype T = T
   { unwrapT :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "unwrapT")
@@ -81,6 +85,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "unwrapT" where
 newtype U = U
   { unwrapU :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -111,6 +116,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U "unwrapU" where
 newtype V = V
   { unwrapV :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -141,6 +147,7 @@ instance HsBindgen.Runtime.HasCField.HasCField V "unwrapV" where
 newtype W = W
   { unwrapW :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -171,6 +178,7 @@ instance HsBindgen.Runtime.HasCField.HasCField W "unwrapW" where
 newtype X = X
   { unwrapX :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
@@ -254,6 +254,7 @@ newtype S
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType S "unwrapS") =>
          HasField "unwrapS" (Ptr S) (Ptr ty)
@@ -275,6 +276,7 @@ newtype T
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType T "unwrapT") =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
@@ -296,6 +298,7 @@ newtype U
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType U "unwrapU") =>
@@ -318,6 +321,7 @@ newtype V
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType V "unwrapV") =>
@@ -340,6 +344,7 @@ newtype W
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType W "unwrapW") =>
@@ -362,6 +367,7 @@ newtype X
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType X "unwrapX") =>

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -33,6 +35,7 @@ import Prelude (Eq, Show)
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -63,6 +66,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Matrix "unwrapMatrix" where
 newtype Triplets = Triplets
   { unwrapTriplets :: HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplets) "unwrapTriplets")

--- a/hs-bindgen/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/fixtures/arrays/multi_dim/th.txt
@@ -174,6 +174,7 @@ newtype Matrix
 
            __exported by:__ @arrays\/multi_dim.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
@@ -198,6 +199,7 @@ newtype Triplets
 
            __exported by:__ @arrays\/multi_dim.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType Triplets "unwrapTriplets") =>
          HasField "unwrapTriplets" (Ptr Triplets) (Ptr ty)

--- a/hs-bindgen/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/attributes/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -46,6 +48,7 @@ data Foo = Foo
          __exported by:__ @attributes\/attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
@@ -120,6 +123,7 @@ data Bar = Bar
          __exported by:__ @attributes\/attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
@@ -194,6 +198,7 @@ data Baz = Baz
          __exported by:__ @attributes\/attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Baz where
@@ -268,6 +273,7 @@ data Qux = Qux
          __exported by:__ @attributes\/attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Qux where
@@ -349,6 +355,7 @@ data FILE = FILE
          __exported by:__ @attributes\/attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FILE where

--- a/hs-bindgen/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/attributes/th.txt
@@ -26,6 +26,7 @@ data Foo
 
            __exported by:__ @attributes\/attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 5 :: Int
@@ -76,6 +77,7 @@ data Bar
 
            __exported by:__ @attributes\/attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 5 :: Int
@@ -126,6 +128,7 @@ data Baz
 
            __exported by:__ @attributes\/attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Baz
     where staticSizeOf = \_ -> 5 :: Int
@@ -176,6 +179,7 @@ data Qux
 
            __exported by:__ @attributes\/attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Qux
     where staticSizeOf = \_ -> 5 :: Int
@@ -233,6 +237,7 @@ data FILE
 
            __exported by:__ @attributes\/attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize FILE
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -23,6 +24,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -51,6 +53,7 @@ data S = S
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
@@ -99,6 +102,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "s_f")
 newtype More_aligned_int = More_aligned_int
   { unwrapMore_aligned_int :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -146,6 +150,7 @@ data S2 = S2
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where
@@ -207,6 +212,7 @@ data My_unpacked_struct = My_unpacked_struct
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize My_unpacked_struct where
@@ -290,6 +296,7 @@ data My_packed_struct = My_packed_struct
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize My_packed_struct where
@@ -368,6 +375,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_packed_struct) "m
 newtype Wait_status_ptr_t = Wait_status_ptr_t
   { unwrapWait_status_ptr_t :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 8 instance HsBindgen.Runtime.Marshal.StaticSize Wait_status_ptr_t
 
@@ -474,6 +482,7 @@ data Wait
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -514,6 +523,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype Short_a = Short_a
   { unwrapShort_a :: FC.CShort
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/type_attributes/th.txt
@@ -19,6 +19,7 @@ data S
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 8 :: Int
@@ -49,6 +50,7 @@ newtype More_aligned_int
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -93,6 +95,7 @@ data S2
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 16 :: Int
@@ -136,6 +139,7 @@ data My_unpacked_struct
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize My_unpacked_struct
     where staticSizeOf = \_ -> 8 :: Int
@@ -197,6 +201,7 @@ data My_packed_struct
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize My_packed_struct
     where staticSizeOf = \_ -> 13 :: Int
@@ -245,6 +250,7 @@ newtype Wait_status_ptr_t
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8
                              8) instance StaticSize Wait_status_ptr_t
 deriving via (SizedByteArray 8
@@ -357,6 +363,7 @@ newtype T1
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -393,6 +400,7 @@ newtype Short_a
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
@@ -13,6 +14,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -29,6 +31,7 @@ import Prelude (Eq, Show)
 newtype MyArray = MyArray
   { unwrapMyArray :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyArray) "unwrapMyArray")
@@ -53,6 +56,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyArray "unwrapMyArray" where
 newtype A = A
   { unwrapA :: MyArray
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
@@ -76,6 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -74,6 +74,7 @@ newtype MyArray
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType MyArray "unwrapMyArray") =>
          HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
@@ -96,6 +97,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType A "unwrapA") =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
@@ -117,6 +119,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -32,6 +34,7 @@ import Prelude (Eq, Show)
 newtype MyArray = MyArray
   { unwrapMyArray :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -62,6 +65,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyArray "unwrapMyArray" where
 newtype A = A
   { unwrapA :: MyArray
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -91,6 +95,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -74,6 +74,7 @@ newtype MyArray
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType MyArray "unwrapMyArray") =>
@@ -97,6 +98,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
@@ -119,6 +121,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -139,6 +142,7 @@ pattern X = MyEnum 0
 newtype A = A
   { unwrapA :: MyEnum
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -170,6 +174,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -74,6 +74,7 @@ newtype MyEnum
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum
@@ -138,6 +139,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -165,6 +167,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -34,6 +36,7 @@ import Prelude (IO)
 newtype MyFunction = MyFunction
   { unwrapMyFunction :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_4e8a459829b269e0_base ::
@@ -90,6 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyFunction "unwrapMyFunction" whe
 newtype A = A
   { unwrapA :: MyFunction
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
@@ -113,6 +117,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
@@ -140,6 +140,7 @@ newtype MyFunction
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_4e8a459829b269e0_base ::
     Int32 -> IO Int32
@@ -181,6 +182,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType A "unwrapA") =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
@@ -202,6 +204,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -38,6 +40,7 @@ __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
 newtype MyFunctionPointer_Aux = MyFunctionPointer_Aux
   { unwrapMyFunctionPointer_Aux :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_47dfd04698dd2e6f_base ::
@@ -94,6 +97,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyFunctionPointer_Aux "unwrapMyFu
 newtype MyFunctionPointer = MyFunctionPointer
   { unwrapMyFunctionPointer :: Ptr.FunPtr MyFunctionPointer_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -125,6 +129,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyFunctionPointer "unwrapMyFuncti
 newtype A = A
   { unwrapA :: MyFunctionPointer
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -155,6 +160,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -79,6 +79,7 @@ newtype MyFunctionPointer_Aux
 
       __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_47dfd04698dd2e6f_base ::
     Int32 -> IO Int32
@@ -126,6 +127,7 @@ newtype MyFunctionPointer
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -154,6 +156,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -180,6 +183,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ data MyStruct = MyStruct
          __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where
@@ -86,6 +89,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyStruct) "myStruct_
 newtype A = A
   { unwrapA :: MyStruct
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -115,6 +119,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -80,6 +80,7 @@ data MyStruct
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 4 :: Int
@@ -110,6 +111,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
@@ -132,6 +134,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -18,6 +19,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -35,6 +37,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype MyUnion = MyUnion
   { unwrapMyUnion :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize MyUnion
 
@@ -92,6 +95,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyUnion) "myUnion_x"
 newtype A = A
   { unwrapA :: MyUnion
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -120,6 +124,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
@@ -74,6 +74,7 @@ newtype MyUnion
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/union.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize MyUnion
 deriving via (SizedByteArray 4 4) instance ReadRaw MyUnion
 deriving via (SizedByteArray 4 4) instance WriteRaw MyUnion
@@ -132,6 +133,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/union.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
@@ -153,6 +155,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/union.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
@@ -13,6 +14,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -30,6 +32,7 @@ import Prelude (Eq, Show)
 newtype A = A
   { unwrapA :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
@@ -54,6 +57,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
@@ -77,6 +81,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
          ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -134,6 +134,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType A "unwrapA") =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
@@ -155,6 +156,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)
@@ -176,6 +178,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -33,6 +35,7 @@ import Prelude (Eq, Show)
 newtype A = A
   { unwrapA :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -63,6 +66,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -92,6 +96,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
          ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -134,6 +134,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
@@ -156,6 +157,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>
@@ -178,6 +180,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -41,6 +43,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -140,6 +143,7 @@ pattern X = MyEnum 0
 newtype A = A
   { unwrapA :: MyEnum
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -171,6 +175,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -202,6 +207,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -134,6 +134,7 @@ newtype MyEnum
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum
@@ -198,6 +199,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -225,6 +227,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -252,6 +255,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -35,6 +37,7 @@ import Prelude (IO)
 newtype A = A
   { unwrapA :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_0c7d4776a632d026_base ::
@@ -90,6 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
@@ -113,6 +117,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
          ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
@@ -266,6 +266,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_0c7d4776a632d026_base ::
     Int32 -> IO Int32
@@ -306,6 +307,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)
@@ -327,6 +329,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -39,6 +41,7 @@ __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
 newtype A_Aux = A_Aux
   { unwrapA_Aux :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_1cabb32c661d9a0e_base ::
@@ -95,6 +98,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_Aux "unwrapA_Aux" where
 newtype A = A
   { unwrapA :: Ptr.FunPtr A_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -125,6 +129,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -155,6 +160,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -144,6 +144,7 @@ newtype A_Aux
 
       __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_1cabb32c661d9a0e_base ::
     Int32 -> IO Int32
@@ -184,6 +185,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -210,6 +212,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -236,6 +239,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -40,6 +42,7 @@ data MyStruct = MyStruct
          __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where
@@ -87,6 +90,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyStruct) "myStruct_
 newtype A = A
   { unwrapA :: MyStruct
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -116,6 +120,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -145,6 +150,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
          ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -140,6 +140,7 @@ data MyStruct
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 4 :: Int
@@ -170,6 +171,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
@@ -192,6 +194,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>
@@ -214,6 +217,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -18,6 +19,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -36,6 +38,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype MyUnion = MyUnion
   { unwrapMyUnion :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize MyUnion
 
@@ -93,6 +96,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyUnion) "myUnion_x"
 newtype A = A
   { unwrapA :: MyUnion
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -121,6 +125,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -149,6 +154,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "unwrapB" where
 newtype E = E
   { unwrapE :: M.C
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
          ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
@@ -134,6 +134,7 @@ newtype MyUnion
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize MyUnion
 deriving via (SizedByteArray 4 4) instance ReadRaw MyUnion
 deriving via (SizedByteArray 4 4) instance WriteRaw MyUnion
@@ -192,6 +193,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType A "unwrapA") =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
@@ -213,6 +215,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType B "unwrapB") =>
          HasField "unwrapB" (Ptr B) (Ptr ty)
@@ -234,6 +237,7 @@ newtype E
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType E "unwrapE") =>
          HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Hoge = Hoge
          __exported by:__ @binding-specs\/name\/squash_both.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Hoge where

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
@@ -26,6 +26,7 @@ data Hoge
 
            __exported by:__ @binding-specs\/name\/squash_both.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Hoge
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Hoge = Hoge
          __exported by:__ @binding-specs\/name\/squash_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Hoge where

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
@@ -26,6 +26,7 @@ data Hoge
 
            __exported by:__ @binding-specs\/name\/squash_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Hoge
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Piyo = Piyo
          __exported by:__ @binding-specs\/name\/squash_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Piyo where

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -26,6 +26,7 @@ data Piyo
 
            __exported by:__ @binding-specs\/name\/squash_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Piyo
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype MySym = MySym
   { unwrapMySym :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/type/th.txt
@@ -13,6 +13,7 @@ newtype MySym
 
            __exported by:__ @binding-specs\/name\/type.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Sym = Sym
   { unwrapSym :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
@@ -13,6 +13,7 @@ newtype Sym
 
            __exported by:__ @binding-specs\/omit_type.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -16,6 +17,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -46,6 +48,7 @@ data Bar = Bar
          __exported by:__ @binding-specs\/rep\/emptydata\/opaque.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
@@ -26,6 +26,7 @@ data Bar
 
            __exported by:__ @binding-specs\/rep\/emptydata\/opaque.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -70,6 +72,7 @@ data Named = Named
          __exported by:__ @binding-specs\/rep\/emptydata\/struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Named where

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
@@ -48,6 +48,7 @@ data Named
 
            __exported by:__ @binding-specs\/rep\/emptydata\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Named
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -18,6 +19,7 @@ import qualified Data.Ix as Ix
 import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype A = A
   { unwrapA :: HsBindgen.Runtime.LibC.CSize
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -36,6 +36,7 @@ newtype A
 
            __exported by:__ @declarations\/declarations_required_for_scoping.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -41,6 +43,7 @@ data X = X
          __exported by:__ @declarations\/definitions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize X where
@@ -88,6 +91,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType X) "x_n")
 newtype Y = Y
   { unwrapY :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize Y
 

--- a/hs-bindgen/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/definitions/th.txt
@@ -46,6 +46,7 @@ data X
 
            __exported by:__ @declarations\/definitions.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize X
     where staticSizeOf = \_ -> 4 :: Int
@@ -76,6 +77,7 @@ newtype Y
 
            __exported by:__ @declarations\/definitions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize Y
 deriving via (SizedByteArray 4 4) instance ReadRaw Y
 deriving via (SizedByteArray 4 4) instance WriteRaw Y

--- a/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data S1_t = S1_t
          __exported by:__ @declarations\/forward_declaration.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1_t where
@@ -91,6 +94,7 @@ data S2 = S2
          __exported by:__ @declarations\/forward_declaration.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where

--- a/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
@@ -19,6 +19,7 @@ data S1_t
 
            __exported by:__ @declarations\/forward_declaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S1_t
     where staticSizeOf = \_ -> 4 :: Int
@@ -55,6 +56,7 @@ data S2
 
            __exported by:__ @declarations\/forward_declaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -16,6 +17,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -53,6 +55,7 @@ data Bar = Bar
          __exported by:__ @declarations\/opaque_declaration.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
@@ -113,6 +116,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_ptrB")
 -}
 data Baz = Baz
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Baz where

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
@@ -33,6 +33,7 @@ data Bar
 
            __exported by:__ @declarations\/opaque_declaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 16 :: Int
@@ -70,6 +71,7 @@ data Baz
 
            __exported by:__ @declarations\/opaque_declaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Baz
     where staticSizeOf = \_ -> 0 :: Int

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -22,6 +23,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -43,6 +45,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype Int_t = Int_t
   { unwrapInt_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -89,6 +92,7 @@ data X = X
          __exported by:__ @declarations\/redeclaration.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize X where
@@ -136,6 +140,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType X) "x_n")
 newtype Y = Y
   { unwrapY :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize Y
 

--- a/hs-bindgen/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/redeclaration/th.txt
@@ -20,6 +20,7 @@ newtype Int_t
 
            __exported by:__ @declarations\/redeclaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -62,6 +63,7 @@ data X
 
            __exported by:__ @declarations\/redeclaration.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize X
     where staticSizeOf = \_ -> 4 :: Int
@@ -92,6 +94,7 @@ newtype Y
 
            __exported by:__ @declarations\/redeclaration.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize Y
 deriving via (SizedByteArray 4 4) instance ReadRaw Y
 deriving via (SizedByteArray 4 4) instance WriteRaw Y

--- a/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype ParsedAndSelected1 = ParsedAndSelected1
   { unwrapParsedAndSelected1 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/select_scoping/th.txt
@@ -14,6 +14,7 @@ newtype ParsedAndSelected1
 
            __exported by:__ @declarations\/select_scoping.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -32,6 +34,7 @@ import Prelude (Eq, Show)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
@@ -13,6 +13,7 @@ newtype Triplet
 
            __exported by:__ @documentation\/data_kind_pragma.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -27,6 +28,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -74,6 +76,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Size_type = Size_type
   { unwrapSize_type :: HsBindgen.Runtime.LibC.CSize
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -145,6 +148,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Color_enum = Color_enum
   { unwrapColor_enum :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -274,6 +278,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Event_callback_t_Aux = Event_callback_t_Aux
   { unwrapEvent_callback_t_Aux :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_111918b0aee2a7fb_base ::
@@ -340,6 +345,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Event_callback_t = Event_callback_t
   { unwrapEvent_callback_t :: Ptr.FunPtr Event_callback_t_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -433,6 +439,7 @@ data Config_t = Config_t
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Config_t where
@@ -552,6 +559,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Status_code_t = Status_code_t
   { unwrapStatus_code_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -730,6 +738,7 @@ data Data_union_t_as_parts = Data_union_t_as_parts
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Data_union_t_as_parts where
@@ -801,6 +810,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Data_union_t = Data_union_t
   { unwrapData_union_t :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize Data_union_t
 
@@ -1036,6 +1046,7 @@ data Bitfield_t = Bitfield_t
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bitfield_t where
@@ -1143,6 +1154,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Processor_fn_t_Aux = Processor_fn_t_Aux
   { unwrapProcessor_fn_t_Aux :: FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_d4e16471c82d5df0_base ::
@@ -1211,6 +1223,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Processor_fn_t = Processor_fn_t
   { unwrapProcessor_fn_t :: Ptr.FunPtr Processor_fn_t_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1248,6 +1261,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Filename_t = Filename_t
   { unwrapFilename_t :: (HsBindgen.Runtime.ConstantArray.ConstantArray 256) FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1296,6 +1310,7 @@ data Flexible_array_Aux = Flexible_array
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Flexible_array_Aux where

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -384,6 +384,7 @@ newtype Size_type
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -455,6 +456,7 @@ newtype Color_enum
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Color_enum
@@ -567,6 +569,7 @@ newtype Event_callback_t_Aux
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_111918b0aee2a7fb_base ::
     Int32 -> Ptr Void -> IO Int32
@@ -635,6 +638,7 @@ newtype Event_callback_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -731,6 +735,7 @@ data Config_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Config_t
     where staticSizeOf = \_ -> 88 :: Int
@@ -805,6 +810,7 @@ newtype Status_code_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Status_code_t
@@ -999,6 +1005,7 @@ data Data_union_t_as_parts
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Data_union_t_as_parts
     where staticSizeOf = \_ -> 4 :: Int
@@ -1062,6 +1069,7 @@ newtype Data_union_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize Data_union_t
 deriving via (SizedByteArray 4 4) instance ReadRaw Data_union_t
 deriving via (SizedByteArray 4 4) instance WriteRaw Data_union_t
@@ -1323,6 +1331,7 @@ data Bitfield_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bitfield_t
     where staticSizeOf = \_ -> 4 :: Int
@@ -1384,6 +1393,7 @@ newtype Processor_fn_t_Aux
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_d4e16471c82d5df0_base ::
     Int32 -> Ptr Void -> IO Int32
@@ -1455,6 +1465,7 @@ newtype Processor_fn_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -1495,6 +1506,7 @@ newtype Filename_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Filename_t "unwrapFilename_t") =>
@@ -1530,6 +1542,7 @@ data Flexible_array_Aux
 
                       __exported by:__ @documentation\/doxygen_docs.h@
                       -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Flexible_array_Aux
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Adio'0301s = Adio'0301s
   { unwrapAdio'0301s :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -79,6 +82,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Adio'0301s "unwrapAdio'0301s" whe
 newtype C数字 = C数字
   { unwrapC数字 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/adios/th.txt
@@ -82,6 +82,7 @@ newtype Adio'0301s
 
            __exported by:__ @edge-cases\/adios.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -118,6 +119,7 @@ newtype C数字
 
            __exported by:__ @edge-cases\/adios.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Some_struct_field1 = Some_struct_field1
          __exported by:__ @edge-cases\/anon_multiple_fields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct_field1 where
@@ -128,6 +131,7 @@ data Some_struct = Some_struct
          __exported by:__ @edge-cases\/anon_multiple_fields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct where

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -26,6 +26,7 @@ data Some_struct_field1
 
            __exported by:__ @edge-cases\/anon_multiple_fields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Some_struct_field1
     where staticSizeOf = \_ -> 8 :: Int
@@ -87,6 +88,7 @@ data Some_struct
 
            __exported by:__ @edge-cases\/anon_multiple_fields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Some_struct
     where staticSizeOf = \_ -> 24 :: Int

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -47,6 +49,7 @@ data Point1a = Point1a
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point1a where
@@ -108,6 +111,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point1a) "point1a_y"
 newtype Point1b = Point1b
   { unwrapPoint1b :: Point1a
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -150,6 +154,7 @@ data Point2a = Point2a
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point2a where
@@ -211,6 +216,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point2a) "point2a_y"
 newtype Point2b = Point2b
   { unwrapPoint2b :: Ptr.Ptr Point2a
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -255,6 +261,7 @@ data Point3a_Aux = Point3a_Aux
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point3a_Aux where
@@ -316,6 +323,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point3a_Aux) "point3
 newtype Point3a = Point3a
   { unwrapPoint3a :: Ptr.Ptr Point3a_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -347,6 +355,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a "unwrapPoint3a" where
 newtype Point3b = Point3b
   { unwrapPoint3b :: Ptr.Ptr Point3a_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -50,6 +50,7 @@ data Point1a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Point1a
     where staticSizeOf = \_ -> 8 :: Int
@@ -87,6 +88,7 @@ newtype Point1b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Point1b "unwrapPoint1b") =>
@@ -122,6 +124,7 @@ data Point2a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Point2a
     where staticSizeOf = \_ -> 8 :: Int
@@ -159,6 +162,7 @@ newtype Point2b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -198,6 +202,7 @@ data Point3a_Aux
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Point3a_Aux
     where staticSizeOf = \_ -> 8 :: Int
@@ -235,6 +240,7 @@ newtype Point3a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -261,6 +267,7 @@ newtype Point3b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
@@ -25,6 +26,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified GHC.Word
@@ -65,6 +67,7 @@ data Another_typedef_struct_t = Another_typedef_struct_t
          __exported by:__ @edge-cases\/distilled_lib_1.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Another_typedef_struct_t where
@@ -130,6 +133,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Another_typedef_stru
 newtype Another_typedef_enum_e = Another_typedef_enum_e
   { unwrapAnother_typedef_enum_e :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -268,6 +272,7 @@ sOME_DEFINED_CONSTANT = (4 :: FC.CInt)
 newtype A_type_t = A_type_t
   { unwrapA_type_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -308,6 +313,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_type_t "unwrapA_type_t" where
 newtype Var_t = Var_t
   { unwrapVar_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -424,6 +430,7 @@ data A_typedef_struct_t = A_typedef_struct_t
          __exported by:__ @edge-cases\/distilled_lib_1.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A_typedef_struct_t where
@@ -669,6 +676,7 @@ tWO_ARGS = (,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 newtype A_typedef_enum_e = A_typedef_enum_e
   { unwrapA_typedef_enum_e :: FC.CUChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -802,6 +810,7 @@ __exported by:__ @edge-cases\/distilled_lib_1.h@
 newtype Callback_t_Aux = Callback_t_Aux
   { unwrapCallback_t_Aux :: (Ptr.Ptr Void) -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_b6b6922e35047658_base ::
@@ -858,6 +867,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Callback_t_Aux "unwrapCallback_t_
 newtype Callback_t = Callback_t
   { unwrapCallback_t :: Ptr.FunPtr Callback_t_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -63,6 +63,7 @@ data Another_typedef_struct_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Another_typedef_struct_t
     where staticSizeOf = \_ -> 8 :: Int
@@ -112,6 +113,7 @@ newtype Another_typedef_enum_e
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Another_typedef_enum_e
@@ -240,6 +242,7 @@ newtype A_type_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -276,6 +279,7 @@ newtype Var_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -392,6 +396,7 @@ data A_typedef_struct_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize A_typedef_struct_t
     where staticSizeOf = \_ -> 140 :: Int
@@ -596,6 +601,7 @@ newtype A_typedef_enum_e
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize A_typedef_enum_e
@@ -714,6 +720,7 @@ newtype Callback_t_Aux
 
       __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_b6b6922e35047658_base ::
     Ptr Void -> Word32 -> IO Word32
@@ -761,6 +768,7 @@ newtype Callback_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype Test = Test
   { unwrapTest :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -20,6 +20,7 @@ newtype Test
 
            __exported by:__ @edge-cases\/enum_as_array_size.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Test

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -40,6 +42,7 @@ data Pascal_Aux = Pascal
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Pascal_Aux where
@@ -113,6 +116,7 @@ data Foo_bar = Foo_bar
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo_bar where
@@ -180,6 +184,7 @@ data Foo_Aux = Foo
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo_Aux where
@@ -253,6 +258,7 @@ data Diff_Aux = Diff
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Diff_Aux where
@@ -335,6 +341,7 @@ data Triplets_Aux = Triplets
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Triplets_Aux where

--- a/hs-bindgen/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam/th.txt
@@ -13,6 +13,7 @@ data Pascal_Aux
 
                    __exported by:__ @edge-cases\/flam.h@
               -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Pascal_Aux
     where staticSizeOf = \_ -> 4 :: Int
@@ -59,6 +60,7 @@ data Foo_bar
 
            __exported by:__ @edge-cases\/flam.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo_bar
     where staticSizeOf = \_ -> 8 :: Int
@@ -96,6 +98,7 @@ data Foo_Aux
 
                 __exported by:__ @edge-cases\/flam.h@
            -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo_Aux
     where staticSizeOf = \_ -> 4 :: Int
@@ -136,6 +139,7 @@ data Diff_Aux
 
                  __exported by:__ @edge-cases\/flam.h@
             -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Diff_Aux
     where staticSizeOf = \_ -> 16 :: Int
@@ -178,6 +182,7 @@ data Triplets_Aux
 
                      __exported by:__ @edge-cases\/flam.h@
                 -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Triplets_Aux
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.FLAM
@@ -39,6 +41,7 @@ data Vector_Aux = Vector
          __exported by:__ @edge-cases\/flam_functions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector_Aux where

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
@@ -74,6 +74,7 @@ data Vector_Aux
 
                    __exported by:__ @edge-cases\/flam_functions.h@
               -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Vector_Aux
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -14,6 +15,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.Block
@@ -31,6 +33,7 @@ import Prelude (IO)
 newtype Toggle = Toggle
   { unwrapToggle :: HsBindgen.Runtime.Block.Block (IO FC.CBool)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Toggle) "unwrapToggle")
@@ -55,6 +58,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Toggle "unwrapToggle" where
 newtype Counter = Counter
   { unwrapCounter :: HsBindgen.Runtime.Block.Block (IO FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Counter) "unwrapCounter")
@@ -79,6 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Counter "unwrapCounter" where
 newtype VarCounter = VarCounter
   { unwrapVarCounter :: HsBindgen.Runtime.Block.Block (FC.CInt -> IO FC.CInt)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType VarCounter) "unwrapVarCounter")

--- a/hs-bindgen/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/iterator/th.txt
@@ -200,6 +200,7 @@ newtype Toggle
 
            __exported by:__ @edge-cases\/iterator.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType Toggle "unwrapToggle") =>
          HasField "unwrapToggle" (Ptr Toggle) (Ptr ty)
@@ -221,6 +222,7 @@ newtype Counter
 
            __exported by:__ @edge-cases\/iterator.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType Counter "unwrapCounter") =>
          HasField "unwrapCounter" (Ptr Counter) (Ptr ty)
@@ -242,6 +244,7 @@ newtype VarCounter
 
            __exported by:__ @edge-cases\/iterator.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType VarCounter "unwrapVarCounter") =>
          HasField "unwrapVarCounter" (Ptr VarCounter) (Ptr ty)

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -22,6 +23,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -44,6 +46,7 @@ __exported by:__ @edge-cases\/spec_examples.h@
 newtype Int16_T = Int16_T
   { unwrapInt16_T :: FC.CShort
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -84,6 +87,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Int16_T "unwrapInt16_T" where
 newtype Int32_T = Int32_T
   { unwrapInt32_T :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -124,6 +128,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Int32_T "unwrapInt32_T" where
 newtype Int64_T = Int64_T
   { unwrapInt64_T :: FC.CLLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -177,6 +182,7 @@ data Cint16_T = Cint16_T
          __exported by:__ @edge-cases\/spec_examples.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Cint16_T where
@@ -237,6 +243,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Cint16_T) "cint16_T_
 -}
 data B = B
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B where
@@ -302,6 +309,7 @@ data A = A
          __exported by:__ @edge-cases\/spec_examples.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
@@ -50,6 +50,7 @@ newtype Int16_T
 
       __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -86,6 +87,7 @@ newtype Int32_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -122,6 +124,7 @@ newtype Int64_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -171,6 +174,7 @@ data Cint16_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Cint16_T
     where staticSizeOf = \_ -> 4 :: Int
@@ -208,6 +212,7 @@ data B
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize B
     where staticSizeOf = \_ -> 0 :: Int
@@ -266,6 +271,7 @@ data A
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 152 :: Int

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.BitfieldPtr
@@ -42,6 +44,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -82,6 +85,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyInt "unwrapMyInt" where
 newtype MyUInt = MyUInt
   { unwrapMyUInt :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -122,6 +126,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUInt "unwrapMyUInt" where
 newtype MyLong = MyLong
   { unwrapMyLong :: FC.CLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -182,6 +187,7 @@ data MyStruct = MyStruct
          __exported by:__ @edge-cases\/typedef_bitfield.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -13,6 +13,7 @@ newtype MyInt
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -49,6 +50,7 @@ newtype MyUInt
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -85,6 +87,7 @@ newtype MyLong
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -141,6 +144,7 @@ data MyStruct
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
@@ -13,6 +13,7 @@ newtype MyEnum
 
            __exported by:__ @edge-cases\/uses_utf8.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -25,6 +26,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -55,6 +57,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype FileOpenedNotification_Aux = FileOpenedNotification_Aux
   { unwrapFileOpenedNotification_Aux :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_b3b8b1fad168671a_base ::
@@ -111,6 +114,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification_Aux "unwra
 newtype FileOpenedNotification = FileOpenedNotification
   { unwrapFileOpenedNotification :: Ptr.FunPtr FileOpenedNotification_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -144,6 +148,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype ProgressUpdate_Aux = ProgressUpdate_Aux
   { unwrapProgressUpdate_Aux :: FC.CInt -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_d551f31556ffa727_base ::
@@ -200,6 +205,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate_Aux "unwrapProgres
 newtype ProgressUpdate = ProgressUpdate
   { unwrapProgressUpdate :: Ptr.FunPtr ProgressUpdate_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -233,6 +239,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype DataValidator_Aux = DataValidator_Aux
   { unwrapDataValidator_Aux :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_c656ca21e63343d6_base ::
@@ -289,6 +296,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataValidator_Aux "unwrapDataVali
 newtype DataValidator = DataValidator
   { unwrapDataValidator :: Ptr.FunPtr DataValidator_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -333,6 +341,7 @@ data Measurement = Measurement
          __exported by:__ @functions\/callbacks.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Measurement where
@@ -398,6 +407,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype MeasurementReceived_Aux = MeasurementReceived_Aux
   { unwrapMeasurementReceived_Aux :: (Ptr.Ptr Measurement) -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_9259654df9d40f5b_base ::
@@ -454,6 +464,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived_Aux "unwrapMe
 newtype MeasurementReceived = MeasurementReceived
   { unwrapMeasurementReceived :: Ptr.FunPtr MeasurementReceived_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -487,6 +498,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
   { unwrapMeasurementReceived2_Aux :: Measurement -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2_Aux) "unwrapMeasurementReceived2_Aux")
          ) => GHC.Records.HasField "unwrapMeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr ty) where
@@ -510,6 +522,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2_Aux "unwrapM
 newtype MeasurementReceived2 = MeasurementReceived2
   { unwrapMeasurementReceived2 :: Ptr.FunPtr MeasurementReceived2_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -543,6 +556,7 @@ __exported by:__ @functions\/callbacks.h@
 newtype SampleBufferFull_Aux = SampleBufferFull_Aux
   { unwrapSampleBufferFull_Aux :: ((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull_Aux) "unwrapSampleBufferFull_Aux")
          ) => GHC.Records.HasField "unwrapSampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr ty) where
@@ -566,6 +580,7 @@ instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull_Aux "unwrapSampl
 newtype SampleBufferFull = SampleBufferFull
   { unwrapSampleBufferFull :: Ptr.FunPtr SampleBufferFull_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -617,6 +632,7 @@ data MeasurementHandler = MeasurementHandler
          __exported by:__ @functions\/callbacks.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MeasurementHandler where
@@ -718,6 +734,7 @@ data DataPipeline = DataPipeline
          __exported by:__ @functions\/callbacks.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize DataPipeline where
@@ -799,6 +816,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataPipeline) "dataP
 newtype ProcessorCallback = ProcessorCallback
   { unwrapProcessorCallback :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 8 instance HsBindgen.Runtime.Marshal.StaticSize ProcessorCallback
 
@@ -937,6 +955,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProcessorCallback) "
 newtype Processor_mode = Processor_mode
   { unwrapProcessor_mode :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -1071,6 +1090,7 @@ data Processor = Processor
          __exported by:__ @functions\/callbacks.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Processor where
 
@@ -1133,6 +1153,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor) "processo
 newtype Foo = Foo
   { unwrapFoo :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1173,6 +1194,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "unwrapFoo" where
 newtype Foo2 = Foo2
   { unwrapFoo2 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -440,6 +440,7 @@ newtype FileOpenedNotification_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_b3b8b1fad168671a_base ::
     IO Unit
@@ -487,6 +488,7 @@ newtype FileOpenedNotification
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -524,6 +526,7 @@ newtype ProgressUpdate_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_d551f31556ffa727_base ::
     Int32 -> IO Unit
@@ -570,6 +573,7 @@ newtype ProgressUpdate
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -602,6 +606,7 @@ newtype DataValidator_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_c656ca21e63343d6_base ::
     Int32 -> IO Int32
@@ -646,6 +651,7 @@ newtype DataValidator
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -687,6 +693,7 @@ data Measurement
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Measurement
     where staticSizeOf = \_ -> 16 :: Int
@@ -730,6 +737,7 @@ newtype MeasurementReceived_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_9259654df9d40f5b_base ::
     Ptr Void -> IO Unit
@@ -778,6 +786,7 @@ newtype MeasurementReceived
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -813,6 +822,7 @@ newtype MeasurementReceived2_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType MeasurementReceived2_Aux
                           "unwrapMeasurementReceived2_Aux") =>
@@ -839,6 +849,7 @@ newtype MeasurementReceived2
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -876,6 +887,7 @@ newtype SampleBufferFull_Aux
 
       __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType SampleBufferFull_Aux "unwrapSampleBufferFull_Aux") =>
          HasField "unwrapSampleBufferFull_Aux"
@@ -901,6 +913,7 @@ newtype SampleBufferFull
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -951,6 +964,7 @@ data MeasurementHandler
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize MeasurementHandler
     where staticSizeOf = \_ -> 24 :: Int
@@ -1031,6 +1045,7 @@ data DataPipeline
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize DataPipeline
     where staticSizeOf = \_ -> 24 :: Int
@@ -1083,6 +1098,7 @@ newtype ProcessorCallback
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8
                              8) instance StaticSize ProcessorCallback
 deriving via (SizedByteArray 8
@@ -1249,6 +1265,7 @@ newtype Processor_mode
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Processor_mode
@@ -1358,6 +1375,7 @@ data Processor
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
 instance StaticSize Processor
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -1395,6 +1413,7 @@ newtype Foo
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -1431,6 +1450,7 @@ newtype Foo2
 
            __exported by:__ @functions\/callbacks.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ __exported by:__ @functions\/circular_dependency_fun.h@
 newtype Fun_ptr_Aux = Fun_ptr_Aux
   { unwrapFun_ptr_Aux :: (Ptr.Ptr Forward_declaration) -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_5964bbadb359ee4a_base ::
@@ -95,6 +98,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux" w
 newtype Fun_ptr = Fun_ptr
   { unwrapFun_ptr :: Ptr.FunPtr Fun_ptr_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -132,6 +136,7 @@ data Forward_declaration = Forward_declaration
          __exported by:__ @functions\/circular_dependency_fun.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Forward_declaration where

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
@@ -18,6 +18,7 @@ newtype Fun_ptr_Aux
 
       __exported by:__ @functions\/circular_dependency_fun.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_5964bbadb359ee4a_base ::
     Ptr Void -> IO Unit
@@ -60,6 +61,7 @@ newtype Fun_ptr
 
            __exported by:__ @functions\/circular_dependency_fun.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -92,6 +94,7 @@ data Forward_declaration
 
            __exported by:__ @functions\/circular_dependency_fun.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Forward_declaration
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -18,6 +19,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -57,6 +59,7 @@ data Outside = Outside
          __exported by:__ @functions\/decls_in_signature.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Outside where
@@ -135,6 +138,7 @@ data Named_struct = Named_struct
          __exported by:__ @functions\/decls_in_signature.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Named_struct where
@@ -198,6 +202,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named_struct) "named
 newtype Named_union = Named_union
   { unwrapNamed_union :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize Named_union
 

--- a/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
@@ -100,6 +100,7 @@ data Outside
 
            __exported by:__ @functions\/decls_in_signature.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Outside
     where staticSizeOf = \_ -> 8 :: Int
@@ -158,6 +159,7 @@ data Named_struct
 
       __exported by:__ @functions\/decls_in_signature.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Named_struct
     where staticSizeOf = \_ -> 8 :: Int
@@ -195,6 +197,7 @@ newtype Named_union
 
            __exported by:__ @functions\/decls_in_signature.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize Named_union
 deriving via (SizedByteArray 4 4) instance ReadRaw Named_union
 deriving via (SizedByteArray 4 4) instance WriteRaw Named_union

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -43,6 +45,7 @@ __exported by:__ @functions\/fun_attributes.h@
 -}
 data FILE = FILE
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FILE where
@@ -74,6 +77,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable FILE instance F.Storable FI
 newtype Size_t = Size_t
   { unwrapSize_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes/th.txt
@@ -451,6 +451,7 @@ data FILE
 
       __exported by:__ @functions\/fun_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize FILE
     where staticSizeOf = \_ -> 0 :: Int
@@ -475,6 +476,7 @@ newtype Size_t
 
            __exported by:__ @functions\/fun_attributes.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where

--- a/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
@@ -42,6 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct_const.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
@@ -42,6 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct_const.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct_const_member.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -42,6 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct_const_member.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ data S = S
          __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
@@ -86,6 +89,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "s_x")
 newtype T = T
   { unwrapT :: S
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -42,6 +42,7 @@ data S
 
            __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 4 :: Int
@@ -72,6 +73,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType T "unwrapT") =>

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -34,6 +36,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype T = T
   { unwrapT :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize T
 

--- a/hs-bindgen/fixtures/functions/heap_types/union/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union/th.txt
@@ -36,6 +36,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/union.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize T
 deriving via (SizedByteArray 4 4) instance ReadRaw T
 deriving via (SizedByteArray 4 4) instance WriteRaw T

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -34,6 +36,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype T = T
   { unwrapT :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize T
 

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
@@ -36,6 +36,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/union_const.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize T
 deriving via (SizedByteArray 4 4) instance ReadRaw T
 deriving via (SizedByteArray 4 4) instance WriteRaw T

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -34,6 +36,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype T = T
   { unwrapT :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize T
 

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
@@ -36,6 +36,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/union_const_member.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize T
 deriving via (SizedByteArray 4 4) instance ReadRaw T
 deriving via (SizedByteArray 4 4) instance WriteRaw T

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -18,6 +19,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -35,6 +37,7 @@ import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 newtype U = U
   { unwrapU :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize U
 
@@ -92,6 +95,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "u_x")
 newtype T = T
   { unwrapT :: U
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -36,6 +36,7 @@ newtype U
 
            __exported by:__ @functions\/heap_types\/union_const_typedef.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize U
 deriving via (SizedByteArray 4 4) instance ReadRaw U
 deriving via (SizedByteArray 4 4) instance WriteRaw U
@@ -94,6 +95,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/union_const_typedef.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType T "unwrapT") =>
          HasField "unwrapT" (Ptr T) (Ptr ty)

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -46,6 +48,7 @@ data Config = Config
          __exported by:__ @globals\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Config where
@@ -120,6 +123,7 @@ data Inline_struct = Inline_struct
          __exported by:__ @globals\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Inline_struct where
@@ -203,6 +207,7 @@ data Version_t = Version_t
          __exported by:__ @globals\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Version_t where
@@ -301,6 +306,7 @@ data Struct1_t = Struct1_t
          __exported by:__ @globals\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1_t where
@@ -384,6 +390,7 @@ data Struct2_t = Struct2_t
          __exported by:__ @globals\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_t where

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -145,6 +145,7 @@ data Config
 
            __exported by:__ @globals\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Config
     where staticSizeOf = \_ -> 8 :: Int
@@ -195,6 +196,7 @@ data Inline_struct
 
            __exported by:__ @globals\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Inline_struct
     where staticSizeOf = \_ -> 8 :: Int
@@ -252,6 +254,7 @@ data Version_t
 
            __exported by:__ @globals\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Version_t
     where staticSizeOf = \_ -> 6 :: Int
@@ -319,6 +322,7 @@ data Struct1_t
 
            __exported by:__ @globals\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct1_t
     where staticSizeOf = \_ -> 10 :: Int
@@ -370,6 +374,7 @@ data Struct2_t
 
            __exported by:__ @globals\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct2_t
     where staticSizeOf = \_ -> 10 :: Int

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -20,6 +21,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -42,6 +44,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord,
 newtype I = I
   { unwrapI :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -82,6 +85,7 @@ instance HsBindgen.Runtime.HasCField.HasCField I "unwrapI" where
 newtype C = C
   { unwrapC :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -122,6 +126,7 @@ instance HsBindgen.Runtime.HasCField.HasCField C "unwrapC" where
 newtype F = F
   { unwrapF :: FC.CFloat
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -160,6 +165,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F "unwrapF" where
 newtype L = L
   { unwrapL :: FC.CLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -200,6 +206,7 @@ instance HsBindgen.Runtime.HasCField.HasCField L "unwrapL" where
 newtype S = S
   { unwrapS :: FC.CShort
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -325,6 +325,7 @@ newtype I
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -361,6 +362,7 @@ newtype C
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -397,6 +399,7 @@ newtype F
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -431,6 +434,7 @@ newtype L
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -467,6 +471,7 @@ newtype S
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -40,6 +42,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype MC = MC
   { unwrapMC :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -80,6 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MC "unwrapMC" where
 newtype TC = TC
   { unwrapTC :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -126,6 +130,7 @@ data Struct1 = Struct1
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1 where
@@ -179,6 +184,7 @@ data Struct2 = Struct2
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2 where
@@ -232,6 +238,7 @@ data Struct3 = Struct3
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct3 where
@@ -279,6 +286,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct3) "struct3_a"
 newtype Struct3_t = Struct3_t
   { unwrapStruct3_t :: Struct3
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -314,6 +322,7 @@ data Struct4 = Struct4
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct4 where

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -244,6 +244,7 @@ newtype MC
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -280,6 +281,7 @@ newtype TC
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -322,6 +324,7 @@ data Struct1
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct1
     where staticSizeOf = \_ -> 4 :: Int
@@ -358,6 +361,7 @@ data Struct2
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct2
     where staticSizeOf = \_ -> 4 :: Int
@@ -394,6 +398,7 @@ data Struct3
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct3
     where staticSizeOf = \_ -> 4 :: Int
@@ -424,6 +429,7 @@ newtype Struct3_t
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct3_t "unwrapStruct3_t") =>
@@ -452,6 +458,7 @@ data Struct4
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct4
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype FILE = FILE
   { unwrapFILE :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
@@ -13,6 +13,7 @@ newtype FILE
 
            __exported by:__ @macros\/macro_redefines_global.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -78,6 +81,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype T2 = T2
   { unwrapT2 :: T1
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -118,6 +122,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T2 "unwrapT2" where
 newtype T3 = T3
   { unwrapT3 :: T2
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -158,6 +163,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T3 "unwrapT3" where
 newtype T4 = T4
   { unwrapT4 :: T3
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
@@ -13,6 +13,7 @@ newtype T1
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -49,6 +50,7 @@ newtype T2
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -85,6 +87,7 @@ newtype T3
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -121,6 +124,7 @@ newtype T4
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -40,6 +42,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype MY_TYPE = MY_TYPE
   { unwrapMY_TYPE :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -93,6 +96,7 @@ data Bar = Bar
          __exported by:__ @macros\/macro_typedef_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
@@ -13,6 +13,7 @@ newtype MY_TYPE
 
            __exported by:__ @macros\/macro_typedef_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -62,6 +63,7 @@ data Bar
 
            __exported by:__ @macros\/macro_typedef_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_types/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Rea
 newtype PtrInt = PtrInt
   { unwrapPtrInt :: Ptr.Ptr FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -69,6 +72,7 @@ instance HsBindgen.Runtime.HasCField.HasCField PtrInt "unwrapPtrInt" where
 newtype PtrPtrChar = PtrPtrChar
   { unwrapPtrPtrChar :: Ptr.Ptr (Ptr.Ptr FC.CChar)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -100,6 +104,7 @@ instance HsBindgen.Runtime.HasCField.HasCField PtrPtrChar "unwrapPtrPtrChar" whe
 newtype MTy = MTy
   { unwrapMTy :: FC.CFloat
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -138,6 +143,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MTy "unwrapMTy" where
 newtype Tty = Tty
   { unwrapTty :: MTy
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -176,6 +182,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tty "unwrapTty" where
 newtype UINT8_T = UINT8_T
   { unwrapUINT8_T :: FC.CUChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -216,6 +223,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UINT8_T "unwrapUINT8_T" where
 newtype BOOLEAN_T = BOOLEAN_T
   { unwrapBOOLEAN_T :: UINT8_T
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -256,6 +264,7 @@ instance HsBindgen.Runtime.HasCField.HasCField BOOLEAN_T "unwrapBOOLEAN_T" where
 newtype Boolean_T = Boolean_T
   { unwrapBoolean_T :: BOOLEAN_T
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_types/th.txt
@@ -13,6 +13,7 @@ newtype PtrInt
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -39,6 +40,7 @@ newtype PtrPtrChar
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -66,6 +68,7 @@ newtype MTy
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -100,6 +103,7 @@ newtype Tty
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -134,6 +138,7 @@ newtype UINT8_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -170,6 +175,7 @@ newtype BOOLEAN_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -206,6 +212,7 @@ newtype Boolean_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -25,6 +26,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -54,6 +56,7 @@ import Prelude ((<*>), (>>), Bounded, Double, Enum, Eq, IO, Int, Integral, Num, 
 newtype A = A
   { unwrapA :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -93,6 +96,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 -}
 data Some_struct = Some_struct
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct where
@@ -124,6 +128,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Some_struct instance F.Stor
 newtype Some_union = Some_union
   { unwrapSome_union :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 0) 1 instance HsBindgen.Runtime.Marshal.StaticSize Some_union
 
@@ -142,6 +147,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Some_union instance F.Stora
 newtype Some_enum = Some_enum
   { unwrapSome_enum :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -242,6 +248,7 @@ pattern ENUM_A = Some_enum 0
 newtype Arr_typedef1 = Arr_typedef1
   { unwrapArr_typedef1 :: HsBindgen.Runtime.IncompleteArray.IncompleteArray A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef1) "unwrapArr_typedef1")
@@ -266,6 +273,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef1 "unwrapArr_typedef1"
 newtype Arr_typedef2 = Arr_typedef2
   { unwrapArr_typedef2 :: HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef2) "unwrapArr_typedef2")
@@ -290,6 +298,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef2 "unwrapArr_typedef2"
 newtype Arr_typedef3 = Arr_typedef3
   { unwrapArr_typedef3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 5) A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -320,6 +329,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef3 "unwrapArr_typedef3"
 newtype Arr_typedef4 = Arr_typedef4
   { unwrapArr_typedef4 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -352,6 +362,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Typedef1 = Typedef1
   { unwrapTypedef1 :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -392,6 +403,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Typedef1 "unwrapTypedef1" where
 newtype Typedef2 = Typedef2
   { unwrapTypedef2 :: Ptr.Ptr A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -422,6 +434,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Typedef2 "unwrapTypedef2" where
 newtype Typedef3 = Typedef3
   { unwrapTypedef3 :: Ptr.Ptr (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -455,6 +468,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Funptr_typedef1_Aux = Funptr_typedef1_Aux
   { unwrapFunptr_typedef1_Aux :: IO A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_c584d0f839fd43de_base ::
@@ -511,6 +525,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1_Aux "unwrapFunptr
 newtype Funptr_typedef1 = Funptr_typedef1
   { unwrapFunptr_typedef1 :: Ptr.FunPtr Funptr_typedef1_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -544,6 +559,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Funptr_typedef2_Aux = Funptr_typedef2_Aux
   { unwrapFunptr_typedef2_Aux :: IO (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_f174457a161ac5a0_base ::
@@ -600,6 +616,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2_Aux "unwrapFunptr
 newtype Funptr_typedef2 = Funptr_typedef2
   { unwrapFunptr_typedef2 :: Ptr.FunPtr Funptr_typedef2_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -633,6 +650,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Funptr_typedef3_Aux = Funptr_typedef3_Aux
   { unwrapFunptr_typedef3_Aux :: IO (Ptr.Ptr (Ptr.Ptr A))
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_031d1a7decd790d8_base ::
@@ -689,6 +707,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3_Aux "unwrapFunptr
 newtype Funptr_typedef3 = Funptr_typedef3
   { unwrapFunptr_typedef3 :: Ptr.FunPtr Funptr_typedef3_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -722,6 +741,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Funptr_typedef4_Aux = Funptr_typedef4_Aux
   { unwrapFunptr_typedef4_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_da2336d254667386_base ::
@@ -778,6 +798,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4_Aux "unwrapFunptr
 newtype Funptr_typedef4 = Funptr_typedef4
   { unwrapFunptr_typedef4 :: Ptr.FunPtr Funptr_typedef4_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -811,6 +832,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Funptr_typedef5_Aux = Funptr_typedef5_Aux
   { unwrapFunptr_typedef5_Aux :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_1f45632f07742a46_base ::
@@ -867,6 +889,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5_Aux "unwrapFunptr
 newtype Funptr_typedef5 = Funptr_typedef5
   { unwrapFunptr_typedef5 :: Ptr.FunPtr Funptr_typedef5_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -898,6 +921,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5 "unwrapFunptr_typ
 newtype Comments2 = Comments2
   { unwrapComments2 :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -960,6 +984,7 @@ data Example_struct = Example_struct
          __exported by:__ @macros\/reparse.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example_struct where
@@ -1041,6 +1066,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct) "exa
 newtype Const_typedef1 = Const_typedef1
   { unwrapConst_typedef1 :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1082,6 +1108,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef1 "unwrapConst_typed
 newtype Const_typedef2 = Const_typedef2
   { unwrapConst_typedef2 :: A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1123,6 +1150,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef2 "unwrapConst_typed
 newtype Const_typedef3 = Const_typedef3
   { unwrapConst_typedef3 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1154,6 +1182,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef3 "unwrapConst_typed
 newtype Const_typedef4 = Const_typedef4
   { unwrapConst_typedef4 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1185,6 +1214,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef4 "unwrapConst_typed
 newtype Const_typedef5 = Const_typedef5
   { unwrapConst_typedef5 :: Ptr.Ptr A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1216,6 +1246,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef5 "unwrapConst_typed
 newtype Const_typedef6 = Const_typedef6
   { unwrapConst_typedef6 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1247,6 +1278,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef6 "unwrapConst_typed
 newtype Const_typedef7 = Const_typedef7
   { unwrapConst_typedef7 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1326,6 +1358,7 @@ data Example_struct_with_const = Example_struct_with_const
          __exported by:__ @macros\/reparse.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example_struct_with_const where
@@ -1473,6 +1506,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr1_Aux = Const_funptr1_Aux
   { unwrapConst_funptr1_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_7f125e20a9d4075b_base ::
@@ -1529,6 +1563,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1_Aux "unwrapConst_fu
 newtype Const_funptr1 = Const_funptr1
   { unwrapConst_funptr1 :: Ptr.FunPtr Const_funptr1_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1562,6 +1597,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr2_Aux = Const_funptr2_Aux
   { unwrapConst_funptr2_Aux :: FC.CInt -> FC.CDouble -> IO A
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_c7b1e36d845634fb_base ::
@@ -1618,6 +1654,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2_Aux "unwrapConst_fu
 newtype Const_funptr2 = Const_funptr2
   { unwrapConst_funptr2 :: Ptr.FunPtr Const_funptr2_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1651,6 +1688,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr3_Aux = Const_funptr3_Aux
   { unwrapConst_funptr3_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_2dcbfe1c2502178c_base ::
@@ -1707,6 +1745,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3_Aux "unwrapConst_fu
 newtype Const_funptr3 = Const_funptr3
   { unwrapConst_funptr3 :: Ptr.FunPtr Const_funptr3_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1740,6 +1779,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr4_Aux = Const_funptr4_Aux
   { unwrapConst_funptr4_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_5461deeda491de0b_base ::
@@ -1796,6 +1836,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4_Aux "unwrapConst_fu
 newtype Const_funptr4 = Const_funptr4
   { unwrapConst_funptr4 :: Ptr.FunPtr Const_funptr4_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1829,6 +1870,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr5_Aux = Const_funptr5_Aux
   { unwrapConst_funptr5_Aux :: FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_7b0174fc978a1ce1_base ::
@@ -1885,6 +1927,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5_Aux "unwrapConst_fu
 newtype Const_funptr5 = Const_funptr5
   { unwrapConst_funptr5 :: Ptr.FunPtr Const_funptr5_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1918,6 +1961,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr6_Aux = Const_funptr6_Aux
   { unwrapConst_funptr6_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_4e32721222f4df9f_base ::
@@ -1974,6 +2018,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6_Aux "unwrapConst_fu
 newtype Const_funptr6 = Const_funptr6
   { unwrapConst_funptr6 :: Ptr.FunPtr Const_funptr6_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -2007,6 +2052,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Const_funptr7_Aux = Const_funptr7_Aux
   { unwrapConst_funptr7_Aux :: FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_0d04fc96ffb9de06_base ::
@@ -2063,6 +2109,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7_Aux "unwrapConst_fu
 newtype Const_funptr7 = Const_funptr7
   { unwrapConst_funptr7 :: Ptr.FunPtr Const_funptr7_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -2094,6 +2141,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7 "unwrapConst_funptr
 newtype BOOL = BOOL
   { unwrapBOOL :: FC.CBool
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -2134,6 +2182,7 @@ instance HsBindgen.Runtime.HasCField.HasCField BOOL "unwrapBOOL" where
 newtype INT = INT
   { unwrapINT :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -2174,6 +2223,7 @@ instance HsBindgen.Runtime.HasCField.HasCField INT "unwrapINT" where
 newtype INTP = INTP
   { unwrapINTP :: Ptr.Ptr FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -2204,6 +2254,7 @@ instance HsBindgen.Runtime.HasCField.HasCField INTP "unwrapINTP" where
 newtype INTCP = INTCP
   { unwrapINTCP :: HsBindgen.Runtime.PtrConst.PtrConst FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2487,6 +2487,7 @@ newtype A
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2523,6 +2524,7 @@ data Some_struct
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Some_struct
     where staticSizeOf = \_ -> 0 :: Int
@@ -2547,6 +2549,7 @@ newtype Some_union
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 0 1) instance StaticSize Some_union
 deriving via (SizedByteArray 0 1) instance ReadRaw Some_union
 deriving via (SizedByteArray 0 1) instance WriteRaw Some_union
@@ -2565,6 +2568,7 @@ newtype Some_enum
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Some_enum
@@ -2630,6 +2634,7 @@ newtype Arr_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType Arr_typedef1 "unwrapArr_typedef1") =>
          HasField "unwrapArr_typedef1" (Ptr Arr_typedef1) (Ptr ty)
@@ -2652,6 +2657,7 @@ newtype Arr_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType Arr_typedef2 "unwrapArr_typedef2") =>
          HasField "unwrapArr_typedef2" (Ptr Arr_typedef2) (Ptr ty)
@@ -2674,6 +2680,7 @@ newtype Arr_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Arr_typedef3 "unwrapArr_typedef3") =>
@@ -2697,6 +2704,7 @@ newtype Arr_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Arr_typedef4 "unwrapArr_typedef4") =>
@@ -2724,6 +2732,7 @@ newtype Typedef1
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2760,6 +2769,7 @@ newtype Typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2786,6 +2796,7 @@ newtype Typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2816,6 +2827,7 @@ newtype Funptr_typedef1_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_c584d0f839fd43de_base ::
     IO Int32
@@ -2861,6 +2873,7 @@ newtype Funptr_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2893,6 +2906,7 @@ newtype Funptr_typedef2_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_f174457a161ac5a0_base ::
     IO (Ptr Void)
@@ -2938,6 +2952,7 @@ newtype Funptr_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -2970,6 +2985,7 @@ newtype Funptr_typedef3_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_031d1a7decd790d8_base ::
     IO (Ptr Void)
@@ -3015,6 +3031,7 @@ newtype Funptr_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3048,6 +3065,7 @@ newtype Funptr_typedef4_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_da2336d254667386_base ::
     Int32 -> Double -> IO Int32
@@ -3095,6 +3113,7 @@ newtype Funptr_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3128,6 +3147,7 @@ newtype Funptr_typedef5_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_1f45632f07742a46_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -3175,6 +3195,7 @@ newtype Funptr_typedef5
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3203,6 +3224,7 @@ newtype Comments2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3263,6 +3285,7 @@ data Example_struct
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Example_struct
     where staticSizeOf = \_ -> 24 :: Int
@@ -3312,6 +3335,7 @@ newtype Const_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3349,6 +3373,7 @@ newtype Const_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3386,6 +3411,7 @@ newtype Const_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3414,6 +3440,7 @@ newtype Const_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3442,6 +3469,7 @@ newtype Const_typedef5
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3469,6 +3497,7 @@ newtype Const_typedef6
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3497,6 +3526,7 @@ newtype Const_typedef7
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3573,6 +3603,7 @@ data Example_struct_with_const
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Example_struct_with_const
     where staticSizeOf = \_ -> 48 :: Int
@@ -3692,6 +3723,7 @@ newtype Const_funptr1_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_7f125e20a9d4075b_base ::
     Int32 -> Double -> IO Int32
@@ -3737,6 +3769,7 @@ newtype Const_funptr1
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3770,6 +3803,7 @@ newtype Const_funptr2_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_c7b1e36d845634fb_base ::
     Int32 -> Double -> IO Int32
@@ -3815,6 +3849,7 @@ newtype Const_funptr2
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3848,6 +3883,7 @@ newtype Const_funptr3_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_2dcbfe1c2502178c_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -3893,6 +3929,7 @@ newtype Const_funptr3
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -3926,6 +3963,7 @@ newtype Const_funptr4_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_5461deeda491de0b_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -3971,6 +4009,7 @@ newtype Const_funptr4
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4004,6 +4043,7 @@ newtype Const_funptr5_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_7b0174fc978a1ce1_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -4049,6 +4089,7 @@ newtype Const_funptr5
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4082,6 +4123,7 @@ newtype Const_funptr6_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_4e32721222f4df9f_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -4127,6 +4169,7 @@ newtype Const_funptr6
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4160,6 +4203,7 @@ newtype Const_funptr7_Aux
 
       __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_0d04fc96ffb9de06_base ::
     Int32 -> Double -> IO (Ptr Void)
@@ -4205,6 +4249,7 @@ newtype Const_funptr7
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4233,6 +4278,7 @@ newtype BOOL
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4269,6 +4315,7 @@ newtype INT
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4305,6 +4352,7 @@ newtype INTP
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -4331,6 +4379,7 @@ newtype INTCP
 
            __exported by:__ @macros\/reparse.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/manual/arrays/Example.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -15,6 +16,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -33,6 +35,7 @@ import Prelude (Eq, Show)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -63,6 +66,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -95,6 +99,7 @@ __exported by:__ @manual\/arrays.h@
 newtype Triplet_ptrs = Triplet_ptrs
   { unwrapTriplet_ptrs :: HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet_ptrs) "unwrapTriplet_ptrs")

--- a/hs-bindgen/fixtures/manual/arrays/th.txt
+++ b/hs-bindgen/fixtures/manual/arrays/th.txt
@@ -93,6 +93,7 @@ newtype Triplet
 
            __exported by:__ @manual\/arrays.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
@@ -116,6 +117,7 @@ newtype Matrix
 
            __exported by:__ @manual\/arrays.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
@@ -144,6 +146,7 @@ newtype Triplet_ptrs
 
       __exported by:__ @manual\/arrays.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType Triplet_ptrs "unwrapTriplet_ptrs") =>
          HasField "unwrapTriplet_ptrs" (Ptr Triplet_ptrs) (Ptr ty)

--- a/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -27,6 +28,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -67,6 +69,7 @@ data Point = Point
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point where
@@ -141,6 +144,7 @@ data Size = Size
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Size where
@@ -229,6 +233,7 @@ data Rect = Rect
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Rect where
@@ -318,6 +323,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rect) "height")
 newtype E = E
   { unwrap :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -426,6 +432,7 @@ pattern Y = E 1
 newtype Value = Value
   { unwrap :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -466,6 +473,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Value "unwrap" where
 newtype U1 = U1
   { unwrap :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize U1
 
@@ -562,6 +570,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U1) "y")
 newtype U2_t = U2_t
   { unwrap :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize U2_t
 
@@ -658,6 +667,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U2_t) "b")
 newtype U3 = U3
   { unwrap :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 4 instance HsBindgen.Runtime.Marshal.StaticSize U3
 
@@ -754,6 +764,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U3) "s")
 newtype U4 = U4
   { unwrap :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize U4
 
@@ -860,6 +871,7 @@ __exported by:__ @manual\/enable_record_dot.h@
 newtype RunDriver_Aux = RunDriver_Aux
   { unwrap :: (Ptr.Ptr Driver) -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_d86ecf261d7044c6_base ::
@@ -916,6 +928,7 @@ instance HsBindgen.Runtime.HasCField.HasCField RunDriver_Aux "unwrap" where
 newtype RunDriver = RunDriver
   { unwrap :: Ptr.FunPtr RunDriver_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
@@ -26,6 +26,7 @@ data Point
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Point
     where staticSizeOf = \_ -> 8 :: Int
@@ -76,6 +77,7 @@ data Size
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Size
     where staticSizeOf = \_ -> 8 :: Int
@@ -140,6 +142,7 @@ data Rect
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Rect
     where staticSizeOf = \_ -> 16 :: Int
@@ -191,6 +194,7 @@ newtype E
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize E
@@ -270,6 +274,7 @@ newtype Value
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -306,6 +311,7 @@ newtype U1
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize U1
 deriving via (SizedByteArray 4 4) instance ReadRaw U1
 deriving via (SizedByteArray 4 4) instance WriteRaw U1
@@ -404,6 +410,7 @@ newtype U2_t
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize U2_t
 deriving via (SizedByteArray 4 4) instance ReadRaw U2_t
 deriving via (SizedByteArray 4 4) instance WriteRaw U2_t
@@ -502,6 +509,7 @@ newtype U3
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8 4) instance StaticSize U3
 deriving via (SizedByteArray 8 4) instance ReadRaw U3
 deriving via (SizedByteArray 8 4) instance WriteRaw U3
@@ -600,6 +608,7 @@ newtype U4
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize U4
 deriving via (SizedByteArray 4 4) instance ReadRaw U4
 deriving via (SizedByteArray 4 4) instance WriteRaw U4
@@ -709,6 +718,7 @@ newtype RunDriver_Aux
 
       __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_d86ecf261d7044c6_base ::
     Ptr Void -> IO Int32
@@ -752,6 +762,7 @@ newtype RunDriver
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/manual/function_pointers/Example.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -19,6 +20,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -42,6 +44,7 @@ import Prelude ((<*>), Eq, IO, Int, Show, pure)
 newtype Int2int = Int2int
   { unwrapInt2int :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_a6c7dd49f5b9d470_base ::
@@ -106,6 +109,7 @@ data Apply1Struct = Apply1Struct
          __exported by:__ @manual\/function_pointers.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Apply1Struct where
@@ -156,6 +160,7 @@ __exported by:__ @manual\/function_pointers.h@
 newtype Apply1Union = Apply1Union
   { unwrapApply1Union :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 8 instance HsBindgen.Runtime.Marshal.StaticSize Apply1Union
 

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -211,6 +211,7 @@ newtype Int2int
 
            __exported by:__ @manual\/function_pointers.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_a6c7dd49f5b9d470_base ::
     Int32 -> IO Int32
@@ -262,6 +263,7 @@ data Apply1Struct
 
       __exported by:__ @manual\/function_pointers.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Apply1Struct
     where staticSizeOf = \_ -> 8 :: Int
@@ -303,6 +305,7 @@ newtype Apply1Union
 
       __exported by:__ @manual\/function_pointers.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8 8) instance StaticSize Apply1Union
 deriving via (SizedByteArray 8 8) instance ReadRaw Apply1Union
 deriving via (SizedByteArray 8 8) instance WriteRaw Apply1Union

--- a/hs-bindgen/fixtures/manual/globals/Example.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
@@ -55,6 +57,7 @@ data GlobalConfig = GlobalConfig
          __exported by:__ @manual\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize GlobalConfig where
@@ -118,6 +121,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType GlobalConfig) "globa
 newtype ConstInt = ConstInt
   { unwrapConstInt :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -171,6 +175,7 @@ data Tuple = Tuple
          __exported by:__ @manual\/globals.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Tuple where
@@ -232,6 +237,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tuple) "tuple_y")
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -262,6 +268,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype List = List
   { unwrapList :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType List) "unwrapList")

--- a/hs-bindgen/fixtures/manual/globals/th.txt
+++ b/hs-bindgen/fixtures/manual/globals/th.txt
@@ -159,6 +159,7 @@ data GlobalConfig
 
            __exported by:__ @manual\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize GlobalConfig
     where staticSizeOf = \_ -> 8 :: Int
@@ -198,6 +199,7 @@ newtype ConstInt
 
            __exported by:__ @manual\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -247,6 +249,7 @@ data Tuple
 
            __exported by:__ @manual\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Tuple
     where staticSizeOf = \_ -> 8 :: Int
@@ -284,6 +287,7 @@ newtype Triplet
 
            __exported by:__ @manual\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
@@ -307,6 +311,7 @@ newtype List
 
            __exported by:__ @manual\/globals.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance TyEq ty (CFieldType List "unwrapList") =>
          HasField "unwrapList" (Ptr List) (Ptr ty)

--- a/hs-bindgen/fixtures/manual/zero_copy/Example.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -22,6 +23,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.BitfieldPtr
@@ -60,6 +62,7 @@ data Point = Point
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point where
@@ -134,6 +137,7 @@ data Rectangle = Rectangle
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Rectangle where
@@ -209,6 +213,7 @@ data Circle = Circle
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Circle where
@@ -270,6 +275,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Circle) "circle_radi
 newtype Shape = Shape
   { unwrapShape :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 16) 4 instance HsBindgen.Runtime.Marshal.StaticSize Shape
 
@@ -400,6 +406,7 @@ data Colour = Colour
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Colour where
@@ -519,6 +526,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colou
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -572,6 +580,7 @@ data Drawing = Drawing
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Drawing where
@@ -655,6 +664,7 @@ data Tic_tac_toe = Tic_tac_toe
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Tic_tac_toe where
@@ -739,6 +749,7 @@ data Vector_Aux = Vector
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector_Aux where
@@ -799,6 +810,7 @@ type Vector =
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -829,6 +841,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/manual/zero_copy/th.txt
+++ b/hs-bindgen/fixtures/manual/zero_copy/th.txt
@@ -76,6 +76,7 @@ data Point
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Point
     where staticSizeOf = \_ -> 8 :: Int
@@ -126,6 +127,7 @@ data Rectangle
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Rectangle
     where staticSizeOf = \_ -> 16 :: Int
@@ -176,6 +178,7 @@ data Circle
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Circle
     where staticSizeOf = \_ -> 12 :: Int
@@ -213,6 +216,7 @@ newtype Shape
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 16 4) instance StaticSize Shape
 deriving via (SizedByteArray 16 4) instance ReadRaw Shape
 deriving via (SizedByteArray 16 4) instance WriteRaw Shape
@@ -345,6 +349,7 @@ data Colour
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Colour
     where staticSizeOf = \_ -> 4 :: Int
@@ -408,6 +413,7 @@ newtype MyInt
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -457,6 +463,7 @@ data Drawing
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Drawing
     where staticSizeOf = \_ -> 16 :: Int
@@ -514,6 +521,7 @@ data Tic_tac_toe
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Tic_tac_toe
     where staticSizeOf = \_ -> 36 :: Int
@@ -561,6 +569,7 @@ data Vector_Aux
 
                    __exported by:__ @manual\/zero_copy.h@
               -}}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Vector_Aux
     where staticSizeOf = \_ -> 4 :: Int
@@ -594,6 +603,7 @@ newtype Triplet
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
@@ -617,6 +627,7 @@ newtype Matrix
 
            __exported by:__ @manual\/zero_copy.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -41,6 +43,7 @@ import Prelude ((<*>), (>>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype FileOperationStatus = FileOperationStatus
   { unwrapFileOperationStatus :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -195,6 +198,7 @@ data FileOperationRecord = FileOperationRecord
          __exported by:__ @program-analysis\/program_slicing_selection.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FileOperationRecord where

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -49,6 +49,7 @@ newtype FileOperationStatus
 
            __exported by:__ @program-analysis\/program_slicing_selection.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize FileOperationStatus
@@ -201,6 +202,7 @@ data FileOperationRecord
 
            __exported by:__ @program-analysis\/program_slicing_selection.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize FileOperationRecord
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -20,6 +21,7 @@ import qualified Data.Proxy
 import qualified Foreign
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype Uint32_t = Uint32_t
   { unwrapUint32_t :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -92,6 +95,7 @@ data Foo = Foo
          __exported by:__ @program-analysis\/program_slicing_simple.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance F.Storable Foo where

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -40,6 +40,7 @@ newtype Uint32_t
 
            __exported by:__ @program-analysis\/program_slicing_simple.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -89,6 +90,7 @@ data Foo
 
            __exported by:__ @program-analysis\/program_slicing_simple.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance Storable Foo
     where sizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype A = A
   { unwrapA :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
@@ -14,6 +14,7 @@ newtype A
 
            __exported by:__ @program-analysis\/selection_bad.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
@@ -91,6 +94,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -19,6 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
@@ -55,6 +56,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
@@ -91,6 +94,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -19,6 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
@@ -55,6 +56,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -19,6 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
@@ -91,6 +94,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
@@ -19,6 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
@@ -55,6 +56,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data NewName = NewName
          __exported by:__ @program-analysis\/selection_matches_c_names.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize NewName where

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -34,6 +34,7 @@ data NewName
 
            __exported by:__ @program-analysis\/selection_matches_c_names.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize NewName
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data UnrelatedDeclaration = UnrelatedDeclaration
          __exported by:__ @program-analysis\/selection_omit_external_a.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize UnrelatedDeclaration where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -20,6 +20,7 @@ data UnrelatedDeclaration
 
            __exported by:__ @program-analysis\/selection_omit_external_a.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize UnrelatedDeclaration
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data Omitted = Omitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Omitted where
@@ -91,6 +94,7 @@ data DirectlyDependsOnOmitted = DirectlyDependsOnOmitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize DirectlyDependsOnOmitted where
@@ -145,6 +149,7 @@ data IndirectlyDependsOnOmitted = IndirectlyDependsOnOmitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize IndirectlyDependsOnOmitted where

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -20,6 +20,7 @@ data Omitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Omitted
     where staticSizeOf = \_ -> 4 :: Int
@@ -56,6 +57,7 @@ data DirectlyDependsOnOmitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize DirectlyDependsOnOmitted
     where staticSizeOf = \_ -> 4 :: Int
@@ -98,6 +100,7 @@ data IndirectlyDependsOnOmitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize IndirectlyDependsOnOmitted
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -18,6 +19,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -36,6 +38,7 @@ __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
 data Struct1_t = Struct1_t
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1_t where
@@ -66,6 +69,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct1_t instance F.Storab
 -}
 data Struct2_t = Struct2_t
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_t where
@@ -112,6 +116,7 @@ data Struct4_t
 -}
 data Struct5 = Struct5
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct5 where
@@ -143,6 +148,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct5 instance F.Storable
 newtype Struct5_t = Struct5_t
   { unwrapStruct5_t :: Ptr.Ptr Struct5
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -173,6 +179,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct5_t "unwrapStruct5_t" where
 -}
 data Struct6_Aux = Struct6_Aux
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct6_Aux where
@@ -204,6 +211,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct6_Aux instance F.Stor
 newtype Struct6 = Struct6
   { unwrapStruct6 :: Ptr.Ptr Struct6_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -234,6 +242,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct6 "unwrapStruct6" where
 -}
 data Struct7 = Struct7
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct7 where
@@ -265,6 +274,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct7 instance F.Storable
 newtype Struct7a = Struct7a
   { unwrapStruct7a :: Struct7
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -294,6 +304,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct7a "unwrapStruct7a" where
 newtype Struct7b = Struct7b
   { unwrapStruct7b :: Struct7
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -322,6 +333,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct7b "unwrapStruct7b" where
 -}
 data Struct8 = Struct8
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct8 where
@@ -353,6 +365,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct8 instance F.Storable
 newtype Struct8b = Struct8b
   { unwrapStruct8b :: Struct8
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -381,6 +394,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct8b "unwrapStruct8b" where
 -}
 data Struct9 = Struct9
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct9 where
@@ -412,6 +426,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct9 instance F.Storable
 newtype Struct9_t = Struct9_t
   { unwrapStruct9_t :: Struct9
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -440,6 +455,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct9_t "unwrapStruct9_t" where
 -}
 data Struct10_t = Struct10_t
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct10_t where
@@ -471,6 +487,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct10_t instance F.Stora
 newtype Struct10_t_t = Struct10_t_t
   { unwrapStruct10_t_t :: Struct10_t
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -514,6 +531,7 @@ data Struct11_t = Struct11_t
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct11_t where
@@ -589,6 +607,7 @@ data Struct12_t = Struct12_t
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct12_t where
@@ -776,6 +795,7 @@ data Use_sites = Use_sites
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Use_sites where

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
@@ -17,6 +17,7 @@ data Struct1_t
 
       __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct1_t
     where staticSizeOf = \_ -> 0 :: Int
@@ -41,6 +42,7 @@ data Struct2_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct2_t
     where staticSizeOf = \_ -> 0 :: Int
@@ -79,6 +81,7 @@ data Struct5
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct5
     where staticSizeOf = \_ -> 0 :: Int
@@ -103,6 +106,7 @@ newtype Struct5_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -129,6 +133,7 @@ data Struct6_Aux
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct6_Aux
     where staticSizeOf = \_ -> 0 :: Int
@@ -153,6 +158,7 @@ newtype Struct6
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -179,6 +185,7 @@ data Struct7
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct7
     where staticSizeOf = \_ -> 0 :: Int
@@ -203,6 +210,7 @@ newtype Struct7a
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct7a "unwrapStruct7a") =>
@@ -225,6 +233,7 @@ newtype Struct7b
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct7b "unwrapStruct7b") =>
@@ -247,6 +256,7 @@ data Struct8
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct8
     where staticSizeOf = \_ -> 0 :: Int
@@ -271,6 +281,7 @@ newtype Struct8b
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct8b "unwrapStruct8b") =>
@@ -293,6 +304,7 @@ data Struct9
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct9
     where staticSizeOf = \_ -> 0 :: Int
@@ -317,6 +329,7 @@ newtype Struct9_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct9_t "unwrapStruct9_t") =>
@@ -339,6 +352,7 @@ data Struct10_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct10_t
     where staticSizeOf = \_ -> 0 :: Int
@@ -363,6 +377,7 @@ newtype Struct10_t_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType Struct10_t_t "unwrapStruct10_t_t") =>
@@ -399,6 +414,7 @@ data Struct11_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct11_t
     where staticSizeOf = \_ -> 16 :: Int
@@ -449,6 +465,7 @@ data Struct12_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct12_t
     where staticSizeOf = \_ -> 16 :: Int
@@ -611,6 +628,7 @@ data Use_sites
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Use_sites
     where staticSizeOf = \_ -> 64 :: Int

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Complex
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -53,6 +55,7 @@ data Complex_object_t = Complex_object_t
          __exported by:__ @types\/complex\/hsb_complex_test.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Complex_object_t where

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
@@ -169,6 +169,7 @@ data Complex_object_t
 
            __exported by:__ @types\/complex\/hsb_complex_test.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Complex_object_t
     where staticSizeOf = \_ -> 32 :: Int

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Vector = Vector
          __exported by:__ @types\/complex\/vector_test.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector where

--- a/hs-bindgen/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/vector_test/th.txt
@@ -50,6 +50,7 @@ data Vector
 
            __exported by:__ @types\/complex\/vector_test.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Vector
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -20,6 +21,7 @@ import qualified Data.List.NonEmpty
 import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype Foo_enum = Foo_enum
   { unwrapFoo_enum :: HsBindgen.Runtime.LibC.Word32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -16,6 +16,7 @@ newtype Foo_enum
 
            __exported by:__ @types\/enums\/enum_cpp_syntax.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Foo_enum

--- a/hs-bindgen/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enums/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype First = First
   { unwrapFirst :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -150,6 +153,7 @@ pattern FIRST2 = First 1
 newtype Second = Second
   { unwrapSecond :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -270,6 +274,7 @@ pattern SECOND_C = Second 1
 newtype Same = Same
   { unwrapSame :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -378,6 +383,7 @@ pattern SAME_B = Same 1
 newtype Nonseq = Nonseq
   { unwrapNonseq :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -488,6 +494,7 @@ pattern NONSEQ_C = Nonseq 404
 newtype Packed = Packed
   { unwrapPacked :: FC.CUChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -608,6 +615,7 @@ pattern PACKED_C = Packed 2
 newtype EnumA = EnumA
   { unwrapEnumA :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -718,6 +726,7 @@ pattern A_BAR = EnumA 1
 newtype EnumB = EnumB
   { unwrapEnumB :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -828,6 +837,7 @@ pattern B_BAR = EnumB 1
 newtype EnumC = EnumC
   { unwrapEnumC :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -938,6 +948,7 @@ pattern C_BAR = EnumC 1
 newtype EnumD_t = EnumD_t
   { unwrapEnumD_t :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 

--- a/hs-bindgen/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enums/th.txt
@@ -13,6 +13,7 @@ newtype First
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize First
@@ -93,6 +94,7 @@ newtype Second
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Second
@@ -188,6 +190,7 @@ newtype Same
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Same
@@ -267,6 +270,7 @@ newtype Nonseq
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Nonseq
@@ -357,6 +361,7 @@ newtype Packed
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Packed
@@ -452,6 +457,7 @@ newtype EnumA
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumA
@@ -532,6 +538,7 @@ newtype EnumB
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumB
@@ -612,6 +619,7 @@ newtype EnumC
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumC
@@ -692,6 +700,7 @@ newtype EnumD_t
 
            __exported by:__ @types\/enums\/enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumD_t

--- a/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -40,6 +42,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype EnumA = EnumA
   { unwrapEnumA :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -156,6 +159,7 @@ data ExA = ExA
          __exported by:__ @types\/enums\/nested_enums.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExA where
@@ -203,6 +207,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExA) "exA_fieldA1")
 newtype ExB_fieldB1 = ExB_fieldB1
   { unwrapExB_fieldB1 :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -320,6 +325,7 @@ data ExB = ExB
          __exported by:__ @types\/enums\/nested_enums.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExB where

--- a/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
@@ -13,6 +13,7 @@ newtype EnumA
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumA
@@ -99,6 +100,7 @@ data ExA
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize ExA
     where staticSizeOf = \_ -> 4 :: Int
@@ -129,6 +131,7 @@ newtype ExB_fieldB1
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize ExB_fieldB1
@@ -215,6 +218,7 @@ data ExB
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize ExB
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Foo = Foo
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
@@ -119,6 +122,7 @@ data Bar = Bar
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
@@ -193,6 +197,7 @@ data Ex3_ex3_struct = Ex3_ex3_struct
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex3_ex3_struct where
@@ -269,6 +274,7 @@ data Ex3 = Ex3
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex3 where
@@ -343,6 +349,7 @@ data Ex4_odd = Ex4_odd
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex4_odd where
@@ -418,6 +425,7 @@ data Ex4_even = Ex4_even
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex4_even where

--- a/hs-bindgen/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/fixtures/types/nested/nested_types/th.txt
@@ -26,6 +26,7 @@ data Foo
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 8 :: Int
@@ -76,6 +77,7 @@ data Bar
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 16 :: Int
@@ -126,6 +128,7 @@ data Ex3_ex3_struct
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Ex3_ex3_struct
     where staticSizeOf = \_ -> 8 :: Int
@@ -178,6 +181,7 @@ data Ex3
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Ex3
     where staticSizeOf = \_ -> 12 :: Int
@@ -228,6 +232,7 @@ data Ex4_odd
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Ex4_odd
     where staticSizeOf = \_ -> 16 :: Int
@@ -278,6 +283,7 @@ data Ex4_even
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Ex4_even
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -53,6 +55,7 @@ data Bools1 = Bools1
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools1 where
@@ -127,6 +130,7 @@ data Bools2 = Bools2
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools2 where
@@ -188,6 +192,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools2) "bools2_y")
 newtype BOOL = BOOL
   { unwrapBOOL :: FC.CBool
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -241,6 +246,7 @@ data Bools3 = Bools3
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools3 where

--- a/hs-bindgen/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/bool/th.txt
@@ -27,6 +27,7 @@ data Bools1
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bools1
     where staticSizeOf = \_ -> 2 :: Int
@@ -77,6 +78,7 @@ data Bools2
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bools2
     where staticSizeOf = \_ -> 2 :: Int
@@ -114,6 +116,7 @@ newtype BOOL
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -163,6 +166,7 @@ data Bools3
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Bools3
     where staticSizeOf = \_ -> 2 :: Int

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -15,6 +16,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Foo = Foo
          __exported by:__ @types\/primitives\/fixedwidth.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
@@ -29,6 +29,7 @@ data Foo
 
            __exported by:__ @types\/primitives\/fixedwidth.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Rea
 newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
   { unwrapPrim_HsPrimCPtrdiff :: HsBindgen.Runtime.LibC.CPtrdiff
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -80,6 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCPtrdiff "unwrapPrim_H
 newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
   { unwrapPrim_HsPrimInt8 :: HsBindgen.Runtime.LibC.Int8
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -121,6 +125,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt8 "unwrapPrim_HsPri
 newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
   { unwrapPrim_HsPrimInt16 :: HsBindgen.Runtime.LibC.Int16
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -162,6 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt16 "unwrapPrim_HsPr
 newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
   { unwrapPrim_HsPrimInt32 :: HsBindgen.Runtime.LibC.Int32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -203,6 +209,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt32 "unwrapPrim_HsPr
 newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
   { unwrapPrim_HsPrimInt64 :: HsBindgen.Runtime.LibC.Int64
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -244,6 +251,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt64 "unwrapPrim_HsPr
 newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
   { unwrapPrim_HsPrimWord8 :: HsBindgen.Runtime.LibC.Word8
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -285,6 +293,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord8 "unwrapPrim_HsPr
 newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
   { unwrapPrim_HsPrimWord16 :: HsBindgen.Runtime.LibC.Word16
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -326,6 +335,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord16 "unwrapPrim_HsP
 newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
   { unwrapPrim_HsPrimWord32 :: HsBindgen.Runtime.LibC.Word32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -367,6 +377,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord32 "unwrapPrim_HsP
 newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
   { unwrapPrim_HsPrimWord64 :: HsBindgen.Runtime.LibC.Word64
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -408,6 +419,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord64 "unwrapPrim_HsP
 newtype Prim_HsPrimCChar = Prim_HsPrimCChar
   { unwrapPrim_HsPrimCChar :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -449,6 +461,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCChar "unwrapPrim_HsPr
 newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
   { unwrapPrim_HsPrimCSChar :: FC.CSChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -490,6 +503,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCSChar "unwrapPrim_HsP
 newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
   { unwrapPrim_HsPrimCUChar :: FC.CUChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -531,6 +545,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUChar "unwrapPrim_HsP
 newtype Prim_HsPrimCShort = Prim_HsPrimCShort
   { unwrapPrim_HsPrimCShort :: FC.CShort
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -572,6 +587,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCShort "unwrapPrim_HsP
 newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
   { unwrapPrim_HsPrimCUShort :: FC.CUShort
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -613,6 +629,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUShort "unwrapPrim_Hs
 newtype Prim_HsPrimCInt = Prim_HsPrimCInt
   { unwrapPrim_HsPrimCInt :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -654,6 +671,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCInt "unwrapPrim_HsPri
 newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
   { unwrapPrim_HsPrimCUInt :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -695,6 +713,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUInt "unwrapPrim_HsPr
 newtype Prim_HsPrimCLong = Prim_HsPrimCLong
   { unwrapPrim_HsPrimCLong :: FC.CLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -736,6 +755,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCLong "unwrapPrim_HsPr
 newtype Prim_HsPrimCULong = Prim_HsPrimCULong
   { unwrapPrim_HsPrimCULong :: FC.CULong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -777,6 +797,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCULong "unwrapPrim_HsP
 newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
   { unwrapPrim_HsPrimCLLong :: FC.CLLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -818,6 +839,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCLLong "unwrapPrim_HsP
 newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
   { unwrapPrim_HsPrimCULLong :: FC.CULLong
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -859,6 +881,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCULLong "unwrapPrim_Hs
 newtype Prim_HsPrimCBool = Prim_HsPrimCBool
   { unwrapPrim_HsPrimCBool :: FC.CBool
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -900,6 +923,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCBool "unwrapPrim_HsPr
 newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
   { unwrapPrim_HsPrimCFloat :: FC.CFloat
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -939,6 +963,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCFloat "unwrapPrim_HsP
 newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
   { unwrapPrim_HsPrimCDouble :: FC.CDouble
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
@@ -18,6 +18,7 @@ newtype Prim_HsPrimCPtrdiff
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -58,6 +59,7 @@ newtype Prim_HsPrimInt8
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -96,6 +98,7 @@ newtype Prim_HsPrimInt16
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -134,6 +137,7 @@ newtype Prim_HsPrimInt32
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -172,6 +176,7 @@ newtype Prim_HsPrimInt64
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -210,6 +215,7 @@ newtype Prim_HsPrimWord8
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -248,6 +254,7 @@ newtype Prim_HsPrimWord16
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -286,6 +293,7 @@ newtype Prim_HsPrimWord32
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -324,6 +332,7 @@ newtype Prim_HsPrimWord64
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -362,6 +371,7 @@ newtype Prim_HsPrimCChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -400,6 +410,7 @@ newtype Prim_HsPrimCSChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -438,6 +449,7 @@ newtype Prim_HsPrimCUChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -476,6 +488,7 @@ newtype Prim_HsPrimCShort
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -514,6 +527,7 @@ newtype Prim_HsPrimCUShort
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -554,6 +568,7 @@ newtype Prim_HsPrimCInt
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -592,6 +607,7 @@ newtype Prim_HsPrimCUInt
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -630,6 +646,7 @@ newtype Prim_HsPrimCLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -668,6 +685,7 @@ newtype Prim_HsPrimCULong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -706,6 +724,7 @@ newtype Prim_HsPrimCLLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -744,6 +763,7 @@ newtype Prim_HsPrimCULLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -784,6 +804,7 @@ newtype Prim_HsPrimCBool
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -822,6 +843,7 @@ newtype Prim_HsPrimCFloat
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -858,6 +880,7 @@ newtype Prim_HsPrimCDouble
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -227,6 +229,7 @@ data Primitive = Primitive
          __exported by:__ @types\/primitives\/primitive_types.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Primitive where

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
@@ -208,6 +208,7 @@ data Primitive
 
            __exported by:__ @types\/primitives\/primitive_types.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Primitive
     where staticSizeOf = \_ -> 152 :: Int

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -24,6 +25,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.CEnum
@@ -46,6 +48,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype I = I
   { unwrapI :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -85,6 +88,7 @@ instance HsBindgen.Runtime.HasCField.HasCField I "unwrapI" where
 -}
 data S = S
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
@@ -116,6 +120,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable S instance F.Storable S
 newtype U = U
   { unwrapU :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 0) 1 instance HsBindgen.Runtime.Marshal.StaticSize U
 
@@ -134,6 +139,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable U instance F.Storable U
 newtype E = E
   { unwrapE :: FC.CUInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
@@ -233,6 +239,7 @@ pattern Foo = E 0
 newtype TI = TI
   { unwrapTI :: I
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -273,6 +280,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TI "unwrapTI" where
 newtype TS = TS
   { unwrapTS :: S
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -302,6 +310,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TS "unwrapTS" where
 newtype TU = TU
   { unwrapTU :: U
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -330,6 +339,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TU "unwrapTU" where
 newtype TE = TE
   { unwrapTE :: E
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -361,6 +371,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TE "unwrapTE" where
 newtype TTI = TTI
   { unwrapTTI :: TI
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -401,6 +412,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TTI "unwrapTTI" where
 newtype TTS = TTS
   { unwrapTTS :: TS
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -430,6 +442,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TTS "unwrapTTS" where
 newtype TTU = TTU
   { unwrapTTU :: TU
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -458,6 +471,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TTU "unwrapTTU" where
 newtype TTE = TTE
   { unwrapTTE :: TE
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -86,6 +86,7 @@ newtype I
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -122,6 +123,7 @@ data S
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 0 :: Int
@@ -146,6 +148,7 @@ newtype U
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 0 1) instance StaticSize U
 deriving via (SizedByteArray 0 1) instance ReadRaw U
 deriving via (SizedByteArray 0 1) instance WriteRaw U
@@ -164,6 +167,7 @@ newtype E
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize E
@@ -229,6 +233,7 @@ newtype TI
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -265,6 +270,7 @@ newtype TS
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType TS "unwrapTS") =>
@@ -287,6 +293,7 @@ newtype TU
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType TU "unwrapTU") =>
          HasField "unwrapTU" (Ptr TU) (Ptr ty)
@@ -308,6 +315,7 @@ newtype TE
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -335,6 +343,7 @@ newtype TTI
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -371,6 +380,7 @@ newtype TTS
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType TTS "unwrapTTS") =>
@@ -393,6 +403,7 @@ newtype TTU
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance TyEq ty (CFieldType TTU "unwrapTTU") =>
          HasField "unwrapTTU" (Ptr TTU) (Ptr ty)
@@ -414,6 +425,7 @@ newtype TTE
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data Struct2 = Struct2
          __exported by:__ @types\/special\/parse_failure_long_double.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2 where

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
@@ -40,6 +40,7 @@ data Struct2
 
            __exported by:__ @types\/special\/parse_failure_long_double.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct2
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -19,6 +20,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -39,6 +41,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Stdlib_CBool = Stdlib_CBool
   { unwrapStdlib_CBool :: FC.CBool
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -80,6 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CBool "unwrapStdlib_CBool"
 newtype Stdlib_Int8 = Stdlib_Int8
   { unwrapStdlib_Int8 :: HsBindgen.Runtime.LibC.Int8
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -121,6 +125,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int8 "unwrapStdlib_Int8" w
 newtype Stdlib_Int16 = Stdlib_Int16
   { unwrapStdlib_Int16 :: HsBindgen.Runtime.LibC.Int16
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -162,6 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int16 "unwrapStdlib_Int16"
 newtype Stdlib_Int32 = Stdlib_Int32
   { unwrapStdlib_Int32 :: HsBindgen.Runtime.LibC.Int32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -203,6 +209,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int32 "unwrapStdlib_Int32"
 newtype Stdlib_Int64 = Stdlib_Int64
   { unwrapStdlib_Int64 :: HsBindgen.Runtime.LibC.Int64
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -244,6 +251,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int64 "unwrapStdlib_Int64"
 newtype Stdlib_Word8 = Stdlib_Word8
   { unwrapStdlib_Word8 :: HsBindgen.Runtime.LibC.Word8
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -285,6 +293,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word8 "unwrapStdlib_Word8"
 newtype Stdlib_Word16 = Stdlib_Word16
   { unwrapStdlib_Word16 :: HsBindgen.Runtime.LibC.Word16
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -326,6 +335,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word16 "unwrapStdlib_Word1
 newtype Stdlib_Word32 = Stdlib_Word32
   { unwrapStdlib_Word32 :: HsBindgen.Runtime.LibC.Word32
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -367,6 +377,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word32 "unwrapStdlib_Word3
 newtype Stdlib_Word64 = Stdlib_Word64
   { unwrapStdlib_Word64 :: HsBindgen.Runtime.LibC.Word64
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -408,6 +419,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word64 "unwrapStdlib_Word6
 newtype Stdlib_CIntMax = Stdlib_CIntMax
   { unwrapStdlib_CIntMax :: HsBindgen.Runtime.LibC.CIntMax
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -449,6 +461,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CIntMax "unwrapStdlib_CInt
 newtype Stdlib_CUIntMax = Stdlib_CUIntMax
   { unwrapStdlib_CUIntMax :: HsBindgen.Runtime.LibC.CUIntMax
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -490,6 +503,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CUIntMax "unwrapStdlib_CUI
 newtype Stdlib_CIntPtr = Stdlib_CIntPtr
   { unwrapStdlib_CIntPtr :: HsBindgen.Runtime.LibC.CIntPtr
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -531,6 +545,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CIntPtr "unwrapStdlib_CInt
 newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
   { unwrapStdlib_CUIntPtr :: HsBindgen.Runtime.LibC.CUIntPtr
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -572,6 +587,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CUIntPtr "unwrapStdlib_CUI
 newtype Stdlib_CFenvT = Stdlib_CFenvT
   { unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFenvT) "unwrapStdlib_CFenvT")
          ) => GHC.Records.HasField "unwrapStdlib_CFenvT" (Ptr.Ptr Stdlib_CFenvT) (Ptr.Ptr ty) where
@@ -595,6 +611,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFenvT "unwrapStdlib_CFenv
 newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   { unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFexceptT) "unwrapStdlib_CFexceptT")
          ) => GHC.Records.HasField "unwrapStdlib_CFexceptT" (Ptr.Ptr Stdlib_CFexceptT) (Ptr.Ptr ty) where
@@ -618,6 +635,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFexceptT "unwrapStdlib_CF
 newtype Stdlib_CSize = Stdlib_CSize
   { unwrapStdlib_CSize :: HsBindgen.Runtime.LibC.CSize
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -659,6 +677,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CSize "unwrapStdlib_CSize"
 newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
   { unwrapStdlib_CPtrdiff :: HsBindgen.Runtime.LibC.CPtrdiff
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -700,6 +719,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CPtrdiff "unwrapStdlib_CPt
 newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   { unwrapStdlib_CJmpBuf :: HsBindgen.Runtime.LibC.CJmpBuf
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CJmpBuf) "unwrapStdlib_CJmpBuf")
          ) => GHC.Records.HasField "unwrapStdlib_CJmpBuf" (Ptr.Ptr Stdlib_CJmpBuf) (Ptr.Ptr ty) where
@@ -723,6 +743,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmp
 newtype Stdlib_CWchar = Stdlib_CWchar
   { unwrapStdlib_CWchar :: HsBindgen.Runtime.LibC.CWchar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -764,6 +785,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWchar "unwrapStdlib_CWcha
 newtype Stdlib_CWintT = Stdlib_CWintT
   { unwrapStdlib_CWintT :: HsBindgen.Runtime.LibC.CWintT
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -805,6 +827,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWintT "unwrapStdlib_CWint
 newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   { unwrapStdlib_CMbstateT :: HsBindgen.Runtime.LibC.CMbstateT
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CMbstateT) "unwrapStdlib_CMbstateT")
          ) => GHC.Records.HasField "unwrapStdlib_CMbstateT" (Ptr.Ptr Stdlib_CMbstateT) (Ptr.Ptr ty) where
@@ -828,6 +851,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CMbstateT "unwrapStdlib_CM
 newtype Stdlib_CWctransT = Stdlib_CWctransT
   { unwrapStdlib_CWctransT :: HsBindgen.Runtime.LibC.CWctransT
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -860,6 +884,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWctransT "unwrapStdlib_CW
 newtype Stdlib_CWctypeT = Stdlib_CWctypeT
   { unwrapStdlib_CWctypeT :: HsBindgen.Runtime.LibC.CWctypeT
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -892,6 +917,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWctypeT "unwrapStdlib_CWc
 newtype Stdlib_CChar16T = Stdlib_CChar16T
   { unwrapStdlib_CChar16T :: HsBindgen.Runtime.LibC.CChar16T
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -933,6 +959,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CChar16T "unwrapStdlib_CCh
 newtype Stdlib_CChar32T = Stdlib_CChar32T
   { unwrapStdlib_CChar32T :: HsBindgen.Runtime.LibC.CChar32T
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -974,6 +1001,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CChar32T "unwrapStdlib_CCh
 newtype Stdlib_CTime = Stdlib_CTime
   { unwrapStdlib_CTime :: HsBindgen.Runtime.LibC.CTime
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1008,6 +1036,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CTime "unwrapStdlib_CTime"
 newtype Stdlib_CClock = Stdlib_CClock
   { unwrapStdlib_CClock :: HsBindgen.Runtime.LibC.CClock
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1042,6 +1071,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CClock "unwrapStdlib_CCloc
 newtype Stdlib_CTm = Stdlib_CTm
   { unwrapStdlib_CTm :: HsBindgen.Runtime.LibC.CTm
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -1070,6 +1100,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CTm "unwrapStdlib_CTm" whe
 newtype Stdlib_CFile = Stdlib_CFile
   { unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFile) "unwrapStdlib_CFile")
          ) => GHC.Records.HasField "unwrapStdlib_CFile" (Ptr.Ptr Stdlib_CFile) (Ptr.Ptr ty) where
@@ -1093,6 +1124,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFile "unwrapStdlib_CFile"
 newtype Stdlib_CFpos = Stdlib_CFpos
   { unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFpos) "unwrapStdlib_CFpos")
          ) => GHC.Records.HasField "unwrapStdlib_CFpos" (Ptr.Ptr Stdlib_CFpos) (Ptr.Ptr ty) where
@@ -1116,6 +1148,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
 newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
   { unwrapStdlib_CSigAtomic :: HsBindgen.Runtime.LibC.CSigAtomic
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
@@ -30,6 +30,7 @@ newtype Stdlib_CBool
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -66,6 +67,7 @@ newtype Stdlib_Int8
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -103,6 +105,7 @@ newtype Stdlib_Int16
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -140,6 +143,7 @@ newtype Stdlib_Int32
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -177,6 +181,7 @@ newtype Stdlib_Int64
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -214,6 +219,7 @@ newtype Stdlib_Word8
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -251,6 +257,7 @@ newtype Stdlib_Word16
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -289,6 +296,7 @@ newtype Stdlib_Word32
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -327,6 +335,7 @@ newtype Stdlib_Word64
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -365,6 +374,7 @@ newtype Stdlib_CIntMax
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -403,6 +413,7 @@ newtype Stdlib_CUIntMax
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -441,6 +452,7 @@ newtype Stdlib_CIntPtr
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -479,6 +491,7 @@ newtype Stdlib_CUIntPtr
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -517,6 +530,7 @@ newtype Stdlib_CFenvT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType Stdlib_CFenvT "unwrapStdlib_CFenvT") =>
          HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
@@ -539,6 +553,7 @@ newtype Stdlib_CFexceptT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType Stdlib_CFexceptT "unwrapStdlib_CFexceptT") =>
          HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
@@ -561,6 +576,7 @@ newtype Stdlib_CSize
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -598,6 +614,7 @@ newtype Stdlib_CPtrdiff
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -636,6 +653,7 @@ newtype Stdlib_CJmpBuf
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf") =>
          HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
@@ -658,6 +676,7 @@ newtype Stdlib_CWchar
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -696,6 +715,7 @@ newtype Stdlib_CWintT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -734,6 +754,7 @@ newtype Stdlib_CMbstateT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty
               (CFieldType Stdlib_CMbstateT "unwrapStdlib_CMbstateT") =>
          HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
@@ -756,6 +777,7 @@ newtype Stdlib_CWctransT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -785,6 +807,7 @@ newtype Stdlib_CWctypeT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -814,6 +837,7 @@ newtype Stdlib_CChar16T
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -852,6 +876,7 @@ newtype Stdlib_CChar32T
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -890,6 +915,7 @@ newtype Stdlib_CTime
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -920,6 +946,7 @@ newtype Stdlib_CClock
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -951,6 +978,7 @@ newtype Stdlib_CTm
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw)
 instance TyEq ty (CFieldType Stdlib_CTm "unwrapStdlib_CTm") =>
@@ -974,6 +1002,7 @@ newtype Stdlib_CFile
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType Stdlib_CFile "unwrapStdlib_CFile") =>
          HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
@@ -995,6 +1024,7 @@ newtype Stdlib_CFpos
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
 instance TyEq ty (CFieldType Stdlib_CFpos "unwrapStdlib_CFpos") =>
          HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
@@ -1016,6 +1046,7 @@ newtype Stdlib_CSigAtomic
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data S1_c = S1_c
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1_c where
@@ -119,6 +122,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
@@ -186,6 +190,7 @@ data S2_inner_deep = S2_inner_deep
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_inner_deep where
@@ -247,6 +252,7 @@ data S2_inner = S2_inner
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_inner where
@@ -322,6 +328,7 @@ data S2 = S2
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where
@@ -396,6 +403,7 @@ data S3 = S3
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3 where
@@ -470,6 +478,7 @@ data S3_c = S3_c
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_c where

--- a/hs-bindgen/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/fixtures/types/structs/anonymous/th.txt
@@ -26,6 +26,7 @@ data S1_c
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S1_c
     where staticSizeOf = \_ -> 8 :: Int
@@ -76,6 +77,7 @@ data S1
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 12 :: Int
@@ -119,6 +121,7 @@ data S2_inner_deep
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2_inner_deep
     where staticSizeOf = \_ -> 4 :: Int
@@ -162,6 +165,7 @@ data S2_inner
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2_inner
     where staticSizeOf = \_ -> 8 :: Int
@@ -212,6 +216,7 @@ data S2
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 12 :: Int
@@ -262,6 +267,7 @@ data S3
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S3
     where staticSizeOf = \_ -> 16 :: Int
@@ -312,6 +318,7 @@ data S3_c
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S3_c
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.BitfieldPtr
@@ -75,6 +77,7 @@ data Flags = Flags
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Flags where
@@ -226,6 +229,7 @@ data Overflow32 = Overflow32
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32 where
@@ -330,6 +334,7 @@ data Overflow32b = Overflow32b
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32b where
@@ -434,6 +439,7 @@ data Overflow32c = Overflow32c
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32c where
@@ -531,6 +537,7 @@ data Overflow64 = Overflow64
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow64 where
@@ -611,6 +618,7 @@ data AlignA = AlignA
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AlignA where
@@ -689,6 +697,7 @@ data AlignB = AlignB
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AlignB where

--- a/hs-bindgen/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/fixtures/types/structs/bitfields/th.txt
@@ -54,6 +54,7 @@ data Flags
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Flags
     where staticSizeOf = \_ -> 4 :: Int
@@ -143,6 +144,7 @@ data Overflow32
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Overflow32
     where staticSizeOf = \_ -> 12 :: Int
@@ -210,6 +212,7 @@ data Overflow32b
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Overflow32b
     where staticSizeOf = \_ -> 8 :: Int
@@ -277,6 +280,7 @@ data Overflow32c
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Overflow32c
     where staticSizeOf = \_ -> 16 :: Int
@@ -337,6 +341,7 @@ data Overflow64
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Overflow64
     where staticSizeOf = \_ -> 16 :: Int
@@ -389,6 +394,7 @@ data AlignA
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize AlignA
     where staticSizeOf = \_ -> 4 :: Int
@@ -441,6 +447,7 @@ data AlignB
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize AlignB
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -15,6 +16,7 @@ module Example where
 
 import qualified Data.Proxy
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -37,6 +39,7 @@ data B = B
          __exported by:__ @types\/structs\/circular_dependency_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B where
@@ -90,6 +93,7 @@ data A = A
          __exported by:__ @types\/structs\/circular_dependency_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -19,6 +19,7 @@ data B
 
            __exported by:__ @types\/structs\/circular_dependency_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize B
     where staticSizeOf = \_ -> 8 :: Int
@@ -55,6 +56,7 @@ data A
 
            __exported by:__ @types\/structs\/circular_dependency_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/structs/named_vs_anon/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/named_vs_anon/Example.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -6,6 +7,7 @@
 module Example where
 
 import qualified Foreign as F
+import qualified GHC.Generics
 import qualified HsBindgen.Runtime.Marshal
 import Prelude (Eq, Int, Show, pure, return)
 
@@ -17,6 +19,7 @@ import Prelude (Eq, Int, Show, pure, return)
 -}
 data A = A
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where
@@ -47,6 +50,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable A instance F.Storable A
 -}
 data Struct1 = Struct1
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1 where
@@ -77,6 +81,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct1 instance F.Storable
 -}
 data B_s = B_s
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B_s where
@@ -107,6 +112,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable B_s instance F.Storable B_s
 -}
 data Struct2_s = Struct2_s
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_s where
@@ -137,6 +143,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct2_s instance F.Storab
 -}
 data C = C
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize C where
@@ -167,6 +174,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable C instance F.Storable C
 -}
 data Struct3 = Struct3
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct3 where
@@ -197,6 +205,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct3 instance F.Storable
 -}
 data D = D
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize D where
@@ -227,6 +236,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable D instance F.Storable D
 -}
 data Struct4 = Struct4
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct4 where
@@ -257,6 +267,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct4 instance F.Storable
 -}
 data E_s = E_s
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize E_s where
@@ -287,6 +298,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable E_s instance F.Storable E_s
 -}
 data Struct5_s = Struct5_s
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct5_s where
@@ -317,6 +329,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct5_s instance F.Storab
 -}
 data F = F
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize F where
@@ -347,6 +360,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable F instance F.Storable F
 -}
 data Typedef1 = Typedef1
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef1 where
@@ -377,6 +391,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Typedef1 instance F.Storabl
 -}
 data G = G
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize G where
@@ -407,6 +422,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable G instance F.Storable G
 -}
 data Typedef2 = Typedef2
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef2 where
@@ -437,6 +453,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Typedef2 instance F.Storabl
 -}
 data H = H
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize H where
@@ -467,6 +484,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable H instance F.Storable H
 -}
 data Typedef3 = Typedef3
   {}
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef3 where

--- a/hs-bindgen/fixtures/types/structs/named_vs_anon/th.txt
+++ b/hs-bindgen/fixtures/types/structs/named_vs_anon/th.txt
@@ -13,6 +13,7 @@ data A
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 0 :: Int
@@ -37,6 +38,7 @@ data Struct1
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct1
     where staticSizeOf = \_ -> 0 :: Int
@@ -61,6 +63,7 @@ data B_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize B_s
     where staticSizeOf = \_ -> 0 :: Int
@@ -85,6 +88,7 @@ data Struct2_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct2_s
     where staticSizeOf = \_ -> 0 :: Int
@@ -109,6 +113,7 @@ data C
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize C
     where staticSizeOf = \_ -> 0 :: Int
@@ -133,6 +138,7 @@ data Struct3
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct3
     where staticSizeOf = \_ -> 0 :: Int
@@ -157,6 +163,7 @@ data D
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize D
     where staticSizeOf = \_ -> 0 :: Int
@@ -181,6 +188,7 @@ data Struct4
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct4
     where staticSizeOf = \_ -> 0 :: Int
@@ -205,6 +213,7 @@ data E_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize E_s
     where staticSizeOf = \_ -> 0 :: Int
@@ -229,6 +238,7 @@ data Struct5_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Struct5_s
     where staticSizeOf = \_ -> 0 :: Int
@@ -253,6 +263,7 @@ data F
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize F
     where staticSizeOf = \_ -> 0 :: Int
@@ -277,6 +288,7 @@ data Typedef1
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Typedef1
     where staticSizeOf = \_ -> 0 :: Int
@@ -301,6 +313,7 @@ data G
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize G
     where staticSizeOf = \_ -> 0 :: Int
@@ -325,6 +338,7 @@ data Typedef2
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Typedef2
     where staticSizeOf = \_ -> 0 :: Int
@@ -349,6 +363,7 @@ data H
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize H
     where staticSizeOf = \_ -> 0 :: Int
@@ -373,6 +388,7 @@ data Typedef3
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Typedef3
     where staticSizeOf = \_ -> 0 :: Int

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -45,6 +47,7 @@ data Linked_list_A_t = Linked_list_A_t
          __exported by:__ @types\/structs\/recursive_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Linked_list_A_t where
@@ -121,6 +124,7 @@ data Linked_list_B_t = Linked_list_B_t
          __exported by:__ @types\/structs\/recursive_struct.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Linked_list_B_t where

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
@@ -26,6 +26,7 @@ data Linked_list_A_t
 
            __exported by:__ @types\/structs\/recursive_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Linked_list_A_t
     where staticSizeOf = \_ -> 16 :: Int
@@ -79,6 +80,7 @@ data Linked_list_B_t
 
            __exported by:__ @types\/structs\/recursive_struct.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Linked_list_B_t
     where staticSizeOf = \_ -> 16 :: Int

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -18,6 +19,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -48,6 +50,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
@@ -129,6 +132,7 @@ data S2_t = S2_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_t where
@@ -210,6 +214,7 @@ data S3_t = S3_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_t where
@@ -277,6 +282,7 @@ data S4 = S4
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S4 where
@@ -365,6 +371,7 @@ data S5 = S5
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S5 where
@@ -439,6 +446,7 @@ data S6 = S6
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S6 where
@@ -513,6 +521,7 @@ data S7a_Aux = S7a_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7a_Aux where
@@ -574,6 +583,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "b")
 newtype S7a = S7a
   { unwrap :: Ptr.Ptr S7a_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -617,6 +627,7 @@ data S7b_Aux = S7b_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7b_Aux where
@@ -678,6 +689,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "b")
 newtype S7b = S7b
   { unwrap :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
@@ -26,6 +26,7 @@ data S1
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 8 :: Int
@@ -83,6 +84,7 @@ data S2_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2_t
     where staticSizeOf = \_ -> 12 :: Int
@@ -133,6 +135,7 @@ data S3_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S3_t
     where staticSizeOf = \_ -> 1 :: Int
@@ -183,6 +186,7 @@ data S4
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S4
     where staticSizeOf = \_ -> 16 :: Int
@@ -240,6 +244,7 @@ data S5
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S5
     where staticSizeOf = \_ -> 8 :: Int
@@ -290,6 +295,7 @@ data S6
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S6
     where staticSizeOf = \_ -> 8 :: Int
@@ -340,6 +346,7 @@ data S7a_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S7a_Aux
     where staticSizeOf = \_ -> 8 :: Int
@@ -377,6 +384,7 @@ newtype S7a
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -416,6 +424,7 @@ data S7b_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S7b_Aux
     where staticSizeOf = \_ -> 8 :: Int
@@ -453,6 +462,7 @@ newtype S7b
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -47,6 +49,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
@@ -128,6 +131,7 @@ data S2_t = S2_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_t where
@@ -209,6 +213,7 @@ data S3_t = S3_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_t where
@@ -276,6 +281,7 @@ data S4 = S4
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S4 where
@@ -364,6 +370,7 @@ data S5 = S5
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S5 where
@@ -438,6 +445,7 @@ data S6 = S6
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S6 where
@@ -512,6 +520,7 @@ data S7a_Aux = S7a_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7a_Aux where
@@ -573,6 +582,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "s7a_Aux_b"
 newtype S7a = S7a
   { unwrapS7a :: Ptr.Ptr S7a_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -616,6 +626,7 @@ data S7b_Aux = S7b_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7b_Aux where
@@ -677,6 +688,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "s7b_Aux_b"
 newtype S7b = S7b
   { unwrapS7b :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
@@ -26,6 +26,7 @@ data S1
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 8 :: Int
@@ -83,6 +84,7 @@ data S2_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S2_t
     where staticSizeOf = \_ -> 12 :: Int
@@ -133,6 +135,7 @@ data S3_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S3_t
     where staticSizeOf = \_ -> 1 :: Int
@@ -183,6 +186,7 @@ data S4
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S4
     where staticSizeOf = \_ -> 16 :: Int
@@ -240,6 +244,7 @@ data S5
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S5
     where staticSizeOf = \_ -> 8 :: Int
@@ -290,6 +295,7 @@ data S6
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S6
     where staticSizeOf = \_ -> 8 :: Int
@@ -340,6 +346,7 @@ data S7a_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S7a_Aux
     where staticSizeOf = \_ -> 8 :: Int
@@ -377,6 +384,7 @@ newtype S7a
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -416,6 +424,7 @@ data S7b_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize S7b_Aux
     where staticSizeOf = \_ -> 8 :: Int
@@ -453,6 +462,7 @@ newtype S7b
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,7 @@ module Example where
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -38,6 +40,7 @@ data Thing = Thing
          __exported by:__ @types\/structs\/struct_arg.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Thing where

--- a/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
@@ -116,6 +116,7 @@ data Thing
 
            __exported by:__ @types\/structs\/struct_arg.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Thing
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -20,6 +21,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -44,6 +46,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F1_Aux = F1_Aux
   { unwrapF1_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c_base ::
@@ -100,6 +103,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "unwrapF1_Aux" where
 newtype F1 = F1
   { unwrapF1 :: Ptr.FunPtr F1_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -132,6 +136,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F2_Aux = F2_Aux
   { unwrapF2_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_c39d7524b75b54e8_base ::
@@ -188,6 +193,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F2_Aux "unwrapF2_Aux" where
 newtype F2 = F2
   { unwrapF2 :: Ptr.Ptr (Ptr.FunPtr F2_Aux)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -221,6 +227,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F3_Aux = F3_Aux
   { unwrapF3_Aux :: FC.CInt -> FC.CInt -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_4a960721e7d1dcef_base ::
@@ -277,6 +284,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F3_Aux "unwrapF3_Aux" where
 newtype F3 = F3
   { unwrapF3 :: Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux))
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -310,6 +318,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F4_Aux = F4_Aux
   { unwrapF4_Aux :: IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_83bcff023b3bc648_base ::
@@ -365,6 +374,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F4_Aux "unwrapF4_Aux" where
 newtype F4 = F4
   { unwrapF4 :: Ptr.Ptr (Ptr.FunPtr F4_Aux)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -398,6 +408,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F5_Aux = F5_Aux
   { unwrapF5_Aux :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_6891cbd81d6f42b9_base ::
@@ -453,6 +464,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F5_Aux "unwrapF5_Aux" where
 newtype F5 = F5
   { unwrapF5 :: Ptr.Ptr (Ptr.FunPtr F5_Aux)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -484,6 +496,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F5 "unwrapF5" where
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -526,6 +539,7 @@ __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
 newtype F6_Aux = F6_Aux
   { unwrapF6_Aux :: MyInt -> IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_c1baf73f98614f45_base ::
@@ -582,6 +596,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F6_Aux "unwrapF6_Aux" where
 newtype F6 = F6
   { unwrapF6 :: Ptr.Ptr (Ptr.FunPtr F6_Aux)
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -17,6 +17,7 @@ newtype F1_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c_base ::
     Int32 -> Int32 -> IO Unit
@@ -59,6 +60,7 @@ newtype F1
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -89,6 +91,7 @@ newtype F2_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_c39d7524b75b54e8_base ::
     Int32 -> Int32 -> IO Unit
@@ -131,6 +134,7 @@ newtype F2
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -161,6 +165,7 @@ newtype F3_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_4a960721e7d1dcef_base ::
     Int32 -> Int32 -> IO Unit
@@ -203,6 +208,7 @@ newtype F3
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -233,6 +239,7 @@ newtype F4_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_83bcff023b3bc648_base ::
     IO Int32
@@ -272,6 +279,7 @@ newtype F4
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -302,6 +310,7 @@ newtype F5_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_6891cbd81d6f42b9_base ::
     IO Unit
@@ -341,6 +350,7 @@ newtype F5
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -367,6 +377,7 @@ newtype MyInt
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -407,6 +418,7 @@ newtype F6_Aux
 
       __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_c1baf73f98614f45_base ::
     Int32 -> IO Unit
@@ -447,6 +459,7 @@ newtype F6
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,6 +22,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -40,6 +42,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -80,6 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype T2 = T2
   { unwrapT2 :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -120,6 +124,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T2 "unwrapT2" where
 newtype M1 = M1
   { unwrapM1 :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -160,6 +165,7 @@ instance HsBindgen.Runtime.HasCField.HasCField M1 "unwrapM1" where
 newtype M2 = M2
   { unwrapM2 :: FC.CChar
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -200,6 +206,7 @@ instance HsBindgen.Runtime.HasCField.HasCField M2 "unwrapM2" where
 newtype M3 = M3
   { unwrapM3 :: Ptr.Ptr FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -257,6 +264,7 @@ data ExampleStruct = ExampleStruct
          __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExampleStruct where
@@ -350,6 +358,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExampleStruct) "exam
 newtype Uint64_t = Uint64_t
   { unwrapUint64_t :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -396,6 +405,7 @@ data Foo = Foo
          __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -13,6 +13,7 @@ newtype T1
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -49,6 +50,7 @@ newtype T2
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -85,6 +87,7 @@ newtype M1
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -121,6 +124,7 @@ newtype M2
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -157,6 +161,7 @@ newtype M3
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -210,6 +215,7 @@ data ExampleStruct
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize ExampleStruct
     where staticSizeOf = \_ -> 16 :: Int
@@ -261,6 +267,7 @@ newtype Uint64_t
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -303,6 +310,7 @@ data Foo
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -20,6 +21,7 @@ import qualified Data.Primitive.Types
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Int
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
@@ -42,6 +44,7 @@ import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 newtype Myint = Myint
   { unwrapMyint :: FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -82,6 +85,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Myint "unwrapMyint" where
 newtype Intptr = Intptr
   { unwrapIntptr :: Ptr.Ptr FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -113,6 +117,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Intptr "unwrapIntptr" where
 newtype Int2int = Int2int
   { unwrapInt2int :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_a6c7dd49f5b9d470_base ::
@@ -171,6 +176,7 @@ __exported by:__ @types\/typedefs\/typedefs.h@
 newtype FunctionPointer_Function_Aux = FunctionPointer_Function_Aux
   { unwrapFunctionPointer_Function_Aux :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_b171c028cdc0781d_base ::
@@ -227,6 +233,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function_Aux "unw
 newtype FunctionPointer_Function = FunctionPointer_Function
   { unwrapFunctionPointer_Function :: Ptr.FunPtr FunctionPointer_Function_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -258,6 +265,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function "unwrapF
 newtype NonFunctionPointer_Function = NonFunctionPointer_Function
   { unwrapNonFunctionPointer_Function :: FC.CInt -> IO FC.CInt
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_766ae751d60365e9_base ::
@@ -316,6 +324,7 @@ __exported by:__ @types\/typedefs\/typedefs.h@
 newtype F1_Aux = F1_Aux
   { unwrapF1_Aux :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c_base ::
@@ -371,6 +380,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "unwrapF1_Aux" where
 newtype F1 = F1
   { unwrapF1 :: Ptr.FunPtr F1_Aux
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -401,6 +411,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1 "unwrapF1" where
 newtype G1 = G1
   { unwrapG1 :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_fa5806570b682579_base ::
@@ -456,6 +467,7 @@ instance HsBindgen.Runtime.HasCField.HasCField G1 "unwrapG1" where
 newtype G2 = G2
   { unwrapG2 :: Ptr.FunPtr G1
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
@@ -486,6 +498,7 @@ instance HsBindgen.Runtime.HasCField.HasCField G2 "unwrapG2" where
 newtype H1 = H1
   { unwrapH1 :: IO ()
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 foreign import ccall safe "wrapper" hs_bindgen_ffae0d1234ed018f_base ::
@@ -541,6 +554,7 @@ instance HsBindgen.Runtime.HasCField.HasCField H1 "unwrapH1" where
 newtype H2 = H2
   { unwrapH2 :: H1
   }
+  deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType H2) "unwrapH2")
@@ -564,6 +578,7 @@ instance HsBindgen.Runtime.HasCField.HasCField H2 "unwrapH2" where
 newtype H3 = H3
   { unwrapH3 :: Ptr.FunPtr H2
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
@@ -13,6 +13,7 @@ newtype Myint
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -49,6 +50,7 @@ newtype Intptr
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -75,6 +77,7 @@ newtype Int2int
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_a6c7dd49f5b9d470_base ::
     Int32 -> IO Int32
@@ -119,6 +122,7 @@ newtype FunctionPointer_Function_Aux
 
       __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_b171c028cdc0781d_base ::
     IO Unit
@@ -166,6 +170,7 @@ newtype FunctionPointer_Function
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -199,6 +204,7 @@ newtype NonFunctionPointer_Function
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_766ae751d60365e9_base ::
     Int32 -> IO Int32
@@ -251,6 +257,7 @@ newtype F1_Aux
 
       __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_00d16e666202ed6c_base ::
     IO Unit
@@ -290,6 +297,7 @@ newtype F1
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -316,6 +324,7 @@ newtype G1
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_fa5806570b682579_base ::
     IO Unit
@@ -355,6 +364,7 @@ newtype G2
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
@@ -381,6 +391,7 @@ newtype H1
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 foreign import ccall safe "wrapper" hs_bindgen_ffae0d1234ed018f_base ::
     IO Unit
@@ -420,6 +431,7 @@ newtype H2
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving newtype HasFFIType
 instance TyEq ty (CFieldType H2 "unwrapH2") =>
          HasField "unwrapH2" (Ptr H2) (Ptr ty)
@@ -441,6 +453,7 @@ newtype H3
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,

--- a/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -35,6 +37,7 @@ import Prelude ((<*>), Int, pure)
 newtype UnionA = UnionA
   { unwrapUnionA :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize UnionA
 
@@ -137,6 +140,7 @@ data ExA = ExA
          __exported by:__ @types\/unions\/nested_unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExA where
 
@@ -183,6 +187,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExA) "exA_fieldA1")
 newtype ExB_fieldB1 = ExB_fieldB1
   { unwrapExB_fieldB1 :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 4) 4 instance HsBindgen.Runtime.Marshal.StaticSize ExB_fieldB1
 
@@ -286,6 +291,7 @@ data ExB = ExB
          __exported by:__ @types\/unions\/nested_unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExB where
 

--- a/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
@@ -13,6 +13,7 @@ newtype UnionA
 
            __exported by:__ @types\/unions\/nested_unions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize UnionA
 deriving via (SizedByteArray 4 4) instance ReadRaw UnionA
 deriving via (SizedByteArray 4 4) instance WriteRaw UnionA
@@ -117,6 +118,7 @@ data ExA
 
            __exported by:__ @types\/unions\/nested_unions.h@
       -}
+    deriving stock Generic
 instance StaticSize ExA
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -146,6 +148,7 @@ newtype ExB_fieldB1
 
            __exported by:__ @types\/unions\/nested_unions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 4 4) instance StaticSize ExB_fieldB1
 deriving via (SizedByteArray 4 4) instance ReadRaw ExB_fieldB1
 deriving via (SizedByteArray 4 4) instance WriteRaw ExB_fieldB1
@@ -250,6 +253,7 @@ data ExB
 
            __exported by:__ @types\/unions\/nested_unions.h@
       -}
+    deriving stock Generic
 instance StaticSize ExB
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/unions/Example.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -17,6 +18,7 @@ import qualified Data.Array.Byte
 import qualified Data.Proxy
 import qualified Foreign as F
 import qualified Foreign.C as FC
+import qualified GHC.Generics
 import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
@@ -48,6 +50,7 @@ data Dim2 = Dim2
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Dim2 where
@@ -129,6 +132,7 @@ data Dim3 = Dim3
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Dim3 where
@@ -204,6 +208,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim3) "dim3_z")
 newtype DimPayload = DimPayload
   { unwrapDimPayload :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 4 instance HsBindgen.Runtime.Marshal.StaticSize DimPayload
 
@@ -313,6 +318,7 @@ data Dim = Dim
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Dim where
 
@@ -373,6 +379,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim) "dim_payload")
 newtype DimPayloadB = DimPayloadB
   { unwrapDimPayloadB :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 8) 4 instance HsBindgen.Runtime.Marshal.StaticSize DimPayloadB
 
@@ -482,6 +489,7 @@ data DimB = DimB
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
 
 instance HsBindgen.Runtime.Marshal.StaticSize DimB where
 
@@ -555,6 +563,7 @@ data AnonA_xy = AnonA_xy
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AnonA_xy where
@@ -629,6 +638,7 @@ data AnonA_polar = AnonA_polar
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
+  deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AnonA_polar where
@@ -692,6 +702,7 @@ instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA_polar) "anonA_
 newtype AnonA = AnonA
   { unwrapAnonA :: Data.Array.Byte.ByteArray
   }
+  deriving stock (GHC.Generics.Generic)
 
 deriving via (HsBindgen.Runtime.Internal.SizedByteArray.SizedByteArray 16) 8 instance HsBindgen.Runtime.Marshal.StaticSize AnonA
 

--- a/hs-bindgen/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/unions/th.txt
@@ -26,6 +26,7 @@ data Dim2
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Dim2
     where staticSizeOf = \_ -> 8 :: Int
@@ -83,6 +84,7 @@ data Dim3
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize Dim3
     where staticSizeOf = \_ -> 12 :: Int
@@ -127,6 +129,7 @@ newtype DimPayload
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8 4) instance StaticSize DimPayload
 deriving via (SizedByteArray 8 4) instance ReadRaw DimPayload
 deriving via (SizedByteArray 8 4) instance WriteRaw DimPayload
@@ -238,6 +241,7 @@ data Dim
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
 instance StaticSize Dim
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -274,6 +278,7 @@ newtype DimPayloadB
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 8 4) instance StaticSize DimPayloadB
 deriving via (SizedByteArray 8 4) instance ReadRaw DimPayloadB
 deriving via (SizedByteArray 8 4) instance WriteRaw DimPayloadB
@@ -385,6 +390,7 @@ data DimB
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
 instance StaticSize DimB
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -434,6 +440,7 @@ data AnonA_xy
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize AnonA_xy
     where staticSizeOf = \_ -> 16 :: Int
@@ -484,6 +491,7 @@ data AnonA_polar
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
     deriving stock (Eq, Show)
 instance StaticSize AnonA_polar
     where staticSizeOf = \_ -> 16 :: Int
@@ -521,6 +529,7 @@ newtype AnonA
 
            __exported by:__ @types\/unions\/unions.h@
       -}
+    deriving stock Generic
 deriving via (SizedByteArray 16 8) instance StaticSize AnonA
 deriving via (SizedByteArray 16 8) instance ReadRaw AnonA
 deriving via (SizedByteArray 16 8) instance WriteRaw AnonA

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -40,11 +40,13 @@ requiredExtensions fieldNaming = \case
         recordExtensions record
       , nestedDeriving record.deriv
       , enableRecordDotExtensions fieldNaming
+      , Set.singleton TH.DeriveGeneric
       ]
     DNewtype newtyp -> mconcat [
         nestedDeriving newtyp.deriv
       , typeExtensions newtyp.field.typ
       , enableRecordDotExtensions fieldNaming
+      , Set.singleton TH.DeriveGeneric
       ]
     DEmptyData{} -> mconcat [
         ext TH.EmptyDataDecls

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Names.hs
@@ -61,6 +61,7 @@ import HsBindgen.Runtime.PtrConst qualified
 import HsBindgen.Backend.Hs.AST.Type
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Imports
+import HsBindgen.Imports qualified as GHC.Generics
 import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
@@ -301,6 +302,7 @@ resolveGlobal = \case
     CharValue_fromAddr    -> importQ 'CExpr.Runtime.charValueFromAddr
     Capi_with             -> importQ 'Foreign.with
     Capi_allocaAndPeek    -> importQ 'HsBindgen.Runtime.Internal.CAPI.allocaAndPeek
+    Generic_class         -> importQ ''GHC.Generics.Generic
 
     -- StaticSize
     StaticSize_class           -> importQ ''HsBindgen.Runtime.Marshal.StaticSize

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
@@ -77,6 +77,7 @@ data Global =
   | ByteArray_getUnionPayload
   | Capi_with
   | Capi_allocaAndPeek
+  | Generic_class
 
     -- StaticSize
   | StaticSize_class

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -146,7 +146,7 @@ translateDeclData :: Hs.Struct n -> SDecl
 translateDeclData struct = DRecord Record{
       typ     = struct.name
     , con     = struct.constr
-    , deriv   = []
+    , deriv   = [(Hs.DeriveStock, [Generic_class])]
     , comment = struct.comment
     , origin  = case struct.origin of
                   Just origin -> origin
@@ -174,7 +174,7 @@ translateNewtype n = DNewtype Newtype{
       name    = n.name
     , con     = n.constr
     , origin  = n.origin
-    , deriv   = []
+    , deriv   = [(Hs.DeriveStock, [Generic_class])]
     , comment = n.comment
     , field   = Field {
           name    = n.field.name

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -30,6 +30,7 @@ import GHC.Exts (Int (..), sizeofByteArray#)
 import GHC.Exts qualified as IsList (IsList (..))
 import GHC.Float (castDoubleToWord64, castFloatToWord32, castWord32ToFloat,
                   castWord64ToDouble)
+import GHC.Generics qualified
 import GHC.Ptr (Ptr (Ptr))
 import GHC.Records qualified
 import Language.Haskell.TH (Quote)
@@ -105,6 +106,7 @@ mkGlobal = \case
       CharValue_fromAddr    -> 'CExpr.Runtime.charValueFromAddr
       Capi_with             -> 'Foreign.with
       Capi_allocaAndPeek    -> 'HsBindgen.Runtime.Internal.CAPI.allocaAndPeek
+      Generic_class         -> ''GHC.Generics.Generic
 
       -- StaticSize
       StaticSize_class           -> ''HsBindgen.Runtime.Marshal.StaticSize
@@ -398,6 +400,7 @@ mkGlobalExpr n = case n of -- in definition order, no wildcards
     ByteArray_getUnionPayload -> TH.varE name
     Capi_with                 -> TH.varE name
     Capi_allocaAndPeek        -> TH.varE name
+    Generic_class             -> panicPure "class in expression"
 
     -- StaticSize
     StaticSize_class           -> panicPure "class in expression"


### PR DESCRIPTION
@TravisCardwell This is quite a bad hack (although _somewhat_ justifiable); I couldn't figure out how to do it better in time for the alpha release. I've opened https://github.com/well-typed/hs-bindgen/issues/1668 for us to consider how we could make this easier, but meanwhile you might want to refactor this to make it bit better with the rest. 