### PR TITLE
Simplify `HasField` instances by expanding `CFieldType`/`CBitfieldType`

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0 -- YYYY-mm-dd
 
-* First version. Released on an unsuspecting world.
+* BREAKING: `TyEq` no longer used in generated `HasField` instances

--- a/hs-bindgen/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @triplet@
@@ -46,8 +43,7 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
-         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -71,8 +67,7 @@ newtype List = List
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType List) "unwrapList")
-         ) => GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapList")
@@ -102,8 +97,7 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Matrix) "unwrapMatrix")
-         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -127,8 +121,7 @@ newtype Tripletlist = Tripletlist
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tripletlist) "unwrapTripletlist")
-         ) => GHC.Records.HasField "unwrapTripletlist" (Ptr.Ptr Tripletlist) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTripletlist" (Ptr.Ptr Tripletlist) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTripletlist")
@@ -198,8 +191,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example "example_triple" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example) "example_triple")
-         ) => GHC.Records.HasField "example_triple" (Ptr.Ptr Example) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_triple" (Ptr.Ptr Example) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_triple")
@@ -211,8 +203,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example "example_sudoku" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example) "example_sudoku")
-         ) => GHC.Records.HasField "example_sudoku" (Ptr.Ptr Example) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_sudoku" (Ptr.Ptr Example) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_sudoku")
@@ -237,8 +228,7 @@ newtype Sudoku = Sudoku
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Sudoku) "unwrapSudoku")
-         ) => GHC.Records.HasField "unwrapSudoku" (Ptr.Ptr Sudoku) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSudoku" (Ptr.Ptr Sudoku) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSudoku")

--- a/hs-bindgen/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/fixtures/arrays/array/th.txt
@@ -668,8 +668,9 @@ newtype Triplet
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -691,8 +692,9 @@ newtype List
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType List "unwrapList") =>
-         HasField "unwrapList" (Ptr List) (Ptr ty)
+instance HasField "unwrapList"
+                  (Ptr List)
+                  (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt
@@ -714,8 +716,9 @@ newtype Matrix
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -738,8 +741,9 @@ newtype Tripletlist
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType Tripletlist "unwrapTripletlist") =>
-         HasField "unwrapTripletlist" (Ptr Tripletlist) (Ptr ty)
+instance HasField "unwrapTripletlist"
+                  (Ptr Tripletlist)
+                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapTripletlist")
 instance HasCField Tripletlist "unwrapTripletlist"
     where type CFieldType Tripletlist
@@ -788,15 +792,17 @@ instance HasCField Example "example_triple"
     where type CFieldType Example "example_triple" = ConstantArray 3
                                                                    CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Example "example_triple") =>
-         HasField "example_triple" (Ptr Example) (Ptr ty)
+instance HasField "example_triple"
+                  (Ptr Example)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"example_triple")
 instance HasCField Example "example_sudoku"
     where type CFieldType Example "example_sudoku" = ConstantArray 3
                                                                    (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 12
-instance TyEq ty (CFieldType Example "example_sudoku") =>
-         HasField "example_sudoku" (Ptr Example) (Ptr ty)
+instance HasField "example_sudoku"
+                  (Ptr Example)
+                  (Ptr (ConstantArray 3 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"example_sudoku")
 {-| Typedef-in-typedef
 
@@ -819,8 +825,9 @@ newtype Sudoku
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Sudoku "unwrapSudoku") =>
-         HasField "unwrapSudoku" (Ptr Sudoku) (Ptr ty)
+instance HasField "unwrapSudoku"
+                  (Ptr Sudoku)
+                  (Ptr (ConstantArray 3 Triplet))
     where getField = fromPtr (Proxy @"unwrapSudoku")
 instance HasCField Sudoku "unwrapSudoku"
     where type CFieldType Sudoku "unwrapSudoku" = ConstantArray 3

--- a/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @S@
@@ -38,8 +35,7 @@ newtype S = S
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "unwrapS")
-         ) => GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS")
@@ -63,8 +59,7 @@ newtype T = T
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "unwrapT")
-         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")
@@ -94,8 +89,7 @@ newtype U = U
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "unwrapU")
-         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")
@@ -125,8 +119,7 @@ newtype V = V
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType V) "unwrapV")
-         ) => GHC.Records.HasField "unwrapV" (Ptr.Ptr V) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapV" (Ptr.Ptr V) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapV")
@@ -156,8 +149,7 @@ newtype W = W
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType W) "unwrapW")
-         ) => GHC.Records.HasField "unwrapW" (Ptr.Ptr W) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapW" (Ptr.Ptr W) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapW")
@@ -187,8 +179,7 @@ newtype X = X
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType X) "unwrapX")
-         ) => GHC.Records.HasField "unwrapX" (Ptr.Ptr X) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapX" (Ptr.Ptr X) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapX")

--- a/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
@@ -256,8 +256,7 @@ newtype S
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType S "unwrapS") =>
-         HasField "unwrapS" (Ptr S) (Ptr ty)
+instance HasField "unwrapS" (Ptr S) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = IncompleteArray CInt
@@ -278,8 +277,7 @@ newtype T
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType T "unwrapT") =>
-         HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = IncompleteArray CInt
@@ -301,8 +299,7 @@ newtype U
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType U "unwrapU") =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = ConstantArray 3 CInt
@@ -324,8 +321,7 @@ newtype V
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType V "unwrapV") =>
-         HasField "unwrapV" (Ptr V) (Ptr ty)
+instance HasField "unwrapV" (Ptr V) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapV")
 instance HasCField V "unwrapV"
     where type CFieldType V "unwrapV" = ConstantArray 3 CInt
@@ -347,8 +343,7 @@ newtype W
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType W "unwrapW") =>
-         HasField "unwrapW" (Ptr W) (Ptr ty)
+instance HasField "unwrapW" (Ptr W) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapW")
 instance HasCField W "unwrapW"
     where type CFieldType W "unwrapW" = ConstantArray 3 CInt
@@ -370,8 +365,7 @@ newtype X
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType X "unwrapX") =>
-         HasField "unwrapX" (Ptr X) (Ptr ty)
+instance HasField "unwrapX" (Ptr X) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapX")
 instance HasCField X "unwrapX"
     where type CFieldType X "unwrapX" = ConstantArray 3 CInt

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @matrix@
@@ -44,8 +41,7 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Matrix) "unwrapMatrix")
-         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -69,8 +65,7 @@ newtype Triplets = Triplets
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplets) "unwrapTriplets")
-         ) => GHC.Records.HasField "unwrapTriplets" (Ptr.Ptr Triplets) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplets" (Ptr.Ptr Triplets) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplets")

--- a/hs-bindgen/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/fixtures/arrays/multi_dim/th.txt
@@ -177,8 +177,9 @@ newtype Matrix
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -201,8 +202,9 @@ newtype Triplets
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType Triplets "unwrapTriplets") =>
-         HasField "unwrapTriplets" (Ptr Triplets) (Ptr ty)
+instance HasField "unwrapTriplets"
+                  (Ptr Triplets)
+                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapTriplets")
 instance HasCField Triplets "unwrapTriplets"
     where type CFieldType Triplets

--- a/hs-bindgen/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/attributes/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, IO, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -83,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_c")
-         ) => GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_c")
@@ -95,8 +91,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_i")
-         ) => GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_i")
@@ -158,8 +153,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_c")
-         ) => GHC.Records.HasField "bar_c" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_c" (Ptr.Ptr Bar) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_c")
@@ -170,8 +164,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_i")
-         ) => GHC.Records.HasField "bar_i" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_i" (Ptr.Ptr Bar) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_i")
@@ -233,8 +226,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Baz "baz_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Baz) "baz_c")
-         ) => GHC.Records.HasField "baz_c" (Ptr.Ptr Baz) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "baz_c" (Ptr.Ptr Baz) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"baz_c")
@@ -245,8 +237,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Baz "baz_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Baz) "baz_i")
-         ) => GHC.Records.HasField "baz_i" (Ptr.Ptr Baz) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "baz_i" (Ptr.Ptr Baz) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"baz_i")
@@ -308,8 +299,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Qux "qux_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Qux) "qux_c")
-         ) => GHC.Records.HasField "qux_c" (Ptr.Ptr Qux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "qux_c" (Ptr.Ptr Qux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"qux_c")
@@ -320,8 +310,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Qux "qux_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Qux) "qux_i")
-         ) => GHC.Records.HasField "qux_i" (Ptr.Ptr Qux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "qux_i" (Ptr.Ptr Qux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"qux_i")
@@ -392,8 +381,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__r" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FILE) "fILE__r")
-         ) => GHC.Records.HasField "fILE__r" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "fILE__r" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__r")
@@ -404,8 +392,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__w" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FILE) "fILE__w")
-         ) => GHC.Records.HasField "fILE__w" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "fILE__w" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__w")
@@ -417,8 +404,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__close" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FILE) "fILE__close")
-         ) => GHC.Records.HasField "fILE__close" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "fILE__close" (Ptr.Ptr FILE) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Void) -> IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__close")

--- a/hs-bindgen/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/attributes/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo "foo_c") =>
-         HasField "foo_c" (Ptr Foo) (Ptr ty)
+instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
     where getField = fromPtr (Proxy @"foo_c")
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Foo "foo_i") =>
-         HasField "foo_i" (Ptr Foo) (Ptr ty)
+instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_i")
 {-| __C declaration:__ @struct bar@
 
@@ -92,14 +90,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_c"
     where type CFieldType Bar "bar_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bar "bar_c") =>
-         HasField "bar_c" (Ptr Bar) (Ptr ty)
+instance HasField "bar_c" (Ptr Bar) (Ptr CChar)
     where getField = fromPtr (Proxy @"bar_c")
 instance HasCField Bar "bar_i"
     where type CFieldType Bar "bar_i" = CInt
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Bar "bar_i") =>
-         HasField "bar_i" (Ptr Bar) (Ptr ty)
+instance HasField "bar_i" (Ptr Bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"bar_i")
 {-| __C declaration:__ @struct baz@
 
@@ -143,14 +139,12 @@ deriving via (EquivStorable Baz) instance Storable Baz
 instance HasCField Baz "baz_c"
     where type CFieldType Baz "baz_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Baz "baz_c") =>
-         HasField "baz_c" (Ptr Baz) (Ptr ty)
+instance HasField "baz_c" (Ptr Baz) (Ptr CChar)
     where getField = fromPtr (Proxy @"baz_c")
 instance HasCField Baz "baz_i"
     where type CFieldType Baz "baz_i" = CInt
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Baz "baz_i") =>
-         HasField "baz_i" (Ptr Baz) (Ptr ty)
+instance HasField "baz_i" (Ptr Baz) (Ptr CInt)
     where getField = fromPtr (Proxy @"baz_i")
 {-| __C declaration:__ @struct qux@
 
@@ -194,14 +188,12 @@ deriving via (EquivStorable Qux) instance Storable Qux
 instance HasCField Qux "qux_c"
     where type CFieldType Qux "qux_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Qux "qux_c") =>
-         HasField "qux_c" (Ptr Qux) (Ptr ty)
+instance HasField "qux_c" (Ptr Qux) (Ptr CChar)
     where getField = fromPtr (Proxy @"qux_c")
 instance HasCField Qux "qux_i"
     where type CFieldType Qux "qux_i" = CInt
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Qux "qux_i") =>
-         HasField "qux_i" (Ptr Qux) (Ptr ty)
+instance HasField "qux_i" (Ptr Qux) (Ptr CInt)
     where getField = fromPtr (Proxy @"qux_i")
 {-| __C declaration:__ @struct __sFILE@
 
@@ -253,19 +245,18 @@ deriving via (EquivStorable FILE) instance Storable FILE
 instance HasCField FILE "fILE__r"
     where type CFieldType FILE "fILE__r" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType FILE "fILE__r") =>
-         HasField "fILE__r" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__r" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"fILE__r")
 instance HasCField FILE "fILE__w"
     where type CFieldType FILE "fILE__w" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType FILE "fILE__w") =>
-         HasField "fILE__w" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__w" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"fILE__w")
 instance HasCField FILE "fILE__close"
     where type CFieldType FILE "fILE__close" = FunPtr (Ptr Void ->
                                                        IO CInt)
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType FILE "fILE__close") =>
-         HasField "fILE__close" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__close"
+                  (Ptr FILE)
+                  (Ptr (FunPtr (Ptr Void -> IO CInt)))
     where getField = fromPtr (Proxy @"fILE__close")

--- a/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -35,7 +33,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -87,8 +84,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S "s_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "s_f")
-         ) => GHC.Records.HasField "s_f" (Ptr.Ptr S) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s_f" (Ptr.Ptr S) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s_f")
@@ -122,8 +118,7 @@ newtype More_aligned_int = More_aligned_int
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType More_aligned_int) "unwrapMore_aligned_int")
-         ) => GHC.Records.HasField "unwrapMore_aligned_int" (Ptr.Ptr More_aligned_int) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMore_aligned_int" (Ptr.Ptr More_aligned_int) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMore_aligned_int")
@@ -184,8 +179,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2) "s2_f")
-         ) => GHC.Records.HasField "s2_f" (Ptr.Ptr S2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_f" (Ptr.Ptr S2) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_f")
@@ -248,8 +242,7 @@ instance HsBindgen.Runtime.HasCField.HasCField My_unpacked_struct "my_unpacked_s
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_unpacked_struct) "my_unpacked_struct_c")
-         ) => GHC.Records.HasField "my_unpacked_struct_c" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "my_unpacked_struct_c" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_unpacked_struct_c")
@@ -261,8 +254,7 @@ instance HsBindgen.Runtime.HasCField.HasCField My_unpacked_struct "my_unpacked_s
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_unpacked_struct) "my_unpacked_struct_i")
-         ) => GHC.Records.HasField "my_unpacked_struct_i" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "my_unpacked_struct_i" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_unpacked_struct_i")
@@ -334,8 +326,7 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_packed_struct) "my_packed_struct_c")
-         ) => GHC.Records.HasField "my_packed_struct_c" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "my_packed_struct_c" (Ptr.Ptr My_packed_struct) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_c")
@@ -347,8 +338,7 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_packed_struct) "my_packed_struct_i")
-         ) => GHC.Records.HasField "my_packed_struct_i" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "my_packed_struct_i" (Ptr.Ptr My_packed_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_i")
@@ -360,8 +350,7 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType My_packed_struct) "my_packed_struct_s")
-         ) => GHC.Records.HasField "my_packed_struct_s" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "my_packed_struct_s" (Ptr.Ptr My_packed_struct) (Ptr.Ptr My_unpacked_struct) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_s")
@@ -446,8 +435,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Wait_status_ptr_t "wait_status_pt
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Wait_status_ptr_t) "wait_status_ptr_t___ip")
-         ) => GHC.Records.HasField "wait_status_ptr_t___ip" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "wait_status_ptr_t___ip" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"wait_status_ptr_t___ip")
@@ -459,8 +447,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Wait_status_ptr_t "wait_status_pt
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Wait_status_ptr_t) "wait_status_ptr_t___up")
-         ) => GHC.Records.HasField "wait_status_ptr_t___up" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "wait_status_ptr_t___up" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr (Ptr.Ptr Wait)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"wait_status_ptr_t___up")
@@ -502,8 +489,7 @@ newtype T1 = T1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T1) "unwrapT1")
-         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -543,8 +529,7 @@ newtype Short_a = Short_a
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Short_a) "unwrapShort_a")
-         ) => GHC.Records.HasField "unwrapShort_a" (Ptr.Ptr Short_a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapShort_a" (Ptr.Ptr Short_a) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapShort_a")

--- a/hs-bindgen/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/type_attributes/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_f"
     where type CFieldType S "s_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S "s_f") =>
-         HasField "s_f" (Ptr S) (Ptr ty)
+instance HasField "s_f" (Ptr S) (Ptr (ConstantArray 3 CShort))
     where getField = fromPtr (Proxy @"s_f")
 {-| __C declaration:__ @more_aligned_int@
 
@@ -67,9 +66,9 @@ newtype More_aligned_int
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType More_aligned_int "unwrapMore_aligned_int") =>
-         HasField "unwrapMore_aligned_int" (Ptr More_aligned_int) (Ptr ty)
+instance HasField "unwrapMore_aligned_int"
+                  (Ptr More_aligned_int)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMore_aligned_int")
 instance HasCField More_aligned_int "unwrapMore_aligned_int"
     where type CFieldType More_aligned_int
@@ -109,8 +108,7 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_f"
     where type CFieldType S2 "s2_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2 "s2_f") =>
-         HasField "s2_f" (Ptr S2) (Ptr ty)
+instance HasField "s2_f" (Ptr S2) (Ptr (ConstantArray 3 CShort))
     where getField = fromPtr (Proxy @"s2_f")
 {-| __C declaration:__ @struct my_unpacked_struct@
 
@@ -155,17 +153,17 @@ instance HasCField My_unpacked_struct "my_unpacked_struct_c"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType My_unpacked_struct "my_unpacked_struct_c") =>
-         HasField "my_unpacked_struct_c" (Ptr My_unpacked_struct) (Ptr ty)
+instance HasField "my_unpacked_struct_c"
+                  (Ptr My_unpacked_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"my_unpacked_struct_c")
 instance HasCField My_unpacked_struct "my_unpacked_struct_i"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_i" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType My_unpacked_struct "my_unpacked_struct_i") =>
-         HasField "my_unpacked_struct_i" (Ptr My_unpacked_struct) (Ptr ty)
+instance HasField "my_unpacked_struct_i"
+                  (Ptr My_unpacked_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"my_unpacked_struct_i")
 {-| __C declaration:__ @struct my_packed_struct@
 
@@ -217,24 +215,24 @@ deriving via (EquivStorable My_packed_struct) instance Storable My_packed_struct
 instance HasCField My_packed_struct "my_packed_struct_c"
     where type CFieldType My_packed_struct "my_packed_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType My_packed_struct "my_packed_struct_c") =>
-         HasField "my_packed_struct_c" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_c"
+                  (Ptr My_packed_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"my_packed_struct_c")
 instance HasCField My_packed_struct "my_packed_struct_i"
     where type CFieldType My_packed_struct "my_packed_struct_i" = CInt
           offset# = \_ -> \_ -> 1
-instance TyEq ty
-              (CFieldType My_packed_struct "my_packed_struct_i") =>
-         HasField "my_packed_struct_i" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_i"
+                  (Ptr My_packed_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"my_packed_struct_i")
 instance HasCField My_packed_struct "my_packed_struct_s"
     where type CFieldType My_packed_struct
                           "my_packed_struct_s" = My_unpacked_struct
           offset# = \_ -> \_ -> 5
-instance TyEq ty
-              (CFieldType My_packed_struct "my_packed_struct_s") =>
-         HasField "my_packed_struct_s" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_s"
+                  (Ptr My_packed_struct)
+                  (Ptr My_unpacked_struct)
     where getField = fromPtr (Proxy @"my_packed_struct_s")
 {-| __C declaration:__ @union wait_status_ptr_t@
 
@@ -330,17 +328,17 @@ instance HasCField Wait_status_ptr_t "wait_status_ptr_t___ip"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___ip" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Wait_status_ptr_t "wait_status_ptr_t___ip") =>
-         HasField "wait_status_ptr_t___ip" (Ptr Wait_status_ptr_t) (Ptr ty)
+instance HasField "wait_status_ptr_t___ip"
+                  (Ptr Wait_status_ptr_t)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"wait_status_ptr_t___ip")
 instance HasCField Wait_status_ptr_t "wait_status_ptr_t___up"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___up" = Ptr Wait
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Wait_status_ptr_t "wait_status_ptr_t___up") =>
-         HasField "wait_status_ptr_t___up" (Ptr Wait_status_ptr_t) (Ptr ty)
+instance HasField "wait_status_ptr_t___up"
+                  (Ptr Wait_status_ptr_t)
+                  (Ptr (Ptr Wait))
     where getField = fromPtr (Proxy @"wait_status_ptr_t___up")
 {-| __C declaration:__ @union wait@
 
@@ -380,8 +378,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T1 "unwrapT1") =>
-         HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -417,8 +414,7 @@ newtype Short_a
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Short_a "unwrapShort_a") =>
-         HasField "unwrapShort_a" (Ptr Short_a) (Ptr ty)
+instance HasField "unwrapShort_a" (Ptr Short_a) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapShort_a")
 instance HasCField Short_a "unwrapShort_a"
     where type CFieldType Short_a "unwrapShort_a" = CShort

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -19,7 +17,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @MyArray@
@@ -34,8 +31,7 @@ newtype MyArray = MyArray
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyArray) "unwrapMyArray")
-         ) => GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyArray")
@@ -59,8 +55,7 @@ newtype A = A
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyArray) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -83,8 +78,7 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -76,8 +76,9 @@ newtype MyArray
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType MyArray "unwrapMyArray") =>
-         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
+instance HasField "unwrapMyArray"
+                  (Ptr MyArray)
+                  (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray
@@ -99,8 +100,7 @@ newtype A
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -121,8 +121,7 @@ newtype B
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @MyArray@
@@ -43,8 +40,7 @@ newtype MyArray = MyArray
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyArray) "unwrapMyArray")
-         ) => GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyArray")
@@ -74,8 +70,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyArray) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -104,8 +99,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -77,8 +77,9 @@ newtype MyArray
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType MyArray "unwrapMyArray") =>
-         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
+instance HasField "unwrapMyArray"
+                  (Ptr MyArray)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray "unwrapMyArray" = ConstantArray 3
@@ -101,8 +102,7 @@ newtype A
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -124,8 +124,7 @@ newtype B
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -112,8 +109,7 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyEnum) "unwrapMyEnum")
-         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")
@@ -153,8 +149,7 @@ newtype A = A
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyEnum) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -185,8 +180,7 @@ newtype B = B
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -105,8 +105,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType MyEnum "unwrapMyEnum") =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -147,8 +146,7 @@ newtype A
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -175,8 +173,7 @@ newtype B
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified Prelude as P
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @MyFunction@
@@ -71,8 +68,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MyFunction where
 
   fromFunPtr = hs_bindgen_bb71f7e730356103
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyFunction) "unwrapMyFunction")
-         ) => GHC.Records.HasField "unwrapMyFunction" (Ptr.Ptr MyFunction) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyFunction" (Ptr.Ptr MyFunction) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunction")
@@ -96,8 +92,7 @@ newtype A = A
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyFunction) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -120,8 +115,7 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
@@ -161,8 +161,9 @@ instance ToFunPtr MyFunction
     where toFunPtr = hs_bindgen_4e8a459829b269e0
 instance FromFunPtr MyFunction
     where fromFunPtr = hs_bindgen_bb71f7e730356103
-instance TyEq ty (CFieldType MyFunction "unwrapMyFunction") =>
-         HasField "unwrapMyFunction" (Ptr MyFunction) (Ptr ty)
+instance HasField "unwrapMyFunction"
+                  (Ptr MyFunction)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapMyFunction")
 instance HasCField MyFunction "unwrapMyFunction"
     where type CFieldType MyFunction "unwrapMyFunction" = CInt ->
@@ -184,8 +185,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyFunction)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunction
@@ -206,8 +206,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -26,7 +24,6 @@ import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, IO, Ord, Show)
 
 {-| Auxiliary type used by 'MyFunctionPointer'
@@ -75,8 +72,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MyFunctionPointer_Aux wher
 
   fromFunPtr = hs_bindgen_5738272f94a589e2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyFunctionPointer_Aux) "unwrapMyFunctionPointer_Aux")
-         ) => GHC.Records.HasField "unwrapMyFunctionPointer_Aux" (Ptr.Ptr MyFunctionPointer_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyFunctionPointer_Aux" (Ptr.Ptr MyFunctionPointer_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunctionPointer_Aux")
@@ -107,8 +103,7 @@ newtype MyFunctionPointer = MyFunctionPointer
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyFunctionPointer) "unwrapMyFunctionPointer")
-         ) => GHC.Records.HasField "unwrapMyFunctionPointer" (Ptr.Ptr MyFunctionPointer) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyFunctionPointer" (Ptr.Ptr MyFunctionPointer) (Ptr.Ptr (Ptr.FunPtr MyFunctionPointer_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunctionPointer")
@@ -139,8 +134,7 @@ newtype A = A
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyFunctionPointer) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -170,8 +164,7 @@ newtype B = B
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -102,11 +102,9 @@ instance ToFunPtr MyFunctionPointer_Aux
     where toFunPtr = hs_bindgen_47dfd04698dd2e6f
 instance FromFunPtr MyFunctionPointer_Aux
     where fromFunPtr = hs_bindgen_5738272f94a589e2
-instance TyEq ty
-              (CFieldType MyFunctionPointer_Aux "unwrapMyFunctionPointer_Aux") =>
-         HasField "unwrapMyFunctionPointer_Aux"
+instance HasField "unwrapMyFunctionPointer_Aux"
                   (Ptr MyFunctionPointer_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer_Aux")
 instance HasCField MyFunctionPointer_Aux
                    "unwrapMyFunctionPointer_Aux"
@@ -134,9 +132,9 @@ newtype MyFunctionPointer
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType MyFunctionPointer "unwrapMyFunctionPointer") =>
-         HasField "unwrapMyFunctionPointer" (Ptr MyFunctionPointer) (Ptr ty)
+instance HasField "unwrapMyFunctionPointer"
+                  (Ptr MyFunctionPointer)
+                  (Ptr (FunPtr MyFunctionPointer_Aux))
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer")
 instance HasCField MyFunctionPointer "unwrapMyFunctionPointer"
     where type CFieldType MyFunctionPointer
@@ -163,8 +161,7 @@ newtype A
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyFunctionPointer)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunctionPointer
@@ -190,8 +187,7 @@ newtype B
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct MyStruct@
@@ -74,8 +71,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyStruct) "myStruct_x")
-         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -98,8 +94,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyStruct) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -128,8 +123,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -94,8 +94,7 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType MyStruct "myStruct_x") =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @A@
 
@@ -114,8 +113,7 @@ newtype A
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -137,8 +135,7 @@ newtype B
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -26,7 +24,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union MyUnion@
 
@@ -80,8 +77,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyUnion) "myUnion_x")
-         ) => GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myUnion_x")
@@ -103,8 +99,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyUnion) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -132,8 +127,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
@@ -116,8 +116,7 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType MyUnion "myUnion_x") =>
-         HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
@@ -135,8 +134,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -157,8 +155,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,7 +18,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified M
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @A@
@@ -35,8 +32,7 @@ newtype A = A
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -60,8 +56,7 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -83,8 +78,7 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -136,8 +136,7 @@ newtype A
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = IncompleteArray CInt
@@ -158,8 +157,7 @@ newtype B
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -179,8 +177,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @A@
@@ -44,8 +41,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -75,8 +71,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -98,8 +93,7 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -137,8 +137,7 @@ newtype A
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = ConstantArray 3 CInt
@@ -160,8 +159,7 @@ newtype B
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -181,8 +179,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -31,7 +29,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -113,8 +110,7 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyEnum) "unwrapMyEnum")
-         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")
@@ -154,8 +150,7 @@ newtype A = A
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyEnum) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -186,8 +181,7 @@ newtype B = B
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -210,8 +204,7 @@ newtype E = E
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -165,8 +165,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType MyEnum "unwrapMyEnum") =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -207,8 +206,7 @@ newtype A
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -235,8 +233,7 @@ newtype B
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -257,8 +254,7 @@ newtype E
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified M
 import qualified Prelude as P
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @A@
@@ -72,8 +69,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr A where
 
   fromFunPtr = hs_bindgen_0cf9a6d50f563441
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -96,8 +92,7 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -119,8 +114,7 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
@@ -287,8 +287,7 @@ instance ToFunPtr A
     where toFunPtr = hs_bindgen_0c7d4776a632d026
 instance FromFunPtr A
     where fromFunPtr = hs_bindgen_0cf9a6d50f563441
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt -> IO CInt
@@ -309,8 +308,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -330,8 +328,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -27,7 +25,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
 import qualified Prelude as P
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, IO, Ord, Show)
 
 {-| Auxiliary type used by 'A'
@@ -76,8 +73,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr A_Aux where
 
   fromFunPtr = hs_bindgen_cdb12400c6863f15
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_Aux) "unwrapA_Aux")
-         ) => GHC.Records.HasField "unwrapA_Aux" (Ptr.Ptr A_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA_Aux" (Ptr.Ptr A_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_Aux")
@@ -108,8 +104,7 @@ newtype A = A
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (Ptr.FunPtr A_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -139,8 +134,7 @@ newtype B = B
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -163,8 +157,7 @@ newtype E = E
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -165,8 +165,7 @@ instance ToFunPtr A_Aux
     where toFunPtr = hs_bindgen_1cabb32c661d9a0e
 instance FromFunPtr A_Aux
     where fromFunPtr = hs_bindgen_cdb12400c6863f15
-instance TyEq ty (CFieldType A_Aux "unwrapA_Aux") =>
-         HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr ty)
+instance HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapA_Aux")
 instance HasCField A_Aux "unwrapA_Aux"
     where type CFieldType A_Aux "unwrapA_Aux" = CInt -> IO CInt
@@ -192,8 +191,7 @@ newtype A
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (FunPtr A_Aux))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = FunPtr A_Aux
@@ -219,8 +217,7 @@ newtype B
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -241,8 +238,7 @@ newtype E
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct MyStruct@
@@ -75,8 +72,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyStruct) "myStruct_x")
-         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -99,8 +95,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyStruct) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -129,8 +124,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -152,8 +146,7 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -154,8 +154,7 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType MyStruct "myStruct_x") =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @A@
 
@@ -174,8 +173,7 @@ newtype A
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -197,8 +195,7 @@ newtype B
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -218,8 +215,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -27,7 +25,6 @@ import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union MyUnion@
 
@@ -81,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyUnion) "myUnion_x")
-         ) => GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myUnion_x")
@@ -104,8 +100,7 @@ newtype A = A
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyUnion) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -133,8 +128,7 @@ newtype B = B
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "unwrapB")
-         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -156,8 +150,7 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
@@ -176,8 +176,7 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType MyUnion "myUnion_x") =>
-         HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
@@ -195,8 +194,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -217,8 +215,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType B "unwrapB") =>
-         HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -238,8 +235,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Hoge) "hoge_x")
-         ) => GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_x")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Hoge) "hoge_y")
-         ) => GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
@@ -41,12 +41,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Hoge "hoge_x") =>
-         HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Hoge "hoge_y") =>
-         HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Hoge) "hoge_x")
-         ) => GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_x")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Hoge) "hoge_y")
-         ) => GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
@@ -41,12 +41,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Hoge "hoge_x") =>
-         HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Hoge "hoge_y") =>
-         HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Piyo "piyo_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Piyo) "piyo_x")
-         ) => GHC.Records.HasField "piyo_x" (Ptr.Ptr Piyo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "piyo_x" (Ptr.Ptr Piyo) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"piyo_x")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Piyo "piyo_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Piyo) "piyo_y")
-         ) => GHC.Records.HasField "piyo_y" (Ptr.Ptr Piyo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "piyo_y" (Ptr.Ptr Piyo) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"piyo_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -41,12 +41,10 @@ deriving via (EquivStorable Piyo) instance Storable Piyo
 instance HasCField Piyo "piyo_x"
     where type CFieldType Piyo "piyo_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Piyo "piyo_x") =>
-         HasField "piyo_x" (Ptr Piyo) (Ptr ty)
+instance HasField "piyo_x" (Ptr Piyo) (Ptr CInt)
     where getField = fromPtr (Proxy @"piyo_x")
 instance HasCField Piyo "piyo_y"
     where type CFieldType Piyo "piyo_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Piyo "piyo_y") =>
-         HasField "piyo_y" (Ptr Piyo) (Ptr ty)
+instance HasField "piyo_y" (Ptr Piyo) (Ptr CInt)
     where getField = fromPtr (Proxy @"piyo_y")

--- a/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @sym@
@@ -60,8 +57,7 @@ newtype MySym = MySym
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MySym) "unwrapMySym")
-         ) => GHC.Records.HasField "unwrapMySym" (Ptr.Ptr MySym) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMySym" (Ptr.Ptr MySym) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMySym")

--- a/hs-bindgen/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/type/th.txt
@@ -30,8 +30,7 @@ newtype MySym
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MySym "unwrapMySym") =>
-         HasField "unwrapMySym" (Ptr MySym) (Ptr ty)
+instance HasField "unwrapMySym" (Ptr MySym) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapMySym")
 instance HasCField MySym "unwrapMySym"
     where type CFieldType MySym "unwrapMySym" = CChar

--- a/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @sym@
@@ -60,8 +57,7 @@ newtype Sym = Sym
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Sym) "unwrapSym")
-         ) => GHC.Records.HasField "unwrapSym" (Ptr.Ptr Sym) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSym" (Ptr.Ptr Sym) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSym")

--- a/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
@@ -30,8 +30,7 @@ newtype Sym
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Sym "unwrapSym") =>
-         HasField "unwrapSym" (Ptr Sym) (Ptr ty)
+instance HasField "unwrapSym" (Ptr Sym) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapSym")
 instance HasCField Sym "unwrapSym"
     where type CFieldType Sym "unwrapSym" = CChar

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -81,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_a")
-         ) => GHC.Records.HasField "bar_a" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_a" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Foo)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_a")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
@@ -40,6 +40,5 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_a"
     where type CFieldType Bar "bar_a" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bar "bar_a") =>
-         HasField "bar_a" (Ptr Bar) (Ptr ty)
+instance HasField "bar_a" (Ptr Bar) (Ptr (Ptr Foo))
     where getField = fromPtr (Proxy @"bar_a")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct rect@
@@ -107,8 +104,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named "named_e" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named) "named_e")
-         ) => GHC.Records.HasField "named_e" (Ptr.Ptr Named) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_e" (Ptr.Ptr Named) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_e")
@@ -119,8 +115,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named "named_f" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named) "named_f")
-         ) => GHC.Records.HasField "named_f" (Ptr.Ptr Named) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_f" (Ptr.Ptr Named) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_f")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
@@ -63,14 +63,12 @@ deriving via (EquivStorable Named) instance Storable Named
 instance HasCField Named "named_e"
     where type CFieldType Named "named_e" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Named "named_e") =>
-         HasField "named_e" (Ptr Named) (Ptr ty)
+instance HasField "named_e" (Ptr Named) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_e")
 instance HasCField Named "named_f"
     where type CFieldType Named "named_f" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Named "named_f") =>
-         HasField "named_f" (Ptr Named) (Ptr ty)
+instance HasField "named_f" (Ptr Named) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_f")
 {-| __C declaration:__ @struct oan@
 

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @A@
@@ -60,8 +57,7 @@ newtype A = A
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -53,8 +53,9 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA"
+                  (Ptr A)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = HsBindgen.Runtime.LibC.CSize

--- a/hs-bindgen/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct X@
@@ -76,8 +73,7 @@ instance HsBindgen.Runtime.HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType X) "x_n")
-         ) => GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x_n")
@@ -161,8 +157,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Y) "y_m")
-         ) => GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_m")
@@ -173,8 +168,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Y) "y_o")
-         ) => GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_o")

--- a/hs-bindgen/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/definitions/th.txt
@@ -60,8 +60,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType X "x_n") =>
-         HasField "x_n" (Ptr X) (Ptr ty)
+instance HasField "x_n" (Ptr X) (Ptr CInt)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -153,14 +152,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Y "y_m") =>
-         HasField "y_m" (Ptr Y) (Ptr ty)
+instance HasField "y_m" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Y "y_o") =>
-         HasField "y_o" (Ptr Y) (Ptr ty)
+instance HasField "y_o" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsdefinitions_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_9cdc88a6d09442d6" hs_bindgen_9cdc88a6d09442d6_base ::

--- a/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_t "s1_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1_t) "s1_t_a")
-         ) => GHC.Records.HasField "s1_t_a" (Ptr.Ptr S1_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_t_a" (Ptr.Ptr S1_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_t_a")
@@ -127,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2) "s2_a")
-         ) => GHC.Records.HasField "s2_a" (Ptr.Ptr S2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_a" (Ptr.Ptr S2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_a")

--- a/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable S1_t) instance Storable S1_t
 instance HasCField S1_t "s1_t_a"
     where type CFieldType S1_t "s1_t_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S1_t "s1_t_a") =>
-         HasField "s1_t_a" (Ptr S1_t) (Ptr ty)
+instance HasField "s1_t_a" (Ptr S1_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_t_a")
 {-| __C declaration:__ @struct S2@
 
@@ -70,6 +69,5 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_a"
     where type CFieldType S2 "s2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2 "s2_a") =>
-         HasField "s2_a" (Ptr S2) (Ptr ty)
+instance HasField "s2_a" (Ptr S2) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_a")

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure, return)
 
 {-| __C declaration:__ @struct foo@
@@ -90,8 +87,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_ptrA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_ptrA")
-         ) => GHC.Records.HasField "bar_ptrA" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_ptrA" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Foo)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_ptrA")
@@ -102,8 +98,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_ptrB" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_ptrB")
-         ) => GHC.Records.HasField "bar_ptrB" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_ptrB" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Bar)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_ptrB")

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
@@ -48,14 +48,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_ptrA"
     where type CFieldType Bar "bar_ptrA" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bar "bar_ptrA") =>
-         HasField "bar_ptrA" (Ptr Bar) (Ptr ty)
+instance HasField "bar_ptrA" (Ptr Bar) (Ptr (Ptr Foo))
     where getField = fromPtr (Proxy @"bar_ptrA")
 instance HasCField Bar "bar_ptrB"
     where type CFieldType Bar "bar_ptrB" = Ptr Bar
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Bar "bar_ptrB") =>
-         HasField "bar_ptrB" (Ptr Bar) (Ptr ty)
+instance HasField "bar_ptrB" (Ptr Bar) (Ptr (Ptr Bar))
     where getField = fromPtr (Proxy @"bar_ptrB")
 {-| __C declaration:__ @struct baz@
 

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -33,7 +31,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @int_t@
@@ -65,8 +62,7 @@ newtype Int_t = Int_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int_t) "unwrapInt_t")
-         ) => GHC.Records.HasField "unwrapInt_t" (Ptr.Ptr Int_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt_t" (Ptr.Ptr Int_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_t")
@@ -125,8 +121,7 @@ instance HsBindgen.Runtime.HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType X) "x_n")
-         ) => GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x_n")
@@ -210,8 +205,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Y) "y_m")
-         ) => GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_m")
@@ -222,8 +216,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Y) "y_o")
-         ) => GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_o")

--- a/hs-bindgen/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/redeclaration/th.txt
@@ -37,8 +37,7 @@ newtype Int_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Int_t "unwrapInt_t") =>
-         HasField "unwrapInt_t" (Ptr Int_t) (Ptr ty)
+instance HasField "unwrapInt_t" (Ptr Int_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapInt_t")
 instance HasCField Int_t "unwrapInt_t"
     where type CFieldType Int_t "unwrapInt_t" = CInt
@@ -77,8 +76,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType X "x_n") =>
-         HasField "x_n" (Ptr X) (Ptr ty)
+instance HasField "x_n" (Ptr X) (Ptr CInt)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -170,14 +168,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Y "y_m") =>
-         HasField "y_m" (Ptr Y) (Ptr ty)
+instance HasField "y_m" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Y "y_o") =>
-         HasField "y_o" (Ptr Y) (Ptr ty)
+instance HasField "y_o" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsredeclaration_Example_get_x@
 foreign import ccall unsafe "hs_bindgen_6f47e5cbb92690b9" hs_bindgen_6f47e5cbb92690b9_base ::

--- a/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @ParsedAndSelected1@
@@ -60,8 +57,7 @@ newtype ParsedAndSelected1 = ParsedAndSelected1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ParsedAndSelected1) "unwrapParsedAndSelected1")
-         ) => GHC.Records.HasField "unwrapParsedAndSelected1" (Ptr.Ptr ParsedAndSelected1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapParsedAndSelected1" (Ptr.Ptr ParsedAndSelected1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapParsedAndSelected1")

--- a/hs-bindgen/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/select_scoping/th.txt
@@ -31,11 +31,9 @@ newtype ParsedAndSelected1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType ParsedAndSelected1 "unwrapParsedAndSelected1") =>
-         HasField "unwrapParsedAndSelected1"
+instance HasField "unwrapParsedAndSelected1"
                   (Ptr ParsedAndSelected1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapParsedAndSelected1")
 instance HasCField ParsedAndSelected1 "unwrapParsedAndSelected1"
     where type CFieldType ParsedAndSelected1

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @triplet@
@@ -43,8 +40,7 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
-         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
@@ -16,8 +16,9 @@ newtype Triplet
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -14,7 +13,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,7 +47,6 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @MAX_NAME_LENGTH@
@@ -96,8 +93,7 @@ newtype Size_type = Size_type
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Size_type) "unwrapSize_type")
-         ) => GHC.Records.HasField "unwrapSize_type" (Ptr.Ptr Size_type) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSize_type" (Ptr.Ptr Size_type) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSize_type")
@@ -221,8 +217,7 @@ instance Read Color_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Color_enum) "unwrapColor_enum")
-         ) => GHC.Records.HasField "unwrapColor_enum" (Ptr.Ptr Color_enum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapColor_enum" (Ptr.Ptr Color_enum) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapColor_enum")
@@ -313,8 +308,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Event_callback_t_Aux where
 
   fromFunPtr = hs_bindgen_9e9d478c2d75628c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Event_callback_t_Aux) "unwrapEvent_callback_t_Aux")
-         ) => GHC.Records.HasField "unwrapEvent_callback_t_Aux" (Ptr.Ptr Event_callback_t_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEvent_callback_t_Aux" (Ptr.Ptr Event_callback_t_Aux) (Ptr.Ptr (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEvent_callback_t_Aux")
@@ -355,8 +349,7 @@ newtype Event_callback_t = Event_callback_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Event_callback_t) "unwrapEvent_callback_t")
-         ) => GHC.Records.HasField "unwrapEvent_callback_t" (Ptr.Ptr Event_callback_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEvent_callback_t" (Ptr.Ptr Event_callback_t) (Ptr.Ptr (Ptr.FunPtr Event_callback_t_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEvent_callback_t")
@@ -486,8 +479,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_id" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config_t) "config_t_id")
-         ) => GHC.Records.HasField "config_t_id" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_t_id" (Ptr.Ptr Config_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_id")
@@ -499,8 +491,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_name" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config_t) "config_t_name")
-         ) => GHC.Records.HasField "config_t_name" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_t_name" (Ptr.Ptr Config_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 64) FC.CChar)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_name")
@@ -512,8 +503,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_flags" where
 
   offset# = \_ -> \_ -> 68
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config_t) "config_t_flags")
-         ) => GHC.Records.HasField "config_t_flags" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_t_flags" (Ptr.Ptr Config_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_flags")
@@ -525,8 +515,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_callback" wher
 
   offset# = \_ -> \_ -> 72
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config_t) "config_t_callback")
-         ) => GHC.Records.HasField "config_t_callback" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_t_callback" (Ptr.Ptr Config_t) (Ptr.Ptr Event_callback_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_callback")
@@ -538,8 +527,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_user_data" whe
 
   offset# = \_ -> \_ -> 80
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config_t) "config_t_user_data")
-         ) => GHC.Records.HasField "config_t_user_data" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_t_user_data" (Ptr.Ptr Config_t) (Ptr.Ptr (Ptr.Ptr Void)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_user_data")
@@ -624,8 +612,7 @@ instance Read Status_code_t where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Status_code_t) "unwrapStatus_code_t")
-         ) => GHC.Records.HasField "unwrapStatus_code_t" (Ptr.Ptr Status_code_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStatus_code_t" (Ptr.Ptr Status_code_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStatus_code_t")
@@ -774,8 +761,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t_as_parts "data_union
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t_as_parts) "data_union_t_as_parts_low")
-         ) => GHC.Records.HasField "data_union_t_as_parts_low" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_parts_low" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts_low")
@@ -787,8 +773,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t_as_parts "data_union
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t_as_parts) "data_union_t_as_parts_high")
-         ) => GHC.Records.HasField "data_union_t_as_parts_high" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_parts_high" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts_high")
@@ -941,8 +926,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_int
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t) "data_union_t_as_int")
-         ) => GHC.Records.HasField "data_union_t_as_int" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_int" (Ptr.Ptr Data_union_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_int")
@@ -954,8 +938,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_flo
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t) "data_union_t_as_float")
-         ) => GHC.Records.HasField "data_union_t_as_float" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_float" (Ptr.Ptr Data_union_t) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_float")
@@ -967,8 +950,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_byt
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t) "data_union_t_as_bytes")
-         ) => GHC.Records.HasField "data_union_t_as_bytes" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_bytes" (Ptr.Ptr Data_union_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.LibC.Word8)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_bytes")
@@ -980,8 +962,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_par
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Data_union_t) "data_union_t_as_parts")
-         ) => GHC.Records.HasField "data_union_t_as_parts" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "data_union_t_as_parts" (Ptr.Ptr Data_union_t) (Ptr.Ptr Data_union_t_as_parts) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts")
@@ -1092,8 +1073,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Bitfield_t) "bitfield_t_flag1")
-         ) => GHC.Records.HasField "bitfield_t_flag1" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "bitfield_t_flag1" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_flag1")
@@ -1107,8 +1087,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Bitfield_t) "bitfield_t_flag2")
-         ) => GHC.Records.HasField "bitfield_t_flag2" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "bitfield_t_flag2" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_flag2")
@@ -1122,8 +1101,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_coun
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Bitfield_t) "bitfield_t_counter")
-         ) => GHC.Records.HasField "bitfield_t_counter" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "bitfield_t_counter" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_counter")
@@ -1137,8 +1115,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_rese
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Bitfield_t) "bitfield_t_reserved")
-         ) => GHC.Records.HasField "bitfield_t_reserved" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "bitfield_t_reserved" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_reserved")
@@ -1189,8 +1166,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Processor_fn_t_Aux where
 
   fromFunPtr = hs_bindgen_0d4b3d0461629423
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_fn_t_Aux) "unwrapProcessor_fn_t_Aux")
-         ) => GHC.Records.HasField "unwrapProcessor_fn_t_Aux" (Ptr.Ptr Processor_fn_t_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapProcessor_fn_t_Aux" (Ptr.Ptr Processor_fn_t_Aux) (Ptr.Ptr (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_fn_t_Aux")
@@ -1233,8 +1209,7 @@ newtype Processor_fn_t = Processor_fn_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_fn_t) "unwrapProcessor_fn_t")
-         ) => GHC.Records.HasField "unwrapProcessor_fn_t" (Ptr.Ptr Processor_fn_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapProcessor_fn_t" (Ptr.Ptr Processor_fn_t) (Ptr.Ptr (Ptr.FunPtr Processor_fn_t_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_fn_t")
@@ -1270,8 +1245,7 @@ newtype Filename_t = Filename_t
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Filename_t) "unwrapFilename_t")
-         ) => GHC.Records.HasField "unwrapFilename_t" (Ptr.Ptr Filename_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFilename_t" (Ptr.Ptr Filename_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 256) FC.CChar)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFilename_t")
@@ -1344,8 +1318,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Flexible_array_Aux "flexible_arra
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Flexible_array_Aux) "flexible_array_count")
-         ) => GHC.Records.HasField "flexible_array_count" (Ptr.Ptr Flexible_array_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "flexible_array_count" (Ptr.Ptr Flexible_array_Aux) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flexible_array_count")

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -401,8 +401,9 @@ newtype Size_type
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Size_type "unwrapSize_type") =>
-         HasField "unwrapSize_type" (Ptr Size_type) (Ptr ty)
+instance HasField "unwrapSize_type"
+                  (Ptr Size_type)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapSize_type")
 instance HasCField Size_type "unwrapSize_type"
     where type CFieldType Size_type
@@ -490,8 +491,7 @@ instance Read Color_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Color_enum "unwrapColor_enum") =>
-         HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr ty)
+instance HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapColor_enum")
 instance HasCField Color_enum "unwrapColor_enum"
     where type CFieldType Color_enum "unwrapColor_enum" = CUInt
@@ -593,11 +593,9 @@ instance ToFunPtr Event_callback_t_Aux
     where toFunPtr = hs_bindgen_111918b0aee2a7fb
 instance FromFunPtr Event_callback_t_Aux
     where fromFunPtr = hs_bindgen_9e9d478c2d75628c
-instance TyEq ty
-              (CFieldType Event_callback_t_Aux "unwrapEvent_callback_t_Aux") =>
-         HasField "unwrapEvent_callback_t_Aux"
+instance HasField "unwrapEvent_callback_t_Aux"
                   (Ptr Event_callback_t_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> Ptr Void -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t_Aux")
 instance HasCField Event_callback_t_Aux
                    "unwrapEvent_callback_t_Aux"
@@ -645,9 +643,9 @@ newtype Event_callback_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Event_callback_t "unwrapEvent_callback_t") =>
-         HasField "unwrapEvent_callback_t" (Ptr Event_callback_t) (Ptr ty)
+instance HasField "unwrapEvent_callback_t"
+                  (Ptr Event_callback_t)
+                  (Ptr (FunPtr Event_callback_t_Aux))
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t")
 instance HasCField Event_callback_t "unwrapEvent_callback_t"
     where type CFieldType Event_callback_t
@@ -754,35 +752,40 @@ instance HasCField Config_t "config_t_id"
     where type CFieldType Config_t
                           "config_t_id" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Config_t "config_t_id") =>
-         HasField "config_t_id" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_id"
+                  (Ptr Config_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"config_t_id")
 instance HasCField Config_t "config_t_name"
     where type CFieldType Config_t "config_t_name" = ConstantArray 64
                                                                    CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Config_t "config_t_name") =>
-         HasField "config_t_name" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_name"
+                  (Ptr Config_t)
+                  (Ptr (ConstantArray 64 CChar))
     where getField = fromPtr (Proxy @"config_t_name")
 instance HasCField Config_t "config_t_flags"
     where type CFieldType Config_t
                           "config_t_flags" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 68
-instance TyEq ty (CFieldType Config_t "config_t_flags") =>
-         HasField "config_t_flags" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_flags"
+                  (Ptr Config_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"config_t_flags")
 instance HasCField Config_t "config_t_callback"
     where type CFieldType Config_t
                           "config_t_callback" = Event_callback_t
           offset# = \_ -> \_ -> 72
-instance TyEq ty (CFieldType Config_t "config_t_callback") =>
-         HasField "config_t_callback" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_callback"
+                  (Ptr Config_t)
+                  (Ptr Event_callback_t)
     where getField = fromPtr (Proxy @"config_t_callback")
 instance HasCField Config_t "config_t_user_data"
     where type CFieldType Config_t "config_t_user_data" = Ptr Void
           offset# = \_ -> \_ -> 80
-instance TyEq ty (CFieldType Config_t "config_t_user_data") =>
-         HasField "config_t_user_data" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_user_data"
+                  (Ptr Config_t)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"config_t_user_data")
 {-|
 
@@ -841,9 +844,9 @@ instance Read Status_code_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty
-              (CFieldType Status_code_t "unwrapStatus_code_t") =>
-         HasField "unwrapStatus_code_t" (Ptr Status_code_t) (Ptr ty)
+instance HasField "unwrapStatus_code_t"
+                  (Ptr Status_code_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapStatus_code_t")
 instance HasCField Status_code_t "unwrapStatus_code_t"
     where type CFieldType Status_code_t "unwrapStatus_code_t" = CInt
@@ -1022,22 +1025,18 @@ instance HasCField Data_union_t_as_parts
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_low" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Data_union_t_as_parts "data_union_t_as_parts_low") =>
-         HasField "data_union_t_as_parts_low"
+instance HasField "data_union_t_as_parts_low"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_low")
 instance HasCField Data_union_t_as_parts
                    "data_union_t_as_parts_high"
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_high" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance TyEq ty
-              (CFieldType Data_union_t_as_parts "data_union_t_as_parts_high") =>
-         HasField "data_union_t_as_parts_high"
+instance HasField "data_union_t_as_parts_high"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_high")
 {-|
 
@@ -1231,32 +1230,33 @@ instance HasCField Data_union_t "data_union_t_as_int"
     where type CFieldType Data_union_t
                           "data_union_t_as_int" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Data_union_t "data_union_t_as_int") =>
-         HasField "data_union_t_as_int" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_int"
+                  (Ptr Data_union_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"data_union_t_as_int")
 instance HasCField Data_union_t "data_union_t_as_float"
     where type CFieldType Data_union_t "data_union_t_as_float" = CFloat
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Data_union_t "data_union_t_as_float") =>
-         HasField "data_union_t_as_float" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_float"
+                  (Ptr Data_union_t)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"data_union_t_as_float")
 instance HasCField Data_union_t "data_union_t_as_bytes"
     where type CFieldType Data_union_t
                           "data_union_t_as_bytes" = ConstantArray 4
                                                                   HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Data_union_t "data_union_t_as_bytes") =>
-         HasField "data_union_t_as_bytes" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_bytes"
+                  (Ptr Data_union_t)
+                  (Ptr (ConstantArray 4 HsBindgen.Runtime.LibC.Word8))
     where getField = fromPtr (Proxy @"data_union_t_as_bytes")
 instance HasCField Data_union_t "data_union_t_as_parts"
     where type CFieldType Data_union_t
                           "data_union_t_as_parts" = Data_union_t_as_parts
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Data_union_t "data_union_t_as_parts") =>
-         HasField "data_union_t_as_parts" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_parts"
+                  (Ptr Data_union_t)
+                  (Ptr Data_union_t_as_parts)
     where getField = fromPtr (Proxy @"data_union_t_as_parts")
 {-|
 
@@ -1349,30 +1349,33 @@ instance HasCBitfield Bitfield_t "bitfield_t_flag1"
     where type CBitfieldType Bitfield_t "bitfield_t_flag1" = CUInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType Bitfield_t "bitfield_t_flag1") =>
-         HasField "bitfield_t_flag1" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_flag1"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_flag1")
 instance HasCBitfield Bitfield_t "bitfield_t_flag2"
     where type CBitfieldType Bitfield_t "bitfield_t_flag2" = CUInt
           bitfieldOffset# = \_ -> \_ -> 1
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType Bitfield_t "bitfield_t_flag2") =>
-         HasField "bitfield_t_flag2" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_flag2"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_flag2")
 instance HasCBitfield Bitfield_t "bitfield_t_counter"
     where type CBitfieldType Bitfield_t "bitfield_t_counter" = CUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 6
-instance TyEq ty (CBitfieldType Bitfield_t "bitfield_t_counter") =>
-         HasField "bitfield_t_counter" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_counter"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_counter")
 instance HasCBitfield Bitfield_t "bitfield_t_reserved"
     where type CBitfieldType Bitfield_t "bitfield_t_reserved" = CUInt
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 24
-instance TyEq ty
-              (CBitfieldType Bitfield_t "bitfield_t_reserved") =>
-         HasField "bitfield_t_reserved" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_reserved"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_reserved")
 {-| Auxiliary type used by 'Processor_fn_t'
 
@@ -1417,11 +1420,9 @@ instance ToFunPtr Processor_fn_t_Aux
     where toFunPtr = hs_bindgen_d4e16471c82d5df0
 instance FromFunPtr Processor_fn_t_Aux
     where fromFunPtr = hs_bindgen_0d4b3d0461629423
-instance TyEq ty
-              (CFieldType Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux") =>
-         HasField "unwrapProcessor_fn_t_Aux"
+instance HasField "unwrapProcessor_fn_t_Aux"
                   (Ptr Processor_fn_t_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> Ptr Void -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t_Aux")
 instance HasCField Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux"
     where type CFieldType Processor_fn_t_Aux
@@ -1472,9 +1473,9 @@ newtype Processor_fn_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Processor_fn_t "unwrapProcessor_fn_t") =>
-         HasField "unwrapProcessor_fn_t" (Ptr Processor_fn_t) (Ptr ty)
+instance HasField "unwrapProcessor_fn_t"
+                  (Ptr Processor_fn_t)
+                  (Ptr (FunPtr Processor_fn_t_Aux))
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t")
 instance HasCField Processor_fn_t "unwrapProcessor_fn_t"
     where type CFieldType Processor_fn_t
@@ -1509,8 +1510,9 @@ newtype Filename_t
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Filename_t "unwrapFilename_t") =>
-         HasField "unwrapFilename_t" (Ptr Filename_t) (Ptr ty)
+instance HasField "unwrapFilename_t"
+                  (Ptr Filename_t)
+                  (Ptr (ConstantArray 256 CChar))
     where getField = fromPtr (Proxy @"unwrapFilename_t")
 instance HasCField Filename_t "unwrapFilename_t"
     where type CFieldType Filename_t
@@ -1557,9 +1559,9 @@ instance HasCField Flexible_array_Aux "flexible_array_count"
     where type CFieldType Flexible_array_Aux
                           "flexible_array_count" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Flexible_array_Aux "flexible_array_count") =>
-         HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
+instance HasField "flexible_array_count"
+                  (Ptr Flexible_array_Aux)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"flexible_array_count")
 instance Offset CInt Flexible_array_Aux
     where offset = \_ty_0 -> 8

--- a/hs-bindgen/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @adiós@
@@ -60,8 +57,7 @@ newtype Adio'0301s = Adio'0301s
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Adio'0301s) "unwrapAdio'0301s")
-         ) => GHC.Records.HasField "unwrapAdio'0301s" (Ptr.Ptr Adio'0301s) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapAdio'0301s" (Ptr.Ptr Adio'0301s) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapAdio'0301s")
@@ -102,8 +98,7 @@ newtype C数字 = C数字
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType C数字) "unwrapC\25968\23383")
-         ) => GHC.Records.HasField "unwrapC\25968\23383" (Ptr.Ptr C数字) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapC\25968\23383" (Ptr.Ptr C数字) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapC\25968\23383")

--- a/hs-bindgen/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/adios/th.txt
@@ -99,8 +99,7 @@ newtype Adio'0301s
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Adio'0301s "unwrapAdio'0301s") =>
-         HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr ty)
+instance HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapAdio'0301s")
 instance HasCField Adio'0301s "unwrapAdio'0301s"
     where type CFieldType Adio'0301s "unwrapAdio'0301s" = CInt
@@ -136,8 +135,7 @@ newtype C数字
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType C数字 "unwrapC\25968\23383") =>
-         HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr ty)
+instance HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapC\25968\23383")
 instance HasCField C数字 "unwrapC\25968\23383"
     where type CFieldType C数字 "unwrapC\25968\23383" = CInt

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct \@some_struct_field1@
@@ -83,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct_field1 "some_struct_f
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_struct_field1) "some_struct_field1_x")
-         ) => GHC.Records.HasField "some_struct_field1_x" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "some_struct_field1_x" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1_x")
@@ -96,8 +92,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct_field1 "some_struct_f
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_struct_field1) "some_struct_field1_y")
-         ) => GHC.Records.HasField "some_struct_field1_y" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "some_struct_field1_y" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1_y")
@@ -169,8 +164,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field1" 
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_struct) "some_struct_field1")
-         ) => GHC.Records.HasField "some_struct_field1" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "some_struct_field1" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1")
@@ -182,8 +176,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field2" 
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_struct) "some_struct_field2")
-         ) => GHC.Records.HasField "some_struct_field2" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "some_struct_field2" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field2")
@@ -195,8 +188,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field3" 
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_struct) "some_struct_field3")
-         ) => GHC.Records.HasField "some_struct_field3" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "some_struct_field3" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field3")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -42,17 +42,17 @@ instance HasCField Some_struct_field1 "some_struct_field1_x"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Some_struct_field1 "some_struct_field1_x") =>
-         HasField "some_struct_field1_x" (Ptr Some_struct_field1) (Ptr ty)
+instance HasField "some_struct_field1_x"
+                  (Ptr Some_struct_field1)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"some_struct_field1_x")
 instance HasCField Some_struct_field1 "some_struct_field1_y"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType Some_struct_field1 "some_struct_field1_y") =>
-         HasField "some_struct_field1_y" (Ptr Some_struct_field1) (Ptr ty)
+instance HasField "some_struct_field1_y"
+                  (Ptr Some_struct_field1)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"some_struct_field1_y")
 {-| __C declaration:__ @struct some_struct@
 
@@ -105,20 +105,23 @@ instance HasCField Some_struct "some_struct_field1"
     where type CFieldType Some_struct
                           "some_struct_field1" = Some_struct_field1
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Some_struct "some_struct_field1") =>
-         HasField "some_struct_field1" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field1"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field1")
 instance HasCField Some_struct "some_struct_field2"
     where type CFieldType Some_struct
                           "some_struct_field2" = Some_struct_field1
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Some_struct "some_struct_field2") =>
-         HasField "some_struct_field2" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field2"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field2")
 instance HasCField Some_struct "some_struct_field3"
     where type CFieldType Some_struct
                           "some_struct_field3" = Some_struct_field1
           offset# = \_ -> \_ -> 16
-instance TyEq ty (CFieldType Some_struct "some_struct_field3") =>
-         HasField "some_struct_field3" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field3"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field3")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct point1a@
@@ -84,8 +81,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point1a "point1a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point1a) "point1a_x")
-         ) => GHC.Records.HasField "point1a_x" (Ptr.Ptr Point1a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point1a_x" (Ptr.Ptr Point1a) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point1a_x")
@@ -96,8 +92,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point1a "point1a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point1a) "point1a_y")
-         ) => GHC.Records.HasField "point1a_y" (Ptr.Ptr Point1a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point1a_y" (Ptr.Ptr Point1a) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point1a_y")
@@ -120,8 +115,7 @@ newtype Point1b = Point1b
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point1b) "unwrapPoint1b")
-         ) => GHC.Records.HasField "unwrapPoint1b" (Ptr.Ptr Point1b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPoint1b" (Ptr.Ptr Point1b) (Ptr.Ptr Point1a) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint1b")
@@ -189,8 +183,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point2a "point2a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point2a) "point2a_x")
-         ) => GHC.Records.HasField "point2a_x" (Ptr.Ptr Point2a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point2a_x" (Ptr.Ptr Point2a) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point2a_x")
@@ -201,8 +194,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point2a "point2a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point2a) "point2a_y")
-         ) => GHC.Records.HasField "point2a_y" (Ptr.Ptr Point2a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point2a_y" (Ptr.Ptr Point2a) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point2a_y")
@@ -226,8 +218,7 @@ newtype Point2b = Point2b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point2b) "unwrapPoint2b")
-         ) => GHC.Records.HasField "unwrapPoint2b" (Ptr.Ptr Point2b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPoint2b" (Ptr.Ptr Point2b) (Ptr.Ptr (Ptr.Ptr Point2a)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint2b")
@@ -296,8 +287,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a_Aux "point3a_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point3a_Aux) "point3a_Aux_x")
-         ) => GHC.Records.HasField "point3a_Aux_x" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point3a_Aux_x" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point3a_Aux_x")
@@ -308,8 +298,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a_Aux "point3a_Aux_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point3a_Aux) "point3a_Aux_y")
-         ) => GHC.Records.HasField "point3a_Aux_y" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point3a_Aux_y" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point3a_Aux_y")
@@ -333,8 +322,7 @@ newtype Point3a = Point3a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point3a) "unwrapPoint3a")
-         ) => GHC.Records.HasField "unwrapPoint3a" (Ptr.Ptr Point3a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPoint3a" (Ptr.Ptr Point3a) (Ptr.Ptr (Ptr.Ptr Point3a_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint3a")
@@ -365,8 +353,7 @@ newtype Point3b = Point3b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point3b) "unwrapPoint3b")
-         ) => GHC.Records.HasField "unwrapPoint3b" (Ptr.Ptr Point3b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPoint3b" (Ptr.Ptr Point3b) (Ptr.Ptr (Ptr.Ptr Point3a_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint3b")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -65,14 +65,12 @@ deriving via (EquivStorable Point1a) instance Storable Point1a
 instance HasCField Point1a "point1a_x"
     where type CFieldType Point1a "point1a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Point1a "point1a_x") =>
-         HasField "point1a_x" (Ptr Point1a) (Ptr ty)
+instance HasField "point1a_x" (Ptr Point1a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point1a_x")
 instance HasCField Point1a "point1a_y"
     where type CFieldType Point1a "point1a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Point1a "point1a_y") =>
-         HasField "point1a_y" (Ptr Point1a) (Ptr ty)
+instance HasField "point1a_y" (Ptr Point1a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point1a_y")
 {-| __C declaration:__ @point1b@
 
@@ -91,8 +89,7 @@ newtype Point1b
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Point1b "unwrapPoint1b") =>
-         HasField "unwrapPoint1b" (Ptr Point1b) (Ptr ty)
+instance HasField "unwrapPoint1b" (Ptr Point1b) (Ptr Point1a)
     where getField = fromPtr (Proxy @"unwrapPoint1b")
 instance HasCField Point1b "unwrapPoint1b"
     where type CFieldType Point1b "unwrapPoint1b" = Point1a
@@ -139,14 +136,12 @@ deriving via (EquivStorable Point2a) instance Storable Point2a
 instance HasCField Point2a "point2a_x"
     where type CFieldType Point2a "point2a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Point2a "point2a_x") =>
-         HasField "point2a_x" (Ptr Point2a) (Ptr ty)
+instance HasField "point2a_x" (Ptr Point2a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point2a_x")
 instance HasCField Point2a "point2a_y"
     where type CFieldType Point2a "point2a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Point2a "point2a_y") =>
-         HasField "point2a_y" (Ptr Point2a) (Ptr ty)
+instance HasField "point2a_y" (Ptr Point2a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point2a_y")
 {-| __C declaration:__ @point2b@
 
@@ -169,8 +164,7 @@ newtype Point2b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Point2b "unwrapPoint2b") =>
-         HasField "unwrapPoint2b" (Ptr Point2b) (Ptr ty)
+instance HasField "unwrapPoint2b" (Ptr Point2b) (Ptr (Ptr Point2a))
     where getField = fromPtr (Proxy @"unwrapPoint2b")
 instance HasCField Point2b "unwrapPoint2b"
     where type CFieldType Point2b "unwrapPoint2b" = Ptr Point2a
@@ -217,14 +211,12 @@ deriving via (EquivStorable Point3a_Aux) instance Storable Point3a_Aux
 instance HasCField Point3a_Aux "point3a_Aux_x"
     where type CFieldType Point3a_Aux "point3a_Aux_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Point3a_Aux "point3a_Aux_x") =>
-         HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr ty)
+instance HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"point3a_Aux_x")
 instance HasCField Point3a_Aux "point3a_Aux_y"
     where type CFieldType Point3a_Aux "point3a_Aux_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Point3a_Aux "point3a_Aux_y") =>
-         HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr ty)
+instance HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"point3a_Aux_y")
 {-| __C declaration:__ @point3a@
 
@@ -247,8 +239,9 @@ newtype Point3a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Point3a "unwrapPoint3a") =>
-         HasField "unwrapPoint3a" (Ptr Point3a) (Ptr ty)
+instance HasField "unwrapPoint3a"
+                  (Ptr Point3a)
+                  (Ptr (Ptr Point3a_Aux))
     where getField = fromPtr (Proxy @"unwrapPoint3a")
 instance HasCField Point3a "unwrapPoint3a"
     where type CFieldType Point3a "unwrapPoint3a" = Ptr Point3a_Aux
@@ -274,8 +267,9 @@ newtype Point3b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Point3b "unwrapPoint3b") =>
-         HasField "unwrapPoint3b" (Ptr Point3b) (Ptr ty)
+instance HasField "unwrapPoint3b"
+                  (Ptr Point3b)
+                  (Ptr (Ptr Point3a_Aux))
     where getField = fromPtr (Proxy @"unwrapPoint3b")
 instance HasCField Point3b "unwrapPoint3b"
     where type CFieldType Point3b "unwrapPoint3b" = Ptr Point3a_Aux

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,7 +12,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -42,7 +40,6 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @struct another_typedef_struct_t@
@@ -105,8 +102,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Another_typedef_struct_t "another
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Another_typedef_struct_t) "another_typedef_struct_t_foo")
-         ) => GHC.Records.HasField "another_typedef_struct_t_foo" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "another_typedef_struct_t_foo" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"another_typedef_struct_t_foo")
@@ -118,8 +114,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Another_typedef_struct_t "another
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Another_typedef_struct_t) "another_typedef_struct_t_bar")
-         ) => GHC.Records.HasField "another_typedef_struct_t_bar" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "another_typedef_struct_t_bar" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"another_typedef_struct_t_bar")
@@ -205,8 +200,7 @@ instance Read Another_typedef_enum_e where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Another_typedef_enum_e) "unwrapAnother_typedef_enum_e")
-         ) => GHC.Records.HasField "unwrapAnother_typedef_enum_e" (Ptr.Ptr Another_typedef_enum_e) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapAnother_typedef_enum_e" (Ptr.Ptr Another_typedef_enum_e) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapAnother_typedef_enum_e")
@@ -292,8 +286,7 @@ newtype A_type_t = A_type_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_type_t) "unwrapA_type_t")
-         ) => GHC.Records.HasField "unwrapA_type_t" (Ptr.Ptr A_type_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA_type_t" (Ptr.Ptr A_type_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_type_t")
@@ -333,8 +326,7 @@ newtype Var_t = Var_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Var_t) "unwrapVar_t")
-         ) => GHC.Records.HasField "unwrapVar_t" (Ptr.Ptr Var_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapVar_t" (Ptr.Ptr Var_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapVar_t")
@@ -495,8 +487,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_0")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_0" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_0" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_0")
@@ -508,8 +499,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_1")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_1" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_1" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_1")
@@ -521,8 +511,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_2")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_2" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_2" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_2")
@@ -534,8 +523,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_3")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_3" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_3" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_3")
@@ -547,8 +535,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_4")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_4" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_4" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr Another_typedef_struct_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_4")
@@ -560,8 +547,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_5")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_5" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_5" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr (Ptr.Ptr Another_typedef_struct_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_5")
@@ -573,8 +559,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_6")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_6" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_6" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr (Ptr.Ptr Void)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_6")
@@ -586,8 +571,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_7")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_7" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_7" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 7) HsBindgen.Runtime.LibC.Word32)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_7")
@@ -599,8 +583,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 60
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_8")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_8" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_8" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr Another_typedef_enum_e) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_8")
@@ -612,8 +595,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 64
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_9")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_9" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_9" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) Another_typedef_enum_e)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_9")
@@ -625,8 +607,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 80
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_struct_t) "a_typedef_struct_t_field_10")
-         ) => GHC.Records.HasField "a_typedef_struct_t_field_10" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_typedef_struct_t_field_10" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Another_typedef_enum_e))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_10")
@@ -750,8 +731,7 @@ instance Read A_typedef_enum_e where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A_typedef_enum_e) "unwrapA_typedef_enum_e")
-         ) => GHC.Records.HasField "unwrapA_typedef_enum_e" (Ptr.Ptr A_typedef_enum_e) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA_typedef_enum_e" (Ptr.Ptr A_typedef_enum_e) (Ptr.Ptr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_typedef_enum_e")
@@ -845,8 +825,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Callback_t_Aux where
 
   fromFunPtr = hs_bindgen_d6debb4b8d5bb869
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Callback_t_Aux) "unwrapCallback_t_Aux")
-         ) => GHC.Records.HasField "unwrapCallback_t_Aux" (Ptr.Ptr Callback_t_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapCallback_t_Aux" (Ptr.Ptr Callback_t_Aux) (Ptr.Ptr ((Ptr.Ptr Void) -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCallback_t_Aux")
@@ -877,8 +856,7 @@ newtype Callback_t = Callback_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Callback_t) "unwrapCallback_t")
-         ) => GHC.Records.HasField "unwrapCallback_t" (Ptr.Ptr Callback_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapCallback_t" (Ptr.Ptr Callback_t) (Ptr.Ptr (Ptr.FunPtr Callback_t_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCallback_t")

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -80,24 +80,18 @@ instance HasCField Another_typedef_struct_t
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_foo" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Another_typedef_struct_t
-                          "another_typedef_struct_t_foo") =>
-         HasField "another_typedef_struct_t_foo"
+instance HasField "another_typedef_struct_t_foo"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_foo")
 instance HasCField Another_typedef_struct_t
                    "another_typedef_struct_t_bar"
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_bar" = CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType Another_typedef_struct_t
-                          "another_typedef_struct_t_bar") =>
-         HasField "another_typedef_struct_t_bar"
+instance HasField "another_typedef_struct_t_bar"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_bar")
 {-| __C declaration:__ @enum another_typedef_enum_e@
 
@@ -146,12 +140,9 @@ instance Read Another_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty
-              (CFieldType Another_typedef_enum_e
-                          "unwrapAnother_typedef_enum_e") =>
-         HasField "unwrapAnother_typedef_enum_e"
+instance HasField "unwrapAnother_typedef_enum_e"
                   (Ptr Another_typedef_enum_e)
-                  (Ptr ty)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapAnother_typedef_enum_e")
 instance HasCField Another_typedef_enum_e
                    "unwrapAnother_typedef_enum_e"
@@ -259,8 +250,7 @@ newtype A_type_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType A_type_t "unwrapA_type_t") =>
-         HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr ty)
+instance HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA_type_t")
 instance HasCField A_type_t "unwrapA_type_t"
     where type CFieldType A_type_t "unwrapA_type_t" = CInt
@@ -296,8 +286,7 @@ newtype Var_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Var_t "unwrapVar_t") =>
-         HasField "unwrapVar_t" (Ptr Var_t) (Ptr ty)
+instance HasField "unwrapVar_t" (Ptr Var_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapVar_t")
 instance HasCField Var_t "unwrapVar_t"
     where type CFieldType Var_t "unwrapVar_t" = CInt
@@ -421,103 +410,83 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_0"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_0" = CBool
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_0") =>
-         HasField "a_typedef_struct_t_field_0"
+instance HasField "a_typedef_struct_t_field_0"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_0")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_1"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_1" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 1
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_1") =>
-         HasField "a_typedef_struct_t_field_1"
+instance HasField "a_typedef_struct_t_field_1"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_1")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_2"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_2" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_2") =>
-         HasField "a_typedef_struct_t_field_2"
+instance HasField "a_typedef_struct_t_field_2"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_2")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_3"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_3" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_3") =>
-         HasField "a_typedef_struct_t_field_3"
+instance HasField "a_typedef_struct_t_field_3"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_3")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_4"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_4" = Another_typedef_struct_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_4") =>
-         HasField "a_typedef_struct_t_field_4"
+instance HasField "a_typedef_struct_t_field_4"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr Another_typedef_struct_t)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_4")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_5"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_5" = Ptr Another_typedef_struct_t
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_5") =>
-         HasField "a_typedef_struct_t_field_5"
+instance HasField "a_typedef_struct_t_field_5"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (Ptr Another_typedef_struct_t))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_5")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_6"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_6" = Ptr Void
           offset# = \_ -> \_ -> 24
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_6") =>
-         HasField "a_typedef_struct_t_field_6"
+instance HasField "a_typedef_struct_t_field_6"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_6")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_7"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_7" = ConstantArray 7
                                                                        HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_7") =>
-         HasField "a_typedef_struct_t_field_7"
+instance HasField "a_typedef_struct_t_field_7"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 7 HsBindgen.Runtime.LibC.Word32))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_7")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_8"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_8" = Another_typedef_enum_e
           offset# = \_ -> \_ -> 60
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_8") =>
-         HasField "a_typedef_struct_t_field_8"
+instance HasField "a_typedef_struct_t_field_8"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr Another_typedef_enum_e)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_8")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_9"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_9" = ConstantArray 4
                                                                        Another_typedef_enum_e
           offset# = \_ -> \_ -> 64
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_9") =>
-         HasField "a_typedef_struct_t_field_9"
+instance HasField "a_typedef_struct_t_field_9"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 4 Another_typedef_enum_e))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_9")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
     where type CFieldType A_typedef_struct_t
@@ -525,11 +494,9 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
                                                                         (ConstantArray 3
                                                                                        Another_typedef_enum_e)
           offset# = \_ -> \_ -> 80
-instance TyEq ty
-              (CFieldType A_typedef_struct_t "a_typedef_struct_t_field_10") =>
-         HasField "a_typedef_struct_t_field_10"
+instance HasField "a_typedef_struct_t_field_10"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_10")
 {-| __C declaration:__ @A_DEFINE_0@
 
@@ -636,9 +603,9 @@ instance Read A_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty
-              (CFieldType A_typedef_enum_e "unwrapA_typedef_enum_e") =>
-         HasField "unwrapA_typedef_enum_e" (Ptr A_typedef_enum_e) (Ptr ty)
+instance HasField "unwrapA_typedef_enum_e"
+                  (Ptr A_typedef_enum_e)
+                  (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapA_typedef_enum_e")
 instance HasCField A_typedef_enum_e "unwrapA_typedef_enum_e"
     where type CFieldType A_typedef_enum_e
@@ -744,9 +711,10 @@ instance ToFunPtr Callback_t_Aux
     where toFunPtr = hs_bindgen_b6b6922e35047658
 instance FromFunPtr Callback_t_Aux
     where fromFunPtr = hs_bindgen_d6debb4b8d5bb869
-instance TyEq ty
-              (CFieldType Callback_t_Aux "unwrapCallback_t_Aux") =>
-         HasField "unwrapCallback_t_Aux" (Ptr Callback_t_Aux) (Ptr ty)
+instance HasField "unwrapCallback_t_Aux"
+                  (Ptr Callback_t_Aux)
+                  (Ptr (Ptr Void ->
+                        HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32))
     where getField = fromPtr (Proxy @"unwrapCallback_t_Aux")
 instance HasCField Callback_t_Aux "unwrapCallback_t_Aux"
     where type CFieldType Callback_t_Aux
@@ -775,8 +743,9 @@ newtype Callback_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Callback_t "unwrapCallback_t") =>
-         HasField "unwrapCallback_t" (Ptr Callback_t) (Ptr ty)
+instance HasField "unwrapCallback_t"
+                  (Ptr Callback_t)
+                  (Ptr (FunPtr Callback_t_Aux))
     where getField = fromPtr (Proxy @"unwrapCallback_t")
 instance HasCField Callback_t "unwrapCallback_t"
     where type CFieldType Callback_t

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum test@
@@ -114,8 +111,7 @@ instance Read Test where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Test) "unwrapTest")
-         ) => GHC.Records.HasField "unwrapTest" (Ptr.Ptr Test) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTest" (Ptr.Ptr Test) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTest")

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -53,8 +53,7 @@ instance Read Test
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Test "unwrapTest") =>
-         HasField "unwrapTest" (Ptr Test) (Ptr ty)
+instance HasField "unwrapTest" (Ptr Test) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapTest")
 instance HasCField Test "unwrapTest"
     where type CFieldType Test "unwrapTest" = CUInt

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.FLAM
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct pascal@
@@ -75,8 +72,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Pascal_Aux "pascal_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Pascal_Aux) "pascal_len")
-         ) => GHC.Records.HasField "pascal_len" (Ptr.Ptr Pascal_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "pascal_len" (Ptr.Ptr Pascal_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"pascal_len")
@@ -151,8 +147,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_bar "foo_bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo_bar) "foo_bar_x")
-         ) => GHC.Records.HasField "foo_bar_x" (Ptr.Ptr Foo_bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_bar_x" (Ptr.Ptr Foo_bar) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_bar_x")
@@ -163,8 +158,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_bar "foo_bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo_bar) "foo_bar_y")
-         ) => GHC.Records.HasField "foo_bar_y" (Ptr.Ptr Foo_bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_bar_y" (Ptr.Ptr Foo_bar) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_bar_y")
@@ -217,8 +211,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_Aux "foo_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo_Aux) "foo_len")
-         ) => GHC.Records.HasField "foo_len" (Ptr.Ptr Foo_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_len" (Ptr.Ptr Foo_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_len")
@@ -293,8 +286,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Diff_Aux "diff_first" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Diff_Aux) "diff_first")
-         ) => GHC.Records.HasField "diff_first" (Ptr.Ptr Diff_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "diff_first" (Ptr.Ptr Diff_Aux) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"diff_first")
@@ -305,8 +297,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Diff_Aux "diff_second" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Diff_Aux) "diff_second")
-         ) => GHC.Records.HasField "diff_second" (Ptr.Ptr Diff_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "diff_second" (Ptr.Ptr Diff_Aux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"diff_second")
@@ -374,8 +365,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplets_Aux "triplets_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplets_Aux) "triplets_len")
-         ) => GHC.Records.HasField "triplets_len" (Ptr.Ptr Triplets_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "triplets_len" (Ptr.Ptr Triplets_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"triplets_len")

--- a/hs-bindgen/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam/th.txt
@@ -27,8 +27,7 @@ deriving via (EquivStorable Pascal_Aux) instance Storable Pascal_Aux
 instance HasCField Pascal_Aux "pascal_len"
     where type CFieldType Pascal_Aux "pascal_len" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Pascal_Aux "pascal_len") =>
-         HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
+instance HasField "pascal_len" (Ptr Pascal_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"pascal_len")
 instance Offset CChar Pascal_Aux
     where offset = \_ty_0 -> 4
@@ -75,14 +74,12 @@ deriving via (EquivStorable Foo_bar) instance Storable Foo_bar
 instance HasCField Foo_bar "foo_bar_x"
     where type CFieldType Foo_bar "foo_bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo_bar "foo_bar_x") =>
-         HasField "foo_bar_x" (Ptr Foo_bar) (Ptr ty)
+instance HasField "foo_bar_x" (Ptr Foo_bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_bar_x")
 instance HasCField Foo_bar "foo_bar_y"
     where type CFieldType Foo_bar "foo_bar_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Foo_bar "foo_bar_y") =>
-         HasField "foo_bar_y" (Ptr Foo_bar) (Ptr ty)
+instance HasField "foo_bar_y" (Ptr Foo_bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_bar_y")
 {-| __C declaration:__ @struct foo@
 
@@ -112,8 +109,7 @@ deriving via (EquivStorable Foo_Aux) instance Storable Foo_Aux
 instance HasCField Foo_Aux "foo_len"
     where type CFieldType Foo_Aux "foo_len" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo_Aux "foo_len") =>
-         HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
+instance HasField "foo_len" (Ptr Foo_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_len")
 instance Offset Foo_bar Foo_Aux
     where offset = \_ty_0 -> 4
@@ -154,14 +150,12 @@ deriving via (EquivStorable Diff_Aux) instance Storable Diff_Aux
 instance HasCField Diff_Aux "diff_first"
     where type CFieldType Diff_Aux "diff_first" = CLong
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Diff_Aux "diff_first") =>
-         HasField "diff_first" (Ptr Diff_Aux) (Ptr ty)
+instance HasField "diff_first" (Ptr Diff_Aux) (Ptr CLong)
     where getField = fromPtr (Proxy @"diff_first")
 instance HasCField Diff_Aux "diff_second"
     where type CFieldType Diff_Aux "diff_second" = CChar
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Diff_Aux "diff_second") =>
-         HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
+instance HasField "diff_second" (Ptr Diff_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"diff_second")
 instance Offset CChar Diff_Aux
     where offset = \_ty_0 -> 9
@@ -196,8 +190,7 @@ deriving via (EquivStorable Triplets_Aux) instance Storable Triplets_Aux
 instance HasCField Triplets_Aux "triplets_len"
     where type CFieldType Triplets_Aux "triplets_len" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Triplets_Aux "triplets_len") =>
-         HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
+instance HasField "triplets_len" (Ptr Triplets_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"triplets_len")
 instance Offset (ConstantArray 3 CInt) Triplets_Aux
     where offset = \_ty_0 -> 4

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.FLAM
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Vector@
@@ -74,8 +71,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector_Aux "vector_length" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Vector_Aux) "vector_length")
-         ) => GHC.Records.HasField "vector_length" (Ptr.Ptr Vector_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "vector_length" (Ptr.Ptr Vector_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_length")

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
@@ -88,8 +88,7 @@ deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
 instance HasCField Vector_Aux "vector_length"
     where type CFieldType Vector_Aux "vector_length" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Vector_Aux "vector_length") =>
-         HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
+instance HasField "vector_length" (Ptr Vector_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"vector_length")
 instance Offset CLong Vector_Aux
     where offset = \_ty_0 -> 8

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,7 +19,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.Block
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @Toggle@
@@ -36,8 +33,7 @@ newtype Toggle = Toggle
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Toggle) "unwrapToggle")
-         ) => GHC.Records.HasField "unwrapToggle" (Ptr.Ptr Toggle) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapToggle" (Ptr.Ptr Toggle) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (IO FC.CBool))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapToggle")
@@ -61,8 +57,7 @@ newtype Counter = Counter
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Counter) "unwrapCounter")
-         ) => GHC.Records.HasField "unwrapCounter" (Ptr.Ptr Counter) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapCounter" (Ptr.Ptr Counter) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCounter")
@@ -86,8 +81,7 @@ newtype VarCounter = VarCounter
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType VarCounter) "unwrapVarCounter")
-         ) => GHC.Records.HasField "unwrapVarCounter" (Ptr.Ptr VarCounter) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapVarCounter" (Ptr.Ptr VarCounter) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (FC.CInt -> IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapVarCounter")

--- a/hs-bindgen/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/iterator/th.txt
@@ -202,8 +202,9 @@ newtype Toggle
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType Toggle "unwrapToggle") =>
-         HasField "unwrapToggle" (Ptr Toggle) (Ptr ty)
+instance HasField "unwrapToggle"
+                  (Ptr Toggle)
+                  (Ptr (Block (IO CBool)))
     where getField = fromPtr (Proxy @"unwrapToggle")
 instance HasCField Toggle "unwrapToggle"
     where type CFieldType Toggle "unwrapToggle" = Block (IO CBool)
@@ -224,8 +225,9 @@ newtype Counter
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType Counter "unwrapCounter") =>
-         HasField "unwrapCounter" (Ptr Counter) (Ptr ty)
+instance HasField "unwrapCounter"
+                  (Ptr Counter)
+                  (Ptr (Block (IO CInt)))
     where getField = fromPtr (Proxy @"unwrapCounter")
 instance HasCField Counter "unwrapCounter"
     where type CFieldType Counter "unwrapCounter" = Block (IO CInt)
@@ -246,8 +248,9 @@ newtype VarCounter
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType VarCounter "unwrapVarCounter") =>
-         HasField "unwrapVarCounter" (Ptr VarCounter) (Ptr ty)
+instance HasField "unwrapVarCounter"
+                  (Ptr VarCounter)
+                  (Ptr (Block (CInt -> IO CInt)))
     where getField = fromPtr (Proxy @"unwrapVarCounter")
 instance HasCField VarCounter "unwrapVarCounter"
     where type CFieldType VarCounter

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 
 {-| Examples from the initial specification
@@ -66,8 +63,7 @@ newtype Int16_T = Int16_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int16_T) "unwrapInt16_T")
-         ) => GHC.Records.HasField "unwrapInt16_T" (Ptr.Ptr Int16_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt16_T" (Ptr.Ptr Int16_T) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt16_T")
@@ -107,8 +103,7 @@ newtype Int32_T = Int32_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int32_T) "unwrapInt32_T")
-         ) => GHC.Records.HasField "unwrapInt32_T" (Ptr.Ptr Int32_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt32_T" (Ptr.Ptr Int32_T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt32_T")
@@ -148,8 +143,7 @@ newtype Int64_T = Int64_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int64_T) "unwrapInt64_T")
-         ) => GHC.Records.HasField "unwrapInt64_T" (Ptr.Ptr Int64_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt64_T" (Ptr.Ptr Int64_T) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt64_T")
@@ -217,8 +211,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Cint16_T "cint16_T_re" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Cint16_T) "cint16_T_re")
-         ) => GHC.Records.HasField "cint16_T_re" (Ptr.Ptr Cint16_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "cint16_T_re" (Ptr.Ptr Cint16_T) (Ptr.Ptr Int16_T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"cint16_T_re")
@@ -229,8 +222,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Cint16_T "cint16_T_im" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Cint16_T) "cint16_T_im")
-         ) => GHC.Records.HasField "cint16_T_im" (Ptr.Ptr Cint16_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "cint16_T_im" (Ptr.Ptr Cint16_T) (Ptr.Ptr Int16_T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"cint16_T_im")
@@ -350,8 +342,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_x")
-         ) => GHC.Records.HasField "a_x" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_x" (Ptr.Ptr A) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_x")
@@ -362,8 +353,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_label" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_label")
-         ) => GHC.Records.HasField "a_label" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_label" (Ptr.Ptr A) (Ptr.Ptr (Ptr.Ptr FC.CChar)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_label")
@@ -375,8 +365,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_samples" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_samples")
-         ) => GHC.Records.HasField "a_samples" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_samples" (Ptr.Ptr A) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 128) FC.CChar)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_samples")
@@ -387,8 +376,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_b" where
 
   offset# = \_ -> \_ -> 144
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_b")
-         ) => GHC.Records.HasField "a_b" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_b" (Ptr.Ptr A) (Ptr.Ptr B) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_b")
@@ -399,8 +387,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_c" where
 
   offset# = \_ -> \_ -> 144
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_c")
-         ) => GHC.Records.HasField "a_c" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_c" (Ptr.Ptr A) (Ptr.Ptr (Ptr.Ptr C)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_c")

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
@@ -67,8 +67,7 @@ newtype Int16_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Int16_T "unwrapInt16_T") =>
-         HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr ty)
+instance HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapInt16_T")
 instance HasCField Int16_T "unwrapInt16_T"
     where type CFieldType Int16_T "unwrapInt16_T" = CShort
@@ -104,8 +103,7 @@ newtype Int32_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Int32_T "unwrapInt32_T") =>
-         HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr ty)
+instance HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapInt32_T")
 instance HasCField Int32_T "unwrapInt32_T"
     where type CFieldType Int32_T "unwrapInt32_T" = CInt
@@ -141,8 +139,7 @@ newtype Int64_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Int64_T "unwrapInt64_T") =>
-         HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr ty)
+instance HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr CLLong)
     where getField = fromPtr (Proxy @"unwrapInt64_T")
 instance HasCField Int64_T "unwrapInt64_T"
     where type CFieldType Int64_T "unwrapInt64_T" = CLLong
@@ -189,14 +186,12 @@ deriving via (EquivStorable Cint16_T) instance Storable Cint16_T
 instance HasCField Cint16_T "cint16_T_re"
     where type CFieldType Cint16_T "cint16_T_re" = Int16_T
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Cint16_T "cint16_T_re") =>
-         HasField "cint16_T_re" (Ptr Cint16_T) (Ptr ty)
+instance HasField "cint16_T_re" (Ptr Cint16_T) (Ptr Int16_T)
     where getField = fromPtr (Proxy @"cint16_T_re")
 instance HasCField Cint16_T "cint16_T_im"
     where type CFieldType Cint16_T "cint16_T_im" = Int16_T
           offset# = \_ -> \_ -> 2
-instance TyEq ty (CFieldType Cint16_T "cint16_T_im") =>
-         HasField "cint16_T_im" (Ptr Cint16_T) (Ptr ty)
+instance HasField "cint16_T_im" (Ptr Cint16_T) (Ptr Int16_T)
     where getField = fromPtr (Proxy @"cint16_T_im")
 {-| __C declaration:__ @struct B@
 
@@ -289,32 +284,29 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_x"
     where type CFieldType A "a_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType A "a_x") =>
-         HasField "a_x" (Ptr A) (Ptr ty)
+instance HasField "a_x" (Ptr A) (Ptr CDouble)
     where getField = fromPtr (Proxy @"a_x")
 instance HasCField A "a_label"
     where type CFieldType A "a_label" = Ptr CChar
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType A "a_label") =>
-         HasField "a_label" (Ptr A) (Ptr ty)
+instance HasField "a_label" (Ptr A) (Ptr (Ptr CChar))
     where getField = fromPtr (Proxy @"a_label")
 instance HasCField A "a_samples"
     where type CFieldType A "a_samples" = ConstantArray 128 CChar
           offset# = \_ -> \_ -> 16
-instance TyEq ty (CFieldType A "a_samples") =>
-         HasField "a_samples" (Ptr A) (Ptr ty)
+instance HasField "a_samples"
+                  (Ptr A)
+                  (Ptr (ConstantArray 128 CChar))
     where getField = fromPtr (Proxy @"a_samples")
 instance HasCField A "a_b"
     where type CFieldType A "a_b" = B
           offset# = \_ -> \_ -> 144
-instance TyEq ty (CFieldType A "a_b") =>
-         HasField "a_b" (Ptr A) (Ptr ty)
+instance HasField "a_b" (Ptr A) (Ptr B)
     where getField = fromPtr (Proxy @"a_b")
 instance HasCField A "a_c"
     where type CFieldType A "a_c" = Ptr C
           offset# = \_ -> \_ -> 144
-instance TyEq ty (CFieldType A "a_c") =>
-         HasField "a_c" (Ptr A) (Ptr ty)
+instance HasField "a_c" (Ptr A) (Ptr (Ptr C))
     where getField = fromPtr (Proxy @"a_c")
 {-| __C declaration:__ @struct C@
 

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @myInt@
@@ -64,8 +61,7 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyInt) "unwrapMyInt")
-         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -105,8 +101,7 @@ newtype MyUInt = MyUInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyUInt) "unwrapMyUInt")
-         ) => GHC.Records.HasField "unwrapMyUInt" (Ptr.Ptr MyUInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyUInt" (Ptr.Ptr MyUInt) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyUInt")
@@ -146,8 +141,7 @@ newtype MyLong = MyLong
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyLong) "unwrapMyLong")
-         ) => GHC.Records.HasField "unwrapMyLong" (Ptr.Ptr MyLong) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyLong" (Ptr.Ptr MyLong) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyLong")
@@ -226,8 +220,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_x" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType MyStruct) "myStruct_x")
-         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -240,8 +233,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_y" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType MyStruct) "myStruct_y")
-         ) => GHC.Records.HasField "myStruct_y" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "myStruct_y" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_y")
@@ -254,8 +246,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_z" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType MyStruct) "myStruct_z")
-         ) => GHC.Records.HasField "myStruct_z" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "myStruct_z" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_z")

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -30,8 +30,7 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MyInt "unwrapMyInt") =>
-         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -67,8 +66,7 @@ newtype MyUInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MyUInt "unwrapMyUInt") =>
-         HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr ty)
+instance HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyUInt")
 instance HasCField MyUInt "unwrapMyUInt"
     where type CFieldType MyUInt "unwrapMyUInt" = CUInt
@@ -104,8 +102,7 @@ newtype MyLong
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MyLong "unwrapMyLong") =>
-         HasField "unwrapMyLong" (Ptr MyLong) (Ptr ty)
+instance HasField "unwrapMyLong" (Ptr MyLong) (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapMyLong")
 instance HasCField MyLong "unwrapMyLong"
     where type CFieldType MyLong "unwrapMyLong" = CLong
@@ -161,20 +158,17 @@ instance HasCBitfield MyStruct "myStruct_x"
     where type CBitfieldType MyStruct "myStruct_x" = MyInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 2
-instance TyEq ty (CBitfieldType MyStruct "myStruct_x") =>
-         HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr MyInt)
     where getField = toPtr (Proxy @"myStruct_x")
 instance HasCBitfield MyStruct "myStruct_y"
     where type CBitfieldType MyStruct "myStruct_y" = MyUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 4
-instance TyEq ty (CBitfieldType MyStruct "myStruct_y") =>
-         HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr MyUInt)
     where getField = toPtr (Proxy @"myStruct_y")
 instance HasCBitfield MyStruct "myStruct_z"
     where type CBitfieldType MyStruct "myStruct_z" = MyLong
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 3
-instance TyEq ty (CBitfieldType MyStruct "myStruct_z") =>
-         HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr MyLong)
     where getField = toPtr (Proxy @"myStruct_z")

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -114,8 +111,7 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyEnum) "unwrapMyEnum")
-         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
@@ -46,8 +46,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType MyEnum "unwrapMyEnum") =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -43,7 +41,6 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| Auxiliary type used by 'FileOpenedNotification'
@@ -92,8 +89,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr FileOpenedNotification_Aux
 
   fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOpenedNotification_Aux) "unwrapFileOpenedNotification_Aux")
-         ) => GHC.Records.HasField "unwrapFileOpenedNotification_Aux" (Ptr.Ptr FileOpenedNotification_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFileOpenedNotification_Aux" (Ptr.Ptr FileOpenedNotification_Aux) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOpenedNotification_Aux")
@@ -124,8 +120,7 @@ newtype FileOpenedNotification = FileOpenedNotification
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOpenedNotification) "unwrapFileOpenedNotification")
-         ) => GHC.Records.HasField "unwrapFileOpenedNotification" (Ptr.Ptr FileOpenedNotification) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFileOpenedNotification" (Ptr.Ptr FileOpenedNotification) (Ptr.Ptr (Ptr.FunPtr FileOpenedNotification_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOpenedNotification")
@@ -183,8 +178,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr ProgressUpdate_Aux where
 
   fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProgressUpdate_Aux) "unwrapProgressUpdate_Aux")
-         ) => GHC.Records.HasField "unwrapProgressUpdate_Aux" (Ptr.Ptr ProgressUpdate_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapProgressUpdate_Aux" (Ptr.Ptr ProgressUpdate_Aux) (Ptr.Ptr (FC.CInt -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProgressUpdate_Aux")
@@ -215,8 +209,7 @@ newtype ProgressUpdate = ProgressUpdate
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProgressUpdate) "unwrapProgressUpdate")
-         ) => GHC.Records.HasField "unwrapProgressUpdate" (Ptr.Ptr ProgressUpdate) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapProgressUpdate" (Ptr.Ptr ProgressUpdate) (Ptr.Ptr (Ptr.FunPtr ProgressUpdate_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProgressUpdate")
@@ -274,8 +267,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr DataValidator_Aux where
 
   fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataValidator_Aux) "unwrapDataValidator_Aux")
-         ) => GHC.Records.HasField "unwrapDataValidator_Aux" (Ptr.Ptr DataValidator_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapDataValidator_Aux" (Ptr.Ptr DataValidator_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapDataValidator_Aux")
@@ -306,8 +298,7 @@ newtype DataValidator = DataValidator
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataValidator) "unwrapDataValidator")
-         ) => GHC.Records.HasField "unwrapDataValidator" (Ptr.Ptr DataValidator) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapDataValidator" (Ptr.Ptr DataValidator) (Ptr.Ptr (Ptr.FunPtr DataValidator_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapDataValidator")
@@ -377,8 +368,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Measurement "measurement_value" w
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Measurement) "measurement_value")
-         ) => GHC.Records.HasField "measurement_value" (Ptr.Ptr Measurement) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "measurement_value" (Ptr.Ptr Measurement) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurement_value")
@@ -390,8 +380,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Measurement "measurement_timestam
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Measurement) "measurement_timestamp")
-         ) => GHC.Records.HasField "measurement_timestamp" (Ptr.Ptr Measurement) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "measurement_timestamp" (Ptr.Ptr Measurement) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurement_timestamp")
@@ -442,8 +431,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MeasurementReceived_Aux wh
 
   fromFunPtr = hs_bindgen_383c36bb22947621
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived_Aux) "unwrapMeasurementReceived_Aux")
-         ) => GHC.Records.HasField "unwrapMeasurementReceived_Aux" (Ptr.Ptr MeasurementReceived_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMeasurementReceived_Aux" (Ptr.Ptr MeasurementReceived_Aux) (Ptr.Ptr ((Ptr.Ptr Measurement) -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived_Aux")
@@ -474,8 +462,7 @@ newtype MeasurementReceived = MeasurementReceived
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived) "unwrapMeasurementReceived")
-         ) => GHC.Records.HasField "unwrapMeasurementReceived" (Ptr.Ptr MeasurementReceived) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMeasurementReceived" (Ptr.Ptr MeasurementReceived) (Ptr.Ptr (Ptr.FunPtr MeasurementReceived_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived")
@@ -500,8 +487,7 @@ newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2_Aux) "unwrapMeasurementReceived2_Aux")
-         ) => GHC.Records.HasField "unwrapMeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr (Measurement -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived2_Aux")
@@ -532,8 +518,7 @@ newtype MeasurementReceived2 = MeasurementReceived2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementReceived2) "unwrapMeasurementReceived2")
-         ) => GHC.Records.HasField "unwrapMeasurementReceived2" (Ptr.Ptr MeasurementReceived2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMeasurementReceived2" (Ptr.Ptr MeasurementReceived2) (Ptr.Ptr (Ptr.FunPtr MeasurementReceived2_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived2")
@@ -558,8 +543,7 @@ newtype SampleBufferFull_Aux = SampleBufferFull_Aux
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull_Aux) "unwrapSampleBufferFull_Aux")
-         ) => GHC.Records.HasField "unwrapSampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr (((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSampleBufferFull_Aux")
@@ -590,8 +574,7 @@ newtype SampleBufferFull = SampleBufferFull
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SampleBufferFull) "unwrapSampleBufferFull")
-         ) => GHC.Records.HasField "unwrapSampleBufferFull" (Ptr.Ptr SampleBufferFull) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSampleBufferFull" (Ptr.Ptr SampleBufferFull) (Ptr.Ptr (Ptr.FunPtr SampleBufferFull_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSampleBufferFull")
@@ -673,8 +656,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementHandler) "measurementHandler_onReceived")
-         ) => GHC.Records.HasField "measurementHandler_onReceived" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "measurementHandler_onReceived" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_onReceived")
@@ -686,8 +668,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementHandler) "measurementHandler_validate")
-         ) => GHC.Records.HasField "measurementHandler_validate" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "measurementHandler_validate" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_validate")
@@ -699,8 +680,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MeasurementHandler) "measurementHandler_onError")
-         ) => GHC.Records.HasField "measurementHandler_onError" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "measurementHandler_onError" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr (FC.CInt -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_onError")
@@ -775,8 +755,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_prePro
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataPipeline) "dataPipeline_preProcess")
-         ) => GHC.Records.HasField "dataPipeline_preProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dataPipeline_preProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_preProcess")
@@ -788,8 +767,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_proces
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataPipeline) "dataPipeline_process")
-         ) => GHC.Records.HasField "dataPipeline_process" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dataPipeline_process" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_process")
@@ -801,8 +779,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_postPr
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DataPipeline) "dataPipeline_postProcess")
-         ) => GHC.Records.HasField "dataPipeline_postProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dataPipeline_postProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_postProcess")
@@ -914,8 +891,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProcessorCallback) "processorCallback_simple")
-         ) => GHC.Records.HasField "processorCallback_simple" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "processorCallback_simple" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_simple")
@@ -927,8 +903,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProcessorCallback) "processorCallback_withValidator")
-         ) => GHC.Records.HasField "processorCallback_withValidator" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "processorCallback_withValidator" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_withValidator")
@@ -940,8 +915,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ProcessorCallback) "processorCallback_withProgress")
-         ) => GHC.Records.HasField "processorCallback_withProgress" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "processorCallback_withProgress" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_withProgress")
@@ -1028,8 +1002,7 @@ instance Read Processor_mode where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor_mode) "unwrapProcessor_mode")
-         ) => GHC.Records.HasField "unwrapProcessor_mode" (Ptr.Ptr Processor_mode) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapProcessor_mode" (Ptr.Ptr Processor_mode) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_mode")
@@ -1125,8 +1098,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Processor "processor_mode" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor) "processor_mode")
-         ) => GHC.Records.HasField "processor_mode" (Ptr.Ptr Processor) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "processor_mode" (Ptr.Ptr Processor) (Ptr.Ptr Processor_mode) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processor_mode")
@@ -1138,8 +1110,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Processor "processor_callback" wh
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Processor) "processor_callback")
-         ) => GHC.Records.HasField "processor_callback" (Ptr.Ptr Processor) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "processor_callback" (Ptr.Ptr Processor) (Ptr.Ptr ProcessorCallback) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processor_callback")
@@ -1173,8 +1144,7 @@ newtype Foo = Foo
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "unwrapFoo")
-         ) => GHC.Records.HasField "unwrapFoo" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFoo" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo")
@@ -1214,8 +1184,7 @@ newtype Foo2 = Foo2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo2) "unwrapFoo2")
-         ) => GHC.Records.HasField "unwrapFoo2" (Ptr.Ptr Foo2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFoo2" (Ptr.Ptr Foo2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo2")

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -462,12 +462,9 @@ instance ToFunPtr FileOpenedNotification_Aux
     where toFunPtr = hs_bindgen_b3b8b1fad168671a
 instance FromFunPtr FileOpenedNotification_Aux
     where fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
-instance TyEq ty
-              (CFieldType FileOpenedNotification_Aux
-                          "unwrapFileOpenedNotification_Aux") =>
-         HasField "unwrapFileOpenedNotification_Aux"
+instance HasField "unwrapFileOpenedNotification_Aux"
                   (Ptr FileOpenedNotification_Aux)
-                  (Ptr ty)
+                  (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification_Aux")
 instance HasCField FileOpenedNotification_Aux
                    "unwrapFileOpenedNotification_Aux"
@@ -495,12 +492,9 @@ newtype FileOpenedNotification
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType FileOpenedNotification
-                          "unwrapFileOpenedNotification") =>
-         HasField "unwrapFileOpenedNotification"
+instance HasField "unwrapFileOpenedNotification"
                   (Ptr FileOpenedNotification)
-                  (Ptr ty)
+                  (Ptr (FunPtr FileOpenedNotification_Aux))
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification")
 instance HasCField FileOpenedNotification
                    "unwrapFileOpenedNotification"
@@ -549,11 +543,9 @@ instance ToFunPtr ProgressUpdate_Aux
     where toFunPtr = hs_bindgen_d551f31556ffa727
 instance FromFunPtr ProgressUpdate_Aux
     where fromFunPtr = hs_bindgen_ccf7f4b62a839a04
-instance TyEq ty
-              (CFieldType ProgressUpdate_Aux "unwrapProgressUpdate_Aux") =>
-         HasField "unwrapProgressUpdate_Aux"
+instance HasField "unwrapProgressUpdate_Aux"
                   (Ptr ProgressUpdate_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapProgressUpdate_Aux")
 instance HasCField ProgressUpdate_Aux "unwrapProgressUpdate_Aux"
     where type CFieldType ProgressUpdate_Aux
@@ -580,9 +572,9 @@ newtype ProgressUpdate
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType ProgressUpdate "unwrapProgressUpdate") =>
-         HasField "unwrapProgressUpdate" (Ptr ProgressUpdate) (Ptr ty)
+instance HasField "unwrapProgressUpdate"
+                  (Ptr ProgressUpdate)
+                  (Ptr (FunPtr ProgressUpdate_Aux))
     where getField = fromPtr (Proxy @"unwrapProgressUpdate")
 instance HasCField ProgressUpdate "unwrapProgressUpdate"
     where type CFieldType ProgressUpdate
@@ -629,9 +621,9 @@ instance ToFunPtr DataValidator_Aux
     where toFunPtr = hs_bindgen_c656ca21e63343d6
 instance FromFunPtr DataValidator_Aux
     where fromFunPtr = hs_bindgen_c1e79a4c11ca4033
-instance TyEq ty
-              (CFieldType DataValidator_Aux "unwrapDataValidator_Aux") =>
-         HasField "unwrapDataValidator_Aux" (Ptr DataValidator_Aux) (Ptr ty)
+instance HasField "unwrapDataValidator_Aux"
+                  (Ptr DataValidator_Aux)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapDataValidator_Aux")
 instance HasCField DataValidator_Aux "unwrapDataValidator_Aux"
     where type CFieldType DataValidator_Aux
@@ -658,9 +650,9 @@ newtype DataValidator
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType DataValidator "unwrapDataValidator") =>
-         HasField "unwrapDataValidator" (Ptr DataValidator) (Ptr ty)
+instance HasField "unwrapDataValidator"
+                  (Ptr DataValidator)
+                  (Ptr (FunPtr DataValidator_Aux))
     where getField = fromPtr (Proxy @"unwrapDataValidator")
 instance HasCField DataValidator "unwrapDataValidator"
     where type CFieldType DataValidator
@@ -708,15 +700,16 @@ deriving via (EquivStorable Measurement) instance Storable Measurement
 instance HasCField Measurement "measurement_value"
     where type CFieldType Measurement "measurement_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Measurement "measurement_value") =>
-         HasField "measurement_value" (Ptr Measurement) (Ptr ty)
+instance HasField "measurement_value"
+                  (Ptr Measurement)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"measurement_value")
 instance HasCField Measurement "measurement_timestamp"
     where type CFieldType Measurement "measurement_timestamp" = CDouble
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Measurement "measurement_timestamp") =>
-         HasField "measurement_timestamp" (Ptr Measurement) (Ptr ty)
+instance HasField "measurement_timestamp"
+                  (Ptr Measurement)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"measurement_timestamp")
 {-| Auxiliary type used by 'MeasurementReceived'
 
@@ -760,12 +753,9 @@ instance ToFunPtr MeasurementReceived_Aux
     where toFunPtr = hs_bindgen_9259654df9d40f5b
 instance FromFunPtr MeasurementReceived_Aux
     where fromFunPtr = hs_bindgen_383c36bb22947621
-instance TyEq ty
-              (CFieldType MeasurementReceived_Aux
-                          "unwrapMeasurementReceived_Aux") =>
-         HasField "unwrapMeasurementReceived_Aux"
+instance HasField "unwrapMeasurementReceived_Aux"
                   (Ptr MeasurementReceived_Aux)
-                  (Ptr ty)
+                  (Ptr (Ptr Measurement -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived_Aux")
 instance HasCField MeasurementReceived_Aux
                    "unwrapMeasurementReceived_Aux"
@@ -793,11 +783,9 @@ newtype MeasurementReceived
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType MeasurementReceived "unwrapMeasurementReceived") =>
-         HasField "unwrapMeasurementReceived"
+instance HasField "unwrapMeasurementReceived"
                   (Ptr MeasurementReceived)
-                  (Ptr ty)
+                  (Ptr (FunPtr MeasurementReceived_Aux))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived")
 instance HasCField MeasurementReceived "unwrapMeasurementReceived"
     where type CFieldType MeasurementReceived
@@ -823,12 +811,9 @@ newtype MeasurementReceived2_Aux
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType MeasurementReceived2_Aux
-                          "unwrapMeasurementReceived2_Aux") =>
-         HasField "unwrapMeasurementReceived2_Aux"
+instance HasField "unwrapMeasurementReceived2_Aux"
                   (Ptr MeasurementReceived2_Aux)
-                  (Ptr ty)
+                  (Ptr (Measurement -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2_Aux")
 instance HasCField MeasurementReceived2_Aux
                    "unwrapMeasurementReceived2_Aux"
@@ -856,11 +841,9 @@ newtype MeasurementReceived2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType MeasurementReceived2 "unwrapMeasurementReceived2") =>
-         HasField "unwrapMeasurementReceived2"
+instance HasField "unwrapMeasurementReceived2"
                   (Ptr MeasurementReceived2)
-                  (Ptr ty)
+                  (Ptr (FunPtr MeasurementReceived2_Aux))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2")
 instance HasCField MeasurementReceived2
                    "unwrapMeasurementReceived2"
@@ -888,11 +871,9 @@ newtype SampleBufferFull_Aux
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType SampleBufferFull_Aux "unwrapSampleBufferFull_Aux") =>
-         HasField "unwrapSampleBufferFull_Aux"
+instance HasField "unwrapSampleBufferFull_Aux"
                   (Ptr SampleBufferFull_Aux)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull_Aux")
 instance HasCField SampleBufferFull_Aux
                    "unwrapSampleBufferFull_Aux"
@@ -920,9 +901,9 @@ newtype SampleBufferFull
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType SampleBufferFull "unwrapSampleBufferFull") =>
-         HasField "unwrapSampleBufferFull" (Ptr SampleBufferFull) (Ptr ty)
+instance HasField "unwrapSampleBufferFull"
+                  (Ptr SampleBufferFull)
+                  (Ptr (FunPtr SampleBufferFull_Aux))
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull")
 instance HasCField SampleBufferFull "unwrapSampleBufferFull"
     where type CFieldType SampleBufferFull
@@ -983,31 +964,25 @@ instance HasCField MeasurementHandler
                           "measurementHandler_onReceived" = FunPtr (Ptr Measurement ->
                                                                     IO Unit)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType MeasurementHandler "measurementHandler_onReceived") =>
-         HasField "measurementHandler_onReceived"
+instance HasField "measurementHandler_onReceived"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
     where getField = fromPtr (Proxy @"measurementHandler_onReceived")
 instance HasCField MeasurementHandler "measurementHandler_validate"
     where type CFieldType MeasurementHandler
                           "measurementHandler_validate" = FunPtr (Ptr Measurement -> IO CInt)
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType MeasurementHandler "measurementHandler_validate") =>
-         HasField "measurementHandler_validate"
+instance HasField "measurementHandler_validate"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO CInt)))
     where getField = fromPtr (Proxy @"measurementHandler_validate")
 instance HasCField MeasurementHandler "measurementHandler_onError"
     where type CFieldType MeasurementHandler
                           "measurementHandler_onError" = FunPtr (CInt -> IO Unit)
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType MeasurementHandler "measurementHandler_onError") =>
-         HasField "measurementHandler_onError"
+instance HasField "measurementHandler_onError"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (CInt -> IO Unit)))
     where getField = fromPtr (Proxy @"measurementHandler_onError")
 {-| __C declaration:__ @struct DataPipeline@
 
@@ -1063,26 +1038,26 @@ instance HasCField DataPipeline "dataPipeline_preProcess"
                           "dataPipeline_preProcess" = FunPtr (Ptr Measurement ->
                                                               DataValidator -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType DataPipeline "dataPipeline_preProcess") =>
-         HasField "dataPipeline_preProcess" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_preProcess"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)))
     where getField = fromPtr (Proxy @"dataPipeline_preProcess")
 instance HasCField DataPipeline "dataPipeline_process"
     where type CFieldType DataPipeline
                           "dataPipeline_process" = FunPtr (Ptr Measurement -> IO Unit)
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType DataPipeline "dataPipeline_process") =>
-         HasField "dataPipeline_process" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_process"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
     where getField = fromPtr (Proxy @"dataPipeline_process")
 instance HasCField DataPipeline "dataPipeline_postProcess"
     where type CFieldType DataPipeline
                           "dataPipeline_postProcess" = FunPtr (Ptr Measurement ->
                                                                ProgressUpdate -> IO Unit)
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType DataPipeline "dataPipeline_postProcess") =>
-         HasField "dataPipeline_postProcess" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_postProcess"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)))
     where getField = fromPtr (Proxy @"dataPipeline_postProcess")
 {-| __C declaration:__ @union ProcessorCallback@
 
@@ -1221,11 +1196,9 @@ instance HasCField ProcessorCallback "processorCallback_simple"
     where type CFieldType ProcessorCallback
                           "processorCallback_simple" = FunPtr (Ptr Measurement -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType ProcessorCallback "processorCallback_simple") =>
-         HasField "processorCallback_simple"
+instance HasField "processorCallback_simple"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
     where getField = fromPtr (Proxy @"processorCallback_simple")
 instance HasCField ProcessorCallback
                    "processorCallback_withValidator"
@@ -1233,11 +1206,9 @@ instance HasCField ProcessorCallback
                           "processorCallback_withValidator" = FunPtr (Ptr Measurement ->
                                                                       DataValidator -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType ProcessorCallback "processorCallback_withValidator") =>
-         HasField "processorCallback_withValidator"
+instance HasField "processorCallback_withValidator"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)))
     where getField = fromPtr (Proxy @"processorCallback_withValidator")
 instance HasCField ProcessorCallback
                    "processorCallback_withProgress"
@@ -1245,11 +1216,9 @@ instance HasCField ProcessorCallback
                           "processorCallback_withProgress" = FunPtr (Ptr Measurement ->
                                                                      ProgressUpdate -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType ProcessorCallback "processorCallback_withProgress") =>
-         HasField "processorCallback_withProgress"
+instance HasField "processorCallback_withProgress"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)))
     where getField = fromPtr (Proxy @"processorCallback_withProgress")
 {-| __C declaration:__ @enum \@Processor_mode@
 
@@ -1299,9 +1268,9 @@ instance Read Processor_mode
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty
-              (CFieldType Processor_mode "unwrapProcessor_mode") =>
-         HasField "unwrapProcessor_mode" (Ptr Processor_mode) (Ptr ty)
+instance HasField "unwrapProcessor_mode"
+                  (Ptr Processor_mode)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapProcessor_mode")
 instance HasCField Processor_mode "unwrapProcessor_mode"
     where type CFieldType Processor_mode "unwrapProcessor_mode" = CUInt
@@ -1389,15 +1358,17 @@ deriving via (EquivStorable Processor) instance Storable Processor
 instance HasCField Processor "processor_mode"
     where type CFieldType Processor "processor_mode" = Processor_mode
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Processor "processor_mode") =>
-         HasField "processor_mode" (Ptr Processor) (Ptr ty)
+instance HasField "processor_mode"
+                  (Ptr Processor)
+                  (Ptr Processor_mode)
     where getField = fromPtr (Proxy @"processor_mode")
 instance HasCField Processor "processor_callback"
     where type CFieldType Processor
                           "processor_callback" = ProcessorCallback
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Processor "processor_callback") =>
-         HasField "processor_callback" (Ptr Processor) (Ptr ty)
+instance HasField "processor_callback"
+                  (Ptr Processor)
+                  (Ptr ProcessorCallback)
     where getField = fromPtr (Proxy @"processor_callback")
 {-| __C declaration:__ @foo@
 
@@ -1430,8 +1401,7 @@ newtype Foo
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Foo "unwrapFoo") =>
-         HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+instance HasField "unwrapFoo" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = CInt
@@ -1467,8 +1437,7 @@ newtype Foo2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Foo2 "unwrapFoo2") =>
-         HasField "unwrapFoo2" (Ptr Foo2) (Ptr ty)
+instance HasField "unwrapFoo2" (Ptr Foo2) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFoo2")
 instance HasCField Foo2 "unwrapFoo2"
     where type CFieldType Foo2 "unwrapFoo2" = CInt

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -27,7 +25,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, IO, Int, Ord, Show, pure)
 
 {-| Auxiliary type used by 'Fun_ptr'
@@ -76,8 +73,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Fun_ptr_Aux where
 
   fromFunPtr = hs_bindgen_f8391e85af67fcb6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Fun_ptr_Aux) "unwrapFun_ptr_Aux")
-         ) => GHC.Records.HasField "unwrapFun_ptr_Aux" (Ptr.Ptr Fun_ptr_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFun_ptr_Aux" (Ptr.Ptr Fun_ptr_Aux) (Ptr.Ptr ((Ptr.Ptr Forward_declaration) -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFun_ptr_Aux")
@@ -108,8 +104,7 @@ newtype Fun_ptr = Fun_ptr
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Fun_ptr) "unwrapFun_ptr")
-         ) => GHC.Records.HasField "unwrapFun_ptr" (Ptr.Ptr Fun_ptr) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFun_ptr" (Ptr.Ptr Fun_ptr) (Ptr.Ptr (Ptr.FunPtr Fun_ptr_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFun_ptr")
@@ -170,8 +165,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Forward_declaration "forward_decl
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Forward_declaration) "forward_declaration_f")
-         ) => GHC.Records.HasField "forward_declaration_f" (Ptr.Ptr Forward_declaration) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "forward_declaration_f" (Ptr.Ptr Forward_declaration) (Ptr.Ptr Fun_ptr) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"forward_declaration_f")

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
@@ -40,8 +40,9 @@ instance ToFunPtr Fun_ptr_Aux
     where toFunPtr = hs_bindgen_5964bbadb359ee4a
 instance FromFunPtr Fun_ptr_Aux
     where fromFunPtr = hs_bindgen_f8391e85af67fcb6
-instance TyEq ty (CFieldType Fun_ptr_Aux "unwrapFun_ptr_Aux") =>
-         HasField "unwrapFun_ptr_Aux" (Ptr Fun_ptr_Aux) (Ptr ty)
+instance HasField "unwrapFun_ptr_Aux"
+                  (Ptr Fun_ptr_Aux)
+                  (Ptr (Ptr Forward_declaration -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapFun_ptr_Aux")
 instance HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux"
     where type CFieldType Fun_ptr_Aux
@@ -68,8 +69,9 @@ newtype Fun_ptr
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Fun_ptr "unwrapFun_ptr") =>
-         HasField "unwrapFun_ptr" (Ptr Fun_ptr) (Ptr ty)
+instance HasField "unwrapFun_ptr"
+                  (Ptr Fun_ptr)
+                  (Ptr (FunPtr Fun_ptr_Aux))
     where getField = fromPtr (Proxy @"unwrapFun_ptr")
 instance HasCField Fun_ptr "unwrapFun_ptr"
     where type CFieldType Fun_ptr "unwrapFun_ptr" = FunPtr Fun_ptr_Aux
@@ -109,9 +111,9 @@ instance HasCField Forward_declaration "forward_declaration_f"
     where type CFieldType Forward_declaration
                           "forward_declaration_f" = Fun_ptr
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Forward_declaration "forward_declaration_f") =>
-         HasField "forward_declaration_f" (Ptr Forward_declaration) (Ptr ty)
+instance HasField "forward_declaration_f"
+                  (Ptr Forward_declaration)
+                  (Ptr Fun_ptr)
     where getField = fromPtr (Proxy @"forward_declaration_f")
 foreign import ccall safe "wrapper" hs_bindgen_fbe9c5dca66824d3_base ::
     Ptr Void -> IO Unit

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -26,7 +24,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct opaque@
@@ -94,8 +91,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Outside "outside_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Outside) "outside_x")
-         ) => GHC.Records.HasField "outside_x" (Ptr.Ptr Outside) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "outside_x" (Ptr.Ptr Outside) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"outside_x")
@@ -106,8 +102,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Outside "outside_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Outside) "outside_y")
-         ) => GHC.Records.HasField "outside_y" (Ptr.Ptr Outside) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "outside_y" (Ptr.Ptr Outside) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"outside_y")
@@ -174,8 +169,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_struct "named_struct_x" whe
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named_struct) "named_struct_x")
-         ) => GHC.Records.HasField "named_struct_x" (Ptr.Ptr Named_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_struct_x" (Ptr.Ptr Named_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_struct_x")
@@ -187,8 +181,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_struct "named_struct_y" whe
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named_struct) "named_struct_y")
-         ) => GHC.Records.HasField "named_struct_y" (Ptr.Ptr Named_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_struct_y" (Ptr.Ptr Named_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_struct_y")
@@ -272,8 +265,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_union "named_union_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named_union) "named_union_x")
-         ) => GHC.Records.HasField "named_union_x" (Ptr.Ptr Named_union) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_union_x" (Ptr.Ptr Named_union) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_union_x")
@@ -285,8 +277,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_union "named_union_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Named_union) "named_union_y")
-         ) => GHC.Records.HasField "named_union_y" (Ptr.Ptr Named_union) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "named_union_y" (Ptr.Ptr Named_union) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_union_y")

--- a/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
@@ -115,14 +115,12 @@ deriving via (EquivStorable Outside) instance Storable Outside
 instance HasCField Outside "outside_x"
     where type CFieldType Outside "outside_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Outside "outside_x") =>
-         HasField "outside_x" (Ptr Outside) (Ptr ty)
+instance HasField "outside_x" (Ptr Outside) (Ptr CInt)
     where getField = fromPtr (Proxy @"outside_x")
 instance HasCField Outside "outside_y"
     where type CFieldType Outside "outside_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Outside "outside_y") =>
-         HasField "outside_y" (Ptr Outside) (Ptr ty)
+instance HasField "outside_y" (Ptr Outside) (Ptr CInt)
     where getField = fromPtr (Proxy @"outside_y")
 {-| Error cases
 
@@ -174,14 +172,12 @@ deriving via (EquivStorable Named_struct) instance Storable Named_struct
 instance HasCField Named_struct "named_struct_x"
     where type CFieldType Named_struct "named_struct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Named_struct "named_struct_x") =>
-         HasField "named_struct_x" (Ptr Named_struct) (Ptr ty)
+instance HasField "named_struct_x" (Ptr Named_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_struct_x")
 instance HasCField Named_struct "named_struct_y"
     where type CFieldType Named_struct "named_struct_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Named_struct "named_struct_y") =>
-         HasField "named_struct_y" (Ptr Named_struct) (Ptr ty)
+instance HasField "named_struct_y" (Ptr Named_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_struct_y")
 {-| __C declaration:__ @union named_union@
 
@@ -273,14 +269,12 @@ set_named_union_y = setUnionPayload
 instance HasCField Named_union "named_union_x"
     where type CFieldType Named_union "named_union_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Named_union "named_union_x") =>
-         HasField "named_union_x" (Ptr Named_union) (Ptr ty)
+instance HasField "named_union_x" (Ptr Named_union) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_union_x")
 instance HasCField Named_union "named_union_y"
     where type CFieldType Named_union "named_union_y" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Named_union "named_union_y") =>
-         HasField "named_union_y" (Ptr Named_union) (Ptr ty)
+instance HasField "named_union_y" (Ptr Named_union) (Ptr CChar)
     where getField = fromPtr (Proxy @"named_union_y")
 -- __unique:__ @test_functionsdecls_in_signature_Example_Safe_normal@
 foreign import ccall safe "hs_bindgen_920e5c20f770432b" hs_bindgen_920e5c20f770432b_base ::

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 
 {-| Attributes on functions
@@ -97,8 +94,7 @@ newtype Size_t = Size_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Size_t) "unwrapSize_t")
-         ) => GHC.Records.HasField "unwrapSize_t" (Ptr.Ptr Size_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSize_t" (Ptr.Ptr Size_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSize_t")

--- a/hs-bindgen/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes/th.txt
@@ -493,8 +493,7 @@ newtype Size_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Size_t "unwrapSize_t") =>
-         HasField "unwrapSize_t" (Ptr Size_t) (Ptr ty)
+instance HasField "unwrapSize_t" (Ptr Size_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapSize_t")
 instance HasCField Size_t "unwrapSize_t"
     where type CFieldType Size_t "unwrapSize_t" = CInt

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
@@ -56,8 +56,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_a5d53f538e59b1fc" hs_bindgen_a5d53f538e59b1fc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
@@ -56,8 +56,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -56,8 +56,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -74,8 +71,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S "s_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "s_x")
-         ) => GHC.Records.HasField "s_x" (Ptr.Ptr S) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s_x" (Ptr.Ptr S) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s_x")
@@ -98,8 +94,7 @@ newtype T = T
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "unwrapT")
-         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr S) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -56,8 +56,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_x"
     where type CFieldType S "s_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S "s_x") =>
-         HasField "s_x" (Ptr S) (Ptr ty)
+instance HasField "s_x" (Ptr S) (Ptr CInt)
     where getField = fromPtr (Proxy @"s_x")
 {-| __C declaration:__ @T@
 
@@ -76,8 +75,7 @@ newtype T
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType T "unwrapT") =>
-         HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -79,8 +76,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union/th.txt
@@ -78,8 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_9fc5746860ab93cb" hs_bindgen_9fc5746860ab93cb_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -79,8 +76,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
@@ -78,8 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -79,8 +76,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "t_x")
-         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
@@ -78,8 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType T "t_x") =>
-         HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -26,7 +24,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -80,8 +77,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U "u_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "u_x")
-         ) => GHC.Records.HasField "u_x" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "u_x" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"u_x")
@@ -103,8 +99,7 @@ newtype T = T
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "unwrapT")
-         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr U) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -78,8 +78,7 @@ set_u_x = setUnionPayload
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U "u_x") =>
-         HasField "u_x" (Ptr U) (Ptr ty)
+instance HasField "u_x" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @T@
 
@@ -97,8 +96,7 @@ newtype T
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType T "unwrapT") =>
-         HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr U)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = U

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct config@
@@ -83,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config "config_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config) "config_x")
-         ) => GHC.Records.HasField "config_x" (Ptr.Ptr Config) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_x" (Ptr.Ptr Config) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_x")
@@ -95,8 +91,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Config "config_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Config) "config_y")
-         ) => GHC.Records.HasField "config_y" (Ptr.Ptr Config) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "config_y" (Ptr.Ptr Config) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_y")
@@ -159,8 +154,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Inline_struct "inline_struct_x" w
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Inline_struct) "inline_struct_x")
-         ) => GHC.Records.HasField "inline_struct_x" (Ptr.Ptr Inline_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "inline_struct_x" (Ptr.Ptr Inline_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"inline_struct_x")
@@ -172,8 +166,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Inline_struct "inline_struct_y" w
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Inline_struct) "inline_struct_y")
-         ) => GHC.Records.HasField "inline_struct_y" (Ptr.Ptr Inline_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "inline_struct_y" (Ptr.Ptr Inline_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"inline_struct_y")
@@ -245,8 +238,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_major" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Version_t) "version_t_major")
-         ) => GHC.Records.HasField "version_t_major" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "version_t_major" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_major")
@@ -258,8 +250,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_minor" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Version_t) "version_t_minor")
-         ) => GHC.Records.HasField "version_t_minor" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "version_t_minor" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_minor")
@@ -271,8 +262,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_patch" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Version_t) "version_t_patch")
-         ) => GHC.Records.HasField "version_t_patch" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "version_t_patch" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_patch")
@@ -344,8 +334,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct1_t) "struct1_t_x")
-         ) => GHC.Records.HasField "struct1_t_x" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct1_t_x" (Ptr.Ptr Struct1_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_x")
@@ -356,8 +345,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_y" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct1_t) "struct1_t_y")
-         ) => GHC.Records.HasField "struct1_t_y" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct1_t_y" (Ptr.Ptr Struct1_t) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_y")
@@ -369,8 +357,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_version" whe
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct1_t) "struct1_t_version")
-         ) => GHC.Records.HasField "struct1_t_version" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct1_t_version" (Ptr.Ptr Struct1_t) (Ptr.Ptr Version_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_version")
@@ -424,8 +411,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2_t "struct2_t_field1" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct2_t) "struct2_t_field1")
-         ) => GHC.Records.HasField "struct2_t_field1" (Ptr.Ptr Struct2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct2_t_field1" (Ptr.Ptr Struct2_t) (Ptr.Ptr Struct1_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_t_field1")

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -160,14 +160,12 @@ deriving via (EquivStorable Config) instance Storable Config
 instance HasCField Config "config_x"
     where type CFieldType Config "config_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Config "config_x") =>
-         HasField "config_x" (Ptr Config) (Ptr ty)
+instance HasField "config_x" (Ptr Config) (Ptr CInt)
     where getField = fromPtr (Proxy @"config_x")
 instance HasCField Config "config_y"
     where type CFieldType Config "config_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Config "config_y") =>
-         HasField "config_y" (Ptr Config) (Ptr ty)
+instance HasField "config_y" (Ptr Config) (Ptr CInt)
     where getField = fromPtr (Proxy @"config_y")
 {-| __C declaration:__ @struct inline_struct@
 
@@ -211,14 +209,12 @@ deriving via (EquivStorable Inline_struct) instance Storable Inline_struct
 instance HasCField Inline_struct "inline_struct_x"
     where type CFieldType Inline_struct "inline_struct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Inline_struct "inline_struct_x") =>
-         HasField "inline_struct_x" (Ptr Inline_struct) (Ptr ty)
+instance HasField "inline_struct_x" (Ptr Inline_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"inline_struct_x")
 instance HasCField Inline_struct "inline_struct_y"
     where type CFieldType Inline_struct "inline_struct_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Inline_struct "inline_struct_y") =>
-         HasField "inline_struct_y" (Ptr Inline_struct) (Ptr ty)
+instance HasField "inline_struct_y" (Ptr Inline_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"inline_struct_y")
 {-| __C declaration:__ @struct version_t@
 
@@ -271,22 +267,25 @@ instance HasCField Version_t "version_t_major"
     where type CFieldType Version_t
                           "version_t_major" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Version_t "version_t_major") =>
-         HasField "version_t_major" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_major"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"version_t_major")
 instance HasCField Version_t "version_t_minor"
     where type CFieldType Version_t
                           "version_t_minor" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance TyEq ty (CFieldType Version_t "version_t_minor") =>
-         HasField "version_t_minor" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_minor"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"version_t_minor")
 instance HasCField Version_t "version_t_patch"
     where type CFieldType Version_t
                           "version_t_patch" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Version_t "version_t_patch") =>
-         HasField "version_t_patch" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_patch"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"version_t_patch")
 {-| __C declaration:__ @struct struct1_t@
 
@@ -339,20 +338,21 @@ instance HasCField Struct1_t "struct1_t_x"
     where type CFieldType Struct1_t
                           "struct1_t_x" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct1_t "struct1_t_x") =>
-         HasField "struct1_t_x" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_x"
+                  (Ptr Struct1_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"struct1_t_x")
 instance HasCField Struct1_t "struct1_t_y"
     where type CFieldType Struct1_t "struct1_t_y" = CBool
           offset# = \_ -> \_ -> 2
-instance TyEq ty (CFieldType Struct1_t "struct1_t_y") =>
-         HasField "struct1_t_y" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_y" (Ptr Struct1_t) (Ptr CBool)
     where getField = fromPtr (Proxy @"struct1_t_y")
 instance HasCField Struct1_t "struct1_t_version"
     where type CFieldType Struct1_t "struct1_t_version" = Version_t
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Struct1_t "struct1_t_version") =>
-         HasField "struct1_t_version" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_version"
+                  (Ptr Struct1_t)
+                  (Ptr Version_t)
     where getField = fromPtr (Proxy @"struct1_t_version")
 {-| __C declaration:__ @struct struct2_t@
 
@@ -388,8 +388,9 @@ deriving via (EquivStorable Struct2_t) instance Storable Struct2_t
 instance HasCField Struct2_t "struct2_t_field1"
     where type CFieldType Struct2_t "struct2_t_field1" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct2_t "struct2_t_field1") =>
-         HasField "struct2_t_field1" (Ptr Struct2_t) (Ptr ty)
+instance HasField "struct2_t_field1"
+                  (Ptr Struct2_t)
+                  (Ptr Struct1_t)
     where getField = fromPtr (Proxy @"struct2_t_field1")
 -- __unique:__ @test_globalsglobals_Example_get_simpleGlobal@
 foreign import ccall unsafe "hs_bindgen_4f8e7b3d91414aa8" hs_bindgen_4f8e7b3d91414aa8_base ::

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @I@
@@ -64,8 +61,7 @@ newtype I = I
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType I) "unwrapI")
-         ) => GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapI")
@@ -105,8 +101,7 @@ newtype C = C
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType C) "unwrapC")
-         ) => GHC.Records.HasField "unwrapC" (Ptr.Ptr C) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapC" (Ptr.Ptr C) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapC")
@@ -144,8 +139,7 @@ newtype F = F
     , RealFrac
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F) "unwrapF")
-         ) => GHC.Records.HasField "unwrapF" (Ptr.Ptr F) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF" (Ptr.Ptr F) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF")
@@ -185,8 +179,7 @@ newtype L = L
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType L) "unwrapL")
-         ) => GHC.Records.HasField "unwrapL" (Ptr.Ptr L) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapL" (Ptr.Ptr L) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapL")
@@ -226,8 +219,7 @@ newtype S = S
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S) "unwrapS")
-         ) => GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS")

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -342,8 +342,7 @@ newtype I
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType I "unwrapI") =>
-         HasField "unwrapI" (Ptr I) (Ptr ty)
+instance HasField "unwrapI" (Ptr I) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -379,8 +378,7 @@ newtype C
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType C "unwrapC") =>
-         HasField "unwrapC" (Ptr C) (Ptr ty)
+instance HasField "unwrapC" (Ptr C) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapC")
 instance HasCField C "unwrapC"
     where type CFieldType C "unwrapC" = CChar
@@ -414,8 +412,7 @@ newtype F
                       Real,
                       RealFloat,
                       RealFrac)
-instance TyEq ty (CFieldType F "unwrapF") =>
-         HasField "unwrapF" (Ptr F) (Ptr ty)
+instance HasField "unwrapF" (Ptr F) (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapF")
 instance HasCField F "unwrapF"
     where type CFieldType F "unwrapF" = CFloat
@@ -451,8 +448,7 @@ newtype L
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType L "unwrapL") =>
-         HasField "unwrapL" (Ptr L) (Ptr ty)
+instance HasField "unwrapL" (Ptr L) (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapL")
 instance HasCField L "unwrapL"
     where type CFieldType L "unwrapL" = CLong
@@ -488,8 +484,7 @@ newtype S
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType S "unwrapS") =>
-         HasField "unwrapS" (Ptr S) (Ptr ty)
+instance HasField "unwrapS" (Ptr S) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = CShort

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @MC@
@@ -62,8 +59,7 @@ newtype MC = MC
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MC) "unwrapMC")
-         ) => GHC.Records.HasField "unwrapMC" (Ptr.Ptr MC) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMC" (Ptr.Ptr MC) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMC")
@@ -103,8 +99,7 @@ newtype TC = TC
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TC) "unwrapTC")
-         ) => GHC.Records.HasField "unwrapTC" (Ptr.Ptr TC) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTC" (Ptr.Ptr TC) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTC")
@@ -163,8 +158,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1 "struct1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct1) "struct1_a")
-         ) => GHC.Records.HasField "struct1_a" (Ptr.Ptr Struct1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct1_a" (Ptr.Ptr Struct1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_a")
@@ -217,8 +211,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2 "struct2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct2) "struct2_a")
-         ) => GHC.Records.HasField "struct2_a" (Ptr.Ptr Struct2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct2_a" (Ptr.Ptr Struct2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_a")
@@ -271,8 +264,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct3 "struct3_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct3) "struct3_a")
-         ) => GHC.Records.HasField "struct3_a" (Ptr.Ptr Struct3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct3_a" (Ptr.Ptr Struct3) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct3_a")
@@ -295,8 +287,7 @@ newtype Struct3_t = Struct3_t
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct3_t) "unwrapStruct3_t")
-         ) => GHC.Records.HasField "unwrapStruct3_t" (Ptr.Ptr Struct3_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct3_t" (Ptr.Ptr Struct3_t) (Ptr.Ptr Struct3) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct3_t")
@@ -355,8 +346,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct4 "struct4_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct4) "struct4_a")
-         ) => GHC.Records.HasField "struct4_a" (Ptr.Ptr Struct4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct4_a" (Ptr.Ptr Struct4) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct4_a")

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -261,8 +261,7 @@ newtype MC
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MC "unwrapMC") =>
-         HasField "unwrapMC" (Ptr MC) (Ptr ty)
+instance HasField "unwrapMC" (Ptr MC) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapMC")
 instance HasCField MC "unwrapMC"
     where type CFieldType MC "unwrapMC" = CChar
@@ -298,8 +297,7 @@ newtype TC
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType TC "unwrapTC") =>
-         HasField "unwrapTC" (Ptr TC) (Ptr ty)
+instance HasField "unwrapTC" (Ptr TC) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapTC")
 instance HasCField TC "unwrapTC"
     where type CFieldType TC "unwrapTC" = CChar
@@ -338,8 +336,7 @@ deriving via (EquivStorable Struct1) instance Storable Struct1
 instance HasCField Struct1 "struct1_a"
     where type CFieldType Struct1 "struct1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct1 "struct1_a") =>
-         HasField "struct1_a" (Ptr Struct1) (Ptr ty)
+instance HasField "struct1_a" (Ptr Struct1) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct1_a")
 {-| __C declaration:__ @struct struct2@
 
@@ -375,8 +372,7 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_a"
     where type CFieldType Struct2 "struct2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct2 "struct2_a") =>
-         HasField "struct2_a" (Ptr Struct2) (Ptr ty)
+instance HasField "struct2_a" (Ptr Struct2) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct2_a")
 {-| __C declaration:__ @struct struct3@
 
@@ -412,8 +408,7 @@ deriving via (EquivStorable Struct3) instance Storable Struct3
 instance HasCField Struct3 "struct3_a"
     where type CFieldType Struct3 "struct3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct3 "struct3_a") =>
-         HasField "struct3_a" (Ptr Struct3) (Ptr ty)
+instance HasField "struct3_a" (Ptr Struct3) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct3_a")
 {-| __C declaration:__ @struct3_t@
 
@@ -432,8 +427,7 @@ newtype Struct3_t
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct3_t "unwrapStruct3_t") =>
-         HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr ty)
+instance HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr Struct3)
     where getField = fromPtr (Proxy @"unwrapStruct3_t")
 instance HasCField Struct3_t "unwrapStruct3_t"
     where type CFieldType Struct3_t "unwrapStruct3_t" = Struct3
@@ -472,8 +466,7 @@ deriving via (EquivStorable Struct4) instance Storable Struct4
 instance HasCField Struct4 "struct4_a"
     where type CFieldType Struct4 "struct4_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct4 "struct4_a") =>
-         HasField "struct4_a" (Ptr Struct4) (Ptr ty)
+instance HasField "struct4_a" (Ptr Struct4) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct4_a")
 -- __unique:__ @test_macrosmacro_in_fundecl_vs_typ_Example_Safe_quux1@
 foreign import ccall safe "hs_bindgen_02e0e3b28d470fd4" hs_bindgen_02e0e3b28d470fd4_base ::

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @FILE@
@@ -60,8 +57,7 @@ newtype FILE = FILE
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FILE) "unwrapFILE")
-         ) => GHC.Records.HasField "unwrapFILE" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFILE" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFILE")

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
@@ -30,8 +30,7 @@ newtype FILE
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType FILE "unwrapFILE") =>
-         HasField "unwrapFILE" (Ptr FILE) (Ptr ty)
+instance HasField "unwrapFILE" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFILE")
 instance HasCField FILE "unwrapFILE"
     where type CFieldType FILE "unwrapFILE" = CInt

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @T1@
@@ -60,8 +57,7 @@ newtype T1 = T1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T1) "unwrapT1")
-         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -101,8 +97,7 @@ newtype T2 = T2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T2) "unwrapT2")
-         ) => GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr T1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT2")
@@ -142,8 +137,7 @@ newtype T3 = T3
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T3) "unwrapT3")
-         ) => GHC.Records.HasField "unwrapT3" (Ptr.Ptr T3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT3" (Ptr.Ptr T3) (Ptr.Ptr T2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT3")
@@ -183,8 +177,7 @@ newtype T4 = T4
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T4) "unwrapT4")
-         ) => GHC.Records.HasField "unwrapT4" (Ptr.Ptr T4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT4" (Ptr.Ptr T4) (Ptr.Ptr T3) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT4")

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
@@ -30,8 +30,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T1 "unwrapT1") =>
-         HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -67,8 +66,7 @@ newtype T2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T2 "unwrapT2") =>
-         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr T1)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = T1
@@ -104,8 +102,7 @@ newtype T3
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T3 "unwrapT3") =>
-         HasField "unwrapT3" (Ptr T3) (Ptr ty)
+instance HasField "unwrapT3" (Ptr T3) (Ptr T2)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = T2
@@ -141,8 +138,7 @@ newtype T4
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T4 "unwrapT4") =>
-         HasField "unwrapT4" (Ptr T4) (Ptr ty)
+instance HasField "unwrapT4" (Ptr T4) (Ptr T3)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = T3

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @MY_TYPE@
@@ -62,8 +59,7 @@ newtype MY_TYPE = MY_TYPE
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MY_TYPE) "unwrapMY_TYPE")
-         ) => GHC.Records.HasField "unwrapMY_TYPE" (Ptr.Ptr MY_TYPE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMY_TYPE" (Ptr.Ptr MY_TYPE) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMY_TYPE")
@@ -131,8 +127,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_x")
-         ) => GHC.Records.HasField "bar_x" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_x" (Ptr.Ptr Bar) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_x")
@@ -143,8 +138,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_y")
-         ) => GHC.Records.HasField "bar_y" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_y" (Ptr.Ptr Bar) (Ptr.Ptr MY_TYPE) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_y")

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
@@ -30,8 +30,7 @@ newtype MY_TYPE
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MY_TYPE "unwrapMY_TYPE") =>
-         HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr ty)
+instance HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMY_TYPE")
 instance HasCField MY_TYPE "unwrapMY_TYPE"
     where type CFieldType MY_TYPE "unwrapMY_TYPE" = CInt
@@ -78,12 +77,10 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_x"
     where type CFieldType Bar "bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bar "bar_x") =>
-         HasField "bar_x" (Ptr Bar) (Ptr ty)
+instance HasField "bar_x" (Ptr Bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"bar_x")
 instance HasCField Bar "bar_y"
     where type CFieldType Bar "bar_y" = MY_TYPE
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Bar "bar_y") =>
-         HasField "bar_y" (Ptr Bar) (Ptr ty)
+instance HasField "bar_y" (Ptr Bar) (Ptr MY_TYPE)
     where getField = fromPtr (Proxy @"bar_y")

--- a/hs-bindgen/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_types/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @PtrInt@
@@ -50,8 +47,7 @@ newtype PtrInt = PtrInt
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType PtrInt) "unwrapPtrInt")
-         ) => GHC.Records.HasField "unwrapPtrInt" (Ptr.Ptr PtrInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPtrInt" (Ptr.Ptr PtrInt) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPtrInt")
@@ -92,8 +88,7 @@ newtype ShortInt = ShortInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ShortInt) "unwrapShortInt")
-         ) => GHC.Records.HasField "unwrapShortInt" (Ptr.Ptr ShortInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapShortInt" (Ptr.Ptr ShortInt) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapShortInt")
@@ -133,8 +128,7 @@ newtype SignedShortInt = SignedShortInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType SignedShortInt) "unwrapSignedShortInt")
-         ) => GHC.Records.HasField "unwrapSignedShortInt" (Ptr.Ptr SignedShortInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSignedShortInt" (Ptr.Ptr SignedShortInt) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSignedShortInt")
@@ -175,8 +169,7 @@ newtype UnsignedShortInt = UnsignedShortInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UnsignedShortInt) "unwrapUnsignedShortInt")
-         ) => GHC.Records.HasField "unwrapUnsignedShortInt" (Ptr.Ptr UnsignedShortInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapUnsignedShortInt" (Ptr.Ptr UnsignedShortInt) (Ptr.Ptr FC.CUShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUnsignedShortInt")
@@ -207,8 +200,7 @@ newtype PtrPtrChar = PtrPtrChar
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType PtrPtrChar) "unwrapPtrPtrChar")
-         ) => GHC.Records.HasField "unwrapPtrPtrChar" (Ptr.Ptr PtrPtrChar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPtrPtrChar" (Ptr.Ptr PtrPtrChar) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr FC.CChar))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPtrPtrChar")
@@ -247,8 +239,7 @@ newtype MTy = MTy
     , RealFrac
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MTy) "unwrapMTy")
-         ) => GHC.Records.HasField "unwrapMTy" (Ptr.Ptr MTy) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMTy" (Ptr.Ptr MTy) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMTy")
@@ -286,8 +277,7 @@ newtype Tty = Tty
     , RealFrac
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tty) "unwrapTty")
-         ) => GHC.Records.HasField "unwrapTty" (Ptr.Ptr Tty) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTty" (Ptr.Ptr Tty) (Ptr.Ptr MTy) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTty")
@@ -327,8 +317,7 @@ newtype UINT8_T = UINT8_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UINT8_T) "unwrapUINT8_T")
-         ) => GHC.Records.HasField "unwrapUINT8_T" (Ptr.Ptr UINT8_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapUINT8_T" (Ptr.Ptr UINT8_T) (Ptr.Ptr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUINT8_T")
@@ -368,8 +357,7 @@ newtype BOOLEAN_T = BOOLEAN_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType BOOLEAN_T) "unwrapBOOLEAN_T")
-         ) => GHC.Records.HasField "unwrapBOOLEAN_T" (Ptr.Ptr BOOLEAN_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapBOOLEAN_T" (Ptr.Ptr BOOLEAN_T) (Ptr.Ptr UINT8_T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOLEAN_T")
@@ -409,8 +397,7 @@ newtype Boolean_T = Boolean_T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Boolean_T) "unwrapBoolean_T")
-         ) => GHC.Records.HasField "unwrapBoolean_T" (Ptr.Ptr Boolean_T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapBoolean_T" (Ptr.Ptr Boolean_T) (Ptr.Ptr BOOLEAN_T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBoolean_T")

--- a/hs-bindgen/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_types/th.txt
@@ -20,8 +20,7 @@ newtype PtrInt
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType PtrInt "unwrapPtrInt") =>
-         HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr ty)
+instance HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapPtrInt")
 instance HasCField PtrInt "unwrapPtrInt"
     where type CFieldType PtrInt "unwrapPtrInt" = Ptr CInt
@@ -57,8 +56,7 @@ newtype ShortInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType ShortInt "unwrapShortInt") =>
-         HasField "unwrapShortInt" (Ptr ShortInt) (Ptr ty)
+instance HasField "unwrapShortInt" (Ptr ShortInt) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapShortInt")
 instance HasCField ShortInt "unwrapShortInt"
     where type CFieldType ShortInt "unwrapShortInt" = CShort
@@ -94,9 +92,9 @@ newtype SignedShortInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType SignedShortInt "unwrapSignedShortInt") =>
-         HasField "unwrapSignedShortInt" (Ptr SignedShortInt) (Ptr ty)
+instance HasField "unwrapSignedShortInt"
+                  (Ptr SignedShortInt)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapSignedShortInt")
 instance HasCField SignedShortInt "unwrapSignedShortInt"
     where type CFieldType SignedShortInt
@@ -133,9 +131,9 @@ newtype UnsignedShortInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType UnsignedShortInt "unwrapUnsignedShortInt") =>
-         HasField "unwrapUnsignedShortInt" (Ptr UnsignedShortInt) (Ptr ty)
+instance HasField "unwrapUnsignedShortInt"
+                  (Ptr UnsignedShortInt)
+                  (Ptr CUShort)
     where getField = fromPtr (Proxy @"unwrapUnsignedShortInt")
 instance HasCField UnsignedShortInt "unwrapUnsignedShortInt"
     where type CFieldType UnsignedShortInt
@@ -162,8 +160,9 @@ newtype PtrPtrChar
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType PtrPtrChar "unwrapPtrPtrChar") =>
-         HasField "unwrapPtrPtrChar" (Ptr PtrPtrChar) (Ptr ty)
+instance HasField "unwrapPtrPtrChar"
+                  (Ptr PtrPtrChar)
+                  (Ptr (Ptr (Ptr CChar)))
     where getField = fromPtr (Proxy @"unwrapPtrPtrChar")
 instance HasCField PtrPtrChar "unwrapPtrPtrChar"
     where type CFieldType PtrPtrChar
@@ -198,8 +197,7 @@ newtype MTy
                       Real,
                       RealFloat,
                       RealFrac)
-instance TyEq ty (CFieldType MTy "unwrapMTy") =>
-         HasField "unwrapMTy" (Ptr MTy) (Ptr ty)
+instance HasField "unwrapMTy" (Ptr MTy) (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapMTy")
 instance HasCField MTy "unwrapMTy"
     where type CFieldType MTy "unwrapMTy" = CFloat
@@ -233,8 +231,7 @@ newtype Tty
                       Real,
                       RealFloat,
                       RealFrac)
-instance TyEq ty (CFieldType Tty "unwrapTty") =>
-         HasField "unwrapTty" (Ptr Tty) (Ptr ty)
+instance HasField "unwrapTty" (Ptr Tty) (Ptr MTy)
     where getField = fromPtr (Proxy @"unwrapTty")
 instance HasCField Tty "unwrapTty"
     where type CFieldType Tty "unwrapTty" = MTy
@@ -270,8 +267,7 @@ newtype UINT8_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType UINT8_T "unwrapUINT8_T") =>
-         HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr ty)
+instance HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapUINT8_T")
 instance HasCField UINT8_T "unwrapUINT8_T"
     where type CFieldType UINT8_T "unwrapUINT8_T" = CUChar
@@ -307,8 +303,7 @@ newtype BOOLEAN_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType BOOLEAN_T "unwrapBOOLEAN_T") =>
-         HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr ty)
+instance HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr UINT8_T)
     where getField = fromPtr (Proxy @"unwrapBOOLEAN_T")
 instance HasCField BOOLEAN_T "unwrapBOOLEAN_T"
     where type CFieldType BOOLEAN_T "unwrapBOOLEAN_T" = UINT8_T
@@ -344,8 +339,7 @@ newtype Boolean_T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Boolean_T "unwrapBoolean_T") =>
-         HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr ty)
+instance HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr BOOLEAN_T)
     where getField = fromPtr (Proxy @"unwrapBoolean_T")
 instance HasCField Boolean_T "unwrapBoolean_T"
     where type CFieldType Boolean_T "unwrapBoolean_T" = BOOLEAN_T

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -44,7 +42,6 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Double, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, return, showsPrec)
 
 {-| __C declaration:__ @A@
@@ -76,8 +73,7 @@ newtype A = A
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -217,8 +213,7 @@ instance Read Some_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Some_enum) "unwrapSome_enum")
-         ) => GHC.Records.HasField "unwrapSome_enum" (Ptr.Ptr Some_enum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSome_enum" (Ptr.Ptr Some_enum) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSome_enum")
@@ -251,8 +246,7 @@ newtype Arr_typedef1 = Arr_typedef1
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef1) "unwrapArr_typedef1")
-         ) => GHC.Records.HasField "unwrapArr_typedef1" (Ptr.Ptr Arr_typedef1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapArr_typedef1" (Ptr.Ptr Arr_typedef1) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef1")
@@ -276,8 +270,7 @@ newtype Arr_typedef2 = Arr_typedef2
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef2) "unwrapArr_typedef2")
-         ) => GHC.Records.HasField "unwrapArr_typedef2" (Ptr.Ptr Arr_typedef2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapArr_typedef2" (Ptr.Ptr Arr_typedef2) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef2")
@@ -307,8 +300,7 @@ newtype Arr_typedef3 = Arr_typedef3
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef3) "unwrapArr_typedef3")
-         ) => GHC.Records.HasField "unwrapArr_typedef3" (Ptr.Ptr Arr_typedef3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapArr_typedef3" (Ptr.Ptr Arr_typedef3) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef3")
@@ -338,8 +330,7 @@ newtype Arr_typedef4 = Arr_typedef4
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Arr_typedef4) "unwrapArr_typedef4")
-         ) => GHC.Records.HasField "unwrapArr_typedef4" (Ptr.Ptr Arr_typedef4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapArr_typedef4" (Ptr.Ptr Arr_typedef4) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef4")
@@ -382,8 +373,7 @@ newtype Typedef1 = Typedef1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Typedef1) "unwrapTypedef1")
-         ) => GHC.Records.HasField "unwrapTypedef1" (Ptr.Ptr Typedef1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTypedef1" (Ptr.Ptr Typedef1) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef1")
@@ -413,8 +403,7 @@ newtype Typedef2 = Typedef2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Typedef2) "unwrapTypedef2")
-         ) => GHC.Records.HasField "unwrapTypedef2" (Ptr.Ptr Typedef2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTypedef2" (Ptr.Ptr Typedef2) (Ptr.Ptr (Ptr.Ptr A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef2")
@@ -444,8 +433,7 @@ newtype Typedef3 = Typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Typedef3) "unwrapTypedef3")
-         ) => GHC.Records.HasField "unwrapTypedef3" (Ptr.Ptr Typedef3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTypedef3" (Ptr.Ptr Typedef3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef3")
@@ -503,8 +491,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef1_Aux where
 
   fromFunPtr = hs_bindgen_806a46dc418a062c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef1_Aux) "unwrapFunptr_typedef1_Aux")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef1_Aux" (Ptr.Ptr Funptr_typedef1_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef1_Aux" (Ptr.Ptr Funptr_typedef1_Aux) (Ptr.Ptr (IO A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef1_Aux")
@@ -535,8 +522,7 @@ newtype Funptr_typedef1 = Funptr_typedef1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef1) "unwrapFunptr_typedef1")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef1" (Ptr.Ptr Funptr_typedef1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef1" (Ptr.Ptr Funptr_typedef1) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef1_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef1")
@@ -594,8 +580,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef2_Aux where
 
   fromFunPtr = hs_bindgen_323d07dff85b802c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef2_Aux) "unwrapFunptr_typedef2_Aux")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef2_Aux" (Ptr.Ptr Funptr_typedef2_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef2_Aux" (Ptr.Ptr Funptr_typedef2_Aux) (Ptr.Ptr (IO (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef2_Aux")
@@ -626,8 +611,7 @@ newtype Funptr_typedef2 = Funptr_typedef2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef2) "unwrapFunptr_typedef2")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef2" (Ptr.Ptr Funptr_typedef2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef2" (Ptr.Ptr Funptr_typedef2) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef2_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef2")
@@ -685,8 +669,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef3_Aux where
 
   fromFunPtr = hs_bindgen_82dc7b932974117e
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef3_Aux) "unwrapFunptr_typedef3_Aux")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef3_Aux" (Ptr.Ptr Funptr_typedef3_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef3_Aux" (Ptr.Ptr Funptr_typedef3_Aux) (Ptr.Ptr (IO (Ptr.Ptr (Ptr.Ptr A)))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef3_Aux")
@@ -717,8 +700,7 @@ newtype Funptr_typedef3 = Funptr_typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef3) "unwrapFunptr_typedef3")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef3" (Ptr.Ptr Funptr_typedef3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef3" (Ptr.Ptr Funptr_typedef3) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef3_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef3")
@@ -776,8 +758,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef4_Aux where
 
   fromFunPtr = hs_bindgen_d4a97954476da161
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef4_Aux) "unwrapFunptr_typedef4_Aux")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef4_Aux" (Ptr.Ptr Funptr_typedef4_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef4_Aux" (Ptr.Ptr Funptr_typedef4_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef4_Aux")
@@ -808,8 +789,7 @@ newtype Funptr_typedef4 = Funptr_typedef4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef4) "unwrapFunptr_typedef4")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef4" (Ptr.Ptr Funptr_typedef4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef4" (Ptr.Ptr Funptr_typedef4) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef4_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef4")
@@ -867,8 +847,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef5_Aux where
 
   fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef5_Aux) "unwrapFunptr_typedef5_Aux")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef5_Aux" (Ptr.Ptr Funptr_typedef5_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef5_Aux" (Ptr.Ptr Funptr_typedef5_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef5_Aux")
@@ -899,8 +878,7 @@ newtype Funptr_typedef5 = Funptr_typedef5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Funptr_typedef5) "unwrapFunptr_typedef5")
-         ) => GHC.Records.HasField "unwrapFunptr_typedef5" (Ptr.Ptr Funptr_typedef5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunptr_typedef5" (Ptr.Ptr Funptr_typedef5) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef5_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef5")
@@ -941,8 +919,7 @@ newtype Comments2 = Comments2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Comments2) "unwrapComments2")
-         ) => GHC.Records.HasField "unwrapComments2" (Ptr.Ptr Comments2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapComments2" (Ptr.Ptr Comments2) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapComments2")
@@ -1025,8 +1002,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct) "example_struct_field1")
-         ) => GHC.Records.HasField "example_struct_field1" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_field1" (Ptr.Ptr Example_struct) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field1")
@@ -1038,8 +1014,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct) "example_struct_field2")
-         ) => GHC.Records.HasField "example_struct_field2" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_field2" (Ptr.Ptr Example_struct) (Ptr.Ptr (Ptr.Ptr A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field2")
@@ -1051,8 +1026,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct) "example_struct_field3")
-         ) => GHC.Records.HasField "example_struct_field3" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_field3" (Ptr.Ptr Example_struct) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field3")
@@ -1086,8 +1060,7 @@ newtype Const_typedef1 = Const_typedef1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef1) "unwrapConst_typedef1")
-         ) => GHC.Records.HasField "unwrapConst_typedef1" (Ptr.Ptr Const_typedef1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef1" (Ptr.Ptr Const_typedef1) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef1")
@@ -1128,8 +1101,7 @@ newtype Const_typedef2 = Const_typedef2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef2) "unwrapConst_typedef2")
-         ) => GHC.Records.HasField "unwrapConst_typedef2" (Ptr.Ptr Const_typedef2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef2" (Ptr.Ptr Const_typedef2) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef2")
@@ -1160,8 +1132,7 @@ newtype Const_typedef3 = Const_typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef3) "unwrapConst_typedef3")
-         ) => GHC.Records.HasField "unwrapConst_typedef3" (Ptr.Ptr Const_typedef3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef3" (Ptr.Ptr Const_typedef3) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef3")
@@ -1192,8 +1163,7 @@ newtype Const_typedef4 = Const_typedef4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef4) "unwrapConst_typedef4")
-         ) => GHC.Records.HasField "unwrapConst_typedef4" (Ptr.Ptr Const_typedef4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef4" (Ptr.Ptr Const_typedef4) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef4")
@@ -1224,8 +1194,7 @@ newtype Const_typedef5 = Const_typedef5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef5) "unwrapConst_typedef5")
-         ) => GHC.Records.HasField "unwrapConst_typedef5" (Ptr.Ptr Const_typedef5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef5" (Ptr.Ptr Const_typedef5) (Ptr.Ptr (Ptr.Ptr A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef5")
@@ -1256,8 +1225,7 @@ newtype Const_typedef6 = Const_typedef6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef6) "unwrapConst_typedef6")
-         ) => GHC.Records.HasField "unwrapConst_typedef6" (Ptr.Ptr Const_typedef6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef6" (Ptr.Ptr Const_typedef6) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef6")
@@ -1288,8 +1256,7 @@ newtype Const_typedef7 = Const_typedef7
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_typedef7) "unwrapConst_typedef7")
-         ) => GHC.Records.HasField "unwrapConst_typedef7" (Ptr.Ptr Const_typedef7) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_typedef7" (Ptr.Ptr Const_typedef7) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef7")
@@ -1411,8 +1378,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field1")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field1" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field1" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field1")
@@ -1424,8 +1390,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field2")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field2" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field2" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr A) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field2")
@@ -1437,8 +1402,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field3")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field3" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field3" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field3")
@@ -1450,8 +1414,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field4")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field4" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field4" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field4")
@@ -1463,8 +1426,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field5")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field5" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field5" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (Ptr.Ptr A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field5")
@@ -1476,8 +1438,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field6")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field6" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field6" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field6")
@@ -1489,8 +1450,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 40
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Example_struct_with_const) "example_struct_with_const_const_field7")
-         ) => GHC.Records.HasField "example_struct_with_const_const_field7" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "example_struct_with_const_const_field7" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field7")
@@ -1541,8 +1501,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr1_Aux where
 
   fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr1_Aux) "unwrapConst_funptr1_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr1_Aux" (Ptr.Ptr Const_funptr1_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr1_Aux" (Ptr.Ptr Const_funptr1_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr1_Aux")
@@ -1573,8 +1532,7 @@ newtype Const_funptr1 = Const_funptr1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr1) "unwrapConst_funptr1")
-         ) => GHC.Records.HasField "unwrapConst_funptr1" (Ptr.Ptr Const_funptr1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr1" (Ptr.Ptr Const_funptr1) (Ptr.Ptr (Ptr.FunPtr Const_funptr1_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr1")
@@ -1632,8 +1590,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr2_Aux where
 
   fromFunPtr = hs_bindgen_352cebf463125ca9
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr2_Aux) "unwrapConst_funptr2_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr2_Aux" (Ptr.Ptr Const_funptr2_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr2_Aux" (Ptr.Ptr Const_funptr2_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr2_Aux")
@@ -1664,8 +1621,7 @@ newtype Const_funptr2 = Const_funptr2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr2) "unwrapConst_funptr2")
-         ) => GHC.Records.HasField "unwrapConst_funptr2" (Ptr.Ptr Const_funptr2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr2" (Ptr.Ptr Const_funptr2) (Ptr.Ptr (Ptr.FunPtr Const_funptr2_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr2")
@@ -1723,8 +1679,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr3_Aux where
 
   fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr3_Aux) "unwrapConst_funptr3_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr3_Aux" (Ptr.Ptr Const_funptr3_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr3_Aux" (Ptr.Ptr Const_funptr3_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr3_Aux")
@@ -1755,8 +1710,7 @@ newtype Const_funptr3 = Const_funptr3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr3) "unwrapConst_funptr3")
-         ) => GHC.Records.HasField "unwrapConst_funptr3" (Ptr.Ptr Const_funptr3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr3" (Ptr.Ptr Const_funptr3) (Ptr.Ptr (Ptr.FunPtr Const_funptr3_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr3")
@@ -1814,8 +1768,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr4_Aux where
 
   fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr4_Aux) "unwrapConst_funptr4_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr4_Aux" (Ptr.Ptr Const_funptr4_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr4_Aux" (Ptr.Ptr Const_funptr4_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr4_Aux")
@@ -1846,8 +1799,7 @@ newtype Const_funptr4 = Const_funptr4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr4) "unwrapConst_funptr4")
-         ) => GHC.Records.HasField "unwrapConst_funptr4" (Ptr.Ptr Const_funptr4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr4" (Ptr.Ptr Const_funptr4) (Ptr.Ptr (Ptr.FunPtr Const_funptr4_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr4")
@@ -1905,8 +1857,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr5_Aux where
 
   fromFunPtr = hs_bindgen_38a21d84bb7115b5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr5_Aux) "unwrapConst_funptr5_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr5_Aux" (Ptr.Ptr Const_funptr5_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr5_Aux" (Ptr.Ptr Const_funptr5_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr5_Aux")
@@ -1937,8 +1888,7 @@ newtype Const_funptr5 = Const_funptr5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr5) "unwrapConst_funptr5")
-         ) => GHC.Records.HasField "unwrapConst_funptr5" (Ptr.Ptr Const_funptr5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr5" (Ptr.Ptr Const_funptr5) (Ptr.Ptr (Ptr.FunPtr Const_funptr5_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr5")
@@ -1996,8 +1946,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr6_Aux where
 
   fromFunPtr = hs_bindgen_45251216b04aa8b5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr6_Aux) "unwrapConst_funptr6_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr6_Aux" (Ptr.Ptr Const_funptr6_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr6_Aux" (Ptr.Ptr Const_funptr6_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr6_Aux")
@@ -2028,8 +1977,7 @@ newtype Const_funptr6 = Const_funptr6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr6) "unwrapConst_funptr6")
-         ) => GHC.Records.HasField "unwrapConst_funptr6" (Ptr.Ptr Const_funptr6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr6" (Ptr.Ptr Const_funptr6) (Ptr.Ptr (Ptr.FunPtr Const_funptr6_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr6")
@@ -2087,8 +2035,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr7_Aux where
 
   fromFunPtr = hs_bindgen_42fbcebf75a973ba
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr7_Aux) "unwrapConst_funptr7_Aux")
-         ) => GHC.Records.HasField "unwrapConst_funptr7_Aux" (Ptr.Ptr Const_funptr7_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr7_Aux" (Ptr.Ptr Const_funptr7_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr7_Aux")
@@ -2119,8 +2066,7 @@ newtype Const_funptr7 = Const_funptr7
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Const_funptr7) "unwrapConst_funptr7")
-         ) => GHC.Records.HasField "unwrapConst_funptr7" (Ptr.Ptr Const_funptr7) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConst_funptr7" (Ptr.Ptr Const_funptr7) (Ptr.Ptr (Ptr.FunPtr Const_funptr7_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr7")
@@ -2161,8 +2107,7 @@ newtype BOOL = BOOL
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType BOOL) "unwrapBOOL")
-         ) => GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOL")
@@ -2202,8 +2147,7 @@ newtype INT = INT
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType INT) "unwrapINT")
-         ) => GHC.Records.HasField "unwrapINT" (Ptr.Ptr INT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapINT" (Ptr.Ptr INT) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINT")
@@ -2233,8 +2177,7 @@ newtype INTP = INTP
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType INTP) "unwrapINTP")
-         ) => GHC.Records.HasField "unwrapINTP" (Ptr.Ptr INTP) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapINTP" (Ptr.Ptr INTP) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINTP")
@@ -2264,8 +2207,7 @@ newtype INTCP = INTCP
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType INTCP) "unwrapINTCP")
-         ) => GHC.Records.HasField "unwrapINTCP" (Ptr.Ptr INTCP) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapINTCP" (Ptr.Ptr INTCP) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINTCP")

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2504,8 +2504,7 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
@@ -2600,8 +2599,7 @@ instance Read Some_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Some_enum "unwrapSome_enum") =>
-         HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr ty)
+instance HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapSome_enum")
 instance HasCField Some_enum "unwrapSome_enum"
     where type CFieldType Some_enum "unwrapSome_enum" = CUInt
@@ -2636,8 +2634,9 @@ newtype Arr_typedef1
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType Arr_typedef1 "unwrapArr_typedef1") =>
-         HasField "unwrapArr_typedef1" (Ptr Arr_typedef1) (Ptr ty)
+instance HasField "unwrapArr_typedef1"
+                  (Ptr Arr_typedef1)
+                  (Ptr (IncompleteArray A))
     where getField = fromPtr (Proxy @"unwrapArr_typedef1")
 instance HasCField Arr_typedef1 "unwrapArr_typedef1"
     where type CFieldType Arr_typedef1
@@ -2659,8 +2658,9 @@ newtype Arr_typedef2
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType Arr_typedef2 "unwrapArr_typedef2") =>
-         HasField "unwrapArr_typedef2" (Ptr Arr_typedef2) (Ptr ty)
+instance HasField "unwrapArr_typedef2"
+                  (Ptr Arr_typedef2)
+                  (Ptr (IncompleteArray (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapArr_typedef2")
 instance HasCField Arr_typedef2 "unwrapArr_typedef2"
     where type CFieldType Arr_typedef2
@@ -2683,8 +2683,9 @@ newtype Arr_typedef3
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Arr_typedef3 "unwrapArr_typedef3") =>
-         HasField "unwrapArr_typedef3" (Ptr Arr_typedef3) (Ptr ty)
+instance HasField "unwrapArr_typedef3"
+                  (Ptr Arr_typedef3)
+                  (Ptr (ConstantArray 5 A))
     where getField = fromPtr (Proxy @"unwrapArr_typedef3")
 instance HasCField Arr_typedef3 "unwrapArr_typedef3"
     where type CFieldType Arr_typedef3
@@ -2707,8 +2708,9 @@ newtype Arr_typedef4
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Arr_typedef4 "unwrapArr_typedef4") =>
-         HasField "unwrapArr_typedef4" (Ptr Arr_typedef4) (Ptr ty)
+instance HasField "unwrapArr_typedef4"
+                  (Ptr Arr_typedef4)
+                  (Ptr (ConstantArray 5 (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapArr_typedef4")
 instance HasCField Arr_typedef4 "unwrapArr_typedef4"
     where type CFieldType Arr_typedef4
@@ -2749,8 +2751,7 @@ newtype Typedef1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Typedef1 "unwrapTypedef1") =>
-         HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr ty)
+instance HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapTypedef1")
 instance HasCField Typedef1 "unwrapTypedef1"
     where type CFieldType Typedef1 "unwrapTypedef1" = A
@@ -2776,8 +2777,7 @@ newtype Typedef2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Typedef2 "unwrapTypedef2") =>
-         HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr ty)
+instance HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"unwrapTypedef2")
 instance HasCField Typedef2 "unwrapTypedef2"
     where type CFieldType Typedef2 "unwrapTypedef2" = Ptr A
@@ -2803,8 +2803,9 @@ newtype Typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Typedef3 "unwrapTypedef3") =>
-         HasField "unwrapTypedef3" (Ptr Typedef3) (Ptr ty)
+instance HasField "unwrapTypedef3"
+                  (Ptr Typedef3)
+                  (Ptr (Ptr (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapTypedef3")
 instance HasCField Typedef3 "unwrapTypedef3"
     where type CFieldType Typedef3 "unwrapTypedef3" = Ptr (Ptr A)
@@ -2849,11 +2850,9 @@ instance ToFunPtr Funptr_typedef1_Aux
     where toFunPtr = hs_bindgen_c584d0f839fd43de
 instance FromFunPtr Funptr_typedef1_Aux
     where fromFunPtr = hs_bindgen_806a46dc418a062c
-instance TyEq ty
-              (CFieldType Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux") =>
-         HasField "unwrapFunptr_typedef1_Aux"
+instance HasField "unwrapFunptr_typedef1_Aux"
                   (Ptr Funptr_typedef1_Aux)
-                  (Ptr ty)
+                  (Ptr (IO A))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1_Aux")
 instance HasCField Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux"
     where type CFieldType Funptr_typedef1_Aux
@@ -2880,9 +2879,9 @@ newtype Funptr_typedef1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Funptr_typedef1 "unwrapFunptr_typedef1") =>
-         HasField "unwrapFunptr_typedef1" (Ptr Funptr_typedef1) (Ptr ty)
+instance HasField "unwrapFunptr_typedef1"
+                  (Ptr Funptr_typedef1)
+                  (Ptr (FunPtr Funptr_typedef1_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1")
 instance HasCField Funptr_typedef1 "unwrapFunptr_typedef1"
     where type CFieldType Funptr_typedef1
@@ -2928,11 +2927,9 @@ instance ToFunPtr Funptr_typedef2_Aux
     where toFunPtr = hs_bindgen_f174457a161ac5a0
 instance FromFunPtr Funptr_typedef2_Aux
     where fromFunPtr = hs_bindgen_323d07dff85b802c
-instance TyEq ty
-              (CFieldType Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux") =>
-         HasField "unwrapFunptr_typedef2_Aux"
+instance HasField "unwrapFunptr_typedef2_Aux"
                   (Ptr Funptr_typedef2_Aux)
-                  (Ptr ty)
+                  (Ptr (IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2_Aux")
 instance HasCField Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux"
     where type CFieldType Funptr_typedef2_Aux
@@ -2959,9 +2956,9 @@ newtype Funptr_typedef2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Funptr_typedef2 "unwrapFunptr_typedef2") =>
-         HasField "unwrapFunptr_typedef2" (Ptr Funptr_typedef2) (Ptr ty)
+instance HasField "unwrapFunptr_typedef2"
+                  (Ptr Funptr_typedef2)
+                  (Ptr (FunPtr Funptr_typedef2_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2")
 instance HasCField Funptr_typedef2 "unwrapFunptr_typedef2"
     where type CFieldType Funptr_typedef2
@@ -3007,11 +3004,9 @@ instance ToFunPtr Funptr_typedef3_Aux
     where toFunPtr = hs_bindgen_031d1a7decd790d8
 instance FromFunPtr Funptr_typedef3_Aux
     where fromFunPtr = hs_bindgen_82dc7b932974117e
-instance TyEq ty
-              (CFieldType Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux") =>
-         HasField "unwrapFunptr_typedef3_Aux"
+instance HasField "unwrapFunptr_typedef3_Aux"
                   (Ptr Funptr_typedef3_Aux)
-                  (Ptr ty)
+                  (Ptr (IO (Ptr (Ptr A))))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3_Aux")
 instance HasCField Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux"
     where type CFieldType Funptr_typedef3_Aux
@@ -3038,9 +3033,9 @@ newtype Funptr_typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Funptr_typedef3 "unwrapFunptr_typedef3") =>
-         HasField "unwrapFunptr_typedef3" (Ptr Funptr_typedef3) (Ptr ty)
+instance HasField "unwrapFunptr_typedef3"
+                  (Ptr Funptr_typedef3)
+                  (Ptr (FunPtr Funptr_typedef3_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3")
 instance HasCField Funptr_typedef3 "unwrapFunptr_typedef3"
     where type CFieldType Funptr_typedef3
@@ -3089,11 +3084,9 @@ instance ToFunPtr Funptr_typedef4_Aux
     where toFunPtr = hs_bindgen_da2336d254667386
 instance FromFunPtr Funptr_typedef4_Aux
     where fromFunPtr = hs_bindgen_d4a97954476da161
-instance TyEq ty
-              (CFieldType Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux") =>
-         HasField "unwrapFunptr_typedef4_Aux"
+instance HasField "unwrapFunptr_typedef4_Aux"
                   (Ptr Funptr_typedef4_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4_Aux")
 instance HasCField Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux"
     where type CFieldType Funptr_typedef4_Aux
@@ -3120,9 +3113,9 @@ newtype Funptr_typedef4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Funptr_typedef4 "unwrapFunptr_typedef4") =>
-         HasField "unwrapFunptr_typedef4" (Ptr Funptr_typedef4) (Ptr ty)
+instance HasField "unwrapFunptr_typedef4"
+                  (Ptr Funptr_typedef4)
+                  (Ptr (FunPtr Funptr_typedef4_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4")
 instance HasCField Funptr_typedef4 "unwrapFunptr_typedef4"
     where type CFieldType Funptr_typedef4
@@ -3171,11 +3164,9 @@ instance ToFunPtr Funptr_typedef5_Aux
     where toFunPtr = hs_bindgen_1f45632f07742a46
 instance FromFunPtr Funptr_typedef5_Aux
     where fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
-instance TyEq ty
-              (CFieldType Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux") =>
-         HasField "unwrapFunptr_typedef5_Aux"
+instance HasField "unwrapFunptr_typedef5_Aux"
                   (Ptr Funptr_typedef5_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5_Aux")
 instance HasCField Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux"
     where type CFieldType Funptr_typedef5_Aux
@@ -3202,9 +3193,9 @@ newtype Funptr_typedef5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Funptr_typedef5 "unwrapFunptr_typedef5") =>
-         HasField "unwrapFunptr_typedef5" (Ptr Funptr_typedef5) (Ptr ty)
+instance HasField "unwrapFunptr_typedef5"
+                  (Ptr Funptr_typedef5)
+                  (Ptr (FunPtr Funptr_typedef5_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5")
 instance HasCField Funptr_typedef5 "unwrapFunptr_typedef5"
     where type CFieldType Funptr_typedef5
@@ -3241,8 +3232,7 @@ newtype Comments2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Comments2 "unwrapComments2") =>
-         HasField "unwrapComments2" (Ptr Comments2) (Ptr ty)
+instance HasField "unwrapComments2" (Ptr Comments2) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapComments2")
 instance HasCField Comments2 "unwrapComments2"
     where type CFieldType Comments2 "unwrapComments2" = A
@@ -3301,25 +3291,25 @@ deriving via (EquivStorable Example_struct) instance Storable Example_struct
 instance HasCField Example_struct "example_struct_field1"
     where type CFieldType Example_struct "example_struct_field1" = A
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Example_struct "example_struct_field1") =>
-         HasField "example_struct_field1" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field1"
+                  (Ptr Example_struct)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_field1")
 instance HasCField Example_struct "example_struct_field2"
     where type CFieldType Example_struct
                           "example_struct_field2" = Ptr A
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Example_struct "example_struct_field2") =>
-         HasField "example_struct_field2" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field2"
+                  (Ptr Example_struct)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"example_struct_field2")
 instance HasCField Example_struct "example_struct_field3"
     where type CFieldType Example_struct
                           "example_struct_field3" = Ptr (Ptr A)
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType Example_struct "example_struct_field3") =>
-         HasField "example_struct_field3" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field3"
+                  (Ptr Example_struct)
+                  (Ptr (Ptr (Ptr A)))
     where getField = fromPtr (Proxy @"example_struct_field3")
 {-| __C declaration:__ @const_typedef1@
 
@@ -3352,9 +3342,9 @@ newtype Const_typedef1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Const_typedef1 "unwrapConst_typedef1") =>
-         HasField "unwrapConst_typedef1" (Ptr Const_typedef1) (Ptr ty)
+instance HasField "unwrapConst_typedef1"
+                  (Ptr Const_typedef1)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"unwrapConst_typedef1")
 instance HasCField Const_typedef1 "unwrapConst_typedef1"
     where type CFieldType Const_typedef1 "unwrapConst_typedef1" = A
@@ -3390,9 +3380,9 @@ newtype Const_typedef2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Const_typedef2 "unwrapConst_typedef2") =>
-         HasField "unwrapConst_typedef2" (Ptr Const_typedef2) (Ptr ty)
+instance HasField "unwrapConst_typedef2"
+                  (Ptr Const_typedef2)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"unwrapConst_typedef2")
 instance HasCField Const_typedef2 "unwrapConst_typedef2"
     where type CFieldType Const_typedef2 "unwrapConst_typedef2" = A
@@ -3418,9 +3408,9 @@ newtype Const_typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_typedef3 "unwrapConst_typedef3") =>
-         HasField "unwrapConst_typedef3" (Ptr Const_typedef3) (Ptr ty)
+instance HasField "unwrapConst_typedef3"
+                  (Ptr Const_typedef3)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef3")
 instance HasCField Const_typedef3 "unwrapConst_typedef3"
     where type CFieldType Const_typedef3
@@ -3447,9 +3437,9 @@ newtype Const_typedef4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_typedef4 "unwrapConst_typedef4") =>
-         HasField "unwrapConst_typedef4" (Ptr Const_typedef4) (Ptr ty)
+instance HasField "unwrapConst_typedef4"
+                  (Ptr Const_typedef4)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef4")
 instance HasCField Const_typedef4 "unwrapConst_typedef4"
     where type CFieldType Const_typedef4
@@ -3476,9 +3466,9 @@ newtype Const_typedef5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_typedef5 "unwrapConst_typedef5") =>
-         HasField "unwrapConst_typedef5" (Ptr Const_typedef5) (Ptr ty)
+instance HasField "unwrapConst_typedef5"
+                  (Ptr Const_typedef5)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef5")
 instance HasCField Const_typedef5 "unwrapConst_typedef5"
     where type CFieldType Const_typedef5 "unwrapConst_typedef5" = Ptr A
@@ -3504,9 +3494,9 @@ newtype Const_typedef6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_typedef6 "unwrapConst_typedef6") =>
-         HasField "unwrapConst_typedef6" (Ptr Const_typedef6) (Ptr ty)
+instance HasField "unwrapConst_typedef6"
+                  (Ptr Const_typedef6)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef6")
 instance HasCField Const_typedef6 "unwrapConst_typedef6"
     where type CFieldType Const_typedef6
@@ -3533,9 +3523,9 @@ newtype Const_typedef7
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_typedef7 "unwrapConst_typedef7") =>
-         HasField "unwrapConst_typedef7" (Ptr Const_typedef7) (Ptr ty)
+instance HasField "unwrapConst_typedef7"
+                  (Ptr Const_typedef7)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef7")
 instance HasCField Const_typedef7 "unwrapConst_typedef7"
     where type CFieldType Const_typedef7
@@ -3625,84 +3615,63 @@ instance HasCField Example_struct_with_const
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field1" = A
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field1") =>
-         HasField "example_struct_with_const_const_field1"
+instance HasField "example_struct_with_const_const_field1"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field1")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field2"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field2" = A
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field2") =>
-         HasField "example_struct_with_const_const_field2"
+instance HasField "example_struct_with_const_const_field2"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field2")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field3"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field3" = PtrConst A
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field3") =>
-         HasField "example_struct_with_const_const_field3"
+instance HasField "example_struct_with_const_const_field3"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field3")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field4"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field4" = PtrConst A
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field4") =>
-         HasField "example_struct_with_const_const_field4"
+instance HasField "example_struct_with_const_const_field4"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field4")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field5"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field5" = Ptr A
           offset# = \_ -> \_ -> 24
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field5") =>
-         HasField "example_struct_with_const_const_field5"
+instance HasField "example_struct_with_const_const_field5"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field5")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field6"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field6" = PtrConst A
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field6") =>
-         HasField "example_struct_with_const_const_field6"
+instance HasField "example_struct_with_const_const_field6"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field6")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field7"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field7" = PtrConst A
           offset# = \_ -> \_ -> 40
-instance TyEq ty
-              (CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field7") =>
-         HasField "example_struct_with_const_const_field7"
+instance HasField "example_struct_with_const_const_field7"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field7")
 {-| Auxiliary type used by 'Const_funptr1'
 
@@ -3747,9 +3716,9 @@ instance ToFunPtr Const_funptr1_Aux
     where toFunPtr = hs_bindgen_7f125e20a9d4075b
 instance FromFunPtr Const_funptr1_Aux
     where fromFunPtr = hs_bindgen_ac4bd8d789bba94b
-instance TyEq ty
-              (CFieldType Const_funptr1_Aux "unwrapConst_funptr1_Aux") =>
-         HasField "unwrapConst_funptr1_Aux" (Ptr Const_funptr1_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr1_Aux"
+                  (Ptr Const_funptr1_Aux)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapConst_funptr1_Aux")
 instance HasCField Const_funptr1_Aux "unwrapConst_funptr1_Aux"
     where type CFieldType Const_funptr1_Aux
@@ -3776,9 +3745,9 @@ newtype Const_funptr1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr1 "unwrapConst_funptr1") =>
-         HasField "unwrapConst_funptr1" (Ptr Const_funptr1) (Ptr ty)
+instance HasField "unwrapConst_funptr1"
+                  (Ptr Const_funptr1)
+                  (Ptr (FunPtr Const_funptr1_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr1")
 instance HasCField Const_funptr1 "unwrapConst_funptr1"
     where type CFieldType Const_funptr1
@@ -3827,9 +3796,9 @@ instance ToFunPtr Const_funptr2_Aux
     where toFunPtr = hs_bindgen_c7b1e36d845634fb
 instance FromFunPtr Const_funptr2_Aux
     where fromFunPtr = hs_bindgen_352cebf463125ca9
-instance TyEq ty
-              (CFieldType Const_funptr2_Aux "unwrapConst_funptr2_Aux") =>
-         HasField "unwrapConst_funptr2_Aux" (Ptr Const_funptr2_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr2_Aux"
+                  (Ptr Const_funptr2_Aux)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapConst_funptr2_Aux")
 instance HasCField Const_funptr2_Aux "unwrapConst_funptr2_Aux"
     where type CFieldType Const_funptr2_Aux
@@ -3856,9 +3825,9 @@ newtype Const_funptr2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr2 "unwrapConst_funptr2") =>
-         HasField "unwrapConst_funptr2" (Ptr Const_funptr2) (Ptr ty)
+instance HasField "unwrapConst_funptr2"
+                  (Ptr Const_funptr2)
+                  (Ptr (FunPtr Const_funptr2_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr2")
 instance HasCField Const_funptr2 "unwrapConst_funptr2"
     where type CFieldType Const_funptr2
@@ -3907,9 +3876,9 @@ instance ToFunPtr Const_funptr3_Aux
     where toFunPtr = hs_bindgen_2dcbfe1c2502178c
 instance FromFunPtr Const_funptr3_Aux
     where fromFunPtr = hs_bindgen_86738dcfd7c9d33c
-instance TyEq ty
-              (CFieldType Const_funptr3_Aux "unwrapConst_funptr3_Aux") =>
-         HasField "unwrapConst_funptr3_Aux" (Ptr Const_funptr3_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr3_Aux"
+                  (Ptr Const_funptr3_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr3_Aux")
 instance HasCField Const_funptr3_Aux "unwrapConst_funptr3_Aux"
     where type CFieldType Const_funptr3_Aux
@@ -3936,9 +3905,9 @@ newtype Const_funptr3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr3 "unwrapConst_funptr3") =>
-         HasField "unwrapConst_funptr3" (Ptr Const_funptr3) (Ptr ty)
+instance HasField "unwrapConst_funptr3"
+                  (Ptr Const_funptr3)
+                  (Ptr (FunPtr Const_funptr3_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr3")
 instance HasCField Const_funptr3 "unwrapConst_funptr3"
     where type CFieldType Const_funptr3
@@ -3987,9 +3956,9 @@ instance ToFunPtr Const_funptr4_Aux
     where toFunPtr = hs_bindgen_5461deeda491de0b
 instance FromFunPtr Const_funptr4_Aux
     where fromFunPtr = hs_bindgen_de7846fca3bfd1b6
-instance TyEq ty
-              (CFieldType Const_funptr4_Aux "unwrapConst_funptr4_Aux") =>
-         HasField "unwrapConst_funptr4_Aux" (Ptr Const_funptr4_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr4_Aux"
+                  (Ptr Const_funptr4_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr4_Aux")
 instance HasCField Const_funptr4_Aux "unwrapConst_funptr4_Aux"
     where type CFieldType Const_funptr4_Aux
@@ -4016,9 +3985,9 @@ newtype Const_funptr4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr4 "unwrapConst_funptr4") =>
-         HasField "unwrapConst_funptr4" (Ptr Const_funptr4) (Ptr ty)
+instance HasField "unwrapConst_funptr4"
+                  (Ptr Const_funptr4)
+                  (Ptr (FunPtr Const_funptr4_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr4")
 instance HasCField Const_funptr4 "unwrapConst_funptr4"
     where type CFieldType Const_funptr4
@@ -4067,9 +4036,9 @@ instance ToFunPtr Const_funptr5_Aux
     where toFunPtr = hs_bindgen_7b0174fc978a1ce1
 instance FromFunPtr Const_funptr5_Aux
     where fromFunPtr = hs_bindgen_38a21d84bb7115b5
-instance TyEq ty
-              (CFieldType Const_funptr5_Aux "unwrapConst_funptr5_Aux") =>
-         HasField "unwrapConst_funptr5_Aux" (Ptr Const_funptr5_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr5_Aux"
+                  (Ptr Const_funptr5_Aux)
+                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr5_Aux")
 instance HasCField Const_funptr5_Aux "unwrapConst_funptr5_Aux"
     where type CFieldType Const_funptr5_Aux
@@ -4096,9 +4065,9 @@ newtype Const_funptr5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr5 "unwrapConst_funptr5") =>
-         HasField "unwrapConst_funptr5" (Ptr Const_funptr5) (Ptr ty)
+instance HasField "unwrapConst_funptr5"
+                  (Ptr Const_funptr5)
+                  (Ptr (FunPtr Const_funptr5_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr5")
 instance HasCField Const_funptr5 "unwrapConst_funptr5"
     where type CFieldType Const_funptr5
@@ -4147,9 +4116,9 @@ instance ToFunPtr Const_funptr6_Aux
     where toFunPtr = hs_bindgen_4e32721222f4df9f
 instance FromFunPtr Const_funptr6_Aux
     where fromFunPtr = hs_bindgen_45251216b04aa8b5
-instance TyEq ty
-              (CFieldType Const_funptr6_Aux "unwrapConst_funptr6_Aux") =>
-         HasField "unwrapConst_funptr6_Aux" (Ptr Const_funptr6_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr6_Aux"
+                  (Ptr Const_funptr6_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr6_Aux")
 instance HasCField Const_funptr6_Aux "unwrapConst_funptr6_Aux"
     where type CFieldType Const_funptr6_Aux
@@ -4176,9 +4145,9 @@ newtype Const_funptr6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr6 "unwrapConst_funptr6") =>
-         HasField "unwrapConst_funptr6" (Ptr Const_funptr6) (Ptr ty)
+instance HasField "unwrapConst_funptr6"
+                  (Ptr Const_funptr6)
+                  (Ptr (FunPtr Const_funptr6_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr6")
 instance HasCField Const_funptr6 "unwrapConst_funptr6"
     where type CFieldType Const_funptr6
@@ -4227,9 +4196,9 @@ instance ToFunPtr Const_funptr7_Aux
     where toFunPtr = hs_bindgen_0d04fc96ffb9de06
 instance FromFunPtr Const_funptr7_Aux
     where fromFunPtr = hs_bindgen_42fbcebf75a973ba
-instance TyEq ty
-              (CFieldType Const_funptr7_Aux "unwrapConst_funptr7_Aux") =>
-         HasField "unwrapConst_funptr7_Aux" (Ptr Const_funptr7_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr7_Aux"
+                  (Ptr Const_funptr7_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr7_Aux")
 instance HasCField Const_funptr7_Aux "unwrapConst_funptr7_Aux"
     where type CFieldType Const_funptr7_Aux
@@ -4256,9 +4225,9 @@ newtype Const_funptr7
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType Const_funptr7 "unwrapConst_funptr7") =>
-         HasField "unwrapConst_funptr7" (Ptr Const_funptr7) (Ptr ty)
+instance HasField "unwrapConst_funptr7"
+                  (Ptr Const_funptr7)
+                  (Ptr (FunPtr Const_funptr7_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr7")
 instance HasCField Const_funptr7 "unwrapConst_funptr7"
     where type CFieldType Const_funptr7
@@ -4295,8 +4264,7 @@ newtype BOOL
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType BOOL "unwrapBOOL") =>
-         HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -4332,8 +4300,7 @@ newtype INT
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType INT "unwrapINT") =>
-         HasField "unwrapINT" (Ptr INT) (Ptr ty)
+instance HasField "unwrapINT" (Ptr INT) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapINT")
 instance HasCField INT "unwrapINT"
     where type CFieldType INT "unwrapINT" = CInt
@@ -4359,8 +4326,7 @@ newtype INTP
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType INTP "unwrapINTP") =>
-         HasField "unwrapINTP" (Ptr INTP) (Ptr ty)
+instance HasField "unwrapINTP" (Ptr INTP) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapINTP")
 instance HasCField INTP "unwrapINTP"
     where type CFieldType INTP "unwrapINTP" = Ptr CInt
@@ -4386,8 +4352,7 @@ newtype INTCP
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType INTCP "unwrapINTCP") =>
-         HasField "unwrapINTCP" (Ptr INTCP) (Ptr ty)
+instance HasField "unwrapINTCP" (Ptr INTCP) (Ptr (PtrConst CInt))
     where getField = fromPtr (Proxy @"unwrapINTCP")
 instance HasCField INTCP "unwrapINTCP"
     where type CFieldType INTCP "unwrapINTCP" = PtrConst CInt

--- a/hs-bindgen/fixtures/manual/arrays/Example.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @triplet@
@@ -44,8 +41,7 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
-         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -75,8 +71,7 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Matrix) "unwrapMatrix")
-         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -102,8 +97,7 @@ newtype Triplet_ptrs = Triplet_ptrs
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet_ptrs) "unwrapTriplet_ptrs")
-         ) => GHC.Records.HasField "unwrapTriplet_ptrs" (Ptr.Ptr Triplet_ptrs) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet_ptrs" (Ptr.Ptr Triplet_ptrs) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet_ptrs")

--- a/hs-bindgen/fixtures/manual/arrays/th.txt
+++ b/hs-bindgen/fixtures/manual/arrays/th.txt
@@ -96,8 +96,9 @@ newtype Triplet
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -120,8 +121,9 @@ newtype Matrix
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 3 Triplet))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 3
@@ -148,8 +150,9 @@ newtype Triplet_ptrs
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType Triplet_ptrs "unwrapTriplet_ptrs") =>
-         HasField "unwrapTriplet_ptrs" (Ptr Triplet_ptrs) (Ptr ty)
+instance HasField "unwrapTriplet_ptrs"
+                  (Ptr Triplet_ptrs)
+                  (Ptr (IncompleteArray (Ptr (ConstantArray 3 CInt))))
     where getField = fromPtr (Proxy @"unwrapTriplet_ptrs")
 instance HasCField Triplet_ptrs "unwrapTriplet_ptrs"
     where type CFieldType Triplet_ptrs

--- a/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -14,7 +13,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -44,7 +42,6 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @struct Point@
@@ -104,8 +101,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point) "x")
-         ) => GHC.Records.HasField "x" (Ptr.Ptr Point) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -116,8 +112,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point) "y")
-         ) => GHC.Records.HasField "y" (Ptr.Ptr Point) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -179,8 +174,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Size "width" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Size) "width")
-         ) => GHC.Records.HasField "width" (Ptr.Ptr Size) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "width" (Ptr.Ptr Size) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"width")
@@ -191,8 +185,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Size "height" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Size) "height")
-         ) => GHC.Records.HasField "height" (Ptr.Ptr Size) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "height" (Ptr.Ptr Size) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"height")
@@ -272,8 +265,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rect) "x")
-         ) => GHC.Records.HasField "x" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -284,8 +276,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rect) "y")
-         ) => GHC.Records.HasField "y" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -296,8 +287,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "width" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rect) "width")
-         ) => GHC.Records.HasField "width" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "width" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"width")
@@ -308,8 +298,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "height" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rect) "height")
-         ) => GHC.Records.HasField "height" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "height" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"height")
@@ -393,8 +382,7 @@ instance Read E where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr E) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -452,8 +440,7 @@ newtype Value = Value
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Value) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr Value) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr Value) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -543,8 +530,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U1 "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U1) "x")
-         ) => GHC.Records.HasField "x" (Ptr.Ptr U1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x" (Ptr.Ptr U1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -555,8 +541,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U1 "y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U1) "y")
-         ) => GHC.Records.HasField "y" (Ptr.Ptr U1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y" (Ptr.Ptr U1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -640,8 +625,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U2_t) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr U2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr U2_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -652,8 +636,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U2_t "b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U2_t) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr U2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr U2_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -737,8 +720,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U3 "p" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U3) "p")
-         ) => GHC.Records.HasField "p" (Ptr.Ptr U3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "p" (Ptr.Ptr U3) (Ptr.Ptr Point) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"p")
@@ -749,8 +731,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U3 "s" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U3) "s")
-         ) => GHC.Records.HasField "s" (Ptr.Ptr U3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s" (Ptr.Ptr U3) (Ptr.Ptr Size) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s")
@@ -834,8 +815,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U4 "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U4) "x")
-         ) => GHC.Records.HasField "x" (Ptr.Ptr U4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "x" (Ptr.Ptr U4) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -846,8 +826,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U4 "y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U4) "y")
-         ) => GHC.Records.HasField "y" (Ptr.Ptr U4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "y" (Ptr.Ptr U4) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -906,8 +885,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr RunDriver_Aux where
 
   fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType RunDriver_Aux) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ((Ptr.Ptr Driver) -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -938,8 +916,7 @@ newtype RunDriver = RunDriver
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType RunDriver) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver) (Ptr.Ptr (Ptr.FunPtr RunDriver_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")

--- a/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable Point) instance Storable Point
 instance HasCField Point "x"
     where type CFieldType Point "x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Point "x") =>
-         HasField "x" (Ptr Point) (Ptr ty)
+instance HasField "x" (Ptr Point) (Ptr CInt)
     where getField = fromPtr (Proxy @"x")
 instance HasCField Point "y"
     where type CFieldType Point "y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Point "y") =>
-         HasField "y" (Ptr Point) (Ptr ty)
+instance HasField "y" (Ptr Point) (Ptr CInt)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @struct Size@
 
@@ -92,14 +90,12 @@ deriving via (EquivStorable Size) instance Storable Size
 instance HasCField Size "width"
     where type CFieldType Size "width" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Size "width") =>
-         HasField "width" (Ptr Size) (Ptr ty)
+instance HasField "width" (Ptr Size) (Ptr CInt)
     where getField = fromPtr (Proxy @"width")
 instance HasCField Size "height"
     where type CFieldType Size "height" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Size "height") =>
-         HasField "height" (Ptr Size) (Ptr ty)
+instance HasField "height" (Ptr Size) (Ptr CInt)
     where getField = fromPtr (Proxy @"height")
 {-| __C declaration:__ @struct Rect@
 
@@ -159,26 +155,22 @@ deriving via (EquivStorable Rect) instance Storable Rect
 instance HasCField Rect "x"
     where type CFieldType Rect "x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Rect "x") =>
-         HasField "x" (Ptr Rect) (Ptr ty)
+instance HasField "x" (Ptr Rect) (Ptr CInt)
     where getField = fromPtr (Proxy @"x")
 instance HasCField Rect "y"
     where type CFieldType Rect "y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Rect "y") =>
-         HasField "y" (Ptr Rect) (Ptr ty)
+instance HasField "y" (Ptr Rect) (Ptr CInt)
     where getField = fromPtr (Proxy @"y")
 instance HasCField Rect "width"
     where type CFieldType Rect "width" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Rect "width") =>
-         HasField "width" (Ptr Rect) (Ptr ty)
+instance HasField "width" (Ptr Rect) (Ptr CInt)
     where getField = fromPtr (Proxy @"width")
 instance HasCField Rect "height"
     where type CFieldType Rect "height" = CInt
           offset# = \_ -> \_ -> 12
-instance TyEq ty (CFieldType Rect "height") =>
-         HasField "height" (Ptr Rect) (Ptr ty)
+instance HasField "height" (Ptr Rect) (Ptr CInt)
     where getField = fromPtr (Proxy @"height")
 {-| __C declaration:__ @enum E@
 
@@ -226,8 +218,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType E "unwrap") =>
-         HasField "unwrap" (Ptr E) (Ptr ty)
+instance HasField "unwrap" (Ptr E) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField E "unwrap"
     where type CFieldType E "unwrap" = CUInt
@@ -291,8 +282,7 @@ newtype Value
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Value "unwrap") =>
-         HasField "unwrap" (Ptr Value) (Ptr ty)
+instance HasField "unwrap" (Ptr Value) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Value "unwrap"
     where type CFieldType Value "unwrap" = CInt
@@ -387,14 +377,12 @@ set_u1_y = setUnionPayload
 instance HasCField U1 "x"
     where type CFieldType U1 "x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U1 "x") =>
-         HasField "x" (Ptr U1) (Ptr ty)
+instance HasField "x" (Ptr U1) (Ptr CInt)
     where getField = fromPtr (Proxy @"x")
 instance HasCField U1 "y"
     where type CFieldType U1 "y" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U1 "y") =>
-         HasField "y" (Ptr U1) (Ptr ty)
+instance HasField "y" (Ptr U1) (Ptr CInt)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @union U2@
 
@@ -486,14 +474,12 @@ set_u2_t_b = setUnionPayload
 instance HasCField U2_t "a"
     where type CFieldType U2_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U2_t "a") =>
-         HasField "a" (Ptr U2_t) (Ptr ty)
+instance HasField "a" (Ptr U2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField U2_t "b"
     where type CFieldType U2_t "b" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U2_t "b") =>
-         HasField "b" (Ptr U2_t) (Ptr ty)
+instance HasField "b" (Ptr U2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @union U3@
 
@@ -585,14 +571,12 @@ set_u3_s = setUnionPayload
 instance HasCField U3 "p"
     where type CFieldType U3 "p" = Point
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U3 "p") =>
-         HasField "p" (Ptr U3) (Ptr ty)
+instance HasField "p" (Ptr U3) (Ptr Point)
     where getField = fromPtr (Proxy @"p")
 instance HasCField U3 "s"
     where type CFieldType U3 "s" = Size
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U3 "s") =>
-         HasField "s" (Ptr U3) (Ptr ty)
+instance HasField "s" (Ptr U3) (Ptr Size)
     where getField = fromPtr (Proxy @"s")
 {-| __C declaration:__ @union U4@
 
@@ -684,14 +668,12 @@ set_u4_y = setUnionPayload
 instance HasCField U4 "x"
     where type CFieldType U4 "x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U4 "x") =>
-         HasField "x" (Ptr U4) (Ptr ty)
+instance HasField "x" (Ptr U4) (Ptr CInt)
     where getField = fromPtr (Proxy @"x")
 instance HasCField U4 "y"
     where type CFieldType U4 "y" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType U4 "y") =>
-         HasField "y" (Ptr U4) (Ptr ty)
+instance HasField "y" (Ptr U4) (Ptr CInt)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @struct Driver@
 
@@ -741,8 +723,9 @@ instance ToFunPtr RunDriver_Aux
     where toFunPtr = hs_bindgen_d86ecf261d7044c6
 instance FromFunPtr RunDriver_Aux
     where fromFunPtr = hs_bindgen_6520ae39b50ffb4e
-instance TyEq ty (CFieldType RunDriver_Aux "unwrap") =>
-         HasField "unwrap" (Ptr RunDriver_Aux) (Ptr ty)
+instance HasField "unwrap"
+                  (Ptr RunDriver_Aux)
+                  (Ptr (Ptr Driver -> IO CInt))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField RunDriver_Aux "unwrap"
     where type CFieldType RunDriver_Aux "unwrap" = Ptr Driver ->
@@ -769,8 +752,9 @@ newtype RunDriver
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType RunDriver "unwrap") =>
-         HasField "unwrap" (Ptr RunDriver) (Ptr ty)
+instance HasField "unwrap"
+                  (Ptr RunDriver)
+                  (Ptr (FunPtr RunDriver_Aux))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField RunDriver "unwrap"
     where type CFieldType RunDriver "unwrap" = FunPtr RunDriver_Aux

--- a/hs-bindgen/fixtures/manual/function_pointers/Example.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Void (Void)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, IO, Int, Show, pure)
 
 {-| __C declaration:__ @int2int@
@@ -79,8 +76,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Int2int where
 
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int2int) "unwrapInt2int")
-         ) => GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt2int")
@@ -143,8 +139,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Apply1Struct "apply1Struct_apply1
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Apply1Struct) "apply1Struct_apply1_nopointer_struct_field")
-         ) => GHC.Records.HasField "apply1Struct_apply1_nopointer_struct_field" (Ptr.Ptr Apply1Struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "apply1Struct_apply1_nopointer_struct_field" (Ptr.Ptr Apply1Struct) (Ptr.Ptr (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"apply1Struct_apply1_nopointer_struct_field")
@@ -204,8 +199,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Apply1Union "apply1Union_apply1_n
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Apply1Union) "apply1Union_apply1_nopointer_union_field")
-         ) => GHC.Records.HasField "apply1Union_apply1_nopointer_union_field" (Ptr.Ptr Apply1Union) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "apply1Union_apply1_nopointer_union_field" (Ptr.Ptr Apply1Union) (Ptr.Ptr (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"apply1Union_apply1_nopointer_union_field")

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -232,8 +232,9 @@ instance ToFunPtr Int2int
     where toFunPtr = hs_bindgen_a6c7dd49f5b9d470
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
-instance TyEq ty (CFieldType Int2int "unwrapInt2int") =>
-         HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
+instance HasField "unwrapInt2int"
+                  (Ptr Int2int)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
@@ -280,12 +281,9 @@ instance HasCField Apply1Struct
                           "apply1Struct_apply1_nopointer_struct_field" = FunPtr (FunPtr Int2int ->
                                                                                  CInt -> IO CInt)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Apply1Struct
-                          "apply1Struct_apply1_nopointer_struct_field") =>
-         HasField "apply1Struct_apply1_nopointer_struct_field"
+instance HasField "apply1Struct_apply1_nopointer_struct_field"
                   (Ptr Apply1Struct)
-                  (Ptr ty)
+                  (Ptr (FunPtr (FunPtr Int2int -> CInt -> IO CInt)))
     where getField = fromPtr (Proxy @"apply1Struct_apply1_nopointer_struct_field")
 {-| A union field pointing to a function like apply1_nopointer().
 
@@ -353,12 +351,9 @@ instance HasCField Apply1Union
                           "apply1Union_apply1_nopointer_union_field" = FunPtr (FunPtr Int2int ->
                                                                                CInt -> IO CInt)
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Apply1Union
-                          "apply1Union_apply1_nopointer_union_field") =>
-         HasField "apply1Union_apply1_nopointer_union_field"
+instance HasField "apply1Union_apply1_nopointer_union_field"
                   (Ptr Apply1Union)
-                  (Ptr ty)
+                  (Ptr (FunPtr (FunPtr Int2int -> CInt -> IO CInt)))
     where getField = fromPtr (Proxy @"apply1Union_apply1_nopointer_union_field")
 foreign import ccall safe "wrapper" hs_bindgen_fe02c1e534fc52ea_base ::
     FunPtr Void -> Int32 -> IO Int32

--- a/hs-bindgen/fixtures/manual/globals/Example.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct globalConfig@
@@ -93,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField GlobalConfig "globalConfig_numThr
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType GlobalConfig) "globalConfig_numThreads")
-         ) => GHC.Records.HasField "globalConfig_numThreads" (Ptr.Ptr GlobalConfig) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "globalConfig_numThreads" (Ptr.Ptr GlobalConfig) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"globalConfig_numThreads")
@@ -106,8 +102,7 @@ instance HsBindgen.Runtime.HasCField.HasCField GlobalConfig "globalConfig_numWor
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType GlobalConfig) "globalConfig_numWorkers")
-         ) => GHC.Records.HasField "globalConfig_numWorkers" (Ptr.Ptr GlobalConfig) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "globalConfig_numWorkers" (Ptr.Ptr GlobalConfig) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"globalConfig_numWorkers")
@@ -141,8 +136,7 @@ newtype ConstInt = ConstInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ConstInt) "unwrapConstInt")
-         ) => GHC.Records.HasField "unwrapConstInt" (Ptr.Ptr ConstInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapConstInt" (Ptr.Ptr ConstInt) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConstInt")
@@ -210,8 +204,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tuple "tuple_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tuple) "tuple_x")
-         ) => GHC.Records.HasField "tuple_x" (Ptr.Ptr Tuple) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "tuple_x" (Ptr.Ptr Tuple) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tuple_x")
@@ -222,8 +215,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tuple "tuple_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tuple) "tuple_y")
-         ) => GHC.Records.HasField "tuple_y" (Ptr.Ptr Tuple) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "tuple_y" (Ptr.Ptr Tuple) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tuple_y")
@@ -246,8 +238,7 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
-         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -271,8 +262,7 @@ newtype List = List
   deriving stock (GHC.Generics.Generic)
   deriving stock (Eq, Show)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType List) "unwrapList")
-         ) => GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapList")

--- a/hs-bindgen/fixtures/manual/globals/th.txt
+++ b/hs-bindgen/fixtures/manual/globals/th.txt
@@ -174,16 +174,16 @@ deriving via (EquivStorable GlobalConfig) instance Storable GlobalConfig
 instance HasCField GlobalConfig "globalConfig_numThreads"
     where type CFieldType GlobalConfig "globalConfig_numThreads" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType GlobalConfig "globalConfig_numThreads") =>
-         HasField "globalConfig_numThreads" (Ptr GlobalConfig) (Ptr ty)
+instance HasField "globalConfig_numThreads"
+                  (Ptr GlobalConfig)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"globalConfig_numThreads")
 instance HasCField GlobalConfig "globalConfig_numWorkers"
     where type CFieldType GlobalConfig "globalConfig_numWorkers" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType GlobalConfig "globalConfig_numWorkers") =>
-         HasField "globalConfig_numWorkers" (Ptr GlobalConfig) (Ptr ty)
+instance HasField "globalConfig_numWorkers"
+                  (Ptr GlobalConfig)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"globalConfig_numWorkers")
 {-| __C declaration:__ @ConstInt@
 
@@ -216,8 +216,7 @@ newtype ConstInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType ConstInt "unwrapConstInt") =>
-         HasField "unwrapConstInt" (Ptr ConstInt) (Ptr ty)
+instance HasField "unwrapConstInt" (Ptr ConstInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapConstInt")
 instance HasCField ConstInt "unwrapConstInt"
     where type CFieldType ConstInt "unwrapConstInt" = CInt
@@ -264,14 +263,12 @@ deriving via (EquivStorable Tuple) instance Storable Tuple
 instance HasCField Tuple "tuple_x"
     where type CFieldType Tuple "tuple_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Tuple "tuple_x") =>
-         HasField "tuple_x" (Ptr Tuple) (Ptr ty)
+instance HasField "tuple_x" (Ptr Tuple) (Ptr CInt)
     where getField = fromPtr (Proxy @"tuple_x")
 instance HasCField Tuple "tuple_y"
     where type CFieldType Tuple "tuple_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Tuple "tuple_y") =>
-         HasField "tuple_y" (Ptr Tuple) (Ptr ty)
+instance HasField "tuple_y" (Ptr Tuple) (Ptr CInt)
     where getField = fromPtr (Proxy @"tuple_y")
 {-| __C declaration:__ @triplet@
 
@@ -290,8 +287,9 @@ newtype Triplet
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -313,8 +311,9 @@ newtype List
       -}
     deriving stock Generic
     deriving stock (Eq, Show)
-instance TyEq ty (CFieldType List "unwrapList") =>
-         HasField "unwrapList" (Ptr List) (Ptr ty)
+instance HasField "unwrapList"
+                  (Ptr List)
+                  (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt

--- a/hs-bindgen/fixtures/manual/zero_copy/Example.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -37,7 +35,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct point@
@@ -97,8 +94,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "point_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point) "point_x")
-         ) => GHC.Records.HasField "point_x" (Ptr.Ptr Point) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point_x" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point_x")
@@ -109,8 +105,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "point_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Point) "point_y")
-         ) => GHC.Records.HasField "point_y" (Ptr.Ptr Point) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "point_y" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point_y")
@@ -172,8 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rectangle "rectangle_topleft" whe
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rectangle) "rectangle_topleft")
-         ) => GHC.Records.HasField "rectangle_topleft" (Ptr.Ptr Rectangle) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "rectangle_topleft" (Ptr.Ptr Rectangle) (Ptr.Ptr Point) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"rectangle_topleft")
@@ -185,8 +179,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Rectangle "rectangle_bottomright"
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Rectangle) "rectangle_bottomright")
-         ) => GHC.Records.HasField "rectangle_bottomright" (Ptr.Ptr Rectangle) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "rectangle_bottomright" (Ptr.Ptr Rectangle) (Ptr.Ptr Point) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"rectangle_bottomright")
@@ -248,8 +241,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Circle "circle_midpoint" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Circle) "circle_midpoint")
-         ) => GHC.Records.HasField "circle_midpoint" (Ptr.Ptr Circle) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "circle_midpoint" (Ptr.Ptr Circle) (Ptr.Ptr Point) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"circle_midpoint")
@@ -260,8 +252,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Circle "circle_radius" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Circle) "circle_radius")
-         ) => GHC.Records.HasField "circle_radius" (Ptr.Ptr Circle) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "circle_radius" (Ptr.Ptr Circle) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"circle_radius")
@@ -345,8 +336,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Shape "shape_rectangle" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Shape) "shape_rectangle")
-         ) => GHC.Records.HasField "shape_rectangle" (Ptr.Ptr Shape) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "shape_rectangle" (Ptr.Ptr Shape) (Ptr.Ptr Rectangle) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"shape_rectangle")
@@ -357,8 +347,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Shape "shape_circle" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Shape) "shape_circle")
-         ) => GHC.Records.HasField "shape_circle" (Ptr.Ptr Shape) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "shape_circle" (Ptr.Ptr Shape) (Ptr.Ptr Circle) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"shape_circle")
@@ -454,8 +443,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_opacity" whe
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colour_opacity")
-         ) => GHC.Records.HasField "colour_opacity" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "colour_opacity" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_opacity")
@@ -469,8 +457,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_brightness" 
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colour_brightness")
-         ) => GHC.Records.HasField "colour_brightness" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "colour_brightness" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_brightness")
@@ -483,8 +470,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_red" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colour_red")
-         ) => GHC.Records.HasField "colour_red" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "colour_red" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_red")
@@ -497,8 +483,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_green" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colour_green")
-         ) => GHC.Records.HasField "colour_green" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "colour_green" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_green")
@@ -511,8 +496,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_blue" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Colour) "colour_blue")
-         ) => GHC.Records.HasField "colour_blue" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "colour_blue" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_blue")
@@ -546,8 +530,7 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyInt) "unwrapMyInt")
-         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -616,8 +599,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Drawing "drawing_shape" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Drawing) "drawing_shape")
-         ) => GHC.Records.HasField "drawing_shape" (Ptr.Ptr Drawing) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "drawing_shape" (Ptr.Ptr Drawing) (Ptr.Ptr (Ptr.Ptr Shape)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"drawing_shape")
@@ -629,8 +611,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Drawing "drawing_colour" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Drawing) "drawing_colour")
-         ) => GHC.Records.HasField "drawing_colour" (Ptr.Ptr Drawing) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "drawing_colour" (Ptr.Ptr Drawing) (Ptr.Ptr (Ptr.Ptr Colour)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"drawing_colour")
@@ -702,8 +683,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row1" wh
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tic_tac_toe) "tic_tac_toe_row1")
-         ) => GHC.Records.HasField "tic_tac_toe_row1" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "tic_tac_toe_row1" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row1")
@@ -715,8 +695,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row2" wh
 
   offset# = \_ -> \_ -> 12
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tic_tac_toe) "tic_tac_toe_row2")
-         ) => GHC.Records.HasField "tic_tac_toe_row2" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "tic_tac_toe_row2" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row2")
@@ -728,8 +707,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row3" wh
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Tic_tac_toe) "tic_tac_toe_row3")
-         ) => GHC.Records.HasField "tic_tac_toe_row3" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "tic_tac_toe_row3" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row3")
@@ -782,8 +760,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector_Aux "vector_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Vector_Aux) "vector_len")
-         ) => GHC.Records.HasField "vector_len" (Ptr.Ptr Vector_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "vector_len" (Ptr.Ptr Vector_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_len")
@@ -819,8 +796,7 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
-         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -850,8 +826,7 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Matrix) "unwrapMatrix")
-         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")

--- a/hs-bindgen/fixtures/manual/zero_copy/th.txt
+++ b/hs-bindgen/fixtures/manual/zero_copy/th.txt
@@ -91,14 +91,12 @@ deriving via (EquivStorable Point) instance Storable Point
 instance HasCField Point "point_x"
     where type CFieldType Point "point_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Point "point_x") =>
-         HasField "point_x" (Ptr Point) (Ptr ty)
+instance HasField "point_x" (Ptr Point) (Ptr CInt)
     where getField = fromPtr (Proxy @"point_x")
 instance HasCField Point "point_y"
     where type CFieldType Point "point_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Point "point_y") =>
-         HasField "point_y" (Ptr Point) (Ptr ty)
+instance HasField "point_y" (Ptr Point) (Ptr CInt)
     where getField = fromPtr (Proxy @"point_y")
 {-| __C declaration:__ @struct rectangle@
 
@@ -142,14 +140,14 @@ deriving via (EquivStorable Rectangle) instance Storable Rectangle
 instance HasCField Rectangle "rectangle_topleft"
     where type CFieldType Rectangle "rectangle_topleft" = Point
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Rectangle "rectangle_topleft") =>
-         HasField "rectangle_topleft" (Ptr Rectangle) (Ptr ty)
+instance HasField "rectangle_topleft" (Ptr Rectangle) (Ptr Point)
     where getField = fromPtr (Proxy @"rectangle_topleft")
 instance HasCField Rectangle "rectangle_bottomright"
     where type CFieldType Rectangle "rectangle_bottomright" = Point
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Rectangle "rectangle_bottomright") =>
-         HasField "rectangle_bottomright" (Ptr Rectangle) (Ptr ty)
+instance HasField "rectangle_bottomright"
+                  (Ptr Rectangle)
+                  (Ptr Point)
     where getField = fromPtr (Proxy @"rectangle_bottomright")
 {-| __C declaration:__ @struct circle@
 
@@ -193,14 +191,12 @@ deriving via (EquivStorable Circle) instance Storable Circle
 instance HasCField Circle "circle_midpoint"
     where type CFieldType Circle "circle_midpoint" = Point
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Circle "circle_midpoint") =>
-         HasField "circle_midpoint" (Ptr Circle) (Ptr ty)
+instance HasField "circle_midpoint" (Ptr Circle) (Ptr Point)
     where getField = fromPtr (Proxy @"circle_midpoint")
 instance HasCField Circle "circle_radius"
     where type CFieldType Circle "circle_radius" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Circle "circle_radius") =>
-         HasField "circle_radius" (Ptr Circle) (Ptr ty)
+instance HasField "circle_radius" (Ptr Circle) (Ptr CInt)
     where getField = fromPtr (Proxy @"circle_radius")
 {-| __C declaration:__ @union shape@
 
@@ -292,14 +288,12 @@ set_shape_circle = setUnionPayload
 instance HasCField Shape "shape_rectangle"
     where type CFieldType Shape "shape_rectangle" = Rectangle
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Shape "shape_rectangle") =>
-         HasField "shape_rectangle" (Ptr Shape) (Ptr ty)
+instance HasField "shape_rectangle" (Ptr Shape) (Ptr Rectangle)
     where getField = fromPtr (Proxy @"shape_rectangle")
 instance HasCField Shape "shape_circle"
     where type CFieldType Shape "shape_circle" = Circle
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Shape "shape_circle") =>
-         HasField "shape_circle" (Ptr Shape) (Ptr ty)
+instance HasField "shape_circle" (Ptr Shape) (Ptr Circle)
     where getField = fromPtr (Proxy @"shape_circle")
 {-| __C declaration:__ @struct colour@
 
@@ -368,36 +362,33 @@ instance HasCBitfield Colour "colour_opacity"
     where type CBitfieldType Colour "colour_opacity" = CUInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 2
-instance TyEq ty (CBitfieldType Colour "colour_opacity") =>
-         HasField "colour_opacity" (Ptr Colour) (BitfieldPtr ty)
+instance HasField "colour_opacity" (Ptr Colour) (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"colour_opacity")
 instance HasCBitfield Colour "colour_brightness"
     where type CBitfieldType Colour "colour_brightness" = CUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 3
-instance TyEq ty (CBitfieldType Colour "colour_brightness") =>
-         HasField "colour_brightness" (Ptr Colour) (BitfieldPtr ty)
+instance HasField "colour_brightness"
+                  (Ptr Colour)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"colour_brightness")
 instance HasCBitfield Colour "colour_red"
     where type CBitfieldType Colour "colour_red" = CUInt
           bitfieldOffset# = \_ -> \_ -> 5
           bitfieldWidth# = \_ -> \_ -> 8
-instance TyEq ty (CBitfieldType Colour "colour_red") =>
-         HasField "colour_red" (Ptr Colour) (BitfieldPtr ty)
+instance HasField "colour_red" (Ptr Colour) (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"colour_red")
 instance HasCBitfield Colour "colour_green"
     where type CBitfieldType Colour "colour_green" = CUInt
           bitfieldOffset# = \_ -> \_ -> 13
           bitfieldWidth# = \_ -> \_ -> 8
-instance TyEq ty (CBitfieldType Colour "colour_green") =>
-         HasField "colour_green" (Ptr Colour) (BitfieldPtr ty)
+instance HasField "colour_green" (Ptr Colour) (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"colour_green")
 instance HasCBitfield Colour "colour_blue"
     where type CBitfieldType Colour "colour_blue" = CUInt
           bitfieldOffset# = \_ -> \_ -> 21
           bitfieldWidth# = \_ -> \_ -> 8
-instance TyEq ty (CBitfieldType Colour "colour_blue") =>
-         HasField "colour_blue" (Ptr Colour) (BitfieldPtr ty)
+instance HasField "colour_blue" (Ptr Colour) (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"colour_blue")
 {-| __C declaration:__ @myInt@
 
@@ -430,8 +421,7 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MyInt "unwrapMyInt") =>
-         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -478,14 +468,12 @@ deriving via (EquivStorable Drawing) instance Storable Drawing
 instance HasCField Drawing "drawing_shape"
     where type CFieldType Drawing "drawing_shape" = Ptr Shape
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Drawing "drawing_shape") =>
-         HasField "drawing_shape" (Ptr Drawing) (Ptr ty)
+instance HasField "drawing_shape" (Ptr Drawing) (Ptr (Ptr Shape))
     where getField = fromPtr (Proxy @"drawing_shape")
 instance HasCField Drawing "drawing_colour"
     where type CFieldType Drawing "drawing_colour" = Ptr Colour
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Drawing "drawing_colour") =>
-         HasField "drawing_colour" (Ptr Drawing) (Ptr ty)
+instance HasField "drawing_colour" (Ptr Drawing) (Ptr (Ptr Colour))
     where getField = fromPtr (Proxy @"drawing_colour")
 {-| __C declaration:__ @struct tic_tac_toe@
 
@@ -538,22 +526,25 @@ instance HasCField Tic_tac_toe "tic_tac_toe_row1"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row1" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Tic_tac_toe "tic_tac_toe_row1") =>
-         HasField "tic_tac_toe_row1" (Ptr Tic_tac_toe) (Ptr ty)
+instance HasField "tic_tac_toe_row1"
+                  (Ptr Tic_tac_toe)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"tic_tac_toe_row1")
 instance HasCField Tic_tac_toe "tic_tac_toe_row2"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row2" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 12
-instance TyEq ty (CFieldType Tic_tac_toe "tic_tac_toe_row2") =>
-         HasField "tic_tac_toe_row2" (Ptr Tic_tac_toe) (Ptr ty)
+instance HasField "tic_tac_toe_row2"
+                  (Ptr Tic_tac_toe)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"tic_tac_toe_row2")
 instance HasCField Tic_tac_toe "tic_tac_toe_row3"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row3" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 24
-instance TyEq ty (CFieldType Tic_tac_toe "tic_tac_toe_row3") =>
-         HasField "tic_tac_toe_row3" (Ptr Tic_tac_toe) (Ptr ty)
+instance HasField "tic_tac_toe_row3"
+                  (Ptr Tic_tac_toe)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"tic_tac_toe_row3")
 {-| __C declaration:__ @struct vector@
 
@@ -583,8 +574,7 @@ deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
 instance HasCField Vector_Aux "vector_len"
     where type CFieldType Vector_Aux "vector_len" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Vector_Aux "vector_len") =>
-         HasField "vector_len" (Ptr Vector_Aux) (Ptr ty)
+instance HasField "vector_len" (Ptr Vector_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"vector_len")
 instance Offset CChar Vector_Aux
     where offset = \_ty_0 -> 4
@@ -606,8 +596,9 @@ newtype Triplet
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Triplet "unwrapTriplet") =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -630,8 +621,9 @@ newtype Matrix
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Matrix "unwrapMatrix") =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 3 Triplet))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 3

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -60,8 +57,7 @@ newtype U = U
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "unwrapU")
-         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
@@ -72,8 +72,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType U "unwrapU") =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -60,8 +57,7 @@ newtype U = U
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "unwrapU")
-         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
@@ -72,8 +72,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType U "unwrapU") =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @T@
@@ -60,8 +57,7 @@ newtype T = T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T) "unwrapT")
-         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")
@@ -101,8 +97,7 @@ newtype U = U
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "unwrapU")
-         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
@@ -72,8 +72,7 @@ newtype T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T "unwrapT") =>
-         HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
@@ -109,8 +108,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType U "unwrapU") =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -60,8 +57,7 @@ newtype U = U
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType U) "unwrapU")
-         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
@@ -52,8 +52,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType U "unwrapU") =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -31,7 +29,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum FileOperationStatus@
@@ -109,8 +106,7 @@ instance Read FileOperationStatus where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOperationStatus) "unwrapFileOperationStatus")
-         ) => GHC.Records.HasField "unwrapFileOperationStatus" (Ptr.Ptr FileOperationStatus) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFileOperationStatus" (Ptr.Ptr FileOperationStatus) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOperationStatus")
@@ -236,8 +232,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOperationRecord "fileOperatio
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOperationRecord) "fileOperationRecord_status")
-         ) => GHC.Records.HasField "fileOperationRecord_status" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "fileOperationRecord_status" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr FileOperationStatus) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fileOperationRecord_status")
@@ -249,8 +244,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOperationRecord "fileOperatio
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FileOperationRecord) "fileOperationRecord_bytes_processed")
-         ) => GHC.Records.HasField "fileOperationRecord_bytes_processed" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "fileOperationRecord_bytes_processed" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fileOperationRecord_bytes_processed")

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -81,11 +81,9 @@ instance Read FileOperationStatus
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty
-              (CFieldType FileOperationStatus "unwrapFileOperationStatus") =>
-         HasField "unwrapFileOperationStatus"
+instance HasField "unwrapFileOperationStatus"
                   (Ptr FileOperationStatus)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFileOperationStatus")
 instance HasCField FileOperationStatus "unwrapFileOperationStatus"
     where type CFieldType FileOperationStatus
@@ -218,23 +216,18 @@ instance HasCField FileOperationRecord "fileOperationRecord_status"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_status" = FileOperationStatus
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType FileOperationRecord "fileOperationRecord_status") =>
-         HasField "fileOperationRecord_status"
+instance HasField "fileOperationRecord_status"
                   (Ptr FileOperationRecord)
-                  (Ptr ty)
+                  (Ptr FileOperationStatus)
     where getField = fromPtr (Proxy @"fileOperationRecord_status")
 instance HasCField FileOperationRecord
                    "fileOperationRecord_bytes_processed"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_bytes_processed" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType FileOperationRecord
-                          "fileOperationRecord_bytes_processed") =>
-         HasField "fileOperationRecord_bytes_processed"
+instance HasField "fileOperationRecord_bytes_processed"
                   (Ptr FileOperationRecord)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"fileOperationRecord_bytes_processed")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_read_file_chunk@
 foreign import ccall safe "hs_bindgen_b2a91b3b7edf2ad3" hs_bindgen_b2a91b3b7edf2ad3_base ::

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,7 +27,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @uint32_t@
@@ -61,8 +58,7 @@ newtype Uint32_t = Uint32_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Uint32_t) "unwrapUint32_t")
-         ) => GHC.Records.HasField "unwrapUint32_t" (Ptr.Ptr Uint32_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapUint32_t" (Ptr.Ptr Uint32_t) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint32_t")
@@ -124,8 +120,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_sixty_four")
-         ) => GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr Foreign.Word64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_sixty_four")
@@ -136,8 +131,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_thirty_two")
-         ) => GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr Uint32_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -57,8 +57,7 @@ newtype Uint32_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Uint32_t "unwrapUint32_t") =>
-         HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr ty)
+instance HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapUint32_t")
 instance HasCField Uint32_t "unwrapUint32_t"
     where type CFieldType Uint32_t "unwrapUint32_t" = CUInt
@@ -102,14 +101,12 @@ instance Storable Foo
 instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo "foo_sixty_four" = Foreign.Word64
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo "foo_sixty_four") =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+instance HasField "foo_sixty_four" (Ptr Foo) (Ptr Foreign.Word64)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo "foo_thirty_two" = Uint32_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Foo "foo_thirty_two") =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+instance HasField "foo_thirty_two" (Ptr Foo) (Ptr Uint32_t)
     where getField = fromPtr (Proxy @"foo_thirty_two")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_48dbbf4b09b5b3c1" hs_bindgen_48dbbf4b09b5b3c1_base ::

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,7 +26,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @A@
@@ -60,8 +57,7 @@ newtype A = A
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "unwrapA")
-         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
@@ -31,8 +31,7 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType A "unwrapA") =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkBefore) "okBefore_x")
-         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -127,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkAfter) "okAfter_x")
-         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkBefore "okBefore_x") =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -70,6 +69,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkAfter "okAfter_x") =>
-         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkBefore) "okBefore_x")
-         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -127,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkAfter) "okAfter_x")
-         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkBefore "okBefore_x") =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -70,6 +69,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkAfter "okAfter_x") =>
-         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkBefore) "okBefore_x")
-         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -33,6 +33,5 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkBefore "okBefore_x") =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkBefore) "okBefore_x")
-         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -127,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType OkAfter) "okAfter_x")
-         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkBefore "okBefore_x") =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -70,6 +69,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType OkAfter "okAfter_x") =>
-         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct StructWithAssignedHaskellNameByPrescriptiveBindingSpecs@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField NewName "newName_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType NewName) "newName_x")
-         ) => GHC.Records.HasField "newName_x" (Ptr.Ptr NewName) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "newName_x" (Ptr.Ptr NewName) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"newName_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -48,8 +48,7 @@ deriving via (EquivStorable NewName) instance Storable NewName
 instance HasCField NewName "newName_x"
     where type CFieldType NewName "newName_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType NewName "newName_x") =>
-         HasField "newName_x" (Ptr NewName) (Ptr ty)
+instance HasField "newName_x" (Ptr NewName) (Ptr CInt)
     where getField = fromPtr (Proxy @"newName_x")
 -- __unique:__ @test_programanalysisselection_mat_Example_Safe_FunctionWithAssignedHaskellNameByNameMangler@
 foreign import ccall safe "hs_bindgen_c9b1dc5577fd8ced" hs_bindgen_c9b1dc5577fd8ced_base ::

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct UnrelatedDeclaration@
@@ -74,8 +71,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UnrelatedDeclaration "unrelatedDe
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UnrelatedDeclaration) "unrelatedDeclaration_m")
-         ) => GHC.Records.HasField "unrelatedDeclaration_m" (Ptr.Ptr UnrelatedDeclaration) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unrelatedDeclaration_m" (Ptr.Ptr UnrelatedDeclaration) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -35,9 +35,7 @@ instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
     where type CFieldType UnrelatedDeclaration
                           "unrelatedDeclaration_m" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType UnrelatedDeclaration "unrelatedDeclaration_m") =>
-         HasField "unrelatedDeclaration_m"
+instance HasField "unrelatedDeclaration_m"
                   (Ptr UnrelatedDeclaration)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Omitted@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Omitted "omitted_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Omitted) "omitted_n")
-         ) => GHC.Records.HasField "omitted_n" (Ptr.Ptr Omitted) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "omitted_n" (Ptr.Ptr Omitted) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"omitted_n")
@@ -128,8 +124,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DirectlyDependsOnOmitted "directl
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DirectlyDependsOnOmitted) "directlyDependsOnOmitted_o")
-         ) => GHC.Records.HasField "directlyDependsOnOmitted_o" (Ptr.Ptr DirectlyDependsOnOmitted) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "directlyDependsOnOmitted_o" (Ptr.Ptr DirectlyDependsOnOmitted) (Ptr.Ptr Omitted) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"directlyDependsOnOmitted_o")
@@ -183,8 +178,7 @@ instance HsBindgen.Runtime.HasCField.HasCField IndirectlyDependsOnOmitted "indir
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType IndirectlyDependsOnOmitted) "indirectlyDependsOnOmitted_d")
-         ) => GHC.Records.HasField "indirectlyDependsOnOmitted_d" (Ptr.Ptr IndirectlyDependsOnOmitted) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "indirectlyDependsOnOmitted_d" (Ptr.Ptr IndirectlyDependsOnOmitted) (Ptr.Ptr DirectlyDependsOnOmitted) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -34,8 +34,7 @@ deriving via (EquivStorable Omitted) instance Storable Omitted
 instance HasCField Omitted "omitted_n"
     where type CFieldType Omitted "omitted_n" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Omitted "omitted_n") =>
-         HasField "omitted_n" (Ptr Omitted) (Ptr ty)
+instance HasField "omitted_n" (Ptr Omitted) (Ptr CInt)
     where getField = fromPtr (Proxy @"omitted_n")
 {-| __C declaration:__ @struct DirectlyDependsOnOmitted@
 
@@ -73,12 +72,9 @@ instance HasCField DirectlyDependsOnOmitted
     where type CFieldType DirectlyDependsOnOmitted
                           "directlyDependsOnOmitted_o" = Omitted
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType DirectlyDependsOnOmitted
-                          "directlyDependsOnOmitted_o") =>
-         HasField "directlyDependsOnOmitted_o"
+instance HasField "directlyDependsOnOmitted_o"
                   (Ptr DirectlyDependsOnOmitted)
-                  (Ptr ty)
+                  (Ptr Omitted)
     where getField = fromPtr (Proxy @"directlyDependsOnOmitted_o")
 {-| __C declaration:__ @struct IndirectlyDependsOnOmitted@
 
@@ -116,10 +112,7 @@ instance HasCField IndirectlyDependsOnOmitted
     where type CFieldType IndirectlyDependsOnOmitted
                           "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType IndirectlyDependsOnOmitted
-                          "indirectlyDependsOnOmitted_d") =>
-         HasField "indirectlyDependsOnOmitted_d"
+instance HasField "indirectlyDependsOnOmitted_d"
                   (Ptr IndirectlyDependsOnOmitted)
-                  (Ptr ty)
+                  (Ptr DirectlyDependsOnOmitted)
     where getField = fromPtr (Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure, return)
 
 {-| Examples for the various cases in by `HsBindgen.Frontend.Analysis.Typedefs`
@@ -158,8 +155,7 @@ newtype Struct5_t = Struct5_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct5_t) "unwrapStruct5_t")
-         ) => GHC.Records.HasField "unwrapStruct5_t" (Ptr.Ptr Struct5_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct5_t" (Ptr.Ptr Struct5_t) (Ptr.Ptr (Ptr.Ptr Struct5)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct5_t")
@@ -221,8 +217,7 @@ newtype Struct6 = Struct6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct6) "unwrapStruct6")
-         ) => GHC.Records.HasField "unwrapStruct6" (Ptr.Ptr Struct6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct6" (Ptr.Ptr Struct6) (Ptr.Ptr (Ptr.Ptr Struct6_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct6")
@@ -283,8 +278,7 @@ newtype Struct7a = Struct7a
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct7a) "unwrapStruct7a")
-         ) => GHC.Records.HasField "unwrapStruct7a" (Ptr.Ptr Struct7a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct7a" (Ptr.Ptr Struct7a) (Ptr.Ptr Struct7) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct7a")
@@ -313,8 +307,7 @@ newtype Struct7b = Struct7b
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct7b) "unwrapStruct7b")
-         ) => GHC.Records.HasField "unwrapStruct7b" (Ptr.Ptr Struct7b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct7b" (Ptr.Ptr Struct7b) (Ptr.Ptr Struct7) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct7b")
@@ -374,8 +367,7 @@ newtype Struct8b = Struct8b
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct8b) "unwrapStruct8b")
-         ) => GHC.Records.HasField "unwrapStruct8b" (Ptr.Ptr Struct8b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct8b" (Ptr.Ptr Struct8b) (Ptr.Ptr Struct8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct8b")
@@ -435,8 +427,7 @@ newtype Struct9_t = Struct9_t
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct9_t) "unwrapStruct9_t")
-         ) => GHC.Records.HasField "unwrapStruct9_t" (Ptr.Ptr Struct9_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct9_t" (Ptr.Ptr Struct9_t) (Ptr.Ptr Struct9) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct9_t")
@@ -496,8 +487,7 @@ newtype Struct10_t_t = Struct10_t_t
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct10_t_t) "unwrapStruct10_t_t")
-         ) => GHC.Records.HasField "unwrapStruct10_t_t" (Ptr.Ptr Struct10_t_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStruct10_t_t" (Ptr.Ptr Struct10_t_t) (Ptr.Ptr Struct10_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct10_t_t")
@@ -566,8 +556,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct11_t "struct11_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct11_t) "struct11_t_x")
-         ) => GHC.Records.HasField "struct11_t_x" (Ptr.Ptr Struct11_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct11_t_x" (Ptr.Ptr Struct11_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct11_t_x")
@@ -579,8 +568,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct11_t "struct11_t_self" wher
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct11_t) "struct11_t_self")
-         ) => GHC.Records.HasField "struct11_t_self" (Ptr.Ptr Struct11_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct11_t_self" (Ptr.Ptr Struct11_t) (Ptr.Ptr (Ptr.Ptr Struct11_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct11_t_self")
@@ -642,8 +630,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct12_t "struct12_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct12_t) "struct12_t_x")
-         ) => GHC.Records.HasField "struct12_t_x" (Ptr.Ptr Struct12_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct12_t_x" (Ptr.Ptr Struct12_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct12_t_x")
@@ -655,8 +642,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct12_t "struct12_t_self" wher
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct12_t) "struct12_t_self")
-         ) => GHC.Records.HasField "struct12_t_self" (Ptr.Ptr Struct12_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct12_t_self" (Ptr.Ptr Struct12_t) (Ptr.Ptr (Ptr.Ptr Struct12_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct12_t_self")
@@ -881,8 +867,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct1_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct1_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct1_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct1_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct1_t")
@@ -894,8 +879,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct2_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct2_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct2_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct2_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct2_t")
@@ -907,8 +891,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct3_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct3_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct3_t" (Ptr.Ptr Use_sites) (Ptr.Ptr (Ptr.Ptr Struct3_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct3_t")
@@ -920,8 +903,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct4_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct4_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct4_t" (Ptr.Ptr Use_sites) (Ptr.Ptr (Ptr.Ptr Struct4_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct4_t")
@@ -933,8 +915,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useStruct_st
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useStruct_struct5")
-         ) => GHC.Records.HasField "use_sites_useStruct_struct5" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useStruct_struct5" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct5) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useStruct_struct5")
@@ -946,8 +927,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct5_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct5_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct5_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct5_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct5_t")
@@ -959,8 +939,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useStruct_st
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useStruct_struct6")
-         ) => GHC.Records.HasField "use_sites_useStruct_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useStruct_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct6_Aux) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useStruct_struct6")
@@ -972,8 +951,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct6")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct6) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct6")
@@ -985,8 +963,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct7a")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct7a" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct7a" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct7a) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct7a")
@@ -998,8 +975,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct7b")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct7b" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct7b" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct7b) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct7b")
@@ -1011,8 +987,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct8")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct8" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct8" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct8")
@@ -1024,8 +999,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct8b")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct8b" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct8b" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct8b) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct8b")
@@ -1037,8 +1011,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct9")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct9" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct9" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct9) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct9")
@@ -1050,8 +1023,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct9_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct9_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct9_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct9_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct9_t")
@@ -1063,8 +1035,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct10_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct10_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct10_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct10_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct10_t")
@@ -1076,8 +1047,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct10_t_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct10_t_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct10_t_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct10_t_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct10_t_t")
@@ -1089,8 +1059,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct11_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct11_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct11_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct11_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct11_t")
@@ -1102,8 +1071,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 48
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Use_sites) "use_sites_useTypedef_struct12_t")
-         ) => GHC.Records.HasField "use_sites_useTypedef_struct12_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "use_sites_useTypedef_struct12_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct12_t) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
@@ -113,8 +113,9 @@ newtype Struct5_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Struct5_t "unwrapStruct5_t") =>
-         HasField "unwrapStruct5_t" (Ptr Struct5_t) (Ptr ty)
+instance HasField "unwrapStruct5_t"
+                  (Ptr Struct5_t)
+                  (Ptr (Ptr Struct5))
     where getField = fromPtr (Proxy @"unwrapStruct5_t")
 instance HasCField Struct5_t "unwrapStruct5_t"
     where type CFieldType Struct5_t "unwrapStruct5_t" = Ptr Struct5
@@ -165,8 +166,9 @@ newtype Struct6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Struct6 "unwrapStruct6") =>
-         HasField "unwrapStruct6" (Ptr Struct6) (Ptr ty)
+instance HasField "unwrapStruct6"
+                  (Ptr Struct6)
+                  (Ptr (Ptr Struct6_Aux))
     where getField = fromPtr (Proxy @"unwrapStruct6")
 instance HasCField Struct6 "unwrapStruct6"
     where type CFieldType Struct6 "unwrapStruct6" = Ptr Struct6_Aux
@@ -213,8 +215,7 @@ newtype Struct7a
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct7a "unwrapStruct7a") =>
-         HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr ty)
+instance HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7a")
 instance HasCField Struct7a "unwrapStruct7a"
     where type CFieldType Struct7a "unwrapStruct7a" = Struct7
@@ -236,8 +237,7 @@ newtype Struct7b
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct7b "unwrapStruct7b") =>
-         HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr ty)
+instance HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7b")
 instance HasCField Struct7b "unwrapStruct7b"
     where type CFieldType Struct7b "unwrapStruct7b" = Struct7
@@ -284,8 +284,7 @@ newtype Struct8b
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct8b "unwrapStruct8b") =>
-         HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr ty)
+instance HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr Struct8)
     where getField = fromPtr (Proxy @"unwrapStruct8b")
 instance HasCField Struct8b "unwrapStruct8b"
     where type CFieldType Struct8b "unwrapStruct8b" = Struct8
@@ -332,8 +331,7 @@ newtype Struct9_t
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct9_t "unwrapStruct9_t") =>
-         HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr ty)
+instance HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr Struct9)
     where getField = fromPtr (Proxy @"unwrapStruct9_t")
 instance HasCField Struct9_t "unwrapStruct9_t"
     where type CFieldType Struct9_t "unwrapStruct9_t" = Struct9
@@ -380,8 +378,9 @@ newtype Struct10_t_t
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType Struct10_t_t "unwrapStruct10_t_t") =>
-         HasField "unwrapStruct10_t_t" (Ptr Struct10_t_t) (Ptr ty)
+instance HasField "unwrapStruct10_t_t"
+                  (Ptr Struct10_t_t)
+                  (Ptr Struct10_t)
     where getField = fromPtr (Proxy @"unwrapStruct10_t_t")
 instance HasCField Struct10_t_t "unwrapStruct10_t_t"
     where type CFieldType Struct10_t_t
@@ -429,14 +428,14 @@ deriving via (EquivStorable Struct11_t) instance Storable Struct11_t
 instance HasCField Struct11_t "struct11_t_x"
     where type CFieldType Struct11_t "struct11_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct11_t "struct11_t_x") =>
-         HasField "struct11_t_x" (Ptr Struct11_t) (Ptr ty)
+instance HasField "struct11_t_x" (Ptr Struct11_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct11_t_x")
 instance HasCField Struct11_t "struct11_t_self"
     where type CFieldType Struct11_t "struct11_t_self" = Ptr Struct11_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Struct11_t "struct11_t_self") =>
-         HasField "struct11_t_self" (Ptr Struct11_t) (Ptr ty)
+instance HasField "struct11_t_self"
+                  (Ptr Struct11_t)
+                  (Ptr (Ptr Struct11_t))
     where getField = fromPtr (Proxy @"struct11_t_self")
 {-| __C declaration:__ @struct struct12@
 
@@ -480,14 +479,14 @@ deriving via (EquivStorable Struct12_t) instance Storable Struct12_t
 instance HasCField Struct12_t "struct12_t_x"
     where type CFieldType Struct12_t "struct12_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct12_t "struct12_t_x") =>
-         HasField "struct12_t_x" (Ptr Struct12_t) (Ptr ty)
+instance HasField "struct12_t_x" (Ptr Struct12_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct12_t_x")
 instance HasCField Struct12_t "struct12_t_self"
     where type CFieldType Struct12_t "struct12_t_self" = Ptr Struct12_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Struct12_t "struct12_t_self") =>
-         HasField "struct12_t_self" (Ptr Struct12_t) (Ptr ty)
+instance HasField "struct12_t_self"
+                  (Ptr Struct12_t)
+                  (Ptr (Ptr Struct12_t))
     where getField = fromPtr (Proxy @"struct12_t_self")
 {-| __C declaration:__ @struct use_sites@
 
@@ -660,145 +659,143 @@ instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct1_t" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct1_t") =>
-         HasField "use_sites_useTypedef_struct1_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct1_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct1_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct1_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct2_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct2_t" = Struct2_t
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct2_t") =>
-         HasField "use_sites_useTypedef_struct2_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct2_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct2_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct2_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct3_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct3_t" = Ptr Struct3_t
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct3_t") =>
-         HasField "use_sites_useTypedef_struct3_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct3_t"
+                  (Ptr Use_sites)
+                  (Ptr (Ptr Struct3_t))
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct3_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct4_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct4_t" = Ptr Struct4_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct4_t") =>
-         HasField "use_sites_useTypedef_struct4_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct4_t"
+                  (Ptr Use_sites)
+                  (Ptr (Ptr Struct4_t))
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct4_t")
 instance HasCField Use_sites "use_sites_useStruct_struct5"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct5" = Struct5
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useStruct_struct5") =>
-         HasField "use_sites_useStruct_struct5" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useStruct_struct5"
+                  (Ptr Use_sites)
+                  (Ptr Struct5)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct5")
 instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct5_t" = Struct5_t
           offset# = \_ -> \_ -> 16
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct5_t") =>
-         HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct5_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct5_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
 instance HasCField Use_sites "use_sites_useStruct_struct6"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct6" = Struct6_Aux
           offset# = \_ -> \_ -> 24
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useStruct_struct6") =>
-         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useStruct_struct6"
+                  (Ptr Use_sites)
+                  (Ptr Struct6_Aux)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct6"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct6" = Struct6
           offset# = \_ -> \_ -> 24
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct6") =>
-         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct6"
+                  (Ptr Use_sites)
+                  (Ptr Struct6)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct7a"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7a" = Struct7a
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct7a") =>
-         HasField "use_sites_useTypedef_struct7a" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct7a"
+                  (Ptr Use_sites)
+                  (Ptr Struct7a)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7a")
 instance HasCField Use_sites "use_sites_useTypedef_struct7b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7b" = Struct7b
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct7b") =>
-         HasField "use_sites_useTypedef_struct7b" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct7b"
+                  (Ptr Use_sites)
+                  (Ptr Struct7b)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7b")
 instance HasCField Use_sites "use_sites_useTypedef_struct8"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8" = Struct8
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct8") =>
-         HasField "use_sites_useTypedef_struct8" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct8"
+                  (Ptr Use_sites)
+                  (Ptr Struct8)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8")
 instance HasCField Use_sites "use_sites_useTypedef_struct8b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8b" = Struct8b
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct8b") =>
-         HasField "use_sites_useTypedef_struct8b" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct8b"
+                  (Ptr Use_sites)
+                  (Ptr Struct8b)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8b")
 instance HasCField Use_sites "use_sites_useTypedef_struct9"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9" = Struct9
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct9") =>
-         HasField "use_sites_useTypedef_struct9" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct9"
+                  (Ptr Use_sites)
+                  (Ptr Struct9)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9")
 instance HasCField Use_sites "use_sites_useTypedef_struct9_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9_t" = Struct9_t
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct9_t") =>
-         HasField "use_sites_useTypedef_struct9_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct9_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct9_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t" = Struct10_t
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct10_t") =>
-         HasField "use_sites_useTypedef_struct10_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct10_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct10_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t_t" = Struct10_t_t
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct10_t_t") =>
-         HasField "use_sites_useTypedef_struct10_t_t"
+instance HasField "use_sites_useTypedef_struct10_t_t"
                   (Ptr Use_sites)
-                  (Ptr ty)
+                  (Ptr Struct10_t_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct11_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct11_t" = Struct11_t
           offset# = \_ -> \_ -> 32
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct11_t") =>
-         HasField "use_sites_useTypedef_struct11_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct11_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct11_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct11_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct12_t" = Struct12_t
           offset# = \_ -> \_ -> 48
-instance TyEq ty
-              (CFieldType Use_sites "use_sites_useTypedef_struct12_t") =>
-         HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct12_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct12_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,7 +21,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct complex_object_t@
@@ -96,8 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Complex_object_t) "complex_object_t_velocity")
-         ) => GHC.Records.HasField "complex_object_t_velocity" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "complex_object_t_velocity" (Ptr.Ptr Complex_object_t) (Ptr.Ptr (Data.Complex.Complex FC.CFloat)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_velocity")
@@ -109,8 +105,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Complex_object_t) "complex_object_t_position")
-         ) => GHC.Records.HasField "complex_object_t_position" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "complex_object_t_position" (Ptr.Ptr Complex_object_t) (Ptr.Ptr (Data.Complex.Complex FC.CDouble)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_position")
@@ -122,8 +117,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Complex_object_t) "complex_object_t_id")
-         ) => GHC.Records.HasField "complex_object_t_id" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "complex_object_t_id" (Ptr.Ptr Complex_object_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_id")

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
@@ -186,28 +186,24 @@ instance HasCField Complex_object_t "complex_object_t_velocity"
     where type CFieldType Complex_object_t
                           "complex_object_t_velocity" = Complex CFloat
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Complex_object_t "complex_object_t_velocity") =>
-         HasField "complex_object_t_velocity"
+instance HasField "complex_object_t_velocity"
                   (Ptr Complex_object_t)
-                  (Ptr ty)
+                  (Ptr (Complex CFloat))
     where getField = fromPtr (Proxy @"complex_object_t_velocity")
 instance HasCField Complex_object_t "complex_object_t_position"
     where type CFieldType Complex_object_t
                           "complex_object_t_position" = Complex CDouble
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Complex_object_t "complex_object_t_position") =>
-         HasField "complex_object_t_position"
+instance HasField "complex_object_t_position"
                   (Ptr Complex_object_t)
-                  (Ptr ty)
+                  (Ptr (Complex CDouble))
     where getField = fromPtr (Proxy @"complex_object_t_position")
 instance HasCField Complex_object_t "complex_object_t_id"
     where type CFieldType Complex_object_t "complex_object_t_id" = CInt
           offset# = \_ -> \_ -> 24
-instance TyEq ty
-              (CFieldType Complex_object_t "complex_object_t_id") =>
-         HasField "complex_object_t_id" (Ptr Complex_object_t) (Ptr ty)
+instance HasField "complex_object_t_id"
+                  (Ptr Complex_object_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"complex_object_t_id")
 -- __unique:__ @test_typescomplexhsb_complex_test_Example_Safe_multiply_complex_f@
 foreign import ccall safe "hs_bindgen_687af703c95fba0e" hs_bindgen_687af703c95fba0e_base ::

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct vector@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector "vector_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Vector) "vector_x")
-         ) => GHC.Records.HasField "vector_x" (Ptr.Ptr Vector) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "vector_x" (Ptr.Ptr Vector) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_x")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector "vector_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Vector) "vector_y")
-         ) => GHC.Records.HasField "vector_y" (Ptr.Ptr Vector) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "vector_y" (Ptr.Ptr Vector) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_y")

--- a/hs-bindgen/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/vector_test/th.txt
@@ -65,14 +65,12 @@ deriving via (EquivStorable Vector) instance Storable Vector
 instance HasCField Vector "vector_x"
     where type CFieldType Vector "vector_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Vector "vector_x") =>
-         HasField "vector_x" (Ptr Vector) (Ptr ty)
+instance HasField "vector_x" (Ptr Vector) (Ptr CDouble)
     where getField = fromPtr (Proxy @"vector_x")
 instance HasCField Vector "vector_y"
     where type CFieldType Vector "vector_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Vector "vector_y") =>
-         HasField "vector_y" (Ptr Vector) (Ptr ty)
+instance HasField "vector_y" (Ptr Vector) (Ptr CDouble)
     where getField = fromPtr (Proxy @"vector_y")
 -- __unique:__ @test_typescomplexvector_test_Example_Safe_new_vector@
 foreign import ccall safe "hs_bindgen_cd5f566bc96dcba0" hs_bindgen_cd5f566bc96dcba0_base ::

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum foo_enum@
@@ -115,8 +112,7 @@ instance Read Foo_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo_enum) "unwrapFoo_enum")
-         ) => GHC.Records.HasField "unwrapFoo_enum" (Ptr.Ptr Foo_enum) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFoo_enum" (Ptr.Ptr Foo_enum) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo_enum")

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -49,8 +49,9 @@ instance Read Foo_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Foo_enum "unwrapFoo_enum") =>
-         HasField "unwrapFoo_enum" (Ptr Foo_enum) (Ptr ty)
+instance HasField "unwrapFoo_enum"
+                  (Ptr Foo_enum)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapFoo_enum")
 instance HasCField Foo_enum "unwrapFoo_enum"
     where type CFieldType Foo_enum

--- a/hs-bindgen/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enums/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum first@
@@ -114,8 +111,7 @@ instance Read First where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType First) "unwrapFirst")
-         ) => GHC.Records.HasField "unwrapFirst" (Ptr.Ptr First) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFirst" (Ptr.Ptr First) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFirst")
@@ -226,8 +222,7 @@ instance Read Second where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Second) "unwrapSecond")
-         ) => GHC.Records.HasField "unwrapSecond" (Ptr.Ptr Second) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSecond" (Ptr.Ptr Second) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSecond")
@@ -344,8 +339,7 @@ instance Read Same where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Same) "unwrapSame")
-         ) => GHC.Records.HasField "unwrapSame" (Ptr.Ptr Same) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapSame" (Ptr.Ptr Same) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSame")
@@ -446,8 +440,7 @@ instance Read Nonseq where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Nonseq) "unwrapNonseq")
-         ) => GHC.Records.HasField "unwrapNonseq" (Ptr.Ptr Nonseq) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapNonseq" (Ptr.Ptr Nonseq) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapNonseq")
@@ -567,8 +560,7 @@ instance Read Packed where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Packed) "unwrapPacked")
-         ) => GHC.Records.HasField "unwrapPacked" (Ptr.Ptr Packed) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPacked" (Ptr.Ptr Packed) (Ptr.Ptr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPacked")
@@ -687,8 +679,7 @@ instance Read EnumA where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType EnumA) "unwrapEnumA")
-         ) => GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumA")
@@ -798,8 +789,7 @@ instance Read EnumB where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType EnumB) "unwrapEnumB")
-         ) => GHC.Records.HasField "unwrapEnumB" (Ptr.Ptr EnumB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEnumB" (Ptr.Ptr EnumB) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumB")
@@ -909,8 +899,7 @@ instance Read EnumC where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType EnumC) "unwrapEnumC")
-         ) => GHC.Records.HasField "unwrapEnumC" (Ptr.Ptr EnumC) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEnumC" (Ptr.Ptr EnumC) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumC")
@@ -1020,8 +1009,7 @@ instance Read EnumD_t where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType EnumD_t) "unwrapEnumD_t")
-         ) => GHC.Records.HasField "unwrapEnumD_t" (Ptr.Ptr EnumD_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEnumD_t" (Ptr.Ptr EnumD_t) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumD_t")

--- a/hs-bindgen/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enums/th.txt
@@ -46,8 +46,7 @@ instance Read First
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType First "unwrapFirst") =>
-         HasField "unwrapFirst" (Ptr First) (Ptr ty)
+instance HasField "unwrapFirst" (Ptr First) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapFirst")
 instance HasCField First "unwrapFirst"
     where type CFieldType First "unwrapFirst" = CUInt
@@ -128,8 +127,7 @@ instance Read Second
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Second "unwrapSecond") =>
-         HasField "unwrapSecond" (Ptr Second) (Ptr ty)
+instance HasField "unwrapSecond" (Ptr Second) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapSecond")
 instance HasCField Second "unwrapSecond"
     where type CFieldType Second "unwrapSecond" = CInt
@@ -222,8 +220,7 @@ instance Read Same
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Same "unwrapSame") =>
-         HasField "unwrapSame" (Ptr Same) (Ptr ty)
+instance HasField "unwrapSame" (Ptr Same) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapSame")
 instance HasCField Same "unwrapSame"
     where type CFieldType Same "unwrapSame" = CUInt
@@ -299,8 +296,7 @@ instance Read Nonseq
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Nonseq "unwrapNonseq") =>
-         HasField "unwrapNonseq" (Ptr Nonseq) (Ptr ty)
+instance HasField "unwrapNonseq" (Ptr Nonseq) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapNonseq")
 instance HasCField Nonseq "unwrapNonseq"
     where type CFieldType Nonseq "unwrapNonseq" = CUInt
@@ -395,8 +391,7 @@ instance Read Packed
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType Packed "unwrapPacked") =>
-         HasField "unwrapPacked" (Ptr Packed) (Ptr ty)
+instance HasField "unwrapPacked" (Ptr Packed) (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapPacked")
 instance HasCField Packed "unwrapPacked"
     where type CFieldType Packed "unwrapPacked" = CUChar
@@ -490,8 +485,7 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType EnumA "unwrapEnumA") =>
-         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
+instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -571,8 +565,7 @@ instance Read EnumB
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType EnumB "unwrapEnumB") =>
-         HasField "unwrapEnumB" (Ptr EnumB) (Ptr ty)
+instance HasField "unwrapEnumB" (Ptr EnumB) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumB")
 instance HasCField EnumB "unwrapEnumB"
     where type CFieldType EnumB "unwrapEnumB" = CUInt
@@ -652,8 +645,7 @@ instance Read EnumC
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType EnumC "unwrapEnumC") =>
-         HasField "unwrapEnumC" (Ptr EnumC) (Ptr ty)
+instance HasField "unwrapEnumC" (Ptr EnumC) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumC")
 instance HasCField EnumC "unwrapEnumC"
     where type CFieldType EnumC "unwrapEnumC" = CUInt
@@ -733,8 +725,7 @@ instance Read EnumD_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType EnumD_t "unwrapEnumD_t") =>
-         HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr ty)
+instance HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumD_t")
 instance HasCField EnumD_t "unwrapEnumD_t"
     where type CFieldType EnumD_t "unwrapEnumD_t" = CUInt

--- a/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum enumA@
@@ -114,8 +111,7 @@ instance Read EnumA where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType EnumA) "unwrapEnumA")
-         ) => GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumA")
@@ -192,8 +188,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExA) "exA_fieldA1")
-         ) => GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr EnumA) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exA_fieldA1")
@@ -279,8 +274,7 @@ instance Read ExB_fieldB1 where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExB_fieldB1) "unwrapExB_fieldB1")
-         ) => GHC.Records.HasField "unwrapExB_fieldB1" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapExB_fieldB1" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapExB_fieldB1")
@@ -358,8 +352,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExB) "exB_fieldB1")
-         ) => GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ExB_fieldB1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
@@ -46,8 +46,7 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType EnumA "unwrapEnumA") =>
-         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
+instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -114,8 +113,7 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = EnumA
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExA "exA_fieldA1") =>
-         HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+instance HasField "exA_fieldA1" (Ptr ExA) (Ptr EnumA)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @enum \@exB_fieldB1@
 
@@ -164,8 +162,7 @@ instance Read ExB_fieldB1
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType ExB_fieldB1 "unwrapExB_fieldB1") =>
-         HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapExB_fieldB1")
 instance HasCField ExB_fieldB1 "unwrapExB_fieldB1"
     where type CFieldType ExB_fieldB1 "unwrapExB_fieldB1" = CUInt
@@ -232,6 +229,5 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExB "exB_fieldB1") =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_i")
-         ) => GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_i")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_c")
-         ) => GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_c")
@@ -157,8 +152,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_foo1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_foo1")
-         ) => GHC.Records.HasField "bar_foo1" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_foo1" (Ptr.Ptr Bar) (Ptr.Ptr Foo) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_foo1")
@@ -169,8 +163,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_foo2" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bar) "bar_foo2")
-         ) => GHC.Records.HasField "bar_foo2" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bar_foo2" (Ptr.Ptr Bar) (Ptr.Ptr Foo) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_foo2")
@@ -233,8 +226,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex3_ex3_struct) "ex3_ex3_struct_ex3_a")
-         ) => GHC.Records.HasField "ex3_ex3_struct_ex3_a" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex3_ex3_struct_ex3_a" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct_ex3_a")
@@ -246,8 +238,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex3_ex3_struct) "ex3_ex3_struct_ex3_b")
-         ) => GHC.Records.HasField "ex3_ex3_struct_ex3_b" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex3_ex3_struct_ex3_b" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct_ex3_b")
@@ -309,8 +300,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3 "ex3_ex3_struct" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex3) "ex3_ex3_struct")
-         ) => GHC.Records.HasField "ex3_ex3_struct" (Ptr.Ptr Ex3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex3_ex3_struct" (Ptr.Ptr Ex3) (Ptr.Ptr Ex3_ex3_struct) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct")
@@ -321,8 +311,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3 "ex3_ex3_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex3) "ex3_ex3_c")
-         ) => GHC.Records.HasField "ex3_ex3_c" (Ptr.Ptr Ex3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex3_ex3_c" (Ptr.Ptr Ex3) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_c")
@@ -384,8 +373,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_odd "ex4_odd_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex4_odd) "ex4_odd_value")
-         ) => GHC.Records.HasField "ex4_odd_value" (Ptr.Ptr Ex4_odd) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex4_odd_value" (Ptr.Ptr Ex4_odd) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_odd_value")
@@ -397,8 +385,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_odd "ex4_odd_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex4_odd) "ex4_odd_next")
-         ) => GHC.Records.HasField "ex4_odd_next" (Ptr.Ptr Ex4_odd) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex4_odd_next" (Ptr.Ptr Ex4_odd) (Ptr.Ptr (Ptr.Ptr Ex4_even)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_odd_next")
@@ -461,8 +448,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_even "ex4_even_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex4_even) "ex4_even_value")
-         ) => GHC.Records.HasField "ex4_even_value" (Ptr.Ptr Ex4_even) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex4_even_value" (Ptr.Ptr Ex4_even) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_even_value")
@@ -474,8 +460,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_even "ex4_even_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Ex4_even) "ex4_even_next")
-         ) => GHC.Records.HasField "ex4_even_next" (Ptr.Ptr Ex4_even) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "ex4_even_next" (Ptr.Ptr Ex4_even) (Ptr.Ptr (Ptr.Ptr Ex4_odd)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_even_next")

--- a/hs-bindgen/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/fixtures/types/nested/nested_types/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo "foo_i") =>
-         HasField "foo_i" (Ptr Foo) (Ptr ty)
+instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_i")
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Foo "foo_c") =>
-         HasField "foo_c" (Ptr Foo) (Ptr ty)
+instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
     where getField = fromPtr (Proxy @"foo_c")
 {-| __C declaration:__ @struct bar@
 
@@ -92,14 +90,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_foo1"
     where type CFieldType Bar "bar_foo1" = Foo
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bar "bar_foo1") =>
-         HasField "bar_foo1" (Ptr Bar) (Ptr ty)
+instance HasField "bar_foo1" (Ptr Bar) (Ptr Foo)
     where getField = fromPtr (Proxy @"bar_foo1")
 instance HasCField Bar "bar_foo2"
     where type CFieldType Bar "bar_foo2" = Foo
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Bar "bar_foo2") =>
-         HasField "bar_foo2" (Ptr Bar) (Ptr ty)
+instance HasField "bar_foo2" (Ptr Bar) (Ptr Foo)
     where getField = fromPtr (Proxy @"bar_foo2")
 {-| __C declaration:__ @struct \@ex3_ex3_struct@
 
@@ -143,16 +139,16 @@ deriving via (EquivStorable Ex3_ex3_struct) instance Storable Ex3_ex3_struct
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a") =>
-         HasField "ex3_ex3_struct_ex3_a" (Ptr Ex3_ex3_struct) (Ptr ty)
+instance HasField "ex3_ex3_struct_ex3_a"
+                  (Ptr Ex3_ex3_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_a")
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" = CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty
-              (CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b") =>
-         HasField "ex3_ex3_struct_ex3_b" (Ptr Ex3_ex3_struct) (Ptr ty)
+instance HasField "ex3_ex3_struct_ex3_b"
+                  (Ptr Ex3_ex3_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_b")
 {-| __C declaration:__ @struct ex3@
 
@@ -196,14 +192,12 @@ deriving via (EquivStorable Ex3) instance Storable Ex3
 instance HasCField Ex3 "ex3_ex3_struct"
     where type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Ex3 "ex3_ex3_struct") =>
-         HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr ty)
+instance HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr Ex3_ex3_struct)
     where getField = fromPtr (Proxy @"ex3_ex3_struct")
 instance HasCField Ex3 "ex3_ex3_c"
     where type CFieldType Ex3 "ex3_ex3_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Ex3 "ex3_ex3_c") =>
-         HasField "ex3_ex3_c" (Ptr Ex3) (Ptr ty)
+instance HasField "ex3_ex3_c" (Ptr Ex3) (Ptr CFloat)
     where getField = fromPtr (Proxy @"ex3_ex3_c")
 {-| __C declaration:__ @struct ex4_odd@
 
@@ -247,14 +241,12 @@ deriving via (EquivStorable Ex4_odd) instance Storable Ex4_odd
 instance HasCField Ex4_odd "ex4_odd_value"
     where type CFieldType Ex4_odd "ex4_odd_value" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Ex4_odd "ex4_odd_value") =>
-         HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr ty)
+instance HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr CInt)
     where getField = fromPtr (Proxy @"ex4_odd_value")
 instance HasCField Ex4_odd "ex4_odd_next"
     where type CFieldType Ex4_odd "ex4_odd_next" = Ptr Ex4_even
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Ex4_odd "ex4_odd_next") =>
-         HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr ty)
+instance HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr (Ptr Ex4_even))
     where getField = fromPtr (Proxy @"ex4_odd_next")
 {-| __C declaration:__ @struct ex4_even@
 
@@ -298,12 +290,12 @@ deriving via (EquivStorable Ex4_even) instance Storable Ex4_even
 instance HasCField Ex4_even "ex4_even_value"
     where type CFieldType Ex4_even "ex4_even_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Ex4_even "ex4_even_value") =>
-         HasField "ex4_even_value" (Ptr Ex4_even) (Ptr ty)
+instance HasField "ex4_even_value" (Ptr Ex4_even) (Ptr CDouble)
     where getField = fromPtr (Proxy @"ex4_even_value")
 instance HasCField Ex4_even "ex4_even_next"
     where type CFieldType Ex4_even "ex4_even_next" = Ptr Ex4_odd
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Ex4_even "ex4_even_next") =>
-         HasField "ex4_even_next" (Ptr Ex4_even) (Ptr ty)
+instance HasField "ex4_even_next"
+                  (Ptr Ex4_even)
+                  (Ptr (Ptr Ex4_odd))
     where getField = fromPtr (Proxy @"ex4_even_next")

--- a/hs-bindgen/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct bools1@
@@ -90,8 +87,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools1 "bools1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools1) "bools1_x")
-         ) => GHC.Records.HasField "bools1_x" (Ptr.Ptr Bools1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools1_x" (Ptr.Ptr Bools1) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools1_x")
@@ -102,8 +98,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools1 "bools1_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools1) "bools1_y")
-         ) => GHC.Records.HasField "bools1_y" (Ptr.Ptr Bools1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools1_y" (Ptr.Ptr Bools1) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools1_y")
@@ -165,8 +160,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools2 "bools2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools2) "bools2_x")
-         ) => GHC.Records.HasField "bools2_x" (Ptr.Ptr Bools2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools2_x" (Ptr.Ptr Bools2) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools2_x")
@@ -177,8 +171,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools2 "bools2_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools2) "bools2_y")
-         ) => GHC.Records.HasField "bools2_y" (Ptr.Ptr Bools2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools2_y" (Ptr.Ptr Bools2) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools2_y")
@@ -212,8 +205,7 @@ newtype BOOL = BOOL
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType BOOL) "unwrapBOOL")
-         ) => GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOL")
@@ -281,8 +273,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools3 "bools3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools3) "bools3_x")
-         ) => GHC.Records.HasField "bools3_x" (Ptr.Ptr Bools3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools3_x" (Ptr.Ptr Bools3) (Ptr.Ptr BOOL) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools3_x")
@@ -293,8 +284,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools3 "bools3_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Bools3) "bools3_y")
-         ) => GHC.Records.HasField "bools3_y" (Ptr.Ptr Bools3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "bools3_y" (Ptr.Ptr Bools3) (Ptr.Ptr BOOL) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools3_y")

--- a/hs-bindgen/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/bool/th.txt
@@ -42,14 +42,12 @@ deriving via (EquivStorable Bools1) instance Storable Bools1
 instance HasCField Bools1 "bools1_x"
     where type CFieldType Bools1 "bools1_x" = CBool
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bools1 "bools1_x") =>
-         HasField "bools1_x" (Ptr Bools1) (Ptr ty)
+instance HasField "bools1_x" (Ptr Bools1) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools1_x")
 instance HasCField Bools1 "bools1_y"
     where type CFieldType Bools1 "bools1_y" = CBool
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Bools1 "bools1_y") =>
-         HasField "bools1_y" (Ptr Bools1) (Ptr ty)
+instance HasField "bools1_y" (Ptr Bools1) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools1_y")
 {-| __C declaration:__ @struct bools2@
 
@@ -93,14 +91,12 @@ deriving via (EquivStorable Bools2) instance Storable Bools2
 instance HasCField Bools2 "bools2_x"
     where type CFieldType Bools2 "bools2_x" = CBool
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bools2 "bools2_x") =>
-         HasField "bools2_x" (Ptr Bools2) (Ptr ty)
+instance HasField "bools2_x" (Ptr Bools2) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools2_x")
 instance HasCField Bools2 "bools2_y"
     where type CFieldType Bools2 "bools2_y" = CBool
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Bools2 "bools2_y") =>
-         HasField "bools2_y" (Ptr Bools2) (Ptr ty)
+instance HasField "bools2_y" (Ptr Bools2) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools2_y")
 {-| __C declaration:__ @BOOL@
 
@@ -133,8 +129,7 @@ newtype BOOL
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType BOOL "unwrapBOOL") =>
-         HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -181,12 +176,10 @@ deriving via (EquivStorable Bools3) instance Storable Bools3
 instance HasCField Bools3 "bools3_x"
     where type CFieldType Bools3 "bools3_x" = BOOL
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Bools3 "bools3_x") =>
-         HasField "bools3_x" (Ptr Bools3) (Ptr ty)
+instance HasField "bools3_x" (Ptr Bools3) (Ptr BOOL)
     where getField = fromPtr (Proxy @"bools3_x")
 instance HasCField Bools3 "bools3_y"
     where type CFieldType Bools3 "bools3_y" = BOOL
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Bools3 "bools3_y") =>
-         HasField "bools3_y" (Ptr Bools3) (Ptr ty)
+instance HasField "bools3_y" (Ptr Bools3) (Ptr BOOL)
     where getField = fromPtr (Proxy @"bools3_y")

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -83,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_sixty_four")
-         ) => GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_sixty_four")
@@ -96,8 +92,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_thirty_two")
-         ) => GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
@@ -45,13 +45,15 @@ instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo
                           "foo_sixty_four" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo "foo_sixty_four") =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+instance HasField "foo_sixty_four"
+                  (Ptr Foo)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo
                           "foo_thirty_two" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Foo "foo_thirty_two") =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+instance HasField "foo_thirty_two"
+                  (Ptr Foo)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,7 +27,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @prim_HsPrimCPtrdiff@
@@ -61,8 +58,7 @@ newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCPtrdiff) "unwrapPrim_HsPrimCPtrdiff")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCPtrdiff" (Ptr.Ptr Prim_HsPrimCPtrdiff) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCPtrdiff" (Ptr.Ptr Prim_HsPrimCPtrdiff) (Ptr.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCPtrdiff")
@@ -103,8 +99,7 @@ newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimInt8) "unwrapPrim_HsPrimInt8")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt8" (Ptr.Ptr Prim_HsPrimInt8) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimInt8" (Ptr.Ptr Prim_HsPrimInt8) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt8")
@@ -145,8 +140,7 @@ newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimInt16) "unwrapPrim_HsPrimInt16")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt16" (Ptr.Ptr Prim_HsPrimInt16) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimInt16" (Ptr.Ptr Prim_HsPrimInt16) (Ptr.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt16")
@@ -187,8 +181,7 @@ newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimInt32) "unwrapPrim_HsPrimInt32")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt32" (Ptr.Ptr Prim_HsPrimInt32) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimInt32" (Ptr.Ptr Prim_HsPrimInt32) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt32")
@@ -229,8 +222,7 @@ newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimInt64) "unwrapPrim_HsPrimInt64")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt64" (Ptr.Ptr Prim_HsPrimInt64) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimInt64" (Ptr.Ptr Prim_HsPrimInt64) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt64")
@@ -271,8 +263,7 @@ newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimWord8) "unwrapPrim_HsPrimWord8")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord8" (Ptr.Ptr Prim_HsPrimWord8) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimWord8" (Ptr.Ptr Prim_HsPrimWord8) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord8")
@@ -313,8 +304,7 @@ newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimWord16) "unwrapPrim_HsPrimWord16")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord16" (Ptr.Ptr Prim_HsPrimWord16) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimWord16" (Ptr.Ptr Prim_HsPrimWord16) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord16")
@@ -355,8 +345,7 @@ newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimWord32) "unwrapPrim_HsPrimWord32")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord32" (Ptr.Ptr Prim_HsPrimWord32) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimWord32" (Ptr.Ptr Prim_HsPrimWord32) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord32")
@@ -397,8 +386,7 @@ newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimWord64) "unwrapPrim_HsPrimWord64")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord64" (Ptr.Ptr Prim_HsPrimWord64) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimWord64" (Ptr.Ptr Prim_HsPrimWord64) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord64")
@@ -439,8 +427,7 @@ newtype Prim_HsPrimCChar = Prim_HsPrimCChar
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCChar) "unwrapPrim_HsPrimCChar")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCChar" (Ptr.Ptr Prim_HsPrimCChar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCChar" (Ptr.Ptr Prim_HsPrimCChar) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCChar")
@@ -481,8 +468,7 @@ newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCSChar) "unwrapPrim_HsPrimCSChar")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCSChar" (Ptr.Ptr Prim_HsPrimCSChar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCSChar" (Ptr.Ptr Prim_HsPrimCSChar) (Ptr.Ptr FC.CSChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCSChar")
@@ -523,8 +509,7 @@ newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCUChar) "unwrapPrim_HsPrimCUChar")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUChar" (Ptr.Ptr Prim_HsPrimCUChar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCUChar" (Ptr.Ptr Prim_HsPrimCUChar) (Ptr.Ptr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUChar")
@@ -565,8 +550,7 @@ newtype Prim_HsPrimCShort = Prim_HsPrimCShort
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCShort) "unwrapPrim_HsPrimCShort")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCShort" (Ptr.Ptr Prim_HsPrimCShort) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCShort" (Ptr.Ptr Prim_HsPrimCShort) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCShort")
@@ -607,8 +591,7 @@ newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCUShort) "unwrapPrim_HsPrimCUShort")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUShort" (Ptr.Ptr Prim_HsPrimCUShort) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCUShort" (Ptr.Ptr Prim_HsPrimCUShort) (Ptr.Ptr FC.CUShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUShort")
@@ -649,8 +632,7 @@ newtype Prim_HsPrimCInt = Prim_HsPrimCInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCInt) "unwrapPrim_HsPrimCInt")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCInt" (Ptr.Ptr Prim_HsPrimCInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCInt" (Ptr.Ptr Prim_HsPrimCInt) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCInt")
@@ -691,8 +673,7 @@ newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCUInt) "unwrapPrim_HsPrimCUInt")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUInt" (Ptr.Ptr Prim_HsPrimCUInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCUInt" (Ptr.Ptr Prim_HsPrimCUInt) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUInt")
@@ -733,8 +714,7 @@ newtype Prim_HsPrimCLong = Prim_HsPrimCLong
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCLong) "unwrapPrim_HsPrimCLong")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCLong" (Ptr.Ptr Prim_HsPrimCLong) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCLong" (Ptr.Ptr Prim_HsPrimCLong) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCLong")
@@ -775,8 +755,7 @@ newtype Prim_HsPrimCULong = Prim_HsPrimCULong
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCULong) "unwrapPrim_HsPrimCULong")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCULong" (Ptr.Ptr Prim_HsPrimCULong) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCULong" (Ptr.Ptr Prim_HsPrimCULong) (Ptr.Ptr FC.CULong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCULong")
@@ -817,8 +796,7 @@ newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCLLong) "unwrapPrim_HsPrimCLLong")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCLLong" (Ptr.Ptr Prim_HsPrimCLLong) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCLLong" (Ptr.Ptr Prim_HsPrimCLLong) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCLLong")
@@ -859,8 +837,7 @@ newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCULLong) "unwrapPrim_HsPrimCULLong")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCULLong" (Ptr.Ptr Prim_HsPrimCULLong) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCULLong" (Ptr.Ptr Prim_HsPrimCULLong) (Ptr.Ptr FC.CULLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCULLong")
@@ -901,8 +878,7 @@ newtype Prim_HsPrimCBool = Prim_HsPrimCBool
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCBool) "unwrapPrim_HsPrimCBool")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCBool" (Ptr.Ptr Prim_HsPrimCBool) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCBool" (Ptr.Ptr Prim_HsPrimCBool) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCBool")
@@ -941,8 +917,7 @@ newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
     , RealFrac
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCFloat) "unwrapPrim_HsPrimCFloat")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCFloat" (Ptr.Ptr Prim_HsPrimCFloat) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCFloat" (Ptr.Ptr Prim_HsPrimCFloat) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCFloat")
@@ -981,8 +956,7 @@ newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
     , RealFrac
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Prim_HsPrimCDouble) "unwrapPrim_HsPrimCDouble")
-         ) => GHC.Records.HasField "unwrapPrim_HsPrimCDouble" (Ptr.Ptr Prim_HsPrimCDouble) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapPrim_HsPrimCDouble" (Ptr.Ptr Prim_HsPrimCDouble) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCDouble")

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
@@ -35,11 +35,9 @@ newtype Prim_HsPrimCPtrdiff
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff") =>
-         HasField "unwrapPrim_HsPrimCPtrdiff"
+instance HasField "unwrapPrim_HsPrimCPtrdiff"
                   (Ptr Prim_HsPrimCPtrdiff)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCPtrdiff")
 instance HasCField Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff"
     where type CFieldType Prim_HsPrimCPtrdiff
@@ -76,9 +74,9 @@ newtype Prim_HsPrimInt8
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8") =>
-         HasField "unwrapPrim_HsPrimInt8" (Ptr Prim_HsPrimInt8) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt8"
+                  (Ptr Prim_HsPrimInt8)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt8")
 instance HasCField Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8"
     where type CFieldType Prim_HsPrimInt8
@@ -115,9 +113,9 @@ newtype Prim_HsPrimInt16
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16") =>
-         HasField "unwrapPrim_HsPrimInt16" (Ptr Prim_HsPrimInt16) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt16"
+                  (Ptr Prim_HsPrimInt16)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt16")
 instance HasCField Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16"
     where type CFieldType Prim_HsPrimInt16
@@ -154,9 +152,9 @@ newtype Prim_HsPrimInt32
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32") =>
-         HasField "unwrapPrim_HsPrimInt32" (Ptr Prim_HsPrimInt32) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt32"
+                  (Ptr Prim_HsPrimInt32)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt32")
 instance HasCField Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32"
     where type CFieldType Prim_HsPrimInt32
@@ -193,9 +191,9 @@ newtype Prim_HsPrimInt64
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64") =>
-         HasField "unwrapPrim_HsPrimInt64" (Ptr Prim_HsPrimInt64) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt64"
+                  (Ptr Prim_HsPrimInt64)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt64")
 instance HasCField Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64"
     where type CFieldType Prim_HsPrimInt64
@@ -232,9 +230,9 @@ newtype Prim_HsPrimWord8
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8") =>
-         HasField "unwrapPrim_HsPrimWord8" (Ptr Prim_HsPrimWord8) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord8"
+                  (Ptr Prim_HsPrimWord8)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord8")
 instance HasCField Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8"
     where type CFieldType Prim_HsPrimWord8
@@ -271,9 +269,9 @@ newtype Prim_HsPrimWord16
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16") =>
-         HasField "unwrapPrim_HsPrimWord16" (Ptr Prim_HsPrimWord16) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord16"
+                  (Ptr Prim_HsPrimWord16)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord16")
 instance HasCField Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16"
     where type CFieldType Prim_HsPrimWord16
@@ -310,9 +308,9 @@ newtype Prim_HsPrimWord32
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32") =>
-         HasField "unwrapPrim_HsPrimWord32" (Ptr Prim_HsPrimWord32) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord32"
+                  (Ptr Prim_HsPrimWord32)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord32")
 instance HasCField Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32"
     where type CFieldType Prim_HsPrimWord32
@@ -349,9 +347,9 @@ newtype Prim_HsPrimWord64
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64") =>
-         HasField "unwrapPrim_HsPrimWord64" (Ptr Prim_HsPrimWord64) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord64"
+                  (Ptr Prim_HsPrimWord64)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord64")
 instance HasCField Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64"
     where type CFieldType Prim_HsPrimWord64
@@ -388,9 +386,9 @@ newtype Prim_HsPrimCChar
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCChar "unwrapPrim_HsPrimCChar") =>
-         HasField "unwrapPrim_HsPrimCChar" (Ptr Prim_HsPrimCChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCChar"
+                  (Ptr Prim_HsPrimCChar)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCChar")
 instance HasCField Prim_HsPrimCChar "unwrapPrim_HsPrimCChar"
     where type CFieldType Prim_HsPrimCChar
@@ -427,9 +425,9 @@ newtype Prim_HsPrimCSChar
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar") =>
-         HasField "unwrapPrim_HsPrimCSChar" (Ptr Prim_HsPrimCSChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCSChar"
+                  (Ptr Prim_HsPrimCSChar)
+                  (Ptr CSChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCSChar")
 instance HasCField Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar"
     where type CFieldType Prim_HsPrimCSChar
@@ -466,9 +464,9 @@ newtype Prim_HsPrimCUChar
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar") =>
-         HasField "unwrapPrim_HsPrimCUChar" (Ptr Prim_HsPrimCUChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCUChar"
+                  (Ptr Prim_HsPrimCUChar)
+                  (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUChar")
 instance HasCField Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar"
     where type CFieldType Prim_HsPrimCUChar
@@ -505,9 +503,9 @@ newtype Prim_HsPrimCShort
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCShort "unwrapPrim_HsPrimCShort") =>
-         HasField "unwrapPrim_HsPrimCShort" (Ptr Prim_HsPrimCShort) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCShort"
+                  (Ptr Prim_HsPrimCShort)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCShort")
 instance HasCField Prim_HsPrimCShort "unwrapPrim_HsPrimCShort"
     where type CFieldType Prim_HsPrimCShort
@@ -544,11 +542,9 @@ newtype Prim_HsPrimCUShort
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort") =>
-         HasField "unwrapPrim_HsPrimCUShort"
+instance HasField "unwrapPrim_HsPrimCUShort"
                   (Ptr Prim_HsPrimCUShort)
-                  (Ptr ty)
+                  (Ptr CUShort)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUShort")
 instance HasCField Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort"
     where type CFieldType Prim_HsPrimCUShort
@@ -585,9 +581,9 @@ newtype Prim_HsPrimCInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCInt "unwrapPrim_HsPrimCInt") =>
-         HasField "unwrapPrim_HsPrimCInt" (Ptr Prim_HsPrimCInt) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCInt"
+                  (Ptr Prim_HsPrimCInt)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCInt")
 instance HasCField Prim_HsPrimCInt "unwrapPrim_HsPrimCInt"
     where type CFieldType Prim_HsPrimCInt
@@ -624,9 +620,9 @@ newtype Prim_HsPrimCUInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt") =>
-         HasField "unwrapPrim_HsPrimCUInt" (Ptr Prim_HsPrimCUInt) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCUInt"
+                  (Ptr Prim_HsPrimCUInt)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUInt")
 instance HasCField Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt"
     where type CFieldType Prim_HsPrimCUInt
@@ -663,9 +659,9 @@ newtype Prim_HsPrimCLong
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCLong "unwrapPrim_HsPrimCLong") =>
-         HasField "unwrapPrim_HsPrimCLong" (Ptr Prim_HsPrimCLong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCLong"
+                  (Ptr Prim_HsPrimCLong)
+                  (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLong")
 instance HasCField Prim_HsPrimCLong "unwrapPrim_HsPrimCLong"
     where type CFieldType Prim_HsPrimCLong
@@ -702,9 +698,9 @@ newtype Prim_HsPrimCULong
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCULong "unwrapPrim_HsPrimCULong") =>
-         HasField "unwrapPrim_HsPrimCULong" (Ptr Prim_HsPrimCULong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCULong"
+                  (Ptr Prim_HsPrimCULong)
+                  (Ptr CULong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULong")
 instance HasCField Prim_HsPrimCULong "unwrapPrim_HsPrimCULong"
     where type CFieldType Prim_HsPrimCULong
@@ -741,9 +737,9 @@ newtype Prim_HsPrimCLLong
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong") =>
-         HasField "unwrapPrim_HsPrimCLLong" (Ptr Prim_HsPrimCLLong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCLLong"
+                  (Ptr Prim_HsPrimCLLong)
+                  (Ptr CLLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLLong")
 instance HasCField Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong"
     where type CFieldType Prim_HsPrimCLLong
@@ -780,11 +776,9 @@ newtype Prim_HsPrimCULLong
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong") =>
-         HasField "unwrapPrim_HsPrimCULLong"
+instance HasField "unwrapPrim_HsPrimCULLong"
                   (Ptr Prim_HsPrimCULLong)
-                  (Ptr ty)
+                  (Ptr CULLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULLong")
 instance HasCField Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong"
     where type CFieldType Prim_HsPrimCULLong
@@ -821,9 +815,9 @@ newtype Prim_HsPrimCBool
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCBool "unwrapPrim_HsPrimCBool") =>
-         HasField "unwrapPrim_HsPrimCBool" (Ptr Prim_HsPrimCBool) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCBool"
+                  (Ptr Prim_HsPrimCBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCBool")
 instance HasCField Prim_HsPrimCBool "unwrapPrim_HsPrimCBool"
     where type CFieldType Prim_HsPrimCBool
@@ -858,9 +852,9 @@ newtype Prim_HsPrimCFloat
                       Real,
                       RealFloat,
                       RealFrac)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat") =>
-         HasField "unwrapPrim_HsPrimCFloat" (Ptr Prim_HsPrimCFloat) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCFloat"
+                  (Ptr Prim_HsPrimCFloat)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCFloat")
 instance HasCField Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat"
     where type CFieldType Prim_HsPrimCFloat
@@ -895,11 +889,9 @@ newtype Prim_HsPrimCDouble
                       Real,
                       RealFloat,
                       RealFrac)
-instance TyEq ty
-              (CFieldType Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble") =>
-         HasField "unwrapPrim_HsPrimCDouble"
+instance HasField "unwrapPrim_HsPrimCDouble"
                   (Ptr Prim_HsPrimCDouble)
-                  (Ptr ty)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCDouble")
 instance HasCField Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble"
     where type CFieldType Prim_HsPrimCDouble

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct primitive@
@@ -344,8 +341,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_c")
-         ) => GHC.Records.HasField "primitive_c" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_c" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_c")
@@ -356,8 +352,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sc" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_sc")
-         ) => GHC.Records.HasField "primitive_sc" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_sc" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CSChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sc")
@@ -368,8 +363,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_uc" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_uc")
-         ) => GHC.Records.HasField "primitive_uc" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_uc" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_uc")
@@ -380,8 +374,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_s" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_s")
-         ) => GHC.Records.HasField "primitive_s" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_s" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_s")
@@ -392,8 +385,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_si" where
 
   offset# = \_ -> \_ -> 6
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_si")
-         ) => GHC.Records.HasField "primitive_si" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_si" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_si")
@@ -404,8 +396,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ss" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ss")
-         ) => GHC.Records.HasField "primitive_ss" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ss" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ss")
@@ -416,8 +407,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ssi" where
 
   offset# = \_ -> \_ -> 10
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ssi")
-         ) => GHC.Records.HasField "primitive_ssi" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ssi" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ssi")
@@ -428,8 +418,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_us" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_us")
-         ) => GHC.Records.HasField "primitive_us" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_us" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_us")
@@ -441,8 +430,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_usi" where
 
   offset# = \_ -> \_ -> 14
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_usi")
-         ) => GHC.Records.HasField "primitive_usi" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_usi" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUShort) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_usi")
@@ -453,8 +441,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_i" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_i")
-         ) => GHC.Records.HasField "primitive_i" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_i" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_i")
@@ -465,8 +452,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_s2" where
 
   offset# = \_ -> \_ -> 20
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_s2")
-         ) => GHC.Records.HasField "primitive_s2" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_s2" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_s2")
@@ -477,8 +463,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_si2" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_si2")
-         ) => GHC.Records.HasField "primitive_si2" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_si2" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_si2")
@@ -489,8 +474,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_u" where
 
   offset# = \_ -> \_ -> 28
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_u")
-         ) => GHC.Records.HasField "primitive_u" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_u" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_u")
@@ -501,8 +485,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ui" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ui")
-         ) => GHC.Records.HasField "primitive_ui" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ui" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ui")
@@ -513,8 +496,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_l" where
 
   offset# = \_ -> \_ -> 40
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_l")
-         ) => GHC.Records.HasField "primitive_l" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_l" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_l")
@@ -525,8 +507,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_li" where
 
   offset# = \_ -> \_ -> 48
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_li")
-         ) => GHC.Records.HasField "primitive_li" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_li" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_li")
@@ -537,8 +518,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sl" where
 
   offset# = \_ -> \_ -> 56
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_sl")
-         ) => GHC.Records.HasField "primitive_sl" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_sl" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sl")
@@ -549,8 +529,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sli" where
 
   offset# = \_ -> \_ -> 64
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_sli")
-         ) => GHC.Records.HasField "primitive_sli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_sli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sli")
@@ -561,8 +540,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ul" where
 
   offset# = \_ -> \_ -> 72
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ul")
-         ) => GHC.Records.HasField "primitive_ul" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ul" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ul")
@@ -573,8 +551,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_uli" where
 
   offset# = \_ -> \_ -> 80
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_uli")
-         ) => GHC.Records.HasField "primitive_uli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_uli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_uli")
@@ -585,8 +562,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ll" where
 
   offset# = \_ -> \_ -> 88
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ll")
-         ) => GHC.Records.HasField "primitive_ll" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ll" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ll")
@@ -597,8 +573,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_lli" where
 
   offset# = \_ -> \_ -> 96
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_lli")
-         ) => GHC.Records.HasField "primitive_lli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_lli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_lli")
@@ -609,8 +584,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sll" where
 
   offset# = \_ -> \_ -> 104
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_sll")
-         ) => GHC.Records.HasField "primitive_sll" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_sll" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sll")
@@ -622,8 +596,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_slli" where
 
   offset# = \_ -> \_ -> 112
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_slli")
-         ) => GHC.Records.HasField "primitive_slli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_slli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_slli")
@@ -635,8 +608,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ull" where
 
   offset# = \_ -> \_ -> 120
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ull")
-         ) => GHC.Records.HasField "primitive_ull" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ull" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ull")
@@ -648,8 +620,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ulli" where
 
   offset# = \_ -> \_ -> 128
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_ulli")
-         ) => GHC.Records.HasField "primitive_ulli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_ulli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULLong) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ulli")
@@ -660,8 +631,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_f" where
 
   offset# = \_ -> \_ -> 136
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_f")
-         ) => GHC.Records.HasField "primitive_f" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_f" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_f")
@@ -672,8 +642,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_d" where
 
   offset# = \_ -> \_ -> 144
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Primitive) "primitive_d")
-         ) => GHC.Records.HasField "primitive_d" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "primitive_d" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_d")

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
@@ -249,168 +249,140 @@ deriving via (EquivStorable Primitive) instance Storable Primitive
 instance HasCField Primitive "primitive_c"
     where type CFieldType Primitive "primitive_c" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Primitive "primitive_c") =>
-         HasField "primitive_c" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_c" (Ptr Primitive) (Ptr CChar)
     where getField = fromPtr (Proxy @"primitive_c")
 instance HasCField Primitive "primitive_sc"
     where type CFieldType Primitive "primitive_sc" = CSChar
           offset# = \_ -> \_ -> 1
-instance TyEq ty (CFieldType Primitive "primitive_sc") =>
-         HasField "primitive_sc" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sc" (Ptr Primitive) (Ptr CSChar)
     where getField = fromPtr (Proxy @"primitive_sc")
 instance HasCField Primitive "primitive_uc"
     where type CFieldType Primitive "primitive_uc" = CUChar
           offset# = \_ -> \_ -> 2
-instance TyEq ty (CFieldType Primitive "primitive_uc") =>
-         HasField "primitive_uc" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_uc" (Ptr Primitive) (Ptr CUChar)
     where getField = fromPtr (Proxy @"primitive_uc")
 instance HasCField Primitive "primitive_s"
     where type CFieldType Primitive "primitive_s" = CShort
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Primitive "primitive_s") =>
-         HasField "primitive_s" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_s" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_s")
 instance HasCField Primitive "primitive_si"
     where type CFieldType Primitive "primitive_si" = CShort
           offset# = \_ -> \_ -> 6
-instance TyEq ty (CFieldType Primitive "primitive_si") =>
-         HasField "primitive_si" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_si" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_si")
 instance HasCField Primitive "primitive_ss"
     where type CFieldType Primitive "primitive_ss" = CShort
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Primitive "primitive_ss") =>
-         HasField "primitive_ss" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ss" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_ss")
 instance HasCField Primitive "primitive_ssi"
     where type CFieldType Primitive "primitive_ssi" = CShort
           offset# = \_ -> \_ -> 10
-instance TyEq ty (CFieldType Primitive "primitive_ssi") =>
-         HasField "primitive_ssi" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ssi" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_ssi")
 instance HasCField Primitive "primitive_us"
     where type CFieldType Primitive "primitive_us" = CUShort
           offset# = \_ -> \_ -> 12
-instance TyEq ty (CFieldType Primitive "primitive_us") =>
-         HasField "primitive_us" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_us" (Ptr Primitive) (Ptr CUShort)
     where getField = fromPtr (Proxy @"primitive_us")
 instance HasCField Primitive "primitive_usi"
     where type CFieldType Primitive "primitive_usi" = CUShort
           offset# = \_ -> \_ -> 14
-instance TyEq ty (CFieldType Primitive "primitive_usi") =>
-         HasField "primitive_usi" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_usi" (Ptr Primitive) (Ptr CUShort)
     where getField = fromPtr (Proxy @"primitive_usi")
 instance HasCField Primitive "primitive_i"
     where type CFieldType Primitive "primitive_i" = CInt
           offset# = \_ -> \_ -> 16
-instance TyEq ty (CFieldType Primitive "primitive_i") =>
-         HasField "primitive_i" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_i" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_i")
 instance HasCField Primitive "primitive_s2"
     where type CFieldType Primitive "primitive_s2" = CInt
           offset# = \_ -> \_ -> 20
-instance TyEq ty (CFieldType Primitive "primitive_s2") =>
-         HasField "primitive_s2" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_s2" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_s2")
 instance HasCField Primitive "primitive_si2"
     where type CFieldType Primitive "primitive_si2" = CInt
           offset# = \_ -> \_ -> 24
-instance TyEq ty (CFieldType Primitive "primitive_si2") =>
-         HasField "primitive_si2" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_si2" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_si2")
 instance HasCField Primitive "primitive_u"
     where type CFieldType Primitive "primitive_u" = CUInt
           offset# = \_ -> \_ -> 28
-instance TyEq ty (CFieldType Primitive "primitive_u") =>
-         HasField "primitive_u" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_u" (Ptr Primitive) (Ptr CUInt)
     where getField = fromPtr (Proxy @"primitive_u")
 instance HasCField Primitive "primitive_ui"
     where type CFieldType Primitive "primitive_ui" = CUInt
           offset# = \_ -> \_ -> 32
-instance TyEq ty (CFieldType Primitive "primitive_ui") =>
-         HasField "primitive_ui" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ui" (Ptr Primitive) (Ptr CUInt)
     where getField = fromPtr (Proxy @"primitive_ui")
 instance HasCField Primitive "primitive_l"
     where type CFieldType Primitive "primitive_l" = CLong
           offset# = \_ -> \_ -> 40
-instance TyEq ty (CFieldType Primitive "primitive_l") =>
-         HasField "primitive_l" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_l" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_l")
 instance HasCField Primitive "primitive_li"
     where type CFieldType Primitive "primitive_li" = CLong
           offset# = \_ -> \_ -> 48
-instance TyEq ty (CFieldType Primitive "primitive_li") =>
-         HasField "primitive_li" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_li" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_li")
 instance HasCField Primitive "primitive_sl"
     where type CFieldType Primitive "primitive_sl" = CLong
           offset# = \_ -> \_ -> 56
-instance TyEq ty (CFieldType Primitive "primitive_sl") =>
-         HasField "primitive_sl" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sl" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_sl")
 instance HasCField Primitive "primitive_sli"
     where type CFieldType Primitive "primitive_sli" = CLong
           offset# = \_ -> \_ -> 64
-instance TyEq ty (CFieldType Primitive "primitive_sli") =>
-         HasField "primitive_sli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sli" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_sli")
 instance HasCField Primitive "primitive_ul"
     where type CFieldType Primitive "primitive_ul" = CULong
           offset# = \_ -> \_ -> 72
-instance TyEq ty (CFieldType Primitive "primitive_ul") =>
-         HasField "primitive_ul" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ul" (Ptr Primitive) (Ptr CULong)
     where getField = fromPtr (Proxy @"primitive_ul")
 instance HasCField Primitive "primitive_uli"
     where type CFieldType Primitive "primitive_uli" = CULong
           offset# = \_ -> \_ -> 80
-instance TyEq ty (CFieldType Primitive "primitive_uli") =>
-         HasField "primitive_uli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_uli" (Ptr Primitive) (Ptr CULong)
     where getField = fromPtr (Proxy @"primitive_uli")
 instance HasCField Primitive "primitive_ll"
     where type CFieldType Primitive "primitive_ll" = CLLong
           offset# = \_ -> \_ -> 88
-instance TyEq ty (CFieldType Primitive "primitive_ll") =>
-         HasField "primitive_ll" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ll" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_ll")
 instance HasCField Primitive "primitive_lli"
     where type CFieldType Primitive "primitive_lli" = CLLong
           offset# = \_ -> \_ -> 96
-instance TyEq ty (CFieldType Primitive "primitive_lli") =>
-         HasField "primitive_lli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_lli" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_lli")
 instance HasCField Primitive "primitive_sll"
     where type CFieldType Primitive "primitive_sll" = CLLong
           offset# = \_ -> \_ -> 104
-instance TyEq ty (CFieldType Primitive "primitive_sll") =>
-         HasField "primitive_sll" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sll" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_sll")
 instance HasCField Primitive "primitive_slli"
     where type CFieldType Primitive "primitive_slli" = CLLong
           offset# = \_ -> \_ -> 112
-instance TyEq ty (CFieldType Primitive "primitive_slli") =>
-         HasField "primitive_slli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_slli" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_slli")
 instance HasCField Primitive "primitive_ull"
     where type CFieldType Primitive "primitive_ull" = CULLong
           offset# = \_ -> \_ -> 120
-instance TyEq ty (CFieldType Primitive "primitive_ull") =>
-         HasField "primitive_ull" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ull" (Ptr Primitive) (Ptr CULLong)
     where getField = fromPtr (Proxy @"primitive_ull")
 instance HasCField Primitive "primitive_ulli"
     where type CFieldType Primitive "primitive_ulli" = CULLong
           offset# = \_ -> \_ -> 128
-instance TyEq ty (CFieldType Primitive "primitive_ulli") =>
-         HasField "primitive_ulli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ulli" (Ptr Primitive) (Ptr CULLong)
     where getField = fromPtr (Proxy @"primitive_ulli")
 instance HasCField Primitive "primitive_f"
     where type CFieldType Primitive "primitive_f" = CFloat
           offset# = \_ -> \_ -> 136
-instance TyEq ty (CFieldType Primitive "primitive_f") =>
-         HasField "primitive_f" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_f" (Ptr Primitive) (Ptr CFloat)
     where getField = fromPtr (Proxy @"primitive_f")
 instance HasCField Primitive "primitive_d"
     where type CFieldType Primitive "primitive_d" = CDouble
           offset# = \_ -> \_ -> 144
-instance TyEq ty (CFieldType Primitive "primitive_d") =>
-         HasField "primitive_d" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_d" (Ptr Primitive) (Ptr CDouble)
     where getField = fromPtr (Proxy @"primitive_d")

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -36,7 +34,6 @@ import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return, showsPrec)
 
 {-| __C declaration:__ @I@
@@ -68,8 +65,7 @@ newtype I = I
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType I) "unwrapI")
-         ) => GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapI")
@@ -209,8 +205,7 @@ instance Read E where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType E) "unwrapE")
-         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr FC.CUInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")
@@ -259,8 +254,7 @@ newtype TI = TI
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TI) "unwrapTI")
-         ) => GHC.Records.HasField "unwrapTI" (Ptr.Ptr TI) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTI" (Ptr.Ptr TI) (Ptr.Ptr I) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTI")
@@ -289,8 +283,7 @@ newtype TS = TS
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TS) "unwrapTS")
-         ) => GHC.Records.HasField "unwrapTS" (Ptr.Ptr TS) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTS" (Ptr.Ptr TS) (Ptr.Ptr S) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTS")
@@ -318,8 +311,7 @@ newtype TU = TU
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TU) "unwrapTU")
-         ) => GHC.Records.HasField "unwrapTU" (Ptr.Ptr TU) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTU" (Ptr.Ptr TU) (Ptr.Ptr U) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTU")
@@ -350,8 +342,7 @@ newtype TE = TE
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TE) "unwrapTE")
-         ) => GHC.Records.HasField "unwrapTE" (Ptr.Ptr TE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTE" (Ptr.Ptr TE) (Ptr.Ptr E) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTE")
@@ -391,8 +382,7 @@ newtype TTI = TTI
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TTI) "unwrapTTI")
-         ) => GHC.Records.HasField "unwrapTTI" (Ptr.Ptr TTI) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTTI" (Ptr.Ptr TTI) (Ptr.Ptr TI) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTI")
@@ -421,8 +411,7 @@ newtype TTS = TTS
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TTS) "unwrapTTS")
-         ) => GHC.Records.HasField "unwrapTTS" (Ptr.Ptr TTS) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTTS" (Ptr.Ptr TTS) (Ptr.Ptr TS) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTS")
@@ -450,8 +439,7 @@ newtype TTU = TTU
     , F.Storable
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TTU) "unwrapTTU")
-         ) => GHC.Records.HasField "unwrapTTU" (Ptr.Ptr TTU) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTTU" (Ptr.Ptr TTU) (Ptr.Ptr TU) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTU")
@@ -482,8 +470,7 @@ newtype TTE = TTE
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType TTE) "unwrapTTE")
-         ) => GHC.Records.HasField "unwrapTTE" (Ptr.Ptr TTE) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapTTE" (Ptr.Ptr TTE) (Ptr.Ptr TE) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTE")

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -103,8 +103,7 @@ newtype I
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType I "unwrapI") =>
-         HasField "unwrapI" (Ptr I) (Ptr ty)
+instance HasField "unwrapI" (Ptr I) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -199,8 +198,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance TyEq ty (CFieldType E "unwrapE") =>
-         HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = CUInt
@@ -250,8 +248,7 @@ newtype TI
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType TI "unwrapTI") =>
-         HasField "unwrapTI" (Ptr TI) (Ptr ty)
+instance HasField "unwrapTI" (Ptr TI) (Ptr I)
     where getField = fromPtr (Proxy @"unwrapTI")
 instance HasCField TI "unwrapTI"
     where type CFieldType TI "unwrapTI" = I
@@ -273,8 +270,7 @@ newtype TS
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType TS "unwrapTS") =>
-         HasField "unwrapTS" (Ptr TS) (Ptr ty)
+instance HasField "unwrapTS" (Ptr TS) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapTS")
 instance HasCField TS "unwrapTS"
     where type CFieldType TS "unwrapTS" = S
@@ -295,8 +291,7 @@ newtype TU
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType TU "unwrapTU") =>
-         HasField "unwrapTU" (Ptr TU) (Ptr ty)
+instance HasField "unwrapTU" (Ptr TU) (Ptr U)
     where getField = fromPtr (Proxy @"unwrapTU")
 instance HasCField TU "unwrapTU"
     where type CFieldType TU "unwrapTU" = U
@@ -323,8 +318,7 @@ newtype TE
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType TE "unwrapTE") =>
-         HasField "unwrapTE" (Ptr TE) (Ptr ty)
+instance HasField "unwrapTE" (Ptr TE) (Ptr E)
     where getField = fromPtr (Proxy @"unwrapTE")
 instance HasCField TE "unwrapTE"
     where type CFieldType TE "unwrapTE" = E
@@ -360,8 +354,7 @@ newtype TTI
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType TTI "unwrapTTI") =>
-         HasField "unwrapTTI" (Ptr TTI) (Ptr ty)
+instance HasField "unwrapTTI" (Ptr TTI) (Ptr TI)
     where getField = fromPtr (Proxy @"unwrapTTI")
 instance HasCField TTI "unwrapTTI"
     where type CFieldType TTI "unwrapTTI" = TI
@@ -383,8 +376,7 @@ newtype TTS
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType TTS "unwrapTTS") =>
-         HasField "unwrapTTS" (Ptr TTS) (Ptr ty)
+instance HasField "unwrapTTS" (Ptr TTS) (Ptr TS)
     where getField = fromPtr (Proxy @"unwrapTTS")
 instance HasCField TTS "unwrapTTS"
     where type CFieldType TTS "unwrapTTS" = TS
@@ -405,8 +397,7 @@ newtype TTU
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance TyEq ty (CFieldType TTU "unwrapTTU") =>
-         HasField "unwrapTTU" (Ptr TTU) (Ptr ty)
+instance HasField "unwrapTTU" (Ptr TTU) (Ptr TU)
     where getField = fromPtr (Proxy @"unwrapTTU")
 instance HasCField TTU "unwrapTTU"
     where type CFieldType TTU "unwrapTTU" = TU
@@ -433,8 +424,7 @@ newtype TTE
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty (CFieldType TTE "unwrapTTE") =>
-         HasField "unwrapTTE" (Ptr TTE) (Ptr ty)
+instance HasField "unwrapTTE" (Ptr TTE) (Ptr TE)
     where getField = fromPtr (Proxy @"unwrapTTE")
 instance HasCField TTE "unwrapTTE"
     where type CFieldType TTE "unwrapTTE" = TE

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct struct2@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2 "struct2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Struct2) "struct2_x")
-         ) => GHC.Records.HasField "struct2_x" (Ptr.Ptr Struct2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "struct2_x" (Ptr.Ptr Struct2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_x")

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
@@ -54,8 +54,7 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_x"
     where type CFieldType Struct2 "struct2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Struct2 "struct2_x") =>
-         HasField "struct2_x" (Ptr Struct2) (Ptr ty)
+instance HasField "struct2_x" (Ptr Struct2) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct2_x")
 -- __unique:__ @test_typesspecialparse_failure_lo_Example_Safe_fun2@
 foreign import ccall safe "hs_bindgen_a1252a3becef09a6" hs_bindgen_a1252a3becef09a6_base ::

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,7 +27,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @stdlib_CBool@
@@ -61,8 +58,7 @@ newtype Stdlib_CBool = Stdlib_CBool
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CBool) "unwrapStdlib_CBool")
-         ) => GHC.Records.HasField "unwrapStdlib_CBool" (Ptr.Ptr Stdlib_CBool) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CBool" (Ptr.Ptr Stdlib_CBool) (Ptr.Ptr FC.CBool) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CBool")
@@ -103,8 +99,7 @@ newtype Stdlib_Int8 = Stdlib_Int8
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Int8) "unwrapStdlib_Int8")
-         ) => GHC.Records.HasField "unwrapStdlib_Int8" (Ptr.Ptr Stdlib_Int8) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Int8" (Ptr.Ptr Stdlib_Int8) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int8")
@@ -145,8 +140,7 @@ newtype Stdlib_Int16 = Stdlib_Int16
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Int16) "unwrapStdlib_Int16")
-         ) => GHC.Records.HasField "unwrapStdlib_Int16" (Ptr.Ptr Stdlib_Int16) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Int16" (Ptr.Ptr Stdlib_Int16) (Ptr.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int16")
@@ -187,8 +181,7 @@ newtype Stdlib_Int32 = Stdlib_Int32
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Int32) "unwrapStdlib_Int32")
-         ) => GHC.Records.HasField "unwrapStdlib_Int32" (Ptr.Ptr Stdlib_Int32) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Int32" (Ptr.Ptr Stdlib_Int32) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int32")
@@ -229,8 +222,7 @@ newtype Stdlib_Int64 = Stdlib_Int64
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Int64) "unwrapStdlib_Int64")
-         ) => GHC.Records.HasField "unwrapStdlib_Int64" (Ptr.Ptr Stdlib_Int64) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Int64" (Ptr.Ptr Stdlib_Int64) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int64")
@@ -271,8 +263,7 @@ newtype Stdlib_Word8 = Stdlib_Word8
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Word8) "unwrapStdlib_Word8")
-         ) => GHC.Records.HasField "unwrapStdlib_Word8" (Ptr.Ptr Stdlib_Word8) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Word8" (Ptr.Ptr Stdlib_Word8) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word8")
@@ -313,8 +304,7 @@ newtype Stdlib_Word16 = Stdlib_Word16
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Word16) "unwrapStdlib_Word16")
-         ) => GHC.Records.HasField "unwrapStdlib_Word16" (Ptr.Ptr Stdlib_Word16) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Word16" (Ptr.Ptr Stdlib_Word16) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word16")
@@ -355,8 +345,7 @@ newtype Stdlib_Word32 = Stdlib_Word32
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Word32) "unwrapStdlib_Word32")
-         ) => GHC.Records.HasField "unwrapStdlib_Word32" (Ptr.Ptr Stdlib_Word32) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Word32" (Ptr.Ptr Stdlib_Word32) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word32")
@@ -397,8 +386,7 @@ newtype Stdlib_Word64 = Stdlib_Word64
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_Word64) "unwrapStdlib_Word64")
-         ) => GHC.Records.HasField "unwrapStdlib_Word64" (Ptr.Ptr Stdlib_Word64) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_Word64" (Ptr.Ptr Stdlib_Word64) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word64")
@@ -439,8 +427,7 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CIntMax) "unwrapStdlib_CIntMax")
-         ) => GHC.Records.HasField "unwrapStdlib_CIntMax" (Ptr.Ptr Stdlib_CIntMax) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CIntMax" (Ptr.Ptr Stdlib_CIntMax) (Ptr.Ptr HsBindgen.Runtime.LibC.CIntMax) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CIntMax")
@@ -481,8 +468,7 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CUIntMax) "unwrapStdlib_CUIntMax")
-         ) => GHC.Records.HasField "unwrapStdlib_CUIntMax" (Ptr.Ptr Stdlib_CUIntMax) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CUIntMax" (Ptr.Ptr Stdlib_CUIntMax) (Ptr.Ptr HsBindgen.Runtime.LibC.CUIntMax) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CUIntMax")
@@ -523,8 +509,7 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CIntPtr) "unwrapStdlib_CIntPtr")
-         ) => GHC.Records.HasField "unwrapStdlib_CIntPtr" (Ptr.Ptr Stdlib_CIntPtr) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CIntPtr" (Ptr.Ptr Stdlib_CIntPtr) (Ptr.Ptr HsBindgen.Runtime.LibC.CIntPtr) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CIntPtr")
@@ -565,8 +550,7 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CUIntPtr) "unwrapStdlib_CUIntPtr")
-         ) => GHC.Records.HasField "unwrapStdlib_CUIntPtr" (Ptr.Ptr Stdlib_CUIntPtr) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CUIntPtr" (Ptr.Ptr Stdlib_CUIntPtr) (Ptr.Ptr HsBindgen.Runtime.LibC.CUIntPtr) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CUIntPtr")
@@ -589,8 +573,7 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFenvT) "unwrapStdlib_CFenvT")
-         ) => GHC.Records.HasField "unwrapStdlib_CFenvT" (Ptr.Ptr Stdlib_CFenvT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CFenvT" (Ptr.Ptr Stdlib_CFenvT) (Ptr.Ptr HsBindgen.Runtime.LibC.CFenvT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFenvT")
@@ -613,8 +596,7 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFexceptT) "unwrapStdlib_CFexceptT")
-         ) => GHC.Records.HasField "unwrapStdlib_CFexceptT" (Ptr.Ptr Stdlib_CFexceptT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CFexceptT" (Ptr.Ptr Stdlib_CFexceptT) (Ptr.Ptr HsBindgen.Runtime.LibC.CFexceptT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFexceptT")
@@ -655,8 +637,7 @@ newtype Stdlib_CSize = Stdlib_CSize
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CSize) "unwrapStdlib_CSize")
-         ) => GHC.Records.HasField "unwrapStdlib_CSize" (Ptr.Ptr Stdlib_CSize) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CSize" (Ptr.Ptr Stdlib_CSize) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CSize")
@@ -697,8 +678,7 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CPtrdiff) "unwrapStdlib_CPtrdiff")
-         ) => GHC.Records.HasField "unwrapStdlib_CPtrdiff" (Ptr.Ptr Stdlib_CPtrdiff) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CPtrdiff" (Ptr.Ptr Stdlib_CPtrdiff) (Ptr.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CPtrdiff")
@@ -721,8 +701,7 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CJmpBuf) "unwrapStdlib_CJmpBuf")
-         ) => GHC.Records.HasField "unwrapStdlib_CJmpBuf" (Ptr.Ptr Stdlib_CJmpBuf) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CJmpBuf" (Ptr.Ptr Stdlib_CJmpBuf) (Ptr.Ptr HsBindgen.Runtime.LibC.CJmpBuf) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CJmpBuf")
@@ -763,8 +742,7 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CWchar) "unwrapStdlib_CWchar")
-         ) => GHC.Records.HasField "unwrapStdlib_CWchar" (Ptr.Ptr Stdlib_CWchar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CWchar" (Ptr.Ptr Stdlib_CWchar) (Ptr.Ptr HsBindgen.Runtime.LibC.CWchar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWchar")
@@ -805,8 +783,7 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CWintT) "unwrapStdlib_CWintT")
-         ) => GHC.Records.HasField "unwrapStdlib_CWintT" (Ptr.Ptr Stdlib_CWintT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CWintT" (Ptr.Ptr Stdlib_CWintT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWintT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWintT")
@@ -829,8 +806,7 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CMbstateT) "unwrapStdlib_CMbstateT")
-         ) => GHC.Records.HasField "unwrapStdlib_CMbstateT" (Ptr.Ptr Stdlib_CMbstateT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CMbstateT" (Ptr.Ptr Stdlib_CMbstateT) (Ptr.Ptr HsBindgen.Runtime.LibC.CMbstateT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CMbstateT")
@@ -862,8 +838,7 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CWctransT) "unwrapStdlib_CWctransT")
-         ) => GHC.Records.HasField "unwrapStdlib_CWctransT" (Ptr.Ptr Stdlib_CWctransT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CWctransT" (Ptr.Ptr Stdlib_CWctransT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWctransT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWctransT")
@@ -895,8 +870,7 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     , Data.Primitive.Types.Prim
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CWctypeT) "unwrapStdlib_CWctypeT")
-         ) => GHC.Records.HasField "unwrapStdlib_CWctypeT" (Ptr.Ptr Stdlib_CWctypeT) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CWctypeT" (Ptr.Ptr Stdlib_CWctypeT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWctypeT) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWctypeT")
@@ -937,8 +911,7 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CChar16T) "unwrapStdlib_CChar16T")
-         ) => GHC.Records.HasField "unwrapStdlib_CChar16T" (Ptr.Ptr Stdlib_CChar16T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CChar16T" (Ptr.Ptr Stdlib_CChar16T) (Ptr.Ptr HsBindgen.Runtime.LibC.CChar16T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CChar16T")
@@ -979,8 +952,7 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CChar32T) "unwrapStdlib_CChar32T")
-         ) => GHC.Records.HasField "unwrapStdlib_CChar32T" (Ptr.Ptr Stdlib_CChar32T) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CChar32T" (Ptr.Ptr Stdlib_CChar32T) (Ptr.Ptr HsBindgen.Runtime.LibC.CChar32T) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CChar32T")
@@ -1014,8 +986,7 @@ newtype Stdlib_CTime = Stdlib_CTime
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CTime) "unwrapStdlib_CTime")
-         ) => GHC.Records.HasField "unwrapStdlib_CTime" (Ptr.Ptr Stdlib_CTime) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CTime" (Ptr.Ptr Stdlib_CTime) (Ptr.Ptr HsBindgen.Runtime.LibC.CTime) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CTime")
@@ -1049,8 +1020,7 @@ newtype Stdlib_CClock = Stdlib_CClock
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CClock) "unwrapStdlib_CClock")
-         ) => GHC.Records.HasField "unwrapStdlib_CClock" (Ptr.Ptr Stdlib_CClock) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CClock" (Ptr.Ptr Stdlib_CClock) (Ptr.Ptr HsBindgen.Runtime.LibC.CClock) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CClock")
@@ -1078,8 +1048,7 @@ newtype Stdlib_CTm = Stdlib_CTm
     , HsBindgen.Runtime.Marshal.ReadRaw
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CTm) "unwrapStdlib_CTm")
-         ) => GHC.Records.HasField "unwrapStdlib_CTm" (Ptr.Ptr Stdlib_CTm) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CTm" (Ptr.Ptr Stdlib_CTm) (Ptr.Ptr HsBindgen.Runtime.LibC.CTm) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CTm")
@@ -1102,8 +1071,7 @@ newtype Stdlib_CFile = Stdlib_CFile
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFile) "unwrapStdlib_CFile")
-         ) => GHC.Records.HasField "unwrapStdlib_CFile" (Ptr.Ptr Stdlib_CFile) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CFile" (Ptr.Ptr Stdlib_CFile) (Ptr.Ptr HsBindgen.Runtime.LibC.CFile) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFile")
@@ -1126,8 +1094,7 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   }
   deriving stock (GHC.Generics.Generic)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CFpos) "unwrapStdlib_CFpos")
-         ) => GHC.Records.HasField "unwrapStdlib_CFpos" (Ptr.Ptr Stdlib_CFpos) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CFpos" (Ptr.Ptr Stdlib_CFpos) (Ptr.Ptr HsBindgen.Runtime.LibC.CFpos) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFpos")
@@ -1168,8 +1135,7 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Stdlib_CSigAtomic) "unwrapStdlib_CSigAtomic")
-         ) => GHC.Records.HasField "unwrapStdlib_CSigAtomic" (Ptr.Ptr Stdlib_CSigAtomic) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapStdlib_CSigAtomic" (Ptr.Ptr Stdlib_CSigAtomic) (Ptr.Ptr HsBindgen.Runtime.LibC.CSigAtomic) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CSigAtomic")

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
@@ -47,8 +47,9 @@ newtype Stdlib_CBool
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_CBool "unwrapStdlib_CBool") =>
-         HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
+instance HasField "unwrapStdlib_CBool"
+                  (Ptr Stdlib_CBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
@@ -84,8 +85,9 @@ newtype Stdlib_Int8
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_Int8 "unwrapStdlib_Int8") =>
-         HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
+instance HasField "unwrapStdlib_Int8"
+                  (Ptr Stdlib_Int8)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
@@ -122,8 +124,9 @@ newtype Stdlib_Int16
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_Int16 "unwrapStdlib_Int16") =>
-         HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
+instance HasField "unwrapStdlib_Int16"
+                  (Ptr Stdlib_Int16)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
@@ -160,8 +163,9 @@ newtype Stdlib_Int32
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_Int32 "unwrapStdlib_Int32") =>
-         HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
+instance HasField "unwrapStdlib_Int32"
+                  (Ptr Stdlib_Int32)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
@@ -198,8 +202,9 @@ newtype Stdlib_Int64
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_Int64 "unwrapStdlib_Int64") =>
-         HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
+instance HasField "unwrapStdlib_Int64"
+                  (Ptr Stdlib_Int64)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
@@ -236,8 +241,9 @@ newtype Stdlib_Word8
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_Word8 "unwrapStdlib_Word8") =>
-         HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
+instance HasField "unwrapStdlib_Word8"
+                  (Ptr Stdlib_Word8)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
@@ -274,9 +280,9 @@ newtype Stdlib_Word16
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_Word16 "unwrapStdlib_Word16") =>
-         HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
+instance HasField "unwrapStdlib_Word16"
+                  (Ptr Stdlib_Word16)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
@@ -313,9 +319,9 @@ newtype Stdlib_Word32
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_Word32 "unwrapStdlib_Word32") =>
-         HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
+instance HasField "unwrapStdlib_Word32"
+                  (Ptr Stdlib_Word32)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
@@ -352,9 +358,9 @@ newtype Stdlib_Word64
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_Word64 "unwrapStdlib_Word64") =>
-         HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
+instance HasField "unwrapStdlib_Word64"
+                  (Ptr Stdlib_Word64)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
@@ -391,9 +397,9 @@ newtype Stdlib_CIntMax
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CIntMax "unwrapStdlib_CIntMax") =>
-         HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CIntMax"
+                  (Ptr Stdlib_CIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
@@ -430,9 +436,9 @@ newtype Stdlib_CUIntMax
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CUIntMax "unwrapStdlib_CUIntMax") =>
-         HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntMax"
+                  (Ptr Stdlib_CUIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
@@ -469,9 +475,9 @@ newtype Stdlib_CIntPtr
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CIntPtr "unwrapStdlib_CIntPtr") =>
-         HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CIntPtr"
+                  (Ptr Stdlib_CIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
@@ -508,9 +514,9 @@ newtype Stdlib_CUIntPtr
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr") =>
-         HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntPtr"
+                  (Ptr Stdlib_CUIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
@@ -531,9 +537,9 @@ newtype Stdlib_CFenvT
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType Stdlib_CFenvT "unwrapStdlib_CFenvT") =>
-         HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
+instance HasField "unwrapStdlib_CFenvT"
+                  (Ptr Stdlib_CFenvT)
+                  (Ptr HsBindgen.Runtime.LibC.CFenvT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
@@ -554,9 +560,9 @@ newtype Stdlib_CFexceptT
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType Stdlib_CFexceptT "unwrapStdlib_CFexceptT") =>
-         HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
+instance HasField "unwrapStdlib_CFexceptT"
+                  (Ptr Stdlib_CFexceptT)
+                  (Ptr HsBindgen.Runtime.LibC.CFexceptT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
@@ -593,8 +599,9 @@ newtype Stdlib_CSize
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_CSize "unwrapStdlib_CSize") =>
-         HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
+instance HasField "unwrapStdlib_CSize"
+                  (Ptr Stdlib_CSize)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
@@ -631,9 +638,9 @@ newtype Stdlib_CPtrdiff
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff") =>
-         HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
+instance HasField "unwrapStdlib_CPtrdiff"
+                  (Ptr Stdlib_CPtrdiff)
+                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
@@ -654,9 +661,9 @@ newtype Stdlib_CJmpBuf
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf") =>
-         HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
+instance HasField "unwrapStdlib_CJmpBuf"
+                  (Ptr Stdlib_CJmpBuf)
+                  (Ptr HsBindgen.Runtime.LibC.CJmpBuf)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
@@ -693,9 +700,9 @@ newtype Stdlib_CWchar
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CWchar "unwrapStdlib_CWchar") =>
-         HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
+instance HasField "unwrapStdlib_CWchar"
+                  (Ptr Stdlib_CWchar)
+                  (Ptr HsBindgen.Runtime.LibC.CWchar)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
@@ -732,9 +739,9 @@ newtype Stdlib_CWintT
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CWintT "unwrapStdlib_CWintT") =>
-         HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
+instance HasField "unwrapStdlib_CWintT"
+                  (Ptr Stdlib_CWintT)
+                  (Ptr HsBindgen.Runtime.LibC.CWintT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
@@ -755,9 +762,9 @@ newtype Stdlib_CMbstateT
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty
-              (CFieldType Stdlib_CMbstateT "unwrapStdlib_CMbstateT") =>
-         HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
+instance HasField "unwrapStdlib_CMbstateT"
+                  (Ptr Stdlib_CMbstateT)
+                  (Ptr HsBindgen.Runtime.LibC.CMbstateT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
@@ -785,9 +792,9 @@ newtype Stdlib_CWctransT
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty
-              (CFieldType Stdlib_CWctransT "unwrapStdlib_CWctransT") =>
-         HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctransT"
+                  (Ptr Stdlib_CWctransT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctransT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
@@ -815,9 +822,9 @@ newtype Stdlib_CWctypeT
                       Storable,
                       HasFFIType,
                       Prim)
-instance TyEq ty
-              (CFieldType Stdlib_CWctypeT "unwrapStdlib_CWctypeT") =>
-         HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctypeT"
+                  (Ptr Stdlib_CWctypeT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctypeT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
@@ -854,9 +861,9 @@ newtype Stdlib_CChar16T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CChar16T "unwrapStdlib_CChar16T") =>
-         HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar16T"
+                  (Ptr Stdlib_CChar16T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar16T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
@@ -893,9 +900,9 @@ newtype Stdlib_CChar32T
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CChar32T "unwrapStdlib_CChar32T") =>
-         HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar32T"
+                  (Ptr Stdlib_CChar32T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar32T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
@@ -925,8 +932,9 @@ newtype Stdlib_CTime
                       Enum,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Stdlib_CTime "unwrapStdlib_CTime") =>
-         HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
+instance HasField "unwrapStdlib_CTime"
+                  (Ptr Stdlib_CTime)
+                  (Ptr HsBindgen.Runtime.LibC.CTime)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
@@ -956,9 +964,9 @@ newtype Stdlib_CClock
                       Enum,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CClock "unwrapStdlib_CClock") =>
-         HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
+instance HasField "unwrapStdlib_CClock"
+                  (Ptr Stdlib_CClock)
+                  (Ptr HsBindgen.Runtime.LibC.CClock)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
@@ -981,8 +989,9 @@ newtype Stdlib_CTm
     deriving stock Generic
     deriving stock (Eq, Show)
     deriving newtype (StaticSize, ReadRaw)
-instance TyEq ty (CFieldType Stdlib_CTm "unwrapStdlib_CTm") =>
-         HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
+instance HasField "unwrapStdlib_CTm"
+                  (Ptr Stdlib_CTm)
+                  (Ptr HsBindgen.Runtime.LibC.CTm)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
@@ -1003,8 +1012,9 @@ newtype Stdlib_CFile
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType Stdlib_CFile "unwrapStdlib_CFile") =>
-         HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
+instance HasField "unwrapStdlib_CFile"
+                  (Ptr Stdlib_CFile)
+                  (Ptr HsBindgen.Runtime.LibC.CFile)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
@@ -1025,8 +1035,9 @@ newtype Stdlib_CFpos
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
     deriving stock Generic
-instance TyEq ty (CFieldType Stdlib_CFpos "unwrapStdlib_CFpos") =>
-         HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
+instance HasField "unwrapStdlib_CFpos"
+                  (Ptr Stdlib_CFpos)
+                  (Ptr HsBindgen.Runtime.LibC.CFpos)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
@@ -1063,9 +1074,9 @@ newtype Stdlib_CSigAtomic
                       Ix,
                       Num,
                       Real)
-instance TyEq ty
-              (CFieldType Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic") =>
-         HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
+instance HasField "unwrapStdlib_CSigAtomic"
+                  (Ptr Stdlib_CSigAtomic)
+                  (Ptr HsBindgen.Runtime.LibC.CSigAtomic)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic

--- a/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct \@S1_c@
@@ -82,8 +79,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_c "s1_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1_c) "s1_c_a")
-         ) => GHC.Records.HasField "s1_c_a" (Ptr.Ptr S1_c) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_c_a" (Ptr.Ptr S1_c) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c_a")
@@ -94,8 +90,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_c "s1_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1_c) "s1_c_b")
-         ) => GHC.Records.HasField "s1_c_b" (Ptr.Ptr S1_c) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_c_b" (Ptr.Ptr S1_c) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c_b")
@@ -157,8 +152,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "s1_c")
-         ) => GHC.Records.HasField "s1_c" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_c" (Ptr.Ptr S1) (Ptr.Ptr S1_c) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c")
@@ -169,8 +163,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "s1_d")
-         ) => GHC.Records.HasField "s1_d" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_d" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_d")
@@ -224,8 +217,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner_deep "s2_inner_deep_b" w
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_inner_deep) "s2_inner_deep_b")
-         ) => GHC.Records.HasField "s2_inner_deep_b" (Ptr.Ptr S2_inner_deep) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_inner_deep_b" (Ptr.Ptr S2_inner_deep) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_deep_b")
@@ -287,8 +279,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner "s2_inner_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_inner) "s2_inner_a")
-         ) => GHC.Records.HasField "s2_inner_a" (Ptr.Ptr S2_inner) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_inner_a" (Ptr.Ptr S2_inner) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_a")
@@ -300,8 +291,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner "s2_inner_deep" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_inner) "s2_inner_deep")
-         ) => GHC.Records.HasField "s2_inner_deep" (Ptr.Ptr S2_inner) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_inner_deep" (Ptr.Ptr S2_inner) (Ptr.Ptr S2_inner_deep) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_deep")
@@ -363,8 +353,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_inner" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2) "s2_inner")
-         ) => GHC.Records.HasField "s2_inner" (Ptr.Ptr S2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_inner" (Ptr.Ptr S2) (Ptr.Ptr S2_inner) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner")
@@ -375,8 +364,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2) "s2_d")
-         ) => GHC.Records.HasField "s2_d" (Ptr.Ptr S2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_d" (Ptr.Ptr S2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_d")
@@ -438,8 +426,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3 "s3_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3) "s3_c")
-         ) => GHC.Records.HasField "s3_c" (Ptr.Ptr S3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s3_c" (Ptr.Ptr S3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S3_c))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c")
@@ -450,8 +437,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3 "s3_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3) "s3_d")
-         ) => GHC.Records.HasField "s3_d" (Ptr.Ptr S3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s3_d" (Ptr.Ptr S3) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_d")
@@ -513,8 +499,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_c "s3_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3_c) "s3_c_a")
-         ) => GHC.Records.HasField "s3_c_a" (Ptr.Ptr S3_c) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s3_c_a" (Ptr.Ptr S3_c) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c_a")
@@ -525,8 +510,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_c "s3_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3_c) "s3_c_b")
-         ) => GHC.Records.HasField "s3_c_b" (Ptr.Ptr S3_c) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s3_c_b" (Ptr.Ptr S3_c) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c_b")

--- a/hs-bindgen/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/fixtures/types/structs/anonymous/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable S1_c) instance Storable S1_c
 instance HasCField S1_c "s1_c_a"
     where type CFieldType S1_c "s1_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S1_c "s1_c_a") =>
-         HasField "s1_c_a" (Ptr S1_c) (Ptr ty)
+instance HasField "s1_c_a" (Ptr S1_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_c_a")
 instance HasCField S1_c "s1_c_b"
     where type CFieldType S1_c "s1_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S1_c "s1_c_b") =>
-         HasField "s1_c_b" (Ptr S1_c) (Ptr ty)
+instance HasField "s1_c_b" (Ptr S1_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_c_b")
 {-| __C declaration:__ @struct S1@
 
@@ -92,14 +90,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_c"
     where type CFieldType S1 "s1_c" = S1_c
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S1 "s1_c") =>
-         HasField "s1_c" (Ptr S1) (Ptr ty)
+instance HasField "s1_c" (Ptr S1) (Ptr S1_c)
     where getField = fromPtr (Proxy @"s1_c")
 instance HasCField S1 "s1_d"
     where type CFieldType S1 "s1_d" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S1 "s1_d") =>
-         HasField "s1_d" (Ptr S1) (Ptr ty)
+instance HasField "s1_d" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_d")
 {-| __C declaration:__ @struct \@S2_inner_deep@
 
@@ -135,8 +131,7 @@ deriving via (EquivStorable S2_inner_deep) instance Storable S2_inner_deep
 instance HasCField S2_inner_deep "s2_inner_deep_b"
     where type CFieldType S2_inner_deep "s2_inner_deep_b" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2_inner_deep "s2_inner_deep_b") =>
-         HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr ty)
+instance HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_inner_deep_b")
 {-| __C declaration:__ @struct \@S2_inner@
 
@@ -180,14 +175,14 @@ deriving via (EquivStorable S2_inner) instance Storable S2_inner
 instance HasCField S2_inner "s2_inner_a"
     where type CFieldType S2_inner "s2_inner_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2_inner "s2_inner_a") =>
-         HasField "s2_inner_a" (Ptr S2_inner) (Ptr ty)
+instance HasField "s2_inner_a" (Ptr S2_inner) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_inner_a")
 instance HasCField S2_inner "s2_inner_deep"
     where type CFieldType S2_inner "s2_inner_deep" = S2_inner_deep
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S2_inner "s2_inner_deep") =>
-         HasField "s2_inner_deep" (Ptr S2_inner) (Ptr ty)
+instance HasField "s2_inner_deep"
+                  (Ptr S2_inner)
+                  (Ptr S2_inner_deep)
     where getField = fromPtr (Proxy @"s2_inner_deep")
 {-| __C declaration:__ @struct S2@
 
@@ -231,14 +226,12 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_inner"
     where type CFieldType S2 "s2_inner" = S2_inner
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2 "s2_inner") =>
-         HasField "s2_inner" (Ptr S2) (Ptr ty)
+instance HasField "s2_inner" (Ptr S2) (Ptr S2_inner)
     where getField = fromPtr (Proxy @"s2_inner")
 instance HasCField S2 "s2_d"
     where type CFieldType S2 "s2_d" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S2 "s2_d") =>
-         HasField "s2_d" (Ptr S2) (Ptr ty)
+instance HasField "s2_d" (Ptr S2) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_d")
 {-| __C declaration:__ @struct S3@
 
@@ -282,14 +275,12 @@ deriving via (EquivStorable S3) instance Storable S3
 instance HasCField S3 "s3_c"
     where type CFieldType S3 "s3_c" = Ptr (Ptr S3_c)
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S3 "s3_c") =>
-         HasField "s3_c" (Ptr S3) (Ptr ty)
+instance HasField "s3_c" (Ptr S3) (Ptr (Ptr (Ptr S3_c)))
     where getField = fromPtr (Proxy @"s3_c")
 instance HasCField S3 "s3_d"
     where type CFieldType S3 "s3_d" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S3 "s3_d") =>
-         HasField "s3_d" (Ptr S3) (Ptr ty)
+instance HasField "s3_d" (Ptr S3) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_d")
 {-| __C declaration:__ @struct \@S3_c@
 
@@ -333,12 +324,10 @@ deriving via (EquivStorable S3_c) instance Storable S3_c
 instance HasCField S3_c "s3_c_a"
     where type CFieldType S3_c "s3_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S3_c "s3_c_a") =>
-         HasField "s3_c_a" (Ptr S3_c) (Ptr ty)
+instance HasField "s3_c_a" (Ptr S3_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_c_a")
 instance HasCField S3_c "s3_c_b"
     where type CFieldType S3_c "s3_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S3_c "s3_c_b") =>
-         HasField "s3_c_b" (Ptr S3_c) (Ptr ty)
+instance HasField "s3_c_b" (Ptr S3_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_c_b")

--- a/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified HsBindgen.Runtime.BitfieldPtr
 import qualified HsBindgen.Runtime.HasCBitfield
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct flags@
@@ -126,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Flags "flags_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Flags) "flags_fieldX")
-         ) => GHC.Records.HasField "flags_fieldX" (Ptr.Ptr Flags) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "flags_fieldX" (Ptr.Ptr Flags) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flags_fieldX")
@@ -140,8 +136,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagA" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Flags) "flags_flagA")
-         ) => GHC.Records.HasField "flags_flagA" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "flags_flagA" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagA")
@@ -154,8 +149,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagB" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Flags) "flags_flagB")
-         ) => GHC.Records.HasField "flags_flagB" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "flags_flagB" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagB")
@@ -168,8 +162,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagC" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Flags) "flags_flagC")
-         ) => GHC.Records.HasField "flags_flagC" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "flags_flagC" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagC")
@@ -180,8 +173,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Flags "flags_fieldY" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Flags) "flags_fieldY")
-         ) => GHC.Records.HasField "flags_fieldY" (Ptr.Ptr Flags) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "flags_fieldY" (Ptr.Ptr Flags) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flags_fieldY")
@@ -194,8 +186,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_bits" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Flags) "flags_bits")
-         ) => GHC.Records.HasField "flags_bits" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "flags_bits" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_bits")
@@ -269,8 +260,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_x" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32) "overflow32_x")
-         ) => GHC.Records.HasField "overflow32_x" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32_x" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_x")
@@ -284,8 +274,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_y" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32) "overflow32_y")
-         ) => GHC.Records.HasField "overflow32_y" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32_y" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_y")
@@ -299,8 +288,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_z" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32) "overflow32_z")
-         ) => GHC.Records.HasField "overflow32_z" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32_z" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_z")
@@ -374,8 +362,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_x"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32b) "overflow32b_x")
-         ) => GHC.Records.HasField "overflow32b_x" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32b_x" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_x")
@@ -389,8 +376,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_y"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32b) "overflow32b_y")
-         ) => GHC.Records.HasField "overflow32b_y" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32b_y" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_y")
@@ -404,8 +390,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_z"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32b) "overflow32b_z")
-         ) => GHC.Records.HasField "overflow32b_z" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32b_z" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_z")
@@ -479,8 +464,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_x"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32c) "overflow32c_x")
-         ) => GHC.Records.HasField "overflow32c_x" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32c_x" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_x")
@@ -494,8 +478,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_y"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32c) "overflow32c_y")
-         ) => GHC.Records.HasField "overflow32c_y" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32c_y" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_y")
@@ -509,8 +492,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_z"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow32c) "overflow32c_z")
-         ) => GHC.Records.HasField "overflow32c_z" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow32c_z" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_z")
@@ -575,8 +557,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow64 "overflow64_x" w
 
   bitfieldWidth# = \_ -> \_ -> 33
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow64) "overflow64_x")
-         ) => GHC.Records.HasField "overflow64_x" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow64_x" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow64_x")
@@ -590,8 +571,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow64 "overflow64_y" w
 
   bitfieldWidth# = \_ -> \_ -> 33
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType Overflow64) "overflow64_y")
-         ) => GHC.Records.HasField "overflow64_y" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "overflow64_y" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow64_y")
@@ -655,8 +635,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignA "alignA_x" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType AlignA) "alignA_x")
-         ) => GHC.Records.HasField "alignA_x" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "alignA_x" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignA_x")
@@ -669,8 +648,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignA "alignA_y" where
 
   bitfieldWidth# = \_ -> \_ -> 10
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType AlignA) "alignA_y")
-         ) => GHC.Records.HasField "alignA_y" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "alignA_y" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignA_y")
@@ -734,8 +712,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignB "alignB_x" where
 
   bitfieldWidth# = \_ -> \_ -> 7
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType AlignB) "alignB_x")
-         ) => GHC.Records.HasField "alignB_x" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "alignB_x" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUChar) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignB_x")
@@ -748,8 +725,7 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignB "alignB_y" where
 
   bitfieldWidth# = \_ -> \_ -> 31
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCBitfield.CBitfieldType AlignB) "alignB_y")
-         ) => GHC.Records.HasField "alignB_y" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
+instance GHC.Records.HasField "alignB_y" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignB_y")

--- a/hs-bindgen/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/fixtures/types/structs/bitfields/th.txt
@@ -73,42 +73,36 @@ deriving via (EquivStorable Flags) instance Storable Flags
 instance HasCField Flags "flags_fieldX"
     where type CFieldType Flags "flags_fieldX" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Flags "flags_fieldX") =>
-         HasField "flags_fieldX" (Ptr Flags) (Ptr ty)
+instance HasField "flags_fieldX" (Ptr Flags) (Ptr CChar)
     where getField = fromPtr (Proxy @"flags_fieldX")
 instance HasCBitfield Flags "flags_flagA"
     where type CBitfieldType Flags "flags_flagA" = CInt
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType Flags "flags_flagA") =>
-         HasField "flags_flagA" (Ptr Flags) (BitfieldPtr ty)
+instance HasField "flags_flagA" (Ptr Flags) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"flags_flagA")
 instance HasCBitfield Flags "flags_flagB"
     where type CBitfieldType Flags "flags_flagB" = CInt
           bitfieldOffset# = \_ -> \_ -> 9
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType Flags "flags_flagB") =>
-         HasField "flags_flagB" (Ptr Flags) (BitfieldPtr ty)
+instance HasField "flags_flagB" (Ptr Flags) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"flags_flagB")
 instance HasCBitfield Flags "flags_flagC"
     where type CBitfieldType Flags "flags_flagC" = CInt
           bitfieldOffset# = \_ -> \_ -> 10
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType Flags "flags_flagC") =>
-         HasField "flags_flagC" (Ptr Flags) (BitfieldPtr ty)
+instance HasField "flags_flagC" (Ptr Flags) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"flags_flagC")
 instance HasCField Flags "flags_fieldY"
     where type CFieldType Flags "flags_fieldY" = CChar
           offset# = \_ -> \_ -> 2
-instance TyEq ty (CFieldType Flags "flags_fieldY") =>
-         HasField "flags_fieldY" (Ptr Flags) (Ptr ty)
+instance HasField "flags_fieldY" (Ptr Flags) (Ptr CChar)
     where getField = fromPtr (Proxy @"flags_fieldY")
 instance HasCBitfield Flags "flags_bits"
     where type CBitfieldType Flags "flags_bits" = CInt
           bitfieldOffset# = \_ -> \_ -> 24
           bitfieldWidth# = \_ -> \_ -> 2
-instance TyEq ty (CBitfieldType Flags "flags_bits") =>
-         HasField "flags_bits" (Ptr Flags) (BitfieldPtr ty)
+instance HasField "flags_bits" (Ptr Flags) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"flags_bits")
 {-| __C declaration:__ @struct overflow32@
 
@@ -161,22 +155,25 @@ instance HasCBitfield Overflow32 "overflow32_x"
     where type CBitfieldType Overflow32 "overflow32_x" = CInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32 "overflow32_x") =>
-         HasField "overflow32_x" (Ptr Overflow32) (BitfieldPtr ty)
+instance HasField "overflow32_x"
+                  (Ptr Overflow32)
+                  (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"overflow32_x")
 instance HasCBitfield Overflow32 "overflow32_y"
     where type CBitfieldType Overflow32 "overflow32_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32 "overflow32_y") =>
-         HasField "overflow32_y" (Ptr Overflow32) (BitfieldPtr ty)
+instance HasField "overflow32_y"
+                  (Ptr Overflow32)
+                  (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"overflow32_y")
 instance HasCBitfield Overflow32 "overflow32_z"
     where type CBitfieldType Overflow32 "overflow32_z" = CInt
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32 "overflow32_z") =>
-         HasField "overflow32_z" (Ptr Overflow32) (BitfieldPtr ty)
+instance HasField "overflow32_z"
+                  (Ptr Overflow32)
+                  (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"overflow32_z")
 {-| __C declaration:__ @struct overflow32b@
 
@@ -229,22 +226,25 @@ instance HasCBitfield Overflow32b "overflow32b_x"
     where type CBitfieldType Overflow32b "overflow32b_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32b "overflow32b_x") =>
-         HasField "overflow32b_x" (Ptr Overflow32b) (BitfieldPtr ty)
+instance HasField "overflow32b_x"
+                  (Ptr Overflow32b)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow32b_x")
 instance HasCBitfield Overflow32b "overflow32b_y"
     where type CBitfieldType Overflow32b "overflow32b_y" = CLong
           bitfieldOffset# = \_ -> \_ -> 17
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32b "overflow32b_y") =>
-         HasField "overflow32b_y" (Ptr Overflow32b) (BitfieldPtr ty)
+instance HasField "overflow32b_y"
+                  (Ptr Overflow32b)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow32b_y")
 instance HasCBitfield Overflow32b "overflow32b_z"
     where type CBitfieldType Overflow32b "overflow32b_z" = CLong
           bitfieldOffset# = \_ -> \_ -> 34
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32b "overflow32b_z") =>
-         HasField "overflow32b_z" (Ptr Overflow32b) (BitfieldPtr ty)
+instance HasField "overflow32b_z"
+                  (Ptr Overflow32b)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow32b_z")
 {-| __C declaration:__ @struct overflow32c@
 
@@ -297,22 +297,25 @@ instance HasCBitfield Overflow32c "overflow32c_x"
     where type CBitfieldType Overflow32c "overflow32c_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32c "overflow32c_x") =>
-         HasField "overflow32c_x" (Ptr Overflow32c) (BitfieldPtr ty)
+instance HasField "overflow32c_x"
+                  (Ptr Overflow32c)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow32c_x")
 instance HasCBitfield Overflow32c "overflow32c_y"
     where type CBitfieldType Overflow32c "overflow32c_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32c "overflow32c_y") =>
-         HasField "overflow32c_y" (Ptr Overflow32c) (BitfieldPtr ty)
+instance HasField "overflow32c_y"
+                  (Ptr Overflow32c)
+                  (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"overflow32c_y")
 instance HasCBitfield Overflow32c "overflow32c_z"
     where type CBitfieldType Overflow32c "overflow32c_z" = CLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 17
-instance TyEq ty (CBitfieldType Overflow32c "overflow32c_z") =>
-         HasField "overflow32c_z" (Ptr Overflow32c) (BitfieldPtr ty)
+instance HasField "overflow32c_z"
+                  (Ptr Overflow32c)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow32c_z")
 {-| __C declaration:__ @struct overflow64@
 
@@ -357,15 +360,17 @@ instance HasCBitfield Overflow64 "overflow64_x"
     where type CBitfieldType Overflow64 "overflow64_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 33
-instance TyEq ty (CBitfieldType Overflow64 "overflow64_x") =>
-         HasField "overflow64_x" (Ptr Overflow64) (BitfieldPtr ty)
+instance HasField "overflow64_x"
+                  (Ptr Overflow64)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow64_x")
 instance HasCBitfield Overflow64 "overflow64_y"
     where type CBitfieldType Overflow64 "overflow64_y" = CLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 33
-instance TyEq ty (CBitfieldType Overflow64 "overflow64_y") =>
-         HasField "overflow64_y" (Ptr Overflow64) (BitfieldPtr ty)
+instance HasField "overflow64_y"
+                  (Ptr Overflow64)
+                  (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"overflow64_y")
 {-| __C declaration:__ @struct alignA@
 
@@ -410,15 +415,13 @@ instance HasCBitfield AlignA "alignA_x"
     where type CBitfieldType AlignA "alignA_x" = CUChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 1
-instance TyEq ty (CBitfieldType AlignA "alignA_x") =>
-         HasField "alignA_x" (Ptr AlignA) (BitfieldPtr ty)
+instance HasField "alignA_x" (Ptr AlignA) (BitfieldPtr CUChar)
     where getField = toPtr (Proxy @"alignA_x")
 instance HasCBitfield AlignA "alignA_y"
     where type CBitfieldType AlignA "alignA_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 1
           bitfieldWidth# = \_ -> \_ -> 10
-instance TyEq ty (CBitfieldType AlignA "alignA_y") =>
-         HasField "alignA_y" (Ptr AlignA) (BitfieldPtr ty)
+instance HasField "alignA_y" (Ptr AlignA) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"alignA_y")
 {-| __C declaration:__ @struct alignB@
 
@@ -463,13 +466,11 @@ instance HasCBitfield AlignB "alignB_x"
     where type CBitfieldType AlignB "alignB_x" = CUChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 7
-instance TyEq ty (CBitfieldType AlignB "alignB_x") =>
-         HasField "alignB_x" (Ptr AlignB) (BitfieldPtr ty)
+instance HasField "alignB_x" (Ptr AlignB) (BitfieldPtr CUChar)
     where getField = toPtr (Proxy @"alignB_x")
 instance HasCBitfield AlignB "alignB_y"
     where type CBitfieldType AlignB "alignB_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 31
-instance TyEq ty (CBitfieldType AlignB "alignB_y") =>
-         HasField "alignB_y" (Ptr AlignB) (BitfieldPtr ty)
+instance HasField "alignB_y" (Ptr AlignB) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"alignB_y")

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,7 +19,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct b@
@@ -72,8 +69,7 @@ instance HsBindgen.Runtime.HasCField.HasCField B "b_toA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType B) "b_toA")
-         ) => GHC.Records.HasField "b_toA" (Ptr.Ptr B) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b_toA" (Ptr.Ptr B) (Ptr.Ptr (Ptr.Ptr A)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b_toA")
@@ -126,8 +122,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_toB" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType A) "a_toB")
-         ) => GHC.Records.HasField "a_toB" (Ptr.Ptr A) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a_toB" (Ptr.Ptr A) (Ptr.Ptr B) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_toB")

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -33,8 +33,7 @@ deriving via (EquivStorable B) instance Storable B
 instance HasCField B "b_toA"
     where type CFieldType B "b_toA" = Ptr A
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType B "b_toA") =>
-         HasField "b_toA" (Ptr B) (Ptr ty)
+instance HasField "b_toA" (Ptr B) (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"b_toA")
 {-| __C declaration:__ @struct a@
 
@@ -70,6 +69,5 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_toB"
     where type CFieldType A "a_toB" = B
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType A "a_toB") =>
-         HasField "a_toB" (Ptr A) (Ptr ty)
+instance HasField "a_toB" (Ptr A) (Ptr B)
     where getField = fromPtr (Proxy @"a_toB")

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct linked_list_A_s@
@@ -83,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_A_t "linked_list_A_t_
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Linked_list_A_t) "linked_list_A_t_x")
-         ) => GHC.Records.HasField "linked_list_A_t_x" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "linked_list_A_t_x" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_A_t_x")
@@ -96,8 +92,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_A_t "linked_list_A_t_
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Linked_list_A_t) "linked_list_A_t_next")
-         ) => GHC.Records.HasField "linked_list_A_t_next" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "linked_list_A_t_next" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr (Ptr.Ptr Linked_list_A_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_A_t_next")
@@ -160,8 +155,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_B_t "linked_list_B_t_
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Linked_list_B_t) "linked_list_B_t_x")
-         ) => GHC.Records.HasField "linked_list_B_t_x" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "linked_list_B_t_x" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_B_t_x")
@@ -173,8 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_B_t "linked_list_B_t_
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Linked_list_B_t) "linked_list_B_t_next")
-         ) => GHC.Records.HasField "linked_list_B_t_next" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "linked_list_B_t_next" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr (Ptr.Ptr Linked_list_B_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
@@ -41,17 +41,17 @@ deriving via (EquivStorable Linked_list_A_t) instance Storable Linked_list_A_t
 instance HasCField Linked_list_A_t "linked_list_A_t_x"
     where type CFieldType Linked_list_A_t "linked_list_A_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Linked_list_A_t "linked_list_A_t_x") =>
-         HasField "linked_list_A_t_x" (Ptr Linked_list_A_t) (Ptr ty)
+instance HasField "linked_list_A_t_x"
+                  (Ptr Linked_list_A_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"linked_list_A_t_x")
 instance HasCField Linked_list_A_t "linked_list_A_t_next"
     where type CFieldType Linked_list_A_t
                           "linked_list_A_t_next" = Ptr Linked_list_A_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Linked_list_A_t "linked_list_A_t_next") =>
-         HasField "linked_list_A_t_next" (Ptr Linked_list_A_t) (Ptr ty)
+instance HasField "linked_list_A_t_next"
+                  (Ptr Linked_list_A_t)
+                  (Ptr (Ptr Linked_list_A_t))
     where getField = fromPtr (Proxy @"linked_list_A_t_next")
 {-| __C declaration:__ @struct linked_list_B_t@
 
@@ -95,15 +95,15 @@ deriving via (EquivStorable Linked_list_B_t) instance Storable Linked_list_B_t
 instance HasCField Linked_list_B_t "linked_list_B_t_x"
     where type CFieldType Linked_list_B_t "linked_list_B_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty
-              (CFieldType Linked_list_B_t "linked_list_B_t_x") =>
-         HasField "linked_list_B_t_x" (Ptr Linked_list_B_t) (Ptr ty)
+instance HasField "linked_list_B_t_x"
+                  (Ptr Linked_list_B_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"linked_list_B_t_x")
 instance HasCField Linked_list_B_t "linked_list_B_t_next"
     where type CFieldType Linked_list_B_t
                           "linked_list_B_t_next" = Ptr Linked_list_B_t
           offset# = \_ -> \_ -> 8
-instance TyEq ty
-              (CFieldType Linked_list_B_t "linked_list_B_t_next") =>
-         HasField "linked_list_B_t_next" (Ptr Linked_list_B_t) (Ptr ty)
+instance HasField "linked_list_B_t_next"
+                  (Ptr Linked_list_B_t)
+                  (Ptr (Ptr Linked_list_B_t))
     where getField = fromPtr (Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -85,8 +82,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -97,8 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S1) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -169,8 +164,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -181,8 +175,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -193,8 +186,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "c")
-         ) => GHC.Records.HasField "c" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "c" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"c")
@@ -247,8 +239,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3_t) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S3_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S3_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -319,8 +310,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S4) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -331,8 +321,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "a" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S4) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -343,8 +332,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "c")
-         ) => GHC.Records.HasField "c" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "c" (Ptr.Ptr S4) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"c")
@@ -406,8 +394,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S5) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S5) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -418,8 +405,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S5) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S5) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -481,8 +467,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S6) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S6) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -493,8 +478,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S6) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S6) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -556,8 +540,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -568,8 +551,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -593,8 +575,7 @@ newtype S7a = S7a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr S7a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr S7a) (Ptr.Ptr (Ptr.Ptr S7a_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -662,8 +643,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "a")
-         ) => GHC.Records.HasField "a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -674,8 +654,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "b")
-         ) => GHC.Records.HasField "b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -699,8 +678,7 @@ newtype S7b = S7b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b) "unwrap")
-         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr S7b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrap" (Ptr.Ptr S7b) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "a"
     where type CFieldType S1 "a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S1 "a") =>
-         HasField "a" (Ptr S1) (Ptr ty)
+instance HasField "a" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S1 "b"
     where type CFieldType S1 "b" = CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S1 "b") =>
-         HasField "b" (Ptr S1) (Ptr ty)
+instance HasField "b" (Ptr S1) (Ptr CChar)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S2@
 
@@ -100,20 +98,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "a"
     where type CFieldType S2_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2_t "a") =>
-         HasField "a" (Ptr S2_t) (Ptr ty)
+instance HasField "a" (Ptr S2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S2_t "b"
     where type CFieldType S2_t "b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S2_t "b") =>
-         HasField "b" (Ptr S2_t) (Ptr ty)
+instance HasField "b" (Ptr S2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S2_t "c"
     where type CFieldType S2_t "c" = CFloat
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S2_t "c") =>
-         HasField "c" (Ptr S2_t) (Ptr ty)
+instance HasField "c" (Ptr S2_t) (Ptr CFloat)
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -149,8 +144,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "a"
     where type CFieldType S3_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S3_t "a") =>
-         HasField "a" (Ptr S3_t) (Ptr ty)
+instance HasField "a" (Ptr S3_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 {-| __C declaration:__ @struct S4@
 
@@ -202,20 +196,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "b"
     where type CFieldType S4 "b" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S4 "b") =>
-         HasField "b" (Ptr S4) (Ptr ty)
+instance HasField "b" (Ptr S4) (Ptr CChar)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S4 "a"
     where type CFieldType S4 "a" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S4 "a") =>
-         HasField "a" (Ptr S4) (Ptr ty)
+instance HasField "a" (Ptr S4) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S4 "c"
     where type CFieldType S4 "c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S4 "c") =>
-         HasField "c" (Ptr S4) (Ptr ty)
+instance HasField "c" (Ptr S4) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S5@
 
@@ -259,14 +250,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "a"
     where type CFieldType S5 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S5 "a") =>
-         HasField "a" (Ptr S5) (Ptr ty)
+instance HasField "a" (Ptr S5) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S5 "b"
     where type CFieldType S5 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S5 "b") =>
-         HasField "b" (Ptr S5) (Ptr ty)
+instance HasField "b" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S6@
 
@@ -310,14 +299,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "a"
     where type CFieldType S6 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S6 "a") =>
-         HasField "a" (Ptr S6) (Ptr ty)
+instance HasField "a" (Ptr S6) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S6 "b"
     where type CFieldType S6 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S6 "b") =>
-         HasField "b" (Ptr S6) (Ptr ty)
+instance HasField "b" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -361,14 +348,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "a"
     where type CFieldType S7a_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7a_Aux "a") =>
-         HasField "a" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "a" (Ptr S7a_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7a_Aux "b"
     where type CFieldType S7a_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7a_Aux "b") =>
-         HasField "b" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "b" (Ptr S7a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7a@
 
@@ -391,8 +376,7 @@ newtype S7a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType S7a "unwrap") =>
-         HasField "unwrap" (Ptr S7a) (Ptr ty)
+instance HasField "unwrap" (Ptr S7a) (Ptr (Ptr S7a_Aux))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7a "unwrap"
     where type CFieldType S7a "unwrap" = Ptr S7a_Aux
@@ -439,14 +423,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "a"
     where type CFieldType S7b_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7b_Aux "a") =>
-         HasField "a" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "a" (Ptr S7b_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7b_Aux "b"
     where type CFieldType S7b_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7b_Aux "b") =>
-         HasField "b" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "b" (Ptr S7b_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7b@
 
@@ -469,8 +451,9 @@ newtype S7b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType S7b "unwrap") =>
-         HasField "unwrap" (Ptr S7b) (Ptr ty)
+instance HasField "unwrap"
+                  (Ptr S7b)
+                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7b "unwrap"
     where type CFieldType S7b "unwrap" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,7 +22,6 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -84,8 +81,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "s1_a")
-         ) => GHC.Records.HasField "s1_a" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_a" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_a")
@@ -96,8 +92,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S1) "s1_b")
-         ) => GHC.Records.HasField "s1_b" (Ptr.Ptr S1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s1_b" (Ptr.Ptr S1) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_b")
@@ -168,8 +163,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "s2_t_a")
-         ) => GHC.Records.HasField "s2_t_a" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_t_a" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_a")
@@ -180,8 +174,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "s2_t_b")
-         ) => GHC.Records.HasField "s2_t_b" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_t_b" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_b")
@@ -192,8 +185,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S2_t) "s2_t_c")
-         ) => GHC.Records.HasField "s2_t_c" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s2_t_c" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CFloat) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_c")
@@ -246,8 +238,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_t "s3_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S3_t) "s3_t_a")
-         ) => GHC.Records.HasField "s3_t_a" (Ptr.Ptr S3_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s3_t_a" (Ptr.Ptr S3_t) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_t_a")
@@ -318,8 +309,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "s4_b")
-         ) => GHC.Records.HasField "s4_b" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s4_b" (Ptr.Ptr S4) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_b")
@@ -330,8 +320,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_a" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "s4_a")
-         ) => GHC.Records.HasField "s4_a" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s4_a" (Ptr.Ptr S4) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_a")
@@ -342,8 +331,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S4) "s4_c")
-         ) => GHC.Records.HasField "s4_c" (Ptr.Ptr S4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s4_c" (Ptr.Ptr S4) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_c")
@@ -405,8 +393,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "s5_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S5) "s5_a")
-         ) => GHC.Records.HasField "s5_a" (Ptr.Ptr S5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s5_a" (Ptr.Ptr S5) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s5_a")
@@ -417,8 +404,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "s5_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S5) "s5_b")
-         ) => GHC.Records.HasField "s5_b" (Ptr.Ptr S5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s5_b" (Ptr.Ptr S5) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s5_b")
@@ -480,8 +466,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "s6_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S6) "s6_a")
-         ) => GHC.Records.HasField "s6_a" (Ptr.Ptr S6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s6_a" (Ptr.Ptr S6) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s6_a")
@@ -492,8 +477,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "s6_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S6) "s6_b")
-         ) => GHC.Records.HasField "s6_b" (Ptr.Ptr S6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s6_b" (Ptr.Ptr S6) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s6_b")
@@ -555,8 +539,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "s7a_Aux_a")
-         ) => GHC.Records.HasField "s7a_Aux_a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s7a_Aux_a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7a_Aux_a")
@@ -567,8 +550,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a_Aux) "s7a_Aux_b")
-         ) => GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7a_Aux_b")
@@ -592,8 +574,7 @@ newtype S7a = S7a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7a) "unwrapS7a")
-         ) => GHC.Records.HasField "unwrapS7a" (Ptr.Ptr S7a) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapS7a" (Ptr.Ptr S7a) (Ptr.Ptr (Ptr.Ptr S7a_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS7a")
@@ -661,8 +642,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "s7b_Aux_a")
-         ) => GHC.Records.HasField "s7b_Aux_a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s7b_Aux_a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7b_Aux_a")
@@ -673,8 +653,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b_Aux) "s7b_Aux_b")
-         ) => GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7b_Aux_b")
@@ -698,8 +677,7 @@ newtype S7b = S7b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType S7b) "unwrapS7b")
-         ) => GHC.Records.HasField "unwrapS7b" (Ptr.Ptr S7b) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapS7b" (Ptr.Ptr S7b) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS7b")

--- a/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_a"
     where type CFieldType S1 "s1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S1 "s1_a") =>
-         HasField "s1_a" (Ptr S1) (Ptr ty)
+instance HasField "s1_a" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_a")
 instance HasCField S1 "s1_b"
     where type CFieldType S1 "s1_b" = CChar
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S1 "s1_b") =>
-         HasField "s1_b" (Ptr S1) (Ptr ty)
+instance HasField "s1_b" (Ptr S1) (Ptr CChar)
     where getField = fromPtr (Proxy @"s1_b")
 {-| __C declaration:__ @struct S2@
 
@@ -100,20 +98,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "s2_t_a"
     where type CFieldType S2_t "s2_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S2_t "s2_t_a") =>
-         HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_a" (Ptr S2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s2_t_a")
 instance HasCField S2_t "s2_t_b"
     where type CFieldType S2_t "s2_t_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S2_t "s2_t_b") =>
-         HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_b" (Ptr S2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_t_b")
 instance HasCField S2_t "s2_t_c"
     where type CFieldType S2_t "s2_t_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S2_t "s2_t_c") =>
-         HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_c" (Ptr S2_t) (Ptr CFloat)
     where getField = fromPtr (Proxy @"s2_t_c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -149,8 +144,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "s3_t_a"
     where type CFieldType S3_t "s3_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S3_t "s3_t_a") =>
-         HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
+instance HasField "s3_t_a" (Ptr S3_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s3_t_a")
 {-| __C declaration:__ @struct S4@
 
@@ -202,20 +196,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "s4_b"
     where type CFieldType S4 "s4_b" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S4 "s4_b") =>
-         HasField "s4_b" (Ptr S4) (Ptr ty)
+instance HasField "s4_b" (Ptr S4) (Ptr CChar)
     where getField = fromPtr (Proxy @"s4_b")
 instance HasCField S4 "s4_a"
     where type CFieldType S4 "s4_a" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S4 "s4_a") =>
-         HasField "s4_a" (Ptr S4) (Ptr ty)
+instance HasField "s4_a" (Ptr S4) (Ptr CInt)
     where getField = fromPtr (Proxy @"s4_a")
 instance HasCField S4 "s4_c"
     where type CFieldType S4 "s4_c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType S4 "s4_c") =>
-         HasField "s4_c" (Ptr S4) (Ptr ty)
+instance HasField "s4_c" (Ptr S4) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"s4_c")
 {-| __C declaration:__ @struct S5@
 
@@ -259,14 +250,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "s5_a"
     where type CFieldType S5 "s5_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S5 "s5_a") =>
-         HasField "s5_a" (Ptr S5) (Ptr ty)
+instance HasField "s5_a" (Ptr S5) (Ptr CChar)
     where getField = fromPtr (Proxy @"s5_a")
 instance HasCField S5 "s5_b"
     where type CFieldType S5 "s5_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S5 "s5_b") =>
-         HasField "s5_b" (Ptr S5) (Ptr ty)
+instance HasField "s5_b" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"s5_b")
 {-| __C declaration:__ @struct S6@
 
@@ -310,14 +299,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "s6_a"
     where type CFieldType S6 "s6_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S6 "s6_a") =>
-         HasField "s6_a" (Ptr S6) (Ptr ty)
+instance HasField "s6_a" (Ptr S6) (Ptr CChar)
     where getField = fromPtr (Proxy @"s6_a")
 instance HasCField S6 "s6_b"
     where type CFieldType S6 "s6_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S6 "s6_b") =>
-         HasField "s6_b" (Ptr S6) (Ptr ty)
+instance HasField "s6_b" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"s6_b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -361,14 +348,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "s7a_Aux_a"
     where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7a_Aux "s7a_Aux_a") =>
-         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance HasCField S7a_Aux "s7a_Aux_b"
     where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7a_Aux "s7a_Aux_b") =>
-         HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7a_Aux_b")
 {-| __C declaration:__ @S7a@
 
@@ -391,8 +376,7 @@ newtype S7a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType S7a "unwrapS7a") =>
-         HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
+instance HasField "unwrapS7a" (Ptr S7a) (Ptr (Ptr S7a_Aux))
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
@@ -439,14 +423,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "s7b_Aux_a"
     where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType S7b_Aux "s7b_Aux_a") =>
-         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance HasCField S7b_Aux "s7b_Aux_b"
     where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType S7b_Aux "s7b_Aux_b") =>
-         HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7b_Aux_b")
 {-| __C declaration:__ @S7b@
 
@@ -469,8 +451,9 @@ newtype S7b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType S7b "unwrapS7b") =>
-         HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
+instance HasField "unwrapS7b"
+                  (Ptr S7b)
+                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,7 +20,6 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct thing@
@@ -73,8 +70,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Thing "thing_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Thing) "thing_x")
-         ) => GHC.Records.HasField "thing_x" (Ptr.Ptr Thing) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "thing_x" (Ptr.Ptr Thing) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"thing_x")

--- a/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
@@ -130,8 +130,7 @@ deriving via (EquivStorable Thing) instance Storable Thing
 instance HasCField Thing "thing_x"
     where type CFieldType Thing "thing_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Thing "thing_x") =>
-         HasField "thing_x" (Ptr Thing) (Ptr ty)
+instance HasField "thing_x" (Ptr Thing) (Ptr CInt)
     where getField = fromPtr (Proxy @"thing_x")
 -- __unique:__ @test_typesstructsstruct_arg_Example_Safe_thing_fun_1@
 foreign import ccall safe "hs_bindgen_4ad25504590fdd2b" hs_bindgen_4ad25504590fdd2b_base ::

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
 {-| Auxiliary type used by 'F1'
@@ -81,8 +78,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Aux) "unwrapF1_Aux")
-         ) => GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1_Aux")
@@ -113,8 +109,7 @@ newtype F1 = F1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1) "unwrapF1")
-         ) => GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr (Ptr.FunPtr F1_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1")
@@ -171,8 +166,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F2_Aux where
 
   fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F2_Aux) "unwrapF2_Aux")
-         ) => GHC.Records.HasField "unwrapF2_Aux" (Ptr.Ptr F2_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF2_Aux" (Ptr.Ptr F2_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF2_Aux")
@@ -203,8 +197,7 @@ newtype F2 = F2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F2) "unwrapF2")
-         ) => GHC.Records.HasField "unwrapF2" (Ptr.Ptr F2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF2" (Ptr.Ptr F2) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F2_Aux))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF2")
@@ -262,8 +255,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F3_Aux where
 
   fromFunPtr = hs_bindgen_66460422a7197535
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F3_Aux) "unwrapF3_Aux")
-         ) => GHC.Records.HasField "unwrapF3_Aux" (Ptr.Ptr F3_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF3_Aux" (Ptr.Ptr F3_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF3_Aux")
@@ -294,8 +286,7 @@ newtype F3 = F3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F3) "unwrapF3")
-         ) => GHC.Records.HasField "unwrapF3" (Ptr.Ptr F3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF3" (Ptr.Ptr F3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux)))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF3")
@@ -353,8 +344,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F4_Aux where
 
   fromFunPtr = hs_bindgen_40f9a8d432b9eb97
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F4_Aux) "unwrapF4_Aux")
-         ) => GHC.Records.HasField "unwrapF4_Aux" (Ptr.Ptr F4_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF4_Aux" (Ptr.Ptr F4_Aux) (Ptr.Ptr (IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF4_Aux")
@@ -384,8 +374,7 @@ newtype F4 = F4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F4) "unwrapF4")
-         ) => GHC.Records.HasField "unwrapF4" (Ptr.Ptr F4) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF4" (Ptr.Ptr F4) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F4_Aux))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF4")
@@ -443,8 +432,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F5_Aux where
 
   fromFunPtr = hs_bindgen_586f6635c057975f
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F5_Aux) "unwrapF5_Aux")
-         ) => GHC.Records.HasField "unwrapF5_Aux" (Ptr.Ptr F5_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF5_Aux" (Ptr.Ptr F5_Aux) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF5_Aux")
@@ -474,8 +462,7 @@ newtype F5 = F5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F5) "unwrapF5")
-         ) => GHC.Records.HasField "unwrapF5" (Ptr.Ptr F5) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF5" (Ptr.Ptr F5) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F5_Aux))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF5")
@@ -516,8 +503,7 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType MyInt) "unwrapMyInt")
-         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -574,8 +560,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F6_Aux where
 
   fromFunPtr = hs_bindgen_a887947b26e58f0c
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F6_Aux) "unwrapF6_Aux")
-         ) => GHC.Records.HasField "unwrapF6_Aux" (Ptr.Ptr F6_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF6_Aux" (Ptr.Ptr F6_Aux) (Ptr.Ptr (MyInt -> IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF6_Aux")
@@ -606,8 +591,7 @@ newtype F6 = F6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F6) "unwrapF6")
-         ) => GHC.Records.HasField "unwrapF6" (Ptr.Ptr F6) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF6" (Ptr.Ptr F6) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F6_Aux))) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF6")

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -39,8 +39,9 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance TyEq ty (CFieldType F1_Aux "unwrapF1_Aux") =>
-         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
+instance HasField "unwrapF1_Aux"
+                  (Ptr F1_Aux)
+                  (Ptr (CInt -> CInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = CInt ->
@@ -67,8 +68,7 @@ newtype F1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F1 "unwrapF1") =>
-         HasField "unwrapF1" (Ptr F1) (Ptr ty)
+instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -113,8 +113,9 @@ instance ToFunPtr F2_Aux
     where toFunPtr = hs_bindgen_c39d7524b75b54e8
 instance FromFunPtr F2_Aux
     where fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
-instance TyEq ty (CFieldType F2_Aux "unwrapF2_Aux") =>
-         HasField "unwrapF2_Aux" (Ptr F2_Aux) (Ptr ty)
+instance HasField "unwrapF2_Aux"
+                  (Ptr F2_Aux)
+                  (Ptr (CInt -> CInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapF2_Aux")
 instance HasCField F2_Aux "unwrapF2_Aux"
     where type CFieldType F2_Aux "unwrapF2_Aux" = CInt ->
@@ -141,8 +142,7 @@ newtype F2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F2 "unwrapF2") =>
-         HasField "unwrapF2" (Ptr F2) (Ptr ty)
+instance HasField "unwrapF2" (Ptr F2) (Ptr (Ptr (FunPtr F2_Aux)))
     where getField = fromPtr (Proxy @"unwrapF2")
 instance HasCField F2 "unwrapF2"
     where type CFieldType F2 "unwrapF2" = Ptr (FunPtr F2_Aux)
@@ -187,8 +187,9 @@ instance ToFunPtr F3_Aux
     where toFunPtr = hs_bindgen_4a960721e7d1dcef
 instance FromFunPtr F3_Aux
     where fromFunPtr = hs_bindgen_66460422a7197535
-instance TyEq ty (CFieldType F3_Aux "unwrapF3_Aux") =>
-         HasField "unwrapF3_Aux" (Ptr F3_Aux) (Ptr ty)
+instance HasField "unwrapF3_Aux"
+                  (Ptr F3_Aux)
+                  (Ptr (CInt -> CInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapF3_Aux")
 instance HasCField F3_Aux "unwrapF3_Aux"
     where type CFieldType F3_Aux "unwrapF3_Aux" = CInt ->
@@ -215,8 +216,9 @@ newtype F3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F3 "unwrapF3") =>
-         HasField "unwrapF3" (Ptr F3) (Ptr ty)
+instance HasField "unwrapF3"
+                  (Ptr F3)
+                  (Ptr (Ptr (Ptr (FunPtr F3_Aux))))
     where getField = fromPtr (Proxy @"unwrapF3")
 instance HasCField F3 "unwrapF3"
     where type CFieldType F3 "unwrapF3" = Ptr (Ptr (FunPtr F3_Aux))
@@ -259,8 +261,7 @@ instance ToFunPtr F4_Aux
     where toFunPtr = hs_bindgen_83bcff023b3bc648
 instance FromFunPtr F4_Aux
     where fromFunPtr = hs_bindgen_40f9a8d432b9eb97
-instance TyEq ty (CFieldType F4_Aux "unwrapF4_Aux") =>
-         HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr ty)
+instance HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr (IO CInt))
     where getField = fromPtr (Proxy @"unwrapF4_Aux")
 instance HasCField F4_Aux "unwrapF4_Aux"
     where type CFieldType F4_Aux "unwrapF4_Aux" = IO CInt
@@ -286,8 +287,7 @@ newtype F4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F4 "unwrapF4") =>
-         HasField "unwrapF4" (Ptr F4) (Ptr ty)
+instance HasField "unwrapF4" (Ptr F4) (Ptr (Ptr (FunPtr F4_Aux)))
     where getField = fromPtr (Proxy @"unwrapF4")
 instance HasCField F4 "unwrapF4"
     where type CFieldType F4 "unwrapF4" = Ptr (FunPtr F4_Aux)
@@ -330,8 +330,7 @@ instance ToFunPtr F5_Aux
     where toFunPtr = hs_bindgen_6891cbd81d6f42b9
 instance FromFunPtr F5_Aux
     where fromFunPtr = hs_bindgen_586f6635c057975f
-instance TyEq ty (CFieldType F5_Aux "unwrapF5_Aux") =>
-         HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr ty)
+instance HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapF5_Aux")
 instance HasCField F5_Aux "unwrapF5_Aux"
     where type CFieldType F5_Aux "unwrapF5_Aux" = IO Unit
@@ -357,8 +356,7 @@ newtype F5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F5 "unwrapF5") =>
-         HasField "unwrapF5" (Ptr F5) (Ptr ty)
+instance HasField "unwrapF5" (Ptr F5) (Ptr (Ptr (FunPtr F5_Aux)))
     where getField = fromPtr (Proxy @"unwrapF5")
 instance HasCField F5 "unwrapF5"
     where type CFieldType F5 "unwrapF5" = Ptr (FunPtr F5_Aux)
@@ -394,8 +392,7 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType MyInt "unwrapMyInt") =>
-         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -439,8 +436,9 @@ instance ToFunPtr F6_Aux
     where toFunPtr = hs_bindgen_c1baf73f98614f45
 instance FromFunPtr F6_Aux
     where fromFunPtr = hs_bindgen_a887947b26e58f0c
-instance TyEq ty (CFieldType F6_Aux "unwrapF6_Aux") =>
-         HasField "unwrapF6_Aux" (Ptr F6_Aux) (Ptr ty)
+instance HasField "unwrapF6_Aux"
+                  (Ptr F6_Aux)
+                  (Ptr (MyInt -> IO Unit))
     where getField = fromPtr (Proxy @"unwrapF6_Aux")
 instance HasCField F6_Aux "unwrapF6_Aux"
     where type CFieldType F6_Aux "unwrapF6_Aux" = MyInt -> IO Unit
@@ -466,8 +464,7 @@ newtype F6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F6 "unwrapF6") =>
-         HasField "unwrapF6" (Ptr F6) (Ptr ty)
+instance HasField "unwrapF6" (Ptr F6) (Ptr (Ptr (FunPtr F6_Aux)))
     where getField = fromPtr (Proxy @"unwrapF6")
 instance HasCField F6 "unwrapF6"
     where type CFieldType F6 "unwrapF6" = Ptr (FunPtr F6_Aux)

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,7 +28,6 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @T1@
@@ -62,8 +59,7 @@ newtype T1 = T1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T1) "unwrapT1")
-         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -103,8 +99,7 @@ newtype T2 = T2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType T2) "unwrapT2")
-         ) => GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT2")
@@ -144,8 +139,7 @@ newtype M1 = M1
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType M1) "unwrapM1")
-         ) => GHC.Records.HasField "unwrapM1" (Ptr.Ptr M1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapM1" (Ptr.Ptr M1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM1")
@@ -185,8 +179,7 @@ newtype M2 = M2
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType M2) "unwrapM2")
-         ) => GHC.Records.HasField "unwrapM2" (Ptr.Ptr M2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapM2" (Ptr.Ptr M2) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM2")
@@ -216,8 +209,7 @@ newtype M3 = M3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType M3) "unwrapM3")
-         ) => GHC.Records.HasField "unwrapM3" (Ptr.Ptr M3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapM3" (Ptr.Ptr M3) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM3")
@@ -307,8 +299,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_t1" 
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExampleStruct) "exampleStruct_t1")
-         ) => GHC.Records.HasField "exampleStruct_t1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exampleStruct_t1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr T1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_t1")
@@ -319,8 +310,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_t2" 
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExampleStruct) "exampleStruct_t2")
-         ) => GHC.Records.HasField "exampleStruct_t2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exampleStruct_t2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr T2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_t2")
@@ -331,8 +321,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_m1" 
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExampleStruct) "exampleStruct_m1")
-         ) => GHC.Records.HasField "exampleStruct_m1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exampleStruct_m1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr M1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_m1")
@@ -343,8 +332,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_m2" 
 
   offset# = \_ -> \_ -> 12
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExampleStruct) "exampleStruct_m2")
-         ) => GHC.Records.HasField "exampleStruct_m2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exampleStruct_m2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr M2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_m2")
@@ -378,8 +366,7 @@ newtype Uint64_t = Uint64_t
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Uint64_t) "unwrapUint64_t")
-         ) => GHC.Records.HasField "unwrapUint64_t" (Ptr.Ptr Uint64_t) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapUint64_t" (Ptr.Ptr Uint64_t) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint64_t")
@@ -438,8 +425,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Foo) "foo_a")
-         ) => GHC.Records.HasField "foo_a" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "foo_a" (Ptr.Ptr Foo) (Ptr.Ptr (Ptr.Ptr Uint64_t)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_a")

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -30,8 +30,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T1 "unwrapT1") =>
-         HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -67,8 +66,7 @@ newtype T2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType T2 "unwrapT2") =>
-         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CChar
@@ -104,8 +102,7 @@ newtype M1
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType M1 "unwrapM1") =>
-         HasField "unwrapM1" (Ptr M1) (Ptr ty)
+instance HasField "unwrapM1" (Ptr M1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
@@ -141,8 +138,7 @@ newtype M2
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType M2 "unwrapM2") =>
-         HasField "unwrapM2" (Ptr M2) (Ptr ty)
+instance HasField "unwrapM2" (Ptr M2) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = CChar
@@ -168,8 +164,7 @@ newtype M3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType M3 "unwrapM3") =>
-         HasField "unwrapM3" (Ptr M3) (Ptr ty)
+instance HasField "unwrapM3" (Ptr M3) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = Ptr CInt
@@ -232,26 +227,22 @@ deriving via (EquivStorable ExampleStruct) instance Storable ExampleStruct
 instance HasCField ExampleStruct "exampleStruct_t1"
     where type CFieldType ExampleStruct "exampleStruct_t1" = T1
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExampleStruct "exampleStruct_t1") =>
-         HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr T1)
     where getField = fromPtr (Proxy @"exampleStruct_t1")
 instance HasCField ExampleStruct "exampleStruct_t2"
     where type CFieldType ExampleStruct "exampleStruct_t2" = T2
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType ExampleStruct "exampleStruct_t2") =>
-         HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr T2)
     where getField = fromPtr (Proxy @"exampleStruct_t2")
 instance HasCField ExampleStruct "exampleStruct_m1"
     where type CFieldType ExampleStruct "exampleStruct_m1" = M1
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType ExampleStruct "exampleStruct_m1") =>
-         HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr M1)
     where getField = fromPtr (Proxy @"exampleStruct_m1")
 instance HasCField ExampleStruct "exampleStruct_m2"
     where type CFieldType ExampleStruct "exampleStruct_m2" = M2
           offset# = \_ -> \_ -> 12
-instance TyEq ty (CFieldType ExampleStruct "exampleStruct_m2") =>
-         HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr M2)
     where getField = fromPtr (Proxy @"exampleStruct_m2")
 {-| __C declaration:__ @uint64_t@
 
@@ -284,8 +275,7 @@ newtype Uint64_t
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Uint64_t "unwrapUint64_t") =>
-         HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr ty)
+instance HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapUint64_t")
 instance HasCField Uint64_t "unwrapUint64_t"
     where type CFieldType Uint64_t "unwrapUint64_t" = CInt
@@ -324,6 +314,5 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_a"
     where type CFieldType Foo "foo_a" = Ptr Uint64_t
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Foo "foo_a") =>
-         HasField "foo_a" (Ptr Foo) (Ptr ty)
+instance HasField "foo_a" (Ptr Foo) (Ptr (Ptr Uint64_t))
     where getField = fromPtr (Proxy @"foo_a")

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -32,7 +30,6 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @myint@
@@ -64,8 +61,7 @@ newtype Myint = Myint
     , Real
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Myint) "unwrapMyint")
-         ) => GHC.Records.HasField "unwrapMyint" (Ptr.Ptr Myint) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapMyint" (Ptr.Ptr Myint) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyint")
@@ -95,8 +91,7 @@ newtype Intptr = Intptr
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Intptr) "unwrapIntptr")
-         ) => GHC.Records.HasField "unwrapIntptr" (Ptr.Ptr Intptr) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapIntptr" (Ptr.Ptr Intptr) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapIntptr")
@@ -152,8 +147,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Int2int where
 
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Int2int) "unwrapInt2int")
-         ) => GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt2int")
@@ -211,8 +205,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr FunctionPointer_Function_A
 
   fromFunPtr = hs_bindgen_4c3da8240a31e036
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FunctionPointer_Function_Aux) "unwrapFunctionPointer_Function_Aux")
-         ) => GHC.Records.HasField "unwrapFunctionPointer_Function_Aux" (Ptr.Ptr FunctionPointer_Function_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunctionPointer_Function_Aux" (Ptr.Ptr FunctionPointer_Function_Aux) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunctionPointer_Function_Aux")
@@ -243,8 +236,7 @@ newtype FunctionPointer_Function = FunctionPointer_Function
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType FunctionPointer_Function) "unwrapFunctionPointer_Function")
-         ) => GHC.Records.HasField "unwrapFunctionPointer_Function" (Ptr.Ptr FunctionPointer_Function) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapFunctionPointer_Function" (Ptr.Ptr FunctionPointer_Function) (Ptr.Ptr (Ptr.FunPtr FunctionPointer_Function_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunctionPointer_Function")
@@ -300,8 +292,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr NonFunctionPointer_Functio
 
   fromFunPtr = hs_bindgen_36c7108d046bcbc3
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType NonFunctionPointer_Function) "unwrapNonFunctionPointer_Function")
-         ) => GHC.Records.HasField "unwrapNonFunctionPointer_Function" (Ptr.Ptr NonFunctionPointer_Function) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapNonFunctionPointer_Function" (Ptr.Ptr NonFunctionPointer_Function) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapNonFunctionPointer_Function")
@@ -359,8 +350,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1_Aux) "unwrapF1_Aux")
-         ) => GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1_Aux")
@@ -390,8 +380,7 @@ newtype F1 = F1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType F1) "unwrapF1")
-         ) => GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr (Ptr.FunPtr F1_Aux)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1")
@@ -446,8 +435,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr G1 where
 
   fromFunPtr = hs_bindgen_8405c8e75aa78be5
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType G1) "unwrapG1")
-         ) => GHC.Records.HasField "unwrapG1" (Ptr.Ptr G1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapG1" (Ptr.Ptr G1) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapG1")
@@ -477,8 +465,7 @@ newtype G2 = G2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType G2) "unwrapG2")
-         ) => GHC.Records.HasField "unwrapG2" (Ptr.Ptr G2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapG2" (Ptr.Ptr G2) (Ptr.Ptr (Ptr.FunPtr G1)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapG2")
@@ -533,8 +520,7 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr H1 where
 
   fromFunPtr = hs_bindgen_1a33688324e1924f
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType H1) "unwrapH1")
-         ) => GHC.Records.HasField "unwrapH1" (Ptr.Ptr H1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapH1" (Ptr.Ptr H1) (Ptr.Ptr (IO ())) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH1")
@@ -557,8 +543,7 @@ newtype H2 = H2
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType H2) "unwrapH2")
-         ) => GHC.Records.HasField "unwrapH2" (Ptr.Ptr H2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapH2" (Ptr.Ptr H2) (Ptr.Ptr H1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH2")
@@ -588,8 +573,7 @@ newtype H3 = H3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType H3) "unwrapH3")
-         ) => GHC.Records.HasField "unwrapH3" (Ptr.Ptr H3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unwrapH3" (Ptr.Ptr H3) (Ptr.Ptr (Ptr.FunPtr H2)) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH3")

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
@@ -30,8 +30,7 @@ newtype Myint
                       Ix,
                       Num,
                       Real)
-instance TyEq ty (CFieldType Myint "unwrapMyint") =>
-         HasField "unwrapMyint" (Ptr Myint) (Ptr ty)
+instance HasField "unwrapMyint" (Ptr Myint) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyint")
 instance HasCField Myint "unwrapMyint"
     where type CFieldType Myint "unwrapMyint" = CInt
@@ -57,8 +56,7 @@ newtype Intptr
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType Intptr "unwrapIntptr") =>
-         HasField "unwrapIntptr" (Ptr Intptr) (Ptr ty)
+instance HasField "unwrapIntptr" (Ptr Intptr) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapIntptr")
 instance HasCField Intptr "unwrapIntptr"
     where type CFieldType Intptr "unwrapIntptr" = Ptr CInt
@@ -98,8 +96,9 @@ instance ToFunPtr Int2int
     where toFunPtr = hs_bindgen_a6c7dd49f5b9d470
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
-instance TyEq ty (CFieldType Int2int "unwrapInt2int") =>
-         HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
+instance HasField "unwrapInt2int"
+                  (Ptr Int2int)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
@@ -144,12 +143,9 @@ instance ToFunPtr FunctionPointer_Function_Aux
     where toFunPtr = hs_bindgen_b171c028cdc0781d
 instance FromFunPtr FunctionPointer_Function_Aux
     where fromFunPtr = hs_bindgen_4c3da8240a31e036
-instance TyEq ty
-              (CFieldType FunctionPointer_Function_Aux
-                          "unwrapFunctionPointer_Function_Aux") =>
-         HasField "unwrapFunctionPointer_Function_Aux"
+instance HasField "unwrapFunctionPointer_Function_Aux"
                   (Ptr FunctionPointer_Function_Aux)
-                  (Ptr ty)
+                  (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function_Aux")
 instance HasCField FunctionPointer_Function_Aux
                    "unwrapFunctionPointer_Function_Aux"
@@ -177,12 +173,9 @@ newtype FunctionPointer_Function
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty
-              (CFieldType FunctionPointer_Function
-                          "unwrapFunctionPointer_Function") =>
-         HasField "unwrapFunctionPointer_Function"
+instance HasField "unwrapFunctionPointer_Function"
                   (Ptr FunctionPointer_Function)
-                  (Ptr ty)
+                  (Ptr (FunPtr FunctionPointer_Function_Aux))
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function")
 instance HasCField FunctionPointer_Function
                    "unwrapFunctionPointer_Function"
@@ -227,12 +220,9 @@ instance ToFunPtr NonFunctionPointer_Function
     where toFunPtr = hs_bindgen_766ae751d60365e9
 instance FromFunPtr NonFunctionPointer_Function
     where fromFunPtr = hs_bindgen_36c7108d046bcbc3
-instance TyEq ty
-              (CFieldType NonFunctionPointer_Function
-                          "unwrapNonFunctionPointer_Function") =>
-         HasField "unwrapNonFunctionPointer_Function"
+instance HasField "unwrapNonFunctionPointer_Function"
                   (Ptr NonFunctionPointer_Function)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapNonFunctionPointer_Function")
 instance HasCField NonFunctionPointer_Function
                    "unwrapNonFunctionPointer_Function"
@@ -277,8 +267,7 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance TyEq ty (CFieldType F1_Aux "unwrapF1_Aux") =>
-         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
+instance HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = IO Unit
@@ -304,8 +293,7 @@ newtype F1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType F1 "unwrapF1") =>
-         HasField "unwrapF1" (Ptr F1) (Ptr ty)
+instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -344,8 +332,7 @@ instance ToFunPtr G1
     where toFunPtr = hs_bindgen_fa5806570b682579
 instance FromFunPtr G1
     where fromFunPtr = hs_bindgen_8405c8e75aa78be5
-instance TyEq ty (CFieldType G1 "unwrapG1") =>
-         HasField "unwrapG1" (Ptr G1) (Ptr ty)
+instance HasField "unwrapG1" (Ptr G1) (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapG1")
 instance HasCField G1 "unwrapG1"
     where type CFieldType G1 "unwrapG1" = IO Unit
@@ -371,8 +358,7 @@ newtype G2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType G2 "unwrapG2") =>
-         HasField "unwrapG2" (Ptr G2) (Ptr ty)
+instance HasField "unwrapG2" (Ptr G2) (Ptr (FunPtr G1))
     where getField = fromPtr (Proxy @"unwrapG2")
 instance HasCField G2 "unwrapG2"
     where type CFieldType G2 "unwrapG2" = FunPtr G1
@@ -411,8 +397,7 @@ instance ToFunPtr H1
     where toFunPtr = hs_bindgen_ffae0d1234ed018f
 instance FromFunPtr H1
     where fromFunPtr = hs_bindgen_1a33688324e1924f
-instance TyEq ty (CFieldType H1 "unwrapH1") =>
-         HasField "unwrapH1" (Ptr H1) (Ptr ty)
+instance HasField "unwrapH1" (Ptr H1) (Ptr (IO Unit))
     where getField = fromPtr (Proxy @"unwrapH1")
 instance HasCField H1 "unwrapH1"
     where type CFieldType H1 "unwrapH1" = IO Unit
@@ -433,8 +418,7 @@ newtype H2
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance TyEq ty (CFieldType H2 "unwrapH2") =>
-         HasField "unwrapH2" (Ptr H2) (Ptr ty)
+instance HasField "unwrapH2" (Ptr H2) (Ptr H1)
     where getField = fromPtr (Proxy @"unwrapH2")
 instance HasCField H2 "unwrapH2"
     where type CFieldType H2 "unwrapH2" = H1
@@ -460,8 +444,7 @@ newtype H3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance TyEq ty (CFieldType H3 "unwrapH3") =>
-         HasField "unwrapH3" (Ptr H3) (Ptr ty)
+instance HasField "unwrapH3" (Ptr H3) (Ptr (FunPtr H2))
     where getField = fromPtr (Proxy @"unwrapH3")
 instance HasCField H3 "unwrapH3"
     where type CFieldType H3 "unwrapH3" = FunPtr H2

--- a/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Int, pure)
 
 {-| __C declaration:__ @union unionA@
@@ -107,8 +104,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UnionA "unionA_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UnionA) "unionA_a")
-         ) => GHC.Records.HasField "unionA_a" (Ptr.Ptr UnionA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unionA_a" (Ptr.Ptr UnionA) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unionA_a")
@@ -119,8 +115,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UnionA "unionA_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType UnionA) "unionA_b")
-         ) => GHC.Records.HasField "unionA_b" (Ptr.Ptr UnionA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "unionA_b" (Ptr.Ptr UnionA) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unionA_b")
@@ -172,8 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExA) "exA_fieldA1")
-         ) => GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr UnionA) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exA_fieldA1")
@@ -257,8 +251,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB_fieldB1 "exB_fieldB1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExB_fieldB1) "exB_fieldB1_a")
-         ) => GHC.Records.HasField "exB_fieldB1_a" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exB_fieldB1_a" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1_a")
@@ -270,8 +263,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB_fieldB1 "exB_fieldB1_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExB_fieldB1) "exB_fieldB1_b")
-         ) => GHC.Records.HasField "exB_fieldB1_b" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exB_fieldB1_b" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CChar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1_b")
@@ -323,8 +315,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType ExB) "exB_fieldB1")
-         ) => GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ExB_fieldB1) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
@@ -89,14 +89,12 @@ set_unionA_b = setUnionPayload
 instance HasCField UnionA "unionA_a"
     where type CFieldType UnionA "unionA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType UnionA "unionA_a") =>
-         HasField "unionA_a" (Ptr UnionA) (Ptr ty)
+instance HasField "unionA_a" (Ptr UnionA) (Ptr CInt)
     where getField = fromPtr (Proxy @"unionA_a")
 instance HasCField UnionA "unionA_b"
     where type CFieldType UnionA "unionA_b" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType UnionA "unionA_b") =>
-         HasField "unionA_b" (Ptr UnionA) (Ptr ty)
+instance HasField "unionA_b" (Ptr UnionA) (Ptr CChar)
     where getField = fromPtr (Proxy @"unionA_b")
 {-| __C declaration:__ @struct exA@
 
@@ -131,8 +129,7 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = UnionA
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExA "exA_fieldA1") =>
-         HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+instance HasField "exA_fieldA1" (Ptr ExA) (Ptr UnionA)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @union \@exB_fieldB1@
 
@@ -224,14 +221,12 @@ set_exB_fieldB1_b = setUnionPayload
 instance HasCField ExB_fieldB1 "exB_fieldB1_a"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExB_fieldB1 "exB_fieldB1_a") =>
-         HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr CInt)
     where getField = fromPtr (Proxy @"exB_fieldB1_a")
 instance HasCField ExB_fieldB1 "exB_fieldB1_b"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_b" = CChar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExB_fieldB1 "exB_fieldB1_b") =>
-         HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr CChar)
     where getField = fromPtr (Proxy @"exB_fieldB1_b")
 {-| __C declaration:__ @struct exB@
 
@@ -266,6 +261,5 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType ExB "exB_fieldB1") =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/unions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,7 +23,6 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
-import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Dim2@
@@ -85,8 +82,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim2 "dim2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim2) "dim2_x")
-         ) => GHC.Records.HasField "dim2_x" (Ptr.Ptr Dim2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim2_x" (Ptr.Ptr Dim2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim2_x")
@@ -97,8 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim2 "dim2_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim2) "dim2_y")
-         ) => GHC.Records.HasField "dim2_y" (Ptr.Ptr Dim2) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim2_y" (Ptr.Ptr Dim2) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim2_y")
@@ -169,8 +164,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim3) "dim3_x")
-         ) => GHC.Records.HasField "dim3_x" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim3_x" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_x")
@@ -181,8 +175,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim3) "dim3_y")
-         ) => GHC.Records.HasField "dim3_y" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim3_y" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_y")
@@ -193,8 +186,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_z" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim3) "dim3_z")
-         ) => GHC.Records.HasField "dim3_z" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim3_z" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_z")
@@ -278,8 +270,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayload "dimPayload_dim2" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimPayload) "dimPayload_dim2")
-         ) => GHC.Records.HasField "dimPayload_dim2" (Ptr.Ptr DimPayload) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimPayload_dim2" (Ptr.Ptr DimPayload) (Ptr.Ptr Dim2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayload_dim2")
@@ -290,8 +281,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayload "dimPayload_dim3" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimPayload) "dimPayload_dim3")
-         ) => GHC.Records.HasField "dimPayload_dim3" (Ptr.Ptr DimPayload) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimPayload_dim3" (Ptr.Ptr DimPayload) (Ptr.Ptr Dim2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayload_dim3")
@@ -352,8 +342,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim "dim_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim) "dim_tag")
-         ) => GHC.Records.HasField "dim_tag" (Ptr.Ptr Dim) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim_tag" (Ptr.Ptr Dim) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim_tag")
@@ -364,8 +353,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim "dim_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Dim) "dim_payload")
-         ) => GHC.Records.HasField "dim_payload" (Ptr.Ptr Dim) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dim_payload" (Ptr.Ptr Dim) (Ptr.Ptr DimPayload) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim_payload")
@@ -449,8 +437,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayloadB "dimPayloadB_dim2" wh
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimPayloadB) "dimPayloadB_dim2")
-         ) => GHC.Records.HasField "dimPayloadB_dim2" (Ptr.Ptr DimPayloadB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimPayloadB_dim2" (Ptr.Ptr DimPayloadB) (Ptr.Ptr Dim2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayloadB_dim2")
@@ -461,8 +448,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayloadB "dimPayloadB_dim3" wh
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimPayloadB) "dimPayloadB_dim3")
-         ) => GHC.Records.HasField "dimPayloadB_dim3" (Ptr.Ptr DimPayloadB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimPayloadB_dim3" (Ptr.Ptr DimPayloadB) (Ptr.Ptr Dim2) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayloadB_dim3")
@@ -523,8 +509,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimB "dimB_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimB) "dimB_tag")
-         ) => GHC.Records.HasField "dimB_tag" (Ptr.Ptr DimB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimB_tag" (Ptr.Ptr DimB) (Ptr.Ptr FC.CInt) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimB_tag")
@@ -535,8 +520,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DimB "dimB_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType DimB) "dimB_payload")
-         ) => GHC.Records.HasField "dimB_payload" (Ptr.Ptr DimB) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "dimB_payload" (Ptr.Ptr DimB) (Ptr.Ptr DimPayloadB) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimB_payload")
@@ -598,8 +582,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_xy "anonA_xy_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA_xy) "anonA_xy_x")
-         ) => GHC.Records.HasField "anonA_xy_x" (Ptr.Ptr AnonA_xy) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_xy_x" (Ptr.Ptr AnonA_xy) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy_x")
@@ -610,8 +593,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_xy "anonA_xy_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA_xy) "anonA_xy_y")
-         ) => GHC.Records.HasField "anonA_xy_y" (Ptr.Ptr AnonA_xy) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_xy_y" (Ptr.Ptr AnonA_xy) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy_y")
@@ -674,8 +656,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_polar "anonA_polar_r" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA_polar) "anonA_polar_r")
-         ) => GHC.Records.HasField "anonA_polar_r" (Ptr.Ptr AnonA_polar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_polar_r" (Ptr.Ptr AnonA_polar) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar_r")
@@ -687,8 +668,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_polar "anonA_polar_p" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA_polar) "anonA_polar_p")
-         ) => GHC.Records.HasField "anonA_polar_p" (Ptr.Ptr AnonA_polar) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_polar_p" (Ptr.Ptr AnonA_polar) (Ptr.Ptr FC.CDouble) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar_p")
@@ -772,8 +752,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA "anonA_xy" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA) "anonA_xy")
-         ) => GHC.Records.HasField "anonA_xy" (Ptr.Ptr AnonA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_xy" (Ptr.Ptr AnonA) (Ptr.Ptr AnonA_xy) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy")
@@ -784,8 +763,7 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA "anonA_polar" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType AnonA) "anonA_polar")
-         ) => GHC.Records.HasField "anonA_polar" (Ptr.Ptr AnonA) (Ptr.Ptr ty) where
+instance GHC.Records.HasField "anonA_polar" (Ptr.Ptr AnonA) (Ptr.Ptr AnonA_polar) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar")

--- a/hs-bindgen/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/unions/th.txt
@@ -41,14 +41,12 @@ deriving via (EquivStorable Dim2) instance Storable Dim2
 instance HasCField Dim2 "dim2_x"
     where type CFieldType Dim2 "dim2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Dim2 "dim2_x") =>
-         HasField "dim2_x" (Ptr Dim2) (Ptr ty)
+instance HasField "dim2_x" (Ptr Dim2) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim2_x")
 instance HasCField Dim2 "dim2_y"
     where type CFieldType Dim2 "dim2_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Dim2 "dim2_y") =>
-         HasField "dim2_y" (Ptr Dim2) (Ptr ty)
+instance HasField "dim2_y" (Ptr Dim2) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim2_y")
 {-| __C declaration:__ @struct Dim3@
 
@@ -100,20 +98,17 @@ deriving via (EquivStorable Dim3) instance Storable Dim3
 instance HasCField Dim3 "dim3_x"
     where type CFieldType Dim3 "dim3_x" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Dim3 "dim3_x") =>
-         HasField "dim3_x" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_x" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_x")
 instance HasCField Dim3 "dim3_y"
     where type CFieldType Dim3 "dim3_y" = CInt
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Dim3 "dim3_y") =>
-         HasField "dim3_y" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_y" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_y")
 instance HasCField Dim3 "dim3_z"
     where type CFieldType Dim3 "dim3_z" = CInt
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType Dim3 "dim3_z") =>
-         HasField "dim3_z" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_z" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_z")
 {-| __C declaration:__ @union DimPayload@
 
@@ -205,14 +200,12 @@ set_dimPayload_dim3 = setUnionPayload
 instance HasCField DimPayload "dimPayload_dim2"
     where type CFieldType DimPayload "dimPayload_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType DimPayload "dimPayload_dim2") =>
-         HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr ty)
+instance HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayload_dim2")
 instance HasCField DimPayload "dimPayload_dim3"
     where type CFieldType DimPayload "dimPayload_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType DimPayload "dimPayload_dim3") =>
-         HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr ty)
+instance HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayload_dim3")
 {-| __C declaration:__ @struct Dim@
 
@@ -255,14 +248,12 @@ deriving via (EquivStorable Dim) instance Storable Dim
 instance HasCField Dim "dim_tag"
     where type CFieldType Dim "dim_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType Dim "dim_tag") =>
-         HasField "dim_tag" (Ptr Dim) (Ptr ty)
+instance HasField "dim_tag" (Ptr Dim) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim_tag")
 instance HasCField Dim "dim_payload"
     where type CFieldType Dim "dim_payload" = DimPayload
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType Dim "dim_payload") =>
-         HasField "dim_payload" (Ptr Dim) (Ptr ty)
+instance HasField "dim_payload" (Ptr Dim) (Ptr DimPayload)
     where getField = fromPtr (Proxy @"dim_payload")
 {-| __C declaration:__ @union DimPayloadB@
 
@@ -354,14 +345,12 @@ set_dimPayloadB_dim3 = setUnionPayload
 instance HasCField DimPayloadB "dimPayloadB_dim2"
     where type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType DimPayloadB "dimPayloadB_dim2") =>
-         HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr ty)
+instance HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayloadB_dim2")
 instance HasCField DimPayloadB "dimPayloadB_dim3"
     where type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType DimPayloadB "dimPayloadB_dim3") =>
-         HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr ty)
+instance HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayloadB_dim3")
 {-| __C declaration:__ @struct DimB@
 
@@ -404,14 +393,12 @@ deriving via (EquivStorable DimB) instance Storable DimB
 instance HasCField DimB "dimB_tag"
     where type CFieldType DimB "dimB_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType DimB "dimB_tag") =>
-         HasField "dimB_tag" (Ptr DimB) (Ptr ty)
+instance HasField "dimB_tag" (Ptr DimB) (Ptr CInt)
     where getField = fromPtr (Proxy @"dimB_tag")
 instance HasCField DimB "dimB_payload"
     where type CFieldType DimB "dimB_payload" = DimPayloadB
           offset# = \_ -> \_ -> 4
-instance TyEq ty (CFieldType DimB "dimB_payload") =>
-         HasField "dimB_payload" (Ptr DimB) (Ptr ty)
+instance HasField "dimB_payload" (Ptr DimB) (Ptr DimPayloadB)
     where getField = fromPtr (Proxy @"dimB_payload")
 {-| __C declaration:__ @struct \@AnonA_xy@
 
@@ -455,14 +442,12 @@ deriving via (EquivStorable AnonA_xy) instance Storable AnonA_xy
 instance HasCField AnonA_xy "anonA_xy_x"
     where type CFieldType AnonA_xy "anonA_xy_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType AnonA_xy "anonA_xy_x") =>
-         HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr ty)
+instance HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_xy_x")
 instance HasCField AnonA_xy "anonA_xy_y"
     where type CFieldType AnonA_xy "anonA_xy_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType AnonA_xy "anonA_xy_y") =>
-         HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr ty)
+instance HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_xy_y")
 {-| __C declaration:__ @struct \@AnonA_polar@
 
@@ -506,14 +491,12 @@ deriving via (EquivStorable AnonA_polar) instance Storable AnonA_polar
 instance HasCField AnonA_polar "anonA_polar_r"
     where type CFieldType AnonA_polar "anonA_polar_r" = CDouble
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType AnonA_polar "anonA_polar_r") =>
-         HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr ty)
+instance HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_polar_r")
 instance HasCField AnonA_polar "anonA_polar_p"
     where type CFieldType AnonA_polar "anonA_polar_p" = CDouble
           offset# = \_ -> \_ -> 8
-instance TyEq ty (CFieldType AnonA_polar "anonA_polar_p") =>
-         HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr ty)
+instance HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_polar_p")
 {-| __C declaration:__ @union AnonA@
 
@@ -605,12 +588,10 @@ set_anonA_polar = setUnionPayload
 instance HasCField AnonA "anonA_xy"
     where type CFieldType AnonA "anonA_xy" = AnonA_xy
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType AnonA "anonA_xy") =>
-         HasField "anonA_xy" (Ptr AnonA) (Ptr ty)
+instance HasField "anonA_xy" (Ptr AnonA) (Ptr AnonA_xy)
     where getField = fromPtr (Proxy @"anonA_xy")
 instance HasCField AnonA "anonA_polar"
     where type CFieldType AnonA "anonA_polar" = AnonA_polar
           offset# = \_ -> \_ -> 0
-instance TyEq ty (CFieldType AnonA "anonA_polar") =>
-         HasField "anonA_polar" (Ptr AnonA) (Ptr ty)
+instance HasField "anonA_polar" (Ptr AnonA) (Ptr AnonA_polar)
     where getField = fromPtr (Proxy @"anonA_polar")


### PR DESCRIPTION
Resolves #1667 

Where we were previously generating instance headers like:

```hs
instance ( TyEq ty ((HsBindgen.Runtime.HasCField.CFieldType Triplet) "unwrapTriplet")
         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
```

Which uses the following `HasCField` instance:

```hs
instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
  type CFieldType Triplet "unwrapTriplet" =
    (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
```

We now generate instance headers where `CFieldType` (or `CBitfieldType`) are expanded:

```hs
instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
```
