### PR TITLE
Reflect `Generic` in generated binding specs

### DIFF
--- a/hs-bindgen/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example.hs
@@ -34,8 +34,7 @@ import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -64,8 +63,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype List = List
   { unwrapList :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
@@ -88,8 +86,7 @@ instance HsBindgen.Runtime.HasCField.HasCField List "unwrapList" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -118,8 +115,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Matrix "unwrapMatrix" where
 newtype Tripletlist = Tripletlist
   { unwrapTripletlist :: HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapTripletlist" (Ptr.Ptr Tripletlist) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 
@@ -155,8 +151,7 @@ data Example = Example
          __exported by:__ @arrays\/array.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example where
 
@@ -219,8 +214,7 @@ __exported by:__ @arrays\/array.h@
 newtype Sudoku = Sudoku
   { unwrapSudoku :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/arrays/array/bindingspec.yaml
+++ b/hs-bindgen/fixtures/arrays/array/bindingspec.yaml
@@ -31,6 +31,7 @@ hstypes:
       - example_sudoku
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -46,6 +47,7 @@ hstypes:
       - unwrapList
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -57,6 +59,7 @@ hstypes:
       - unwrapMatrix
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -72,6 +75,7 @@ hstypes:
       - unwrapSudoku
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -87,6 +91,7 @@ hstypes:
       - unwrapTriplet
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -102,6 +107,7 @@ hstypes:
       - unwrapTripletlist
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show

--- a/hs-bindgen/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/fixtures/arrays/array/th.txt
@@ -665,8 +665,7 @@ newtype Triplet
 
            __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTriplet"
                   (Ptr Triplet)
@@ -690,8 +689,7 @@ newtype List
 
            __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapList"
                   (Ptr List)
                   (Ptr (IncompleteArray CInt))
@@ -713,8 +711,7 @@ newtype Matrix
 
            __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapMatrix"
                   (Ptr Matrix)
@@ -739,8 +736,7 @@ newtype Tripletlist
 
            __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapTripletlist"
                   (Ptr Tripletlist)
                   (Ptr (IncompleteArray (ConstantArray 3 CInt)))
@@ -776,8 +772,7 @@ data Example
 
            __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Example
     where staticSizeOf = \_ -> 48 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -822,8 +817,7 @@ newtype Sudoku
 
       __exported by:__ @arrays\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapSudoku"
                   (Ptr Sudoku)

--- a/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
@@ -32,8 +32,7 @@ import Prelude (Eq, Show)
 newtype S = S
   { unwrapS :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
@@ -56,8 +55,7 @@ instance HsBindgen.Runtime.HasCField.HasCField S "unwrapS" where
 newtype T = T
   { unwrapT :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
@@ -80,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "unwrapT" where
 newtype U = U
   { unwrapU :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -110,8 +107,7 @@ instance HsBindgen.Runtime.HasCField.HasCField U "unwrapU" where
 newtype V = V
   { unwrapV :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -140,8 +136,7 @@ instance HsBindgen.Runtime.HasCField.HasCField V "unwrapV" where
 newtype W = W
   { unwrapW :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -170,8 +165,7 @@ instance HsBindgen.Runtime.HasCField.HasCField W "unwrapW" where
 newtype X = X
   { unwrapX :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/arrays/const_qualifier/bindingspec.yaml
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/bindingspec.yaml
@@ -30,6 +30,7 @@ hstypes:
       - unwrapS
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -41,6 +42,7 @@ hstypes:
       - unwrapT
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -52,6 +54,7 @@ hstypes:
       - unwrapU
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -67,6 +70,7 @@ hstypes:
       - unwrapV
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -82,6 +86,7 @@ hstypes:
       - unwrapW
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -97,6 +102,7 @@ hstypes:
       - unwrapX
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
@@ -254,8 +254,7 @@ newtype S
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapS" (Ptr S) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
@@ -275,8 +274,7 @@ newtype T
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapT" (Ptr T) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
@@ -296,8 +294,7 @@ newtype U
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapU" (Ptr U) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapU")
@@ -318,8 +315,7 @@ newtype V
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapV" (Ptr V) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapV")
@@ -340,8 +336,7 @@ newtype W
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapW" (Ptr W) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapW")
@@ -362,8 +357,7 @@ newtype X
 
            __exported by:__ @arrays\/const_qualifier.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapX" (Ptr X) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapX")

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
@@ -32,8 +32,7 @@ import Prelude (Eq, Show)
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -62,8 +61,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Matrix "unwrapMatrix" where
 newtype Triplets = Triplets
   { unwrapTriplets :: HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapTriplets" (Ptr.Ptr Triplets) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
 

--- a/hs-bindgen/fixtures/arrays/multi_dim/bindingspec.yaml
+++ b/hs-bindgen/fixtures/arrays/multi_dim/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - unwrapMatrix
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - unwrapTriplets
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show

--- a/hs-bindgen/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/fixtures/arrays/multi_dim/th.txt
@@ -174,8 +174,7 @@ newtype Matrix
 
            __exported by:__ @arrays\/multi_dim.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapMatrix"
                   (Ptr Matrix)
@@ -200,8 +199,7 @@ newtype Triplets
 
            __exported by:__ @arrays\/multi_dim.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapTriplets"
                   (Ptr Triplets)
                   (Ptr (IncompleteArray (ConstantArray 3 CInt)))

--- a/hs-bindgen/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/attributes/Example.hs
@@ -45,8 +45,7 @@ data Foo = Foo
          __exported by:__ @attributes\/attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
 
@@ -118,8 +117,7 @@ data Bar = Bar
          __exported by:__ @attributes\/attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
 
@@ -191,8 +189,7 @@ data Baz = Baz
          __exported by:__ @attributes\/attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Baz where
 
@@ -264,8 +261,7 @@ data Qux = Qux
          __exported by:__ @attributes\/attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Qux where
 
@@ -344,8 +340,7 @@ data FILE = FILE
          __exported by:__ @attributes\/attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FILE where
 

--- a/hs-bindgen/fixtures/attributes/attributes/bindingspec.yaml
+++ b/hs-bindgen/fixtures/attributes/attributes/bindingspec.yaml
@@ -37,6 +37,7 @@ hstypes:
       - bar_i
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -53,6 +54,7 @@ hstypes:
       - baz_i
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -70,6 +72,7 @@ hstypes:
       - fILE__close
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -86,6 +89,7 @@ hstypes:
       - foo_i
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -102,6 +106,7 @@ hstypes:
       - qux_i
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/attributes/th.txt
@@ -26,8 +26,7 @@ data Foo
 
            __exported by:__ @attributes\/attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 5 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -75,8 +74,7 @@ data Bar
 
            __exported by:__ @attributes\/attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 5 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -124,8 +122,7 @@ data Baz
 
            __exported by:__ @attributes\/attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Baz
     where staticSizeOf = \_ -> 5 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -173,8 +170,7 @@ data Qux
 
            __exported by:__ @attributes\/attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Qux
     where staticSizeOf = \_ -> 5 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -229,8 +225,7 @@ data FILE
 
            __exported by:__ @attributes\/attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize FILE
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
@@ -50,8 +50,7 @@ data S = S
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
 
@@ -98,8 +97,7 @@ instance GHC.Records.HasField "s_f" (Ptr.Ptr S) (Ptr.Ptr ((HsBindgen.Runtime.Con
 newtype More_aligned_int = More_aligned_int
   { unwrapMore_aligned_int :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -145,8 +143,7 @@ data S2 = S2
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where
 
@@ -206,8 +203,7 @@ data My_unpacked_struct = My_unpacked_struct
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize My_unpacked_struct where
 
@@ -288,8 +284,7 @@ data My_packed_struct = My_packed_struct
          __exported by:__ @attributes\/type_attributes.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize My_packed_struct where
 
@@ -469,8 +464,7 @@ data Wait
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -509,8 +503,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype Short_a = Short_a
   { unwrapShort_a :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/attributes/type_attributes/bindingspec.yaml
+++ b/hs-bindgen/fixtures/attributes/type_attributes/bindingspec.yaml
@@ -47,6 +47,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -72,6 +73,7 @@ hstypes:
       - my_packed_struct_s
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -88,6 +90,7 @@ hstypes:
       - my_unpacked_struct_i
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -103,6 +106,7 @@ hstypes:
       - s_f
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -118,6 +122,7 @@ hstypes:
       - s2_f
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -138,6 +143,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -166,6 +172,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -190,6 +197,7 @@ hstypes:
       fields:
       - unwrapWait_status_ptr_t
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/type_attributes/th.txt
@@ -19,8 +19,7 @@ data S
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -49,8 +48,7 @@ newtype More_aligned_int
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -94,8 +92,7 @@ data S2
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 16 :: Int
@@ -137,8 +134,7 @@ data My_unpacked_struct
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize My_unpacked_struct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -199,8 +195,7 @@ data My_packed_struct
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize My_packed_struct
     where staticSizeOf = \_ -> 13 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -361,8 +356,7 @@ newtype T1
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -397,8 +391,7 @@ newtype Short_a
 
            __exported by:__ @attributes\/type_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -28,8 +28,7 @@ import Prelude (Eq, Show)
 newtype MyArray = MyArray
   { unwrapMyArray :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
@@ -52,8 +51,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyArray "unwrapMyArray" where
 newtype A = A
   { unwrapA :: MyArray
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyArray) where
 
@@ -75,8 +73,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -32,6 +33,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -43,6 +45,7 @@ hstypes:
       - unwrapMyArray
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -74,8 +74,7 @@ newtype MyArray
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapMyArray"
                   (Ptr MyArray)
                   (Ptr (IncompleteArray CInt))
@@ -98,8 +97,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
@@ -119,8 +117,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -31,8 +31,7 @@ import Prelude (Eq, Show)
 newtype MyArray = MyArray
   { unwrapMyArray :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -61,8 +60,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyArray "unwrapMyArray" where
 newtype A = A
   { unwrapA :: MyArray
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -90,8 +88,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -51,6 +53,7 @@ hstypes:
       - unwrapMyArray
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -74,8 +74,7 @@ newtype MyArray
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapMyArray"
                   (Ptr MyArray)
@@ -99,8 +98,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
@@ -121,8 +119,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyEnum where
@@ -138,8 +137,7 @@ pattern X = MyEnum 0
 newtype A = A
   { unwrapA :: MyEnum
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -169,8 +167,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -40,6 +41,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -60,6 +62,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -74,8 +74,7 @@ newtype MyEnum
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum
     where staticSizeOf = \_ -> 4 :: Int
@@ -138,8 +137,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -165,8 +163,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       fields:
       - unwrapA
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -30,6 +31,7 @@ hstypes:
       fields:
       - unwrapB
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -41,6 +43,7 @@ hstypes:
       - unwrapMyFunction
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -93,8 +93,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyFunctionPointer_Aux "unwrapMyFu
 newtype MyFunctionPointer = MyFunctionPointer
   { unwrapMyFunctionPointer :: Ptr.FunPtr MyFunctionPointer_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -124,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyFunctionPointer "unwrapMyFuncti
 newtype A = A
   { unwrapA :: MyFunctionPointer
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -154,8 +152,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -38,6 +39,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -55,6 +57,7 @@ hstypes:
       - unwrapMyFunctionPointer
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -125,8 +125,7 @@ newtype MyFunctionPointer
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -154,8 +153,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -180,8 +178,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -38,8 +38,7 @@ data MyStruct = MyStruct
          __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where
 
@@ -85,8 +84,7 @@ instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) 
 newtype A = A
   { unwrapA :: MyStruct
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -114,8 +112,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -51,6 +53,7 @@ hstypes:
       - myStruct_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -80,8 +80,7 @@ data MyStruct
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -110,8 +109,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
@@ -132,8 +130,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       fields:
       - unwrapA
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       fields:
       - unwrapB
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -46,6 +48,7 @@ hstypes:
       fields:
       - unwrapMyUnion
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -29,8 +29,7 @@ import Prelude (Eq, Show)
 newtype A = A
   { unwrapA :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 
@@ -53,8 +52,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
 

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -32,6 +33,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -42,5 +44,6 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -134,8 +134,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapA" (Ptr A) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
@@ -155,8 +154,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -32,8 +32,7 @@ import Prelude (Eq, Show)
 newtype A = A
   { unwrapA :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -62,8 +61,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -50,5 +52,6 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -134,8 +134,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapA" (Ptr A) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapA")
@@ -156,8 +155,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -40,8 +40,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyEnum where
@@ -139,8 +138,7 @@ pattern X = MyEnum 0
 newtype A = A
   { unwrapA :: MyEnum
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -170,8 +168,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
@@ -24,6 +24,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -43,6 +44,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -61,6 +63,7 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -73,6 +76,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -134,8 +134,7 @@ newtype MyEnum
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum
     where staticSizeOf = \_ -> 4 :: Int
@@ -198,8 +197,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -225,8 +223,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/enum.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -32,6 +33,7 @@ hstypes:
       fields:
       - unwrapB
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -42,5 +44,6 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -94,8 +94,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_Aux "unwrapA_Aux" where
 newtype A = A
   { unwrapA :: Ptr.FunPtr A_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -124,8 +123,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -38,6 +39,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -54,6 +56,7 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -184,8 +184,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -210,8 +209,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -39,8 +39,7 @@ data MyStruct = MyStruct
          __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where
 
@@ -86,8 +85,7 @@ instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) 
 newtype A = A
   { unwrapA :: MyStruct
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -115,8 +113,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 newtype B = B
   { unwrapB :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/bindingspec.yaml
@@ -24,6 +24,7 @@ hstypes:
       - unwrapA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -39,6 +40,7 @@ hstypes:
       - unwrapB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -53,6 +55,7 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: MyStruct
@@ -63,6 +66,7 @@ hstypes:
       - myStruct_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -140,8 +140,7 @@ data MyStruct
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -170,8 +169,7 @@ newtype A
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
@@ -192,8 +190,7 @@ newtype B
 
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/bindingspec.yaml
@@ -23,6 +23,7 @@ hstypes:
       fields:
       - unwrapA
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       fields:
       - unwrapB
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -49,6 +51,7 @@ hstypes:
       fields:
       - unwrapE
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: MyUnion
@@ -58,6 +61,7 @@ hstypes:
       fields:
       - unwrapMyUnion
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
@@ -44,8 +44,7 @@ data Hoge = Hoge
          __exported by:__ @binding-specs\/name\/squash_both.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Hoge where
 

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - hoge_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
@@ -26,8 +26,7 @@ data Hoge
 
            __exported by:__ @binding-specs\/name\/squash_both.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Hoge
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -44,8 +44,7 @@ data Hoge = Hoge
          __exported by:__ @binding-specs\/name\/squash_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Hoge where
 

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - hoge_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
@@ -26,8 +26,7 @@ data Hoge
 
            __exported by:__ @binding-specs\/name\/squash_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Hoge
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -44,8 +44,7 @@ data Piyo = Piyo
          __exported by:__ @binding-specs\/name\/squash_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Piyo where
 

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - piyo_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -26,8 +26,7 @@ data Piyo
 
            __exported by:__ @binding-specs\/name\/squash_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Piyo
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype MySym = MySym
   { unwrapMySym :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/name/type/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/name/type/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/type/th.txt
@@ -13,8 +13,7 @@ newtype MySym
 
            __exported by:__ @binding-specs\/name\/type.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Sym = Sym
   { unwrapSym :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/omit_type/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/bindingspec.yaml
@@ -23,6 +23,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
@@ -13,8 +13,7 @@ newtype Sym
 
            __exported by:__ @binding-specs\/omit_type.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
@@ -45,8 +45,7 @@ data Bar = Bar
          __exported by:__ @binding-specs\/rep\/emptydata\/opaque.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
 

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - bar_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
@@ -26,8 +26,7 @@ data Bar
 
            __exported by:__ @binding-specs\/rep\/emptydata\/opaque.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
@@ -69,8 +69,7 @@ data Named = Named
          __exported by:__ @binding-specs\/rep\/emptydata\/struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Named where
 

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/bindingspec.yaml
@@ -30,6 +30,7 @@ hstypes:
       - named_f
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
@@ -48,8 +48,7 @@ data Named
 
            __exported by:__ @binding-specs\/rep\/emptydata\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Named
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype A = A
   { unwrapA :: HsBindgen.Runtime.LibC.CSize
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -36,8 +36,7 @@ newtype A
 
            __exported by:__ @declarations\/declarations_required_for_scoping.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example.hs
@@ -40,8 +40,7 @@ data X = X
          __exported by:__ @declarations\/definitions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize X where
 

--- a/hs-bindgen/fixtures/declarations/definitions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/definitions/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - x_n
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -32,6 +33,7 @@ hstypes:
       fields:
       - unwrapY
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/definitions/th.txt
@@ -46,8 +46,7 @@ data X
 
            __exported by:__ @declarations\/definitions.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize X
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
@@ -37,8 +37,7 @@ data S1_t = S1_t
          __exported by:__ @declarations\/forward_declaration.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1_t where
 
@@ -90,8 +89,7 @@ data S2 = S2
          __exported by:__ @declarations\/forward_declaration.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where
 

--- a/hs-bindgen/fixtures/declarations/forward_declaration/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - s1_t_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - s2_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
@@ -19,8 +19,7 @@ data S1_t
 
            __exported by:__ @declarations\/forward_declaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S1_t
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -55,8 +54,7 @@ data S2
 
            __exported by:__ @declarations\/forward_declaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
@@ -52,8 +52,7 @@ data Bar = Bar
          __exported by:__ @declarations\/opaque_declaration.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
 
@@ -111,8 +110,7 @@ instance GHC.Records.HasField "bar_ptrB" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Bar)) w
 -}
 data Baz = Baz
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Baz where
 

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/bindingspec.yaml
@@ -28,6 +28,7 @@ hstypes:
       - bar_ptrB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -42,6 +43,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
@@ -33,8 +33,7 @@ data Bar
 
            __exported by:__ @declarations\/opaque_declaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -69,8 +68,7 @@ data Baz
 
            __exported by:__ @declarations\/opaque_declaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Baz
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
@@ -42,8 +42,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype Int_t = Int_t
   { unwrapInt_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -88,8 +87,7 @@ data X = X
          __exported by:__ @declarations\/redeclaration.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize X where
 

--- a/hs-bindgen/fixtures/declarations/redeclaration/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/redeclaration/bindingspec.yaml
@@ -26,6 +26,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -49,6 +50,7 @@ hstypes:
       - x_n
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -63,6 +65,7 @@ hstypes:
       fields:
       - unwrapY
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/redeclaration/th.txt
@@ -20,8 +20,7 @@ newtype Int_t
 
            __exported by:__ @declarations\/redeclaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -62,8 +61,7 @@ data X
 
            __exported by:__ @declarations\/redeclaration.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize X
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype ParsedAndSelected1 = ParsedAndSelected1
   { unwrapParsedAndSelected1 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/declarations/select_scoping/bindingspec.yaml
+++ b/hs-bindgen/fixtures/declarations/select_scoping/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/select_scoping/th.txt
@@ -14,8 +14,7 @@ newtype ParsedAndSelected1
 
            __exported by:__ @declarations\/select_scoping.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
@@ -31,8 +31,7 @@ import Prelude (Eq, Show)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/bindingspec.yaml
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - unwrapTriplet
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
@@ -13,8 +13,7 @@ newtype Triplet
 
            __exported by:__ @documentation\/data_kind_pragma.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTriplet"
                   (Ptr Triplet)

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -73,8 +73,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Size_type = Size_type
   { unwrapSize_type :: HsBindgen.Runtime.LibC.CSize
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -144,8 +143,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Color_enum = Color_enum
   { unwrapColor_enum :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Color_enum where
@@ -339,8 +337,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Event_callback_t = Event_callback_t
   { unwrapEvent_callback_t :: Ptr.FunPtr Event_callback_t_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -432,8 +429,7 @@ data Config_t = Config_t
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Config_t where
 
@@ -547,8 +543,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Status_code_t = Status_code_t
   { unwrapStatus_code_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Status_code_t where
@@ -725,8 +720,7 @@ data Data_union_t_as_parts = Data_union_t_as_parts
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Data_union_t_as_parts where
 
@@ -1027,8 +1021,7 @@ data Bitfield_t = Bitfield_t
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bitfield_t where
 
@@ -1199,8 +1192,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Processor_fn_t = Processor_fn_t
   { unwrapProcessor_fn_t :: Ptr.FunPtr Processor_fn_t_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1236,8 +1228,7 @@ __exported by:__ @documentation\/doxygen_docs.h@
 newtype Filename_t = Filename_t
   { unwrapFilename_t :: (HsBindgen.Runtime.ConstantArray.ConstantArray 256) FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1284,8 +1275,7 @@ data Flexible_array_Aux = Flexible_array
     __exported by:__ @documentation\/doxygen_docs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Flexible_array_Aux where
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/bindingspec.yaml
@@ -69,6 +69,7 @@ hstypes:
       - bitfield_t_reserved
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -85,6 +86,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -109,6 +111,7 @@ hstypes:
       - config_t_user_data
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -123,6 +126,7 @@ hstypes:
       fields:
       - unwrapData_union_t
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -138,6 +142,7 @@ hstypes:
       - data_union_t_as_parts_high
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -153,6 +158,7 @@ hstypes:
       - unwrapEvent_callback_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -170,6 +176,7 @@ hstypes:
       - unwrapFilename_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -188,6 +195,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -207,6 +215,7 @@ hstypes:
       - unwrapProcessor_fn_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -229,6 +238,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -253,6 +263,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -384,8 +384,7 @@ newtype Size_type
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -457,8 +456,7 @@ newtype Color_enum
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Color_enum
     where staticSizeOf = \_ -> 4 :: Int
@@ -636,8 +634,7 @@ newtype Event_callback_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -733,8 +730,7 @@ data Config_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Config_t
     where staticSizeOf = \_ -> 88 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -813,8 +809,7 @@ newtype Status_code_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Status_code_t
     where staticSizeOf = \_ -> 4 :: Int
@@ -1008,8 +1003,7 @@ data Data_union_t_as_parts
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Data_union_t_as_parts
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 2 :: Int
@@ -1331,8 +1325,7 @@ data Bitfield_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bitfield_t
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -1466,8 +1459,7 @@ newtype Processor_fn_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -1507,8 +1499,7 @@ newtype Filename_t
 
       __exported by:__ @documentation\/doxygen_docs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapFilename_t"
                   (Ptr Filename_t)
@@ -1544,8 +1535,7 @@ data Flexible_array_Aux
 
                       __exported by:__ @documentation\/doxygen_docs.h@
                       -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Flexible_array_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Adio'0301s = Adio'0301s
   { unwrapAdio'0301s :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -78,8 +77,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Adio'0301s "unwrapAdio'0301s" whe
 newtype C数字 = C数字
   { unwrapC数字 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/adios/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/adios/bindingspec.yaml
@@ -23,6 +23,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -51,6 +52,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/adios/th.txt
@@ -82,8 +82,7 @@ newtype Adio'0301s
 
            __exported by:__ @edge-cases\/adios.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -118,8 +117,7 @@ newtype C数字
 
            __exported by:__ @edge-cases\/adios.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -44,8 +44,7 @@ data Some_struct_field1 = Some_struct_field1
          __exported by:__ @edge-cases\/anon_multiple_fields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct_field1 where
 
@@ -126,8 +125,7 @@ data Some_struct = Some_struct
          __exported by:__ @edge-cases\/anon_multiple_fields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct where
 

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       - some_struct_field3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - some_struct_field1_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -26,8 +26,7 @@ data Some_struct_field1
 
            __exported by:__ @edge-cases\/anon_multiple_fields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Some_struct_field1
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -88,8 +87,7 @@ data Some_struct
 
            __exported by:__ @edge-cases\/anon_multiple_fields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Some_struct
     where staticSizeOf = \_ -> 24 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -46,8 +46,7 @@ data Point1a = Point1a
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point1a where
 
@@ -106,8 +105,7 @@ instance GHC.Records.HasField "point1a_y" (Ptr.Ptr Point1a) (Ptr.Ptr FC.CInt) wh
 newtype Point1b = Point1b
   { unwrapPoint1b :: Point1a
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -148,8 +146,7 @@ data Point2a = Point2a
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point2a where
 
@@ -208,8 +205,7 @@ instance GHC.Records.HasField "point2a_y" (Ptr.Ptr Point2a) (Ptr.Ptr FC.CInt) wh
 newtype Point2b = Point2b
   { unwrapPoint2b :: Ptr.Ptr Point2a
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -252,8 +248,7 @@ data Point3a_Aux = Point3a_Aux
          __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point3a_Aux where
 
@@ -312,8 +307,7 @@ instance GHC.Records.HasField "point3a_Aux_y" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr FC.
 newtype Point3a = Point3a
   { unwrapPoint3a :: Ptr.Ptr Point3a_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -343,8 +337,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a "unwrapPoint3a" where
 newtype Point3b = Point3b
   { unwrapPoint3b :: Ptr.Ptr Point3a_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/bindingspec.yaml
@@ -40,6 +40,7 @@ hstypes:
       - point1a_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -55,6 +56,7 @@ hstypes:
       - unwrapPoint1b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -71,6 +73,7 @@ hstypes:
       - point2a_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -86,6 +89,7 @@ hstypes:
       - unwrapPoint2b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -103,6 +107,7 @@ hstypes:
       - unwrapPoint3a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -121,6 +126,7 @@ hstypes:
       - point3a_Aux_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -136,6 +142,7 @@ hstypes:
       - unwrapPoint3b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -50,8 +50,7 @@ data Point1a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Point1a
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -86,8 +85,7 @@ newtype Point1b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapPoint1b" (Ptr Point1b) (Ptr Point1a)
     where getField = fromPtr (Proxy @"unwrapPoint1b")
@@ -121,8 +119,7 @@ data Point2a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Point2a
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -157,8 +154,7 @@ newtype Point2b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -196,8 +192,7 @@ data Point3a_Aux
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Point3a_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -232,8 +227,7 @@ newtype Point3a
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -260,8 +254,7 @@ newtype Point3b
 
            __exported by:__ @edge-cases\/anon_multiple_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -64,8 +64,7 @@ data Another_typedef_struct_t = Another_typedef_struct_t
          __exported by:__ @edge-cases\/distilled_lib_1.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Another_typedef_struct_t where
 
@@ -128,8 +127,7 @@ instance GHC.Records.HasField "another_typedef_struct_t_bar" (Ptr.Ptr Another_ty
 newtype Another_typedef_enum_e = Another_typedef_enum_e
   { unwrapAnother_typedef_enum_e :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Another_typedef_enum_e where
@@ -266,8 +264,7 @@ sOME_DEFINED_CONSTANT = (4 :: FC.CInt)
 newtype A_type_t = A_type_t
   { unwrapA_type_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -306,8 +303,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A_type_t "unwrapA_type_t" where
 newtype Var_t = Var_t
   { unwrapVar_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -422,8 +418,7 @@ data A_typedef_struct_t = A_typedef_struct_t
          __exported by:__ @edge-cases\/distilled_lib_1.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A_typedef_struct_t where
 
@@ -657,8 +652,7 @@ tWO_ARGS = (,) (13398 :: FC.CInt) (30874 :: FC.CInt)
 newtype A_typedef_enum_e = A_typedef_enum_e
   { unwrapA_typedef_enum_e :: FC.CUChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A_typedef_enum_e where
@@ -846,8 +840,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Callback_t_Aux "unwrapCallback_t_
 newtype Callback_t = Callback_t
   { unwrapCallback_t :: Ptr.FunPtr Callback_t_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
@@ -50,6 +50,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -74,6 +75,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -104,6 +106,7 @@ hstypes:
       - a_typedef_struct_t_field_10
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -120,6 +123,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -141,6 +145,7 @@ hstypes:
       - another_typedef_struct_t_bar
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -156,6 +161,7 @@ hstypes:
       - unwrapCallback_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -178,6 +184,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -63,8 +63,7 @@ data Another_typedef_struct_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Another_typedef_struct_t
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -107,8 +106,7 @@ newtype Another_typedef_enum_e
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Another_typedef_enum_e
     where staticSizeOf = \_ -> 4 :: Int
@@ -233,8 +231,7 @@ newtype A_type_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -269,8 +266,7 @@ newtype Var_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -385,8 +381,7 @@ data A_typedef_struct_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize A_typedef_struct_t
     where staticSizeOf = \_ -> 140 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -568,8 +563,7 @@ newtype A_typedef_enum_e
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize A_typedef_enum_e
     where staticSizeOf = \_ -> 1 :: Int
@@ -736,8 +730,7 @@ newtype Callback_t
 
            __exported by:__ @edge-cases\/distilled_lib_1.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype Test = Test
   { unwrapTest :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Test where

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
@@ -16,6 +16,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -20,8 +20,7 @@ newtype Test
 
            __exported by:__ @edge-cases\/enum_as_array_size.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Test
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -39,8 +39,7 @@ data Pascal_Aux = Pascal
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Pascal_Aux where
 
@@ -112,8 +111,7 @@ data Foo_bar = Foo_bar
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo_bar where
 
@@ -178,8 +176,7 @@ data Foo_Aux = Foo
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo_Aux where
 
@@ -251,8 +248,7 @@ data Diff_Aux = Diff
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Diff_Aux where
 
@@ -332,8 +328,7 @@ data Triplets_Aux = Triplets
          __exported by:__ @edge-cases\/flam.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Triplets_Aux where
 

--- a/hs-bindgen/fixtures/edge-cases/flam/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/flam/bindingspec.yaml
@@ -43,6 +43,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -61,6 +62,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -77,6 +79,7 @@ hstypes:
       - foo_bar_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -95,6 +98,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -113,6 +117,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam/th.txt
@@ -13,8 +13,7 @@ data Pascal_Aux
 
                    __exported by:__ @edge-cases\/flam.h@
               -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Pascal_Aux
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -59,8 +58,7 @@ data Foo_bar
 
            __exported by:__ @edge-cases\/flam.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo_bar
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -95,8 +93,7 @@ data Foo_Aux
 
                 __exported by:__ @edge-cases\/flam.h@
            -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo_Aux
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -135,8 +132,7 @@ data Diff_Aux
 
                  __exported by:__ @edge-cases\/flam.h@
             -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Diff_Aux
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -176,8 +172,7 @@ data Triplets_Aux
 
                      __exported by:__ @edge-cases\/flam.h@
                 -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Triplets_Aux
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
@@ -38,8 +38,7 @@ data Vector_Aux = Vector
          __exported by:__ @edge-cases\/flam_functions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector_Aux where
 

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
@@ -74,8 +74,7 @@ data Vector_Aux
 
                    __exported by:__ @edge-cases\/flam_functions.h@
               -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Vector_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/iterator/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/iterator/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       fields:
       - unwrapCounter
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -30,6 +31,7 @@ hstypes:
       fields:
       - unwrapToggle
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -40,6 +42,7 @@ hstypes:
       fields:
       - unwrapVarCounter
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
@@ -43,8 +43,7 @@ __exported by:__ @edge-cases\/spec_examples.h@
 newtype Int16_T = Int16_T
   { unwrapInt16_T :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -83,8 +82,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Int16_T "unwrapInt16_T" where
 newtype Int32_T = Int32_T
   { unwrapInt32_T :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -123,8 +121,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Int32_T "unwrapInt32_T" where
 newtype Int64_T = Int64_T
   { unwrapInt64_T :: FC.CLLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -176,8 +173,7 @@ data Cint16_T = Cint16_T
          __exported by:__ @edge-cases\/spec_examples.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Cint16_T where
 
@@ -235,8 +231,7 @@ instance GHC.Records.HasField "cint16_T_im" (Ptr.Ptr Cint16_T) (Ptr.Ptr Int16_T)
 -}
 data B = B
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B where
 
@@ -301,8 +296,7 @@ data A = A
          __exported by:__ @edge-cases\/spec_examples.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where
 

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/bindingspec.yaml
@@ -40,6 +40,7 @@ hstypes:
       - a_c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -54,6 +55,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -70,6 +72,7 @@ hstypes:
       - cint16_T_im
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -90,6 +93,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -118,6 +122,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -146,6 +151,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
@@ -50,8 +50,7 @@ newtype Int16_T
 
       __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -86,8 +85,7 @@ newtype Int32_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -122,8 +120,7 @@ newtype Int64_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -171,8 +168,7 @@ data Cint16_T
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Cint16_T
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 2 :: Int
@@ -207,8 +203,7 @@ data B
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize B
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -266,8 +261,7 @@ data A
 
            __exported by:__ @edge-cases\/spec_examples.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 152 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -41,8 +41,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -81,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyInt "unwrapMyInt" where
 newtype MyUInt = MyUInt
   { unwrapMyUInt :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -121,8 +119,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUInt "unwrapMyUInt" where
 newtype MyLong = MyLong
   { unwrapMyLong :: FC.CLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -181,8 +178,7 @@ data MyStruct = MyStruct
          __exported by:__ @edge-cases\/typedef_bitfield.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyStruct where
 

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/bindingspec.yaml
@@ -29,6 +29,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -57,6 +58,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -82,6 +84,7 @@ hstypes:
       - myStruct_z
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -102,6 +105,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -13,8 +13,7 @@ newtype MyInt
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -49,8 +48,7 @@ newtype MyUInt
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -85,8 +83,7 @@ newtype MyLong
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -141,8 +138,7 @@ data MyStruct
 
            __exported by:__ @edge-cases\/typedef_bitfield.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize MyStruct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype MyEnum = MyEnum
   { unwrapMyEnum :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MyEnum where

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/bindingspec.yaml
@@ -16,6 +16,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
@@ -13,8 +13,7 @@ newtype MyEnum
 
            __exported by:__ @edge-cases\/uses_utf8.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize MyEnum
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -110,8 +110,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOpenedNotification_Aux "unwra
 newtype FileOpenedNotification = FileOpenedNotification
   { unwrapFileOpenedNotification :: Ptr.FunPtr FileOpenedNotification_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -199,8 +198,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ProgressUpdate_Aux "unwrapProgres
 newtype ProgressUpdate = ProgressUpdate
   { unwrapProgressUpdate :: Ptr.FunPtr ProgressUpdate_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -288,8 +286,7 @@ instance HsBindgen.Runtime.HasCField.HasCField DataValidator_Aux "unwrapDataVali
 newtype DataValidator = DataValidator
   { unwrapDataValidator :: Ptr.FunPtr DataValidator_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -332,8 +329,7 @@ data Measurement = Measurement
          __exported by:__ @functions\/callbacks.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Measurement where
 
@@ -452,8 +448,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived_Aux "unwrapMe
 newtype MeasurementReceived = MeasurementReceived
   { unwrapMeasurementReceived :: Ptr.FunPtr MeasurementReceived_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -508,8 +503,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementReceived2_Aux "unwrapM
 newtype MeasurementReceived2 = MeasurementReceived2
   { unwrapMeasurementReceived2 :: Ptr.FunPtr MeasurementReceived2_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -564,8 +558,7 @@ instance HsBindgen.Runtime.HasCField.HasCField SampleBufferFull_Aux "unwrapSampl
 newtype SampleBufferFull = SampleBufferFull
   { unwrapSampleBufferFull :: Ptr.FunPtr SampleBufferFull_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -615,8 +608,7 @@ data MeasurementHandler = MeasurementHandler
          __exported by:__ @functions\/callbacks.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize MeasurementHandler where
 
@@ -714,8 +706,7 @@ data DataPipeline = DataPipeline
          __exported by:__ @functions\/callbacks.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize DataPipeline where
 
@@ -929,8 +920,7 @@ instance GHC.Records.HasField "processorCallback_withProgress" (Ptr.Ptr Processo
 newtype Processor_mode = Processor_mode
   { unwrapProcessor_mode :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Processor_mode where
@@ -1124,8 +1114,7 @@ instance GHC.Records.HasField "processor_callback" (Ptr.Ptr Processor) (Ptr.Ptr 
 newtype Foo = Foo
   { unwrapFoo :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1164,8 +1153,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "unwrapFoo" where
 newtype Foo2 = Foo2
   { unwrapFoo2 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/functions/callbacks/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/callbacks/bindingspec.yaml
@@ -56,6 +56,7 @@ hstypes:
       - dataPipeline_postProcess
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -71,6 +72,7 @@ hstypes:
       - unwrapDataValidator
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -88,6 +90,7 @@ hstypes:
       - unwrapFileOpenedNotification
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -110,6 +113,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -138,6 +142,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -162,6 +167,7 @@ hstypes:
       - measurement_timestamp
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -179,6 +185,7 @@ hstypes:
       - measurementHandler_onError
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -194,6 +201,7 @@ hstypes:
       - unwrapMeasurementReceived
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -211,6 +219,7 @@ hstypes:
       - unwrapMeasurementReceived2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -228,6 +237,7 @@ hstypes:
       - processor_mode
       - processor_callback
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -241,6 +251,7 @@ hstypes:
       fields:
       - unwrapProcessorCallback
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -256,6 +267,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -276,6 +288,7 @@ hstypes:
       - unwrapProgressUpdate
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -293,6 +306,7 @@ hstypes:
       - unwrapSampleBufferFull
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -485,8 +485,7 @@ newtype FileOpenedNotification
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -565,8 +564,7 @@ newtype ProgressUpdate
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -643,8 +641,7 @@ newtype DataValidator
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -685,8 +682,7 @@ data Measurement
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Measurement
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -776,8 +772,7 @@ newtype MeasurementReceived
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -834,8 +829,7 @@ newtype MeasurementReceived2
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -894,8 +888,7 @@ newtype SampleBufferFull
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -945,8 +938,7 @@ data MeasurementHandler
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize MeasurementHandler
     where staticSizeOf = \_ -> 24 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -1020,8 +1012,7 @@ data DataPipeline
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize DataPipeline
     where staticSizeOf = \_ -> 24 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -1234,8 +1225,7 @@ newtype Processor_mode
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Processor_mode
     where staticSizeOf = \_ -> 4 :: Int
@@ -1384,8 +1374,7 @@ newtype Foo
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -1420,8 +1409,7 @@ newtype Foo2
 
            __exported by:__ @functions\/callbacks.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
@@ -94,8 +94,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux" w
 newtype Fun_ptr = Fun_ptr
   { unwrapFun_ptr :: Ptr.FunPtr Fun_ptr_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -131,8 +130,7 @@ data Forward_declaration = Forward_declaration
          __exported by:__ @functions\/circular_dependency_fun.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Forward_declaration where
 

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - forward_declaration_f
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - unwrapFun_ptr
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
@@ -62,8 +62,7 @@ newtype Fun_ptr
 
            __exported by:__ @functions\/circular_dependency_fun.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -96,8 +95,7 @@ data Forward_declaration
 
            __exported by:__ @functions\/circular_dependency_fun.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Forward_declaration
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
@@ -56,8 +56,7 @@ data Outside = Outside
          __exported by:__ @functions\/decls_in_signature.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Outside where
 
@@ -133,8 +132,7 @@ data Named_struct = Named_struct
          __exported by:__ @functions\/decls_in_signature.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Named_struct where
 

--- a/hs-bindgen/fixtures/functions/decls_in_signature/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/bindingspec.yaml
@@ -25,6 +25,7 @@ hstypes:
       - named_struct_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -39,6 +40,7 @@ hstypes:
       fields:
       - unwrapNamed_union
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -56,6 +58,7 @@ hstypes:
       - outside_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
@@ -100,8 +100,7 @@ data Outside
 
            __exported by:__ @functions\/decls_in_signature.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Outside
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -157,8 +156,7 @@ data Named_struct
 
       __exported by:__ @functions\/decls_in_signature.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Named_struct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
@@ -42,8 +42,7 @@ __exported by:__ @functions\/fun_attributes.h@
 -}
 data FILE = FILE
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FILE where
 
@@ -74,8 +73,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable FILE instance F.Storable FI
 newtype Size_t = Size_t
   { unwrapSize_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/functions/fun_attributes/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/fun_attributes/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -38,6 +39,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes/th.txt
@@ -451,8 +451,7 @@ data FILE
 
       __exported by:__ @functions\/fun_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize FILE
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -476,8 +475,7 @@ newtype Size_t
 
            __exported by:__ @functions\/fun_attributes.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
@@ -37,8 +37,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where
 

--- a/hs-bindgen/fixtures/functions/heap_types/struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - t_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
@@ -42,8 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
@@ -37,8 +37,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct_const.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where
 

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - t_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
@@ -42,8 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct_const.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -37,8 +37,7 @@ data T = T
          __exported by:__ @functions\/heap_types\/struct_const_member.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize T where
 

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - t_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -42,8 +42,7 @@ data T
 
            __exported by:__ @functions\/heap_types\/struct_const_member.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -38,8 +38,7 @@ data S = S
          __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
 
@@ -85,8 +84,7 @@ instance GHC.Records.HasField "s_x" (Ptr.Ptr S) (Ptr.Ptr FC.CInt) where
 newtype T = T
   { unwrapT :: S
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - s_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - unwrapT
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -42,8 +42,7 @@ data S
 
            __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -72,8 +71,7 @@ newtype T
 
            __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapT" (Ptr T) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapT")

--- a/hs-bindgen/fixtures/functions/heap_types/union/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/union/bindingspec.yaml
@@ -17,6 +17,7 @@ hstypes:
       fields:
       - unwrapT
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/bindingspec.yaml
@@ -17,6 +17,7 @@ hstypes:
       fields:
       - unwrapT
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/bindingspec.yaml
@@ -17,6 +17,7 @@ hstypes:
       fields:
       - unwrapT
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
@@ -17,6 +17,7 @@ hstypes:
       fields:
       - unwrapT
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -30,6 +31,7 @@ hstypes:
       fields:
       - unwrapU
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -45,8 +45,7 @@ data Config = Config
          __exported by:__ @globals\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Config where
 
@@ -118,8 +117,7 @@ data Inline_struct = Inline_struct
          __exported by:__ @globals\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Inline_struct where
 
@@ -200,8 +198,7 @@ data Version_t = Version_t
          __exported by:__ @globals\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Version_t where
 
@@ -296,8 +293,7 @@ data Struct1_t = Struct1_t
          __exported by:__ @globals\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1_t where
 
@@ -377,8 +373,7 @@ data Struct2_t = Struct2_t
          __exported by:__ @globals\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_t where
 

--- a/hs-bindgen/fixtures/globals/globals/bindingspec.yaml
+++ b/hs-bindgen/fixtures/globals/globals/bindingspec.yaml
@@ -37,6 +37,7 @@ hstypes:
       - config_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -53,6 +54,7 @@ hstypes:
       - inline_struct_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -70,6 +72,7 @@ hstypes:
       - struct1_t_version
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -85,6 +88,7 @@ hstypes:
       - struct2_t_field1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -102,6 +106,7 @@ hstypes:
       - version_t_patch
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -145,8 +145,7 @@ data Config
 
            __exported by:__ @globals\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Config
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -194,8 +193,7 @@ data Inline_struct
 
            __exported by:__ @globals\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Inline_struct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -250,8 +248,7 @@ data Version_t
 
            __exported by:__ @globals\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Version_t
     where staticSizeOf = \_ -> 6 :: Int
           staticAlignment = \_ -> 2 :: Int
@@ -321,8 +318,7 @@ data Struct1_t
 
            __exported by:__ @globals\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct1_t
     where staticSizeOf = \_ -> 10 :: Int
           staticAlignment = \_ -> 2 :: Int
@@ -374,8 +370,7 @@ data Struct2_t
 
            __exported by:__ @globals\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct2_t
     where staticSizeOf = \_ -> 10 :: Int
           staticAlignment = \_ -> 2 :: Int

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
@@ -41,8 +41,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord,
 newtype I = I
   { unwrapI :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -81,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField I "unwrapI" where
 newtype C = C
   { unwrapC :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -121,8 +119,7 @@ instance HsBindgen.Runtime.HasCField.HasCField C "unwrapC" where
 newtype F = F
   { unwrapF :: FC.CFloat
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -159,8 +156,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F "unwrapF" where
 newtype L = L
   { unwrapL :: FC.CLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -199,8 +195,7 @@ instance HsBindgen.Runtime.HasCField.HasCField L "unwrapL" where
 newtype S = S
   { unwrapS :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/bindingspec.yaml
@@ -32,6 +32,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -58,6 +59,7 @@ hstypes:
   - Eq
   - Floating
   - Fractional
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -86,6 +88,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -114,6 +117,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -142,6 +146,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -325,8 +325,7 @@ newtype I
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -361,8 +360,7 @@ newtype C
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -397,8 +395,7 @@ newtype F
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -431,8 +428,7 @@ newtype L
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -467,8 +463,7 @@ newtype S
 
            __exported by:__ @macros\/macro_in_fundecl.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype MC = MC
   { unwrapMC :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -79,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MC "unwrapMC" where
 newtype TC = TC
   { unwrapTC :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -125,8 +123,7 @@ data Struct1 = Struct1
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1 where
 
@@ -178,8 +175,7 @@ data Struct2 = Struct2
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2 where
 
@@ -231,8 +227,7 @@ data Struct3 = Struct3
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct3 where
 
@@ -278,8 +273,7 @@ instance GHC.Records.HasField "struct3_a" (Ptr.Ptr Struct3) (Ptr.Ptr FC.CInt) wh
 newtype Struct3_t = Struct3_t
   { unwrapStruct3_t :: Struct3
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -313,8 +307,7 @@ data Struct4 = Struct4
          __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct4 where
 

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/bindingspec.yaml
@@ -44,6 +44,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -67,6 +68,7 @@ hstypes:
       - struct1_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -82,6 +84,7 @@ hstypes:
       - struct2_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -97,6 +100,7 @@ hstypes:
       - struct3_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -112,6 +116,7 @@ hstypes:
       - unwrapStruct3_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -127,6 +132,7 @@ hstypes:
       - struct4_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -147,6 +153,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -244,8 +244,7 @@ newtype MC
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -280,8 +279,7 @@ newtype TC
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -322,8 +320,7 @@ data Struct1
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct1
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -358,8 +355,7 @@ data Struct2
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct2
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -394,8 +390,7 @@ data Struct3
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct3
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -424,8 +419,7 @@ newtype Struct3_t
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr Struct3)
     where getField = fromPtr (Proxy @"unwrapStruct3_t")
@@ -452,8 +446,7 @@ data Struct4
 
            __exported by:__ @macros\/macro_in_fundecl_vs_typedef.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct4
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype FILE = FILE
   { unwrapFILE :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
@@ -13,8 +13,7 @@ newtype FILE
 
            __exported by:__ @macros\/macro_redefines_global.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -77,8 +76,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype T2 = T2
   { unwrapT2 :: T1
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -117,8 +115,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T2 "unwrapT2" where
 newtype T3 = T3
   { unwrapT3 :: T2
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -157,8 +154,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T3 "unwrapT3" where
 newtype T4 = T4
   { unwrapT4 :: T3
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/bindingspec.yaml
@@ -29,6 +29,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -57,6 +58,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -85,6 +87,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -113,6 +116,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
@@ -13,8 +13,7 @@ newtype T1
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -49,8 +48,7 @@ newtype T2
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -85,8 +83,7 @@ newtype T3
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -121,8 +118,7 @@ newtype T4
 
            __exported by:__ @macros\/macro_typedef_scope.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype MY_TYPE = MY_TYPE
   { unwrapMY_TYPE :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -92,8 +91,7 @@ data Bar = Bar
          __exported by:__ @macros\/macro_typedef_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
 

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/bindingspec.yaml
@@ -22,6 +22,7 @@ hstypes:
       - bar_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -42,6 +43,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
@@ -13,8 +13,7 @@ newtype MY_TYPE
 
            __exported by:__ @macros\/macro_typedef_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -62,8 +61,7 @@ data Bar
 
            __exported by:__ @macros\/macro_typedef_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_types/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Rea
 newtype PtrInt = PtrInt
   { unwrapPtrInt :: Ptr.Ptr FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -68,8 +67,7 @@ instance HsBindgen.Runtime.HasCField.HasCField PtrInt "unwrapPtrInt" where
 newtype ShortInt = ShortInt
   { unwrapShortInt :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -108,8 +106,7 @@ instance HsBindgen.Runtime.HasCField.HasCField ShortInt "unwrapShortInt" where
 newtype SignedShortInt = SignedShortInt
   { unwrapSignedShortInt :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -149,8 +146,7 @@ instance HsBindgen.Runtime.HasCField.HasCField SignedShortInt "unwrapSignedShort
 newtype UnsignedShortInt = UnsignedShortInt
   { unwrapUnsignedShortInt :: FC.CUShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -190,8 +186,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UnsignedShortInt "unwrapUnsignedS
 newtype PtrPtrChar = PtrPtrChar
   { unwrapPtrPtrChar :: Ptr.Ptr (Ptr.Ptr FC.CChar)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -221,8 +216,7 @@ instance HsBindgen.Runtime.HasCField.HasCField PtrPtrChar "unwrapPtrPtrChar" whe
 newtype MTy = MTy
   { unwrapMTy :: FC.CFloat
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -259,8 +253,7 @@ instance HsBindgen.Runtime.HasCField.HasCField MTy "unwrapMTy" where
 newtype Tty = Tty
   { unwrapTty :: MTy
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -297,8 +290,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Tty "unwrapTty" where
 newtype UINT8_T = UINT8_T
   { unwrapUINT8_T :: FC.CUChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -337,8 +329,7 @@ instance HsBindgen.Runtime.HasCField.HasCField UINT8_T "unwrapUINT8_T" where
 newtype BOOLEAN_T = BOOLEAN_T
   { unwrapBOOLEAN_T :: UINT8_T
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -377,8 +368,7 @@ instance HsBindgen.Runtime.HasCField.HasCField BOOLEAN_T "unwrapBOOLEAN_T" where
 newtype Boolean_T = Boolean_T
   { unwrapBoolean_T :: BOOLEAN_T
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/macros/macro_types/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_types/bindingspec.yaml
@@ -47,6 +47,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -75,6 +76,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -101,6 +103,7 @@ hstypes:
   - Eq
   - Floating
   - Fractional
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -124,6 +127,7 @@ hstypes:
       - unwrapPtrInt
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -141,6 +145,7 @@ hstypes:
       - unwrapPtrPtrChar
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -163,6 +168,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -191,6 +197,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -217,6 +224,7 @@ hstypes:
   - Eq
   - Floating
   - Fractional
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -245,6 +253,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -273,6 +282,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_types/th.txt
@@ -13,8 +13,7 @@ newtype PtrInt
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -39,8 +38,7 @@ newtype ShortInt
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -75,8 +73,7 @@ newtype SignedShortInt
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -114,8 +111,7 @@ newtype UnsignedShortInt
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -153,8 +149,7 @@ newtype PtrPtrChar
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -182,8 +177,7 @@ newtype MTy
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -216,8 +210,7 @@ newtype Tty
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -250,8 +243,7 @@ newtype UINT8_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -286,8 +278,7 @@ newtype BOOLEAN_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -322,8 +313,7 @@ newtype Boolean_T
 
            __exported by:__ @macros\/macro_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -53,8 +53,7 @@ import Prelude ((<*>), (>>), Bounded, Double, Enum, Eq, IO, Int, Integral, Num, 
 newtype A = A
   { unwrapA :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -92,8 +91,7 @@ instance HsBindgen.Runtime.HasCField.HasCField A "unwrapA" where
 -}
 data Some_struct = Some_struct
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_struct where
 
@@ -143,8 +141,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Some_union instance F.Stora
 newtype Some_enum = Some_enum
   { unwrapSome_enum :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Some_enum where
@@ -243,8 +240,7 @@ pattern ENUM_A = Some_enum 0
 newtype Arr_typedef1 = Arr_typedef1
   { unwrapArr_typedef1 :: HsBindgen.Runtime.IncompleteArray.IncompleteArray A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapArr_typedef1" (Ptr.Ptr Arr_typedef1) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray A)) where
 
@@ -267,8 +263,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef1 "unwrapArr_typedef1"
 newtype Arr_typedef2 = Arr_typedef2
   { unwrapArr_typedef2 :: HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapArr_typedef2" (Ptr.Ptr Arr_typedef2) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A))) where
 
@@ -291,8 +286,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef2 "unwrapArr_typedef2"
 newtype Arr_typedef3 = Arr_typedef3
   { unwrapArr_typedef3 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 5) A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -321,8 +315,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Arr_typedef3 "unwrapArr_typedef3"
 newtype Arr_typedef4 = Arr_typedef4
   { unwrapArr_typedef4 :: (HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -353,8 +346,7 @@ __exported by:__ @macros\/reparse.h@
 newtype Typedef1 = Typedef1
   { unwrapTypedef1 :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -393,8 +385,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Typedef1 "unwrapTypedef1" where
 newtype Typedef2 = Typedef2
   { unwrapTypedef2 :: Ptr.Ptr A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -423,8 +414,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Typedef2 "unwrapTypedef2" where
 newtype Typedef3 = Typedef3
   { unwrapTypedef3 :: Ptr.Ptr (Ptr.Ptr A)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -512,8 +502,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef1_Aux "unwrapFunptr
 newtype Funptr_typedef1 = Funptr_typedef1
   { unwrapFunptr_typedef1 :: Ptr.FunPtr Funptr_typedef1_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -601,8 +590,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef2_Aux "unwrapFunptr
 newtype Funptr_typedef2 = Funptr_typedef2
   { unwrapFunptr_typedef2 :: Ptr.FunPtr Funptr_typedef2_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -690,8 +678,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef3_Aux "unwrapFunptr
 newtype Funptr_typedef3 = Funptr_typedef3
   { unwrapFunptr_typedef3 :: Ptr.FunPtr Funptr_typedef3_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -779,8 +766,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef4_Aux "unwrapFunptr
 newtype Funptr_typedef4 = Funptr_typedef4
   { unwrapFunptr_typedef4 :: Ptr.FunPtr Funptr_typedef4_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -868,8 +854,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5_Aux "unwrapFunptr
 newtype Funptr_typedef5 = Funptr_typedef5
   { unwrapFunptr_typedef5 :: Ptr.FunPtr Funptr_typedef5_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -899,8 +884,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Funptr_typedef5 "unwrapFunptr_typ
 newtype Comments2 = Comments2
   { unwrapComments2 :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -961,8 +945,7 @@ data Example_struct = Example_struct
          __exported by:__ @macros\/reparse.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example_struct where
 
@@ -1040,8 +1023,7 @@ instance GHC.Records.HasField "example_struct_field3" (Ptr.Ptr Example_struct) (
 newtype Const_typedef1 = Const_typedef1
   { unwrapConst_typedef1 :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1081,8 +1063,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef1 "unwrapConst_typed
 newtype Const_typedef2 = Const_typedef2
   { unwrapConst_typedef2 :: A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1122,8 +1103,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef2 "unwrapConst_typed
 newtype Const_typedef3 = Const_typedef3
   { unwrapConst_typedef3 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1153,8 +1133,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef3 "unwrapConst_typed
 newtype Const_typedef4 = Const_typedef4
   { unwrapConst_typedef4 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1184,8 +1163,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef4 "unwrapConst_typed
 newtype Const_typedef5 = Const_typedef5
   { unwrapConst_typedef5 :: Ptr.Ptr A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1215,8 +1193,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef5 "unwrapConst_typed
 newtype Const_typedef6 = Const_typedef6
   { unwrapConst_typedef6 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1246,8 +1223,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_typedef6 "unwrapConst_typed
 newtype Const_typedef7 = Const_typedef7
   { unwrapConst_typedef7 :: HsBindgen.Runtime.PtrConst.PtrConst A
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1325,8 +1301,7 @@ data Example_struct_with_const = Example_struct_with_const
          __exported by:__ @macros\/reparse.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Example_struct_with_const where
 
@@ -1522,8 +1497,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr1_Aux "unwrapConst_fu
 newtype Const_funptr1 = Const_funptr1
   { unwrapConst_funptr1 :: Ptr.FunPtr Const_funptr1_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1611,8 +1585,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr2_Aux "unwrapConst_fu
 newtype Const_funptr2 = Const_funptr2
   { unwrapConst_funptr2 :: Ptr.FunPtr Const_funptr2_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1700,8 +1673,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr3_Aux "unwrapConst_fu
 newtype Const_funptr3 = Const_funptr3
   { unwrapConst_funptr3 :: Ptr.FunPtr Const_funptr3_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1789,8 +1761,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr4_Aux "unwrapConst_fu
 newtype Const_funptr4 = Const_funptr4
   { unwrapConst_funptr4 :: Ptr.FunPtr Const_funptr4_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1878,8 +1849,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr5_Aux "unwrapConst_fu
 newtype Const_funptr5 = Const_funptr5
   { unwrapConst_funptr5 :: Ptr.FunPtr Const_funptr5_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1967,8 +1937,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr6_Aux "unwrapConst_fu
 newtype Const_funptr6 = Const_funptr6
   { unwrapConst_funptr6 :: Ptr.FunPtr Const_funptr6_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -2056,8 +2025,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7_Aux "unwrapConst_fu
 newtype Const_funptr7 = Const_funptr7
   { unwrapConst_funptr7 :: Ptr.FunPtr Const_funptr7_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -2087,8 +2055,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Const_funptr7 "unwrapConst_funptr
 newtype BOOL = BOOL
   { unwrapBOOL :: FC.CBool
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -2127,8 +2094,7 @@ instance HsBindgen.Runtime.HasCField.HasCField BOOL "unwrapBOOL" where
 newtype INT = INT
   { unwrapINT :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -2167,8 +2133,7 @@ instance HsBindgen.Runtime.HasCField.HasCField INT "unwrapINT" where
 newtype INTP = INTP
   { unwrapINTP :: Ptr.Ptr FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -2197,8 +2162,7 @@ instance HsBindgen.Runtime.HasCField.HasCField INTP "unwrapINTP" where
 newtype INTCP = INTCP
   { unwrapINTCP :: HsBindgen.Runtime.PtrConst.PtrConst FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/macros/reparse/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/reparse/bindingspec.yaml
@@ -128,6 +128,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -151,6 +152,7 @@ hstypes:
       - unwrapArr_typedef1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -162,6 +164,7 @@ hstypes:
       - unwrapArr_typedef2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -173,6 +176,7 @@ hstypes:
       - unwrapArr_typedef3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -188,6 +192,7 @@ hstypes:
       - unwrapArr_typedef4
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -208,6 +213,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -236,6 +242,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -259,6 +266,7 @@ hstypes:
       - unwrapConst_funptr1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -276,6 +284,7 @@ hstypes:
       - unwrapConst_funptr2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -293,6 +302,7 @@ hstypes:
       - unwrapConst_funptr3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -310,6 +320,7 @@ hstypes:
       - unwrapConst_funptr4
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -327,6 +338,7 @@ hstypes:
       - unwrapConst_funptr5
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -344,6 +356,7 @@ hstypes:
       - unwrapConst_funptr6
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -361,6 +374,7 @@ hstypes:
       - unwrapConst_funptr7
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -383,6 +397,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -411,6 +426,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -434,6 +450,7 @@ hstypes:
       - unwrapConst_typedef3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -451,6 +468,7 @@ hstypes:
       - unwrapConst_typedef4
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -468,6 +486,7 @@ hstypes:
       - unwrapConst_typedef5
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -485,6 +504,7 @@ hstypes:
       - unwrapConst_typedef6
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -502,6 +522,7 @@ hstypes:
       - unwrapConst_typedef7
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -521,6 +542,7 @@ hstypes:
       - example_struct_field3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -542,6 +564,7 @@ hstypes:
       - example_struct_with_const_const_field7
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -557,6 +580,7 @@ hstypes:
       - unwrapFunptr_typedef1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -574,6 +598,7 @@ hstypes:
       - unwrapFunptr_typedef2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -591,6 +616,7 @@ hstypes:
       - unwrapFunptr_typedef3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -608,6 +634,7 @@ hstypes:
       - unwrapFunptr_typedef4
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -625,6 +652,7 @@ hstypes:
       - unwrapFunptr_typedef5
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -647,6 +675,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -670,6 +699,7 @@ hstypes:
       - unwrapINTCP
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -687,6 +717,7 @@ hstypes:
       - unwrapINTP
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -705,6 +736,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -724,6 +756,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -736,6 +769,7 @@ hstypes:
       fields:
       - unwrapSome_union
   instances:
+  - Generic
   - ReadRaw
   - StaticSize
   - Storable
@@ -753,6 +787,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -776,6 +811,7 @@ hstypes:
       - unwrapTypedef2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -793,6 +829,7 @@ hstypes:
       - unwrapTypedef3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2487,8 +2487,7 @@ newtype A
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -2523,8 +2522,7 @@ data Some_struct
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Some_struct
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -2567,8 +2565,7 @@ newtype Some_enum
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Some_enum
     where staticSizeOf = \_ -> 4 :: Int
@@ -2632,8 +2629,7 @@ newtype Arr_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapArr_typedef1"
                   (Ptr Arr_typedef1)
                   (Ptr (IncompleteArray A))
@@ -2656,8 +2652,7 @@ newtype Arr_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapArr_typedef2"
                   (Ptr Arr_typedef2)
                   (Ptr (IncompleteArray (Ptr A)))
@@ -2680,8 +2675,7 @@ newtype Arr_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapArr_typedef3"
                   (Ptr Arr_typedef3)
@@ -2705,8 +2699,7 @@ newtype Arr_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapArr_typedef4"
                   (Ptr Arr_typedef4)
@@ -2734,8 +2727,7 @@ newtype Typedef1
 
       __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -2770,8 +2762,7 @@ newtype Typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -2796,8 +2787,7 @@ newtype Typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -2872,8 +2862,7 @@ newtype Funptr_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -2949,8 +2938,7 @@ newtype Funptr_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3026,8 +3014,7 @@ newtype Funptr_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3106,8 +3093,7 @@ newtype Funptr_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3186,8 +3172,7 @@ newtype Funptr_typedef5
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3215,8 +3200,7 @@ newtype Comments2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3275,8 +3259,7 @@ data Example_struct
 
       __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Example_struct
     where staticSizeOf = \_ -> 24 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -3325,8 +3308,7 @@ newtype Const_typedef1
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3363,8 +3345,7 @@ newtype Const_typedef2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3401,8 +3382,7 @@ newtype Const_typedef3
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3430,8 +3410,7 @@ newtype Const_typedef4
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3459,8 +3438,7 @@ newtype Const_typedef5
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3487,8 +3465,7 @@ newtype Const_typedef6
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3516,8 +3493,7 @@ newtype Const_typedef7
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3593,8 +3569,7 @@ data Example_struct_with_const
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Example_struct_with_const
     where staticSizeOf = \_ -> 48 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -3738,8 +3713,7 @@ newtype Const_funptr1
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3818,8 +3792,7 @@ newtype Const_funptr2
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3898,8 +3871,7 @@ newtype Const_funptr3
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -3978,8 +3950,7 @@ newtype Const_funptr4
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4058,8 +4029,7 @@ newtype Const_funptr5
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4138,8 +4108,7 @@ newtype Const_funptr6
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4218,8 +4187,7 @@ newtype Const_funptr7
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4247,8 +4215,7 @@ newtype BOOL
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4283,8 +4250,7 @@ newtype INT
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4319,8 +4285,7 @@ newtype INTP
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -4345,8 +4310,7 @@ newtype INTCP
 
            __exported by:__ @macros\/reparse.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/manual/arrays/Example.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example.hs
@@ -32,8 +32,7 @@ import Prelude (Eq, Show)
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -62,8 +61,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -94,8 +92,7 @@ __exported by:__ @manual\/arrays.h@
 newtype Triplet_ptrs = Triplet_ptrs
   { unwrapTriplet_ptrs :: HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapTriplet_ptrs" (Ptr.Ptr Triplet_ptrs) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))) where
 

--- a/hs-bindgen/fixtures/manual/arrays/bindingspec.yaml
+++ b/hs-bindgen/fixtures/manual/arrays/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - unwrapMatrix
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - unwrapTriplet
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -51,6 +53,7 @@ hstypes:
       - unwrapTriplet_ptrs
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show

--- a/hs-bindgen/fixtures/manual/arrays/th.txt
+++ b/hs-bindgen/fixtures/manual/arrays/th.txt
@@ -93,8 +93,7 @@ newtype Triplet
 
            __exported by:__ @manual\/arrays.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTriplet"
                   (Ptr Triplet)
@@ -118,8 +117,7 @@ newtype Matrix
 
            __exported by:__ @manual\/arrays.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapMatrix"
                   (Ptr Matrix)
@@ -148,8 +146,7 @@ newtype Triplet_ptrs
 
       __exported by:__ @manual\/arrays.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapTriplet_ptrs"
                   (Ptr Triplet_ptrs)
                   (Ptr (IncompleteArray (Ptr (ConstantArray 3 CInt))))

--- a/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
@@ -66,8 +66,7 @@ data Point = Point
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point where
 
@@ -139,8 +138,7 @@ data Size = Size
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Size where
 
@@ -226,8 +224,7 @@ data Rect = Rect
          __exported by:__ @manual\/enable_record_dot.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Rect where
 
@@ -312,8 +309,7 @@ instance GHC.Records.HasField "height" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
 newtype E = E
   { unwrap :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize E where
@@ -420,8 +416,7 @@ pattern Y = E 1
 newtype Value = Value
   { unwrap :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -906,8 +901,7 @@ instance HsBindgen.Runtime.HasCField.HasCField RunDriver_Aux "unwrap" where
 newtype RunDriver = RunDriver
   { unwrap :: Ptr.FunPtr RunDriver_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/manual/enable_record_dot/bindingspec.yaml
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/bindingspec.yaml
@@ -51,6 +51,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -72,6 +73,7 @@ hstypes:
       - 'y'
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -90,6 +92,7 @@ hstypes:
       - height
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -105,6 +108,7 @@ hstypes:
       - unwrap
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -123,6 +127,7 @@ hstypes:
       - height
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -137,6 +142,7 @@ hstypes:
       fields:
       - unwrap
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -150,6 +156,7 @@ hstypes:
       fields:
       - unwrap
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -163,6 +170,7 @@ hstypes:
       fields:
       - unwrap
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -176,6 +184,7 @@ hstypes:
       fields:
       - unwrap
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -195,6 +204,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
@@ -26,8 +26,7 @@ data Point
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Point
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -75,8 +74,7 @@ data Size
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Size
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -138,8 +136,7 @@ data Rect
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Rect
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -186,8 +183,7 @@ newtype E
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize E
     where staticSizeOf = \_ -> 4 :: Int
@@ -265,8 +261,7 @@ newtype Value
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -745,8 +740,7 @@ newtype RunDriver
 
            __exported by:__ @manual\/enable_record_dot.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/manual/function_pointers/Example.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example.hs
@@ -105,8 +105,7 @@ data Apply1Struct = Apply1Struct
          __exported by:__ @manual\/function_pointers.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Apply1Struct where
 

--- a/hs-bindgen/fixtures/manual/function_pointers/bindingspec.yaml
+++ b/hs-bindgen/fixtures/manual/function_pointers/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - apply1Struct_apply1_nopointer_struct_field
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -35,6 +36,7 @@ hstypes:
       fields:
       - unwrapApply1Union
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -49,6 +51,7 @@ hstypes:
       - unwrapInt2int
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -264,8 +264,7 @@ data Apply1Struct
 
       __exported by:__ @manual\/function_pointers.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Apply1Struct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/manual/globals/Example.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example.hs
@@ -54,8 +54,7 @@ data GlobalConfig = GlobalConfig
          __exported by:__ @manual\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize GlobalConfig where
 
@@ -116,8 +115,7 @@ instance GHC.Records.HasField "globalConfig_numWorkers" (Ptr.Ptr GlobalConfig) (
 newtype ConstInt = ConstInt
   { unwrapConstInt :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -169,8 +167,7 @@ data Tuple = Tuple
          __exported by:__ @manual\/globals.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Tuple where
 
@@ -229,8 +226,7 @@ instance GHC.Records.HasField "tuple_y" (Ptr.Ptr Tuple) (Ptr.Ptr FC.CInt) where
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -259,8 +255,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype List = List
   { unwrapList :: HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
 

--- a/hs-bindgen/fixtures/manual/globals/bindingspec.yaml
+++ b/hs-bindgen/fixtures/manual/globals/bindingspec.yaml
@@ -32,6 +32,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -56,6 +57,7 @@ hstypes:
       - globalConfig_numWorkers
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -71,6 +73,7 @@ hstypes:
       - unwrapList
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -82,6 +85,7 @@ hstypes:
       - unwrapTriplet
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -98,6 +102,7 @@ hstypes:
       - tuple_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/manual/globals/th.txt
+++ b/hs-bindgen/fixtures/manual/globals/th.txt
@@ -159,8 +159,7 @@ data GlobalConfig
 
            __exported by:__ @manual\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize GlobalConfig
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -199,8 +198,7 @@ newtype ConstInt
 
            __exported by:__ @manual\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -248,8 +246,7 @@ data Tuple
 
            __exported by:__ @manual\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Tuple
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -284,8 +281,7 @@ newtype Triplet
 
            __exported by:__ @manual\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTriplet"
                   (Ptr Triplet)
@@ -309,8 +305,7 @@ newtype List
 
            __exported by:__ @manual\/globals.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance HasField "unwrapList"
                   (Ptr List)
                   (Ptr (IncompleteArray CInt))

--- a/hs-bindgen/fixtures/manual/zero_copy/Example.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example.hs
@@ -59,8 +59,7 @@ data Point = Point
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Point where
 
@@ -132,8 +131,7 @@ data Rectangle = Rectangle
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Rectangle where
 
@@ -206,8 +204,7 @@ data Circle = Circle
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Circle where
 
@@ -395,8 +392,7 @@ data Colour = Colour
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Colour where
 
@@ -510,8 +506,7 @@ instance GHC.Records.HasField "colour_blue" (Ptr.Ptr Colour) (HsBindgen.Runtime.
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -563,8 +558,7 @@ data Drawing = Drawing
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Drawing where
 
@@ -645,8 +639,7 @@ data Tic_tac_toe = Tic_tac_toe
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Tic_tac_toe where
 
@@ -727,8 +720,7 @@ data Vector_Aux = Vector
          __exported by:__ @manual\/zero_copy.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector_Aux where
 
@@ -787,8 +779,7 @@ type Vector =
 newtype Triplet = Triplet
   { unwrapTriplet :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -817,8 +808,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplet "unwrapTriplet" where
 newtype Matrix = Matrix
   { unwrapMatrix :: (HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/manual/zero_copy/bindingspec.yaml
+++ b/hs-bindgen/fixtures/manual/zero_copy/bindingspec.yaml
@@ -55,6 +55,7 @@ hstypes:
       - circle_radius
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -74,6 +75,7 @@ hstypes:
       - colour_blue
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -90,6 +92,7 @@ hstypes:
       - drawing_colour
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -105,6 +108,7 @@ hstypes:
       - unwrapMatrix
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -125,6 +129,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -149,6 +154,7 @@ hstypes:
       - point_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -165,6 +171,7 @@ hstypes:
       - rectangle_bottomright
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -179,6 +186,7 @@ hstypes:
       fields:
       - unwrapShape
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -195,6 +203,7 @@ hstypes:
       - tic_tac_toe_row3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -210,6 +219,7 @@ hstypes:
       - unwrapTriplet
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -228,6 +238,7 @@ hstypes:
   instances:
   - Eq
   - Flam_Offset
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/manual/zero_copy/th.txt
+++ b/hs-bindgen/fixtures/manual/zero_copy/th.txt
@@ -76,8 +76,7 @@ data Point
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Point
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -125,8 +124,7 @@ data Rectangle
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Rectangle
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -176,8 +174,7 @@ data Circle
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Circle
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -343,8 +340,7 @@ data Colour
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Colour
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -404,8 +400,7 @@ newtype MyInt
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -453,8 +448,7 @@ data Drawing
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Drawing
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -509,8 +503,7 @@ data Tic_tac_toe
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Tic_tac_toe
     where staticSizeOf = \_ -> 36 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -560,8 +553,7 @@ data Vector_Aux
 
                    __exported by:__ @manual\/zero_copy.h@
               -}}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Vector_Aux
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -593,8 +585,7 @@ newtype Triplet
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTriplet"
                   (Ptr Triplet)
@@ -618,8 +609,7 @@ newtype Matrix
 
            __exported by:__ @manual\/zero_copy.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapMatrix"
                   (Ptr Matrix)

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype U = U
   { unwrapU :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
@@ -55,8 +55,7 @@ newtype U
 
            __exported by:__ @program-analysis\/program-slicing\/macro_selected.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype U = U
   { unwrapU :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
@@ -55,8 +55,7 @@ newtype U
 
            __exported by:__ @program-analysis\/program-slicing\/macro_unselected.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype T = T
   { unwrapT :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -77,8 +76,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T "unwrapT" where
 newtype U = U
   { unwrapU :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/bindingspec.yaml
@@ -23,6 +23,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -51,6 +52,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
@@ -55,8 +55,7 @@ newtype T
 
            __exported by:__ @program-analysis\/program-slicing\/typedef_selected.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -91,8 +90,7 @@ newtype U
 
            __exported by:__ @program-analysis\/program-slicing\/typedef_selected.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype U = U
   { unwrapU :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
@@ -35,8 +35,7 @@ newtype U
 
            __exported by:__ @program-analysis\/program-slicing\/typedef_unselected.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -40,8 +40,7 @@ import Prelude ((<*>), (>>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype FileOperationStatus = FileOperationStatus
   { unwrapFileOperationStatus :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FileOperationStatus where
@@ -194,8 +193,7 @@ data FileOperationRecord = FileOperationRecord
          __exported by:__ @program-analysis\/program_slicing_selection.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize FileOperationRecord where
 

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - fileOperationRecord_bytes_processed
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -35,6 +36,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -49,8 +49,7 @@ newtype FileOperationStatus
 
            __exported by:__ @program-analysis\/program_slicing_selection.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize FileOperationStatus
     where staticSizeOf = \_ -> 4 :: Int
@@ -200,8 +199,7 @@ data FileOperationRecord
 
            __exported by:__ @program-analysis\/program_slicing_selection.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize FileOperationRecord
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -38,8 +38,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype Uint32_t = Uint32_t
   { unwrapUint32_t :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -91,8 +90,7 @@ data Foo = Foo
          __exported by:__ @program-analysis\/program_slicing_simple.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance F.Storable Foo where
 

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - foo_thirty_two
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - Show
@@ -36,6 +37,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -40,8 +40,7 @@ newtype Uint32_t
 
            __exported by:__ @program-analysis\/program_slicing_simple.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -89,8 +88,7 @@ data Foo
 
            __exported by:__ @program-analysis\/program_slicing_simple.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance Storable Foo
     where sizeOf = \_ -> 16 :: Int
           alignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
@@ -37,8 +37,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype A = A
   { unwrapA :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
@@ -14,8 +14,7 @@ newtype A
 
            __exported by:__ @program-analysis\/selection_bad.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -37,8 +37,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
 
@@ -90,8 +89,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - okAfter_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - okBefore_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -19,8 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -55,8 +54,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -37,8 +37,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
 
@@ -90,8 +89,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - okAfter_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - okBefore_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -19,8 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -55,8 +54,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -37,8 +37,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - okBefore_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -19,8 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
@@ -37,8 +37,7 @@ data OkBefore = OkBefore
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkBefore where
 
@@ -90,8 +89,7 @@ data OkAfter = OkAfter
          __exported by:__ @program-analysis\/selection_fail.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize OkAfter where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - okAfter_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - okBefore_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
@@ -19,8 +19,7 @@ data OkBefore
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkBefore
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -55,8 +54,7 @@ data OkAfter
 
            __exported by:__ @program-analysis\/selection_fail.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize OkAfter
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -37,8 +37,7 @@ data NewName = NewName
          __exported by:__ @program-analysis\/selection_matches_c_names.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize NewName where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - newName_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -34,8 +34,7 @@ data NewName
 
            __exported by:__ @program-analysis\/selection_matches_c_names.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize NewName
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -37,8 +37,7 @@ data UnrelatedDeclaration = UnrelatedDeclaration
          __exported by:__ @program-analysis\/selection_omit_external_a.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize UnrelatedDeclaration where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - unrelatedDeclaration_m
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -20,8 +20,7 @@ data UnrelatedDeclaration
 
            __exported by:__ @program-analysis\/selection_omit_external_a.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize UnrelatedDeclaration
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -37,8 +37,7 @@ data Omitted = Omitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Omitted where
 
@@ -90,8 +89,7 @@ data DirectlyDependsOnOmitted = DirectlyDependsOnOmitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize DirectlyDependsOnOmitted where
 
@@ -144,8 +142,7 @@ data IndirectlyDependsOnOmitted = IndirectlyDependsOnOmitted
          __exported by:__ @program-analysis\/selection_omit_external_b.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize IndirectlyDependsOnOmitted where
 

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
@@ -21,6 +21,7 @@ hstypes:
       - directlyDependsOnOmitted_o
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       - indirectlyDependsOnOmitted_d
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -51,6 +53,7 @@ hstypes:
       - omitted_n
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -20,8 +20,7 @@ data Omitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Omitted
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -56,8 +55,7 @@ data DirectlyDependsOnOmitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize DirectlyDependsOnOmitted
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -96,8 +94,7 @@ data IndirectlyDependsOnOmitted
 
            __exported by:__ @program-analysis\/selection_omit_external_b.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize IndirectlyDependsOnOmitted
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -35,8 +35,7 @@ __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
 data Struct1_t = Struct1_t
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1_t where
 
@@ -66,8 +65,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct1_t instance F.Storab
 -}
 data Struct2_t = Struct2_t
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_t where
 
@@ -113,8 +111,7 @@ data Struct4_t
 -}
 data Struct5 = Struct5
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct5 where
 
@@ -145,8 +142,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct5 instance F.Storable
 newtype Struct5_t = Struct5_t
   { unwrapStruct5_t :: Ptr.Ptr Struct5
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -175,8 +171,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct5_t "unwrapStruct5_t" where
 -}
 data Struct6_Aux = Struct6_Aux
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct6_Aux where
 
@@ -207,8 +202,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct6_Aux instance F.Stor
 newtype Struct6 = Struct6
   { unwrapStruct6 :: Ptr.Ptr Struct6_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -237,8 +231,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct6 "unwrapStruct6" where
 -}
 data Struct7 = Struct7
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct7 where
 
@@ -269,8 +262,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct7 instance F.Storable
 newtype Struct7a = Struct7a
   { unwrapStruct7a :: Struct7
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -298,8 +290,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct7a "unwrapStruct7a" where
 newtype Struct7b = Struct7b
   { unwrapStruct7b :: Struct7
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -326,8 +317,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct7b "unwrapStruct7b" where
 -}
 data Struct8 = Struct8
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct8 where
 
@@ -358,8 +348,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct8 instance F.Storable
 newtype Struct8b = Struct8b
   { unwrapStruct8b :: Struct8
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -386,8 +375,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct8b "unwrapStruct8b" where
 -}
 data Struct9 = Struct9
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct9 where
 
@@ -418,8 +406,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct9 instance F.Storable
 newtype Struct9_t = Struct9_t
   { unwrapStruct9_t :: Struct9
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -446,8 +433,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct9_t "unwrapStruct9_t" where
 -}
 data Struct10_t = Struct10_t
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct10_t where
 
@@ -478,8 +464,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct10_t instance F.Stora
 newtype Struct10_t_t = Struct10_t_t
   { unwrapStruct10_t_t :: Struct10_t
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -521,8 +506,7 @@ data Struct11_t = Struct11_t
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct11_t where
 
@@ -595,8 +579,7 @@ data Struct12_t = Struct12_t
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct12_t where
 
@@ -781,8 +764,7 @@ data Use_sites = Use_sites
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Use_sites where
 

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
@@ -98,6 +98,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -111,6 +112,7 @@ hstypes:
       - unwrapStruct10_t_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -127,6 +129,7 @@ hstypes:
       - struct11_t_self
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -143,6 +146,7 @@ hstypes:
       - struct12_t_self
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -157,6 +161,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -169,6 +174,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -185,6 +191,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -198,6 +205,7 @@ hstypes:
       - unwrapStruct5_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -215,6 +223,7 @@ hstypes:
       - unwrapStruct6
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -231,6 +240,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -243,6 +253,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -256,6 +267,7 @@ hstypes:
       - unwrapStruct7a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -271,6 +283,7 @@ hstypes:
       - unwrapStruct7b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -285,6 +298,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -298,6 +312,7 @@ hstypes:
       - unwrapStruct8b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -312,6 +327,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -325,6 +341,7 @@ hstypes:
       - unwrapStruct9_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -357,6 +374,7 @@ hstypes:
       - use_sites_useTypedef_struct12_t
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
@@ -17,8 +17,7 @@ data Struct1_t
 
       __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct1_t
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -42,8 +41,7 @@ data Struct2_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct2_t
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -81,8 +79,7 @@ data Struct5
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct5
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -106,8 +103,7 @@ newtype Struct5_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -134,8 +130,7 @@ data Struct6_Aux
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct6_Aux
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -159,8 +154,7 @@ newtype Struct6
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -187,8 +181,7 @@ data Struct7
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct7
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -212,8 +205,7 @@ newtype Struct7a
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7a")
@@ -234,8 +226,7 @@ newtype Struct7b
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7b")
@@ -256,8 +247,7 @@ data Struct8
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct8
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -281,8 +271,7 @@ newtype Struct8b
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr Struct8)
     where getField = fromPtr (Proxy @"unwrapStruct8b")
@@ -303,8 +292,7 @@ data Struct9
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct9
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -328,8 +316,7 @@ newtype Struct9_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr Struct9)
     where getField = fromPtr (Proxy @"unwrapStruct9_t")
@@ -350,8 +337,7 @@ data Struct10_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct10_t
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -375,8 +361,7 @@ newtype Struct10_t_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapStruct10_t_t"
                   (Ptr Struct10_t_t)
@@ -413,8 +398,7 @@ data Struct11_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct11_t
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -464,8 +448,7 @@ data Struct12_t
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct12_t
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -627,8 +610,7 @@ data Use_sites
 
            __exported by:__ @program-analysis\/typedef_analysis.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Use_sites
     where staticSizeOf = \_ -> 64 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -52,8 +52,7 @@ data Complex_object_t = Complex_object_t
          __exported by:__ @types\/complex\/hsb_complex_test.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Complex_object_t where
 

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/bindingspec.yaml
@@ -20,6 +20,7 @@ hstypes:
       - complex_object_t_id
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
@@ -169,8 +169,7 @@ data Complex_object_t
 
            __exported by:__ @types\/complex\/hsb_complex_test.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Complex_object_t
     where staticSizeOf = \_ -> 32 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
@@ -44,8 +44,7 @@ data Vector = Vector
          __exported by:__ @types\/complex\/vector_test.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Vector where
 

--- a/hs-bindgen/fixtures/types/complex/vector_test/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/complex/vector_test/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
       - vector_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/vector_test/th.txt
@@ -50,8 +50,7 @@ data Vector
 
            __exported by:__ @types\/complex\/vector_test.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Vector
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype Foo_enum = Foo_enum
   { unwrapFoo_enum :: HsBindgen.Runtime.LibC.Word32
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo_enum where

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
@@ -19,6 +19,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -16,8 +16,7 @@ newtype Foo_enum
 
            __exported by:__ @types\/enums\/enum_cpp_syntax.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Foo_enum
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enums/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype First = First
   { unwrapFirst :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize First where
@@ -149,8 +148,7 @@ pattern FIRST2 = First 1
 newtype Second = Second
   { unwrapSecond :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Second where
@@ -269,8 +267,7 @@ pattern SECOND_C = Second 1
 newtype Same = Same
   { unwrapSame :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Same where
@@ -377,8 +374,7 @@ pattern SAME_B = Same 1
 newtype Nonseq = Nonseq
   { unwrapNonseq :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Nonseq where
@@ -487,8 +483,7 @@ pattern NONSEQ_C = Nonseq 404
 newtype Packed = Packed
   { unwrapPacked :: FC.CUChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Packed where
@@ -607,8 +602,7 @@ pattern PACKED_C = Packed 2
 newtype EnumA = EnumA
   { unwrapEnumA :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize EnumA where
@@ -717,8 +711,7 @@ pattern A_BAR = EnumA 1
 newtype EnumB = EnumB
   { unwrapEnumB :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize EnumB where
@@ -827,8 +820,7 @@ pattern B_BAR = EnumB 1
 newtype EnumC = EnumC
   { unwrapEnumC :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize EnumC where
@@ -937,8 +929,7 @@ pattern C_BAR = EnumC 1
 newtype EnumD_t = EnumD_t
   { unwrapEnumD_t :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize EnumD_t where

--- a/hs-bindgen/fixtures/types/enums/enums/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/enums/enums/bindingspec.yaml
@@ -52,6 +52,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -73,6 +74,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -94,6 +96,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -115,6 +118,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -136,6 +140,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -157,6 +162,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -177,6 +183,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -198,6 +205,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -219,6 +227,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enums/th.txt
@@ -13,8 +13,7 @@ newtype First
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize First
     where staticSizeOf = \_ -> 4 :: Int
@@ -93,8 +92,7 @@ newtype Second
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Second
     where staticSizeOf = \_ -> 4 :: Int
@@ -188,8 +186,7 @@ newtype Same
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Same
     where staticSizeOf = \_ -> 4 :: Int
@@ -267,8 +264,7 @@ newtype Nonseq
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Nonseq
     where staticSizeOf = \_ -> 4 :: Int
@@ -357,8 +353,7 @@ newtype Packed
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize Packed
     where staticSizeOf = \_ -> 1 :: Int
@@ -452,8 +447,7 @@ newtype EnumA
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumA
     where staticSizeOf = \_ -> 4 :: Int
@@ -532,8 +526,7 @@ newtype EnumB
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumB
     where staticSizeOf = \_ -> 4 :: Int
@@ -612,8 +605,7 @@ newtype EnumC
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumC
     where staticSizeOf = \_ -> 4 :: Int
@@ -692,8 +684,7 @@ newtype EnumD_t
 
            __exported by:__ @types\/enums\/enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumD_t
     where staticSizeOf = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 newtype EnumA = EnumA
   { unwrapEnumA :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize EnumA where
@@ -155,8 +154,7 @@ data ExA = ExA
          __exported by:__ @types\/enums\/nested_enums.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExA where
 
@@ -202,8 +200,7 @@ instance GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr EnumA) where
 newtype ExB_fieldB1 = ExB_fieldB1
   { unwrapExB_fieldB1 :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExB_fieldB1 where
@@ -319,8 +316,7 @@ data ExB = ExB
          __exported by:__ @types\/enums\/nested_enums.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExB where
 

--- a/hs-bindgen/fixtures/types/enums/nested_enums/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/bindingspec.yaml
@@ -25,6 +25,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -45,6 +46,7 @@ hstypes:
       - exA_fieldA1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -60,6 +62,7 @@ hstypes:
       - exB_fieldB1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -76,6 +79,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
@@ -13,8 +13,7 @@ newtype EnumA
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize EnumA
     where staticSizeOf = \_ -> 4 :: Int
@@ -99,8 +98,7 @@ data ExA
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize ExA
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -129,8 +127,7 @@ newtype ExB_fieldB1
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize ExB_fieldB1
     where staticSizeOf = \_ -> 4 :: Int
@@ -215,8 +212,7 @@ data ExB
 
            __exported by:__ @types\/enums\/nested_enums.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize ExB
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
@@ -44,8 +44,7 @@ data Foo = Foo
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
 
@@ -117,8 +116,7 @@ data Bar = Bar
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bar where
 
@@ -190,8 +188,7 @@ data Ex3_ex3_struct = Ex3_ex3_struct
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex3_ex3_struct where
 
@@ -265,8 +262,7 @@ data Ex3 = Ex3
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex3 where
 
@@ -338,8 +334,7 @@ data Ex4_odd = Ex4_odd
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex4_odd where
 
@@ -412,8 +407,7 @@ data Ex4_even = Ex4_even
          __exported by:__ @types\/nested\/nested_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Ex4_even where
 

--- a/hs-bindgen/fixtures/types/nested/nested_types/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/nested/nested_types/bindingspec.yaml
@@ -31,6 +31,7 @@ hstypes:
       - bar_foo2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -47,6 +48,7 @@ hstypes:
       - ex3_ex3_c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -63,6 +65,7 @@ hstypes:
       - ex3_ex3_struct_ex3_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -79,6 +82,7 @@ hstypes:
       - ex4_even_next
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -95,6 +99,7 @@ hstypes:
       - ex4_odd_next
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -111,6 +116,7 @@ hstypes:
       - foo_c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/fixtures/types/nested/nested_types/th.txt
@@ -26,8 +26,7 @@ data Foo
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -75,8 +74,7 @@ data Bar
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bar
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -124,8 +122,7 @@ data Ex3_ex3_struct
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Ex3_ex3_struct
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -177,8 +174,7 @@ data Ex3
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Ex3
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -226,8 +222,7 @@ data Ex4_odd
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Ex4_odd
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -275,8 +270,7 @@ data Ex4_even
 
            __exported by:__ @types\/nested\/nested_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Ex4_even
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool/Example.hs
@@ -52,8 +52,7 @@ data Bools1 = Bools1
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools1 where
 
@@ -125,8 +124,7 @@ data Bools2 = Bools2
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools2 where
 
@@ -185,8 +183,7 @@ instance GHC.Records.HasField "bools2_y" (Ptr.Ptr Bools2) (Ptr.Ptr FC.CBool) whe
 newtype BOOL = BOOL
   { unwrapBOOL :: FC.CBool
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -238,8 +235,7 @@ data Bools3 = Bools3
          __exported by:__ @types\/primitives\/bool.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Bools3 where
 

--- a/hs-bindgen/fixtures/types/primitives/bool/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/primitives/bool/bindingspec.yaml
@@ -29,6 +29,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -53,6 +54,7 @@ hstypes:
       - bools1_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -69,6 +71,7 @@ hstypes:
       - bools2_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -85,6 +88,7 @@ hstypes:
       - bools3_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/bool/th.txt
@@ -27,8 +27,7 @@ data Bools1
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bools1
     where staticSizeOf = \_ -> 2 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -76,8 +75,7 @@ data Bools2
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bools2
     where staticSizeOf = \_ -> 2 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -112,8 +110,7 @@ newtype BOOL
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -161,8 +158,7 @@ data Bools3
 
            __exported by:__ @types\/primitives\/bool.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Bools3
     where staticSizeOf = \_ -> 2 :: Int
           staticAlignment = \_ -> 1 :: Int

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
@@ -44,8 +44,7 @@ data Foo = Foo
          __exported by:__ @types\/primitives\/fixedwidth.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
 

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/bindingspec.yaml
@@ -16,6 +16,7 @@ hstypes:
       - foo_thirty_two
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
@@ -29,8 +29,7 @@ data Foo
 
            __exported by:__ @types\/primitives\/fixedwidth.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
@@ -38,8 +38,7 @@ import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Rea
 newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
   { unwrapPrim_HsPrimCPtrdiff :: HsBindgen.Runtime.LibC.CPtrdiff
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -79,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCPtrdiff "unwrapPrim_H
 newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
   { unwrapPrim_HsPrimInt8 :: HsBindgen.Runtime.LibC.Int8
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -120,8 +118,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt8 "unwrapPrim_HsPri
 newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
   { unwrapPrim_HsPrimInt16 :: HsBindgen.Runtime.LibC.Int16
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -161,8 +158,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt16 "unwrapPrim_HsPr
 newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
   { unwrapPrim_HsPrimInt32 :: HsBindgen.Runtime.LibC.Int32
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -202,8 +198,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt32 "unwrapPrim_HsPr
 newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
   { unwrapPrim_HsPrimInt64 :: HsBindgen.Runtime.LibC.Int64
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -243,8 +238,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimInt64 "unwrapPrim_HsPr
 newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
   { unwrapPrim_HsPrimWord8 :: HsBindgen.Runtime.LibC.Word8
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -284,8 +278,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord8 "unwrapPrim_HsPr
 newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
   { unwrapPrim_HsPrimWord16 :: HsBindgen.Runtime.LibC.Word16
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -325,8 +318,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord16 "unwrapPrim_HsP
 newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
   { unwrapPrim_HsPrimWord32 :: HsBindgen.Runtime.LibC.Word32
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -366,8 +358,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord32 "unwrapPrim_HsP
 newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
   { unwrapPrim_HsPrimWord64 :: HsBindgen.Runtime.LibC.Word64
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -407,8 +398,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimWord64 "unwrapPrim_HsP
 newtype Prim_HsPrimCChar = Prim_HsPrimCChar
   { unwrapPrim_HsPrimCChar :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -448,8 +438,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCChar "unwrapPrim_HsPr
 newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
   { unwrapPrim_HsPrimCSChar :: FC.CSChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -489,8 +478,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCSChar "unwrapPrim_HsP
 newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
   { unwrapPrim_HsPrimCUChar :: FC.CUChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -530,8 +518,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUChar "unwrapPrim_HsP
 newtype Prim_HsPrimCShort = Prim_HsPrimCShort
   { unwrapPrim_HsPrimCShort :: FC.CShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -571,8 +558,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCShort "unwrapPrim_HsP
 newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
   { unwrapPrim_HsPrimCUShort :: FC.CUShort
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -612,8 +598,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUShort "unwrapPrim_Hs
 newtype Prim_HsPrimCInt = Prim_HsPrimCInt
   { unwrapPrim_HsPrimCInt :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -653,8 +638,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCInt "unwrapPrim_HsPri
 newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
   { unwrapPrim_HsPrimCUInt :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -694,8 +678,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCUInt "unwrapPrim_HsPr
 newtype Prim_HsPrimCLong = Prim_HsPrimCLong
   { unwrapPrim_HsPrimCLong :: FC.CLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -735,8 +718,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCLong "unwrapPrim_HsPr
 newtype Prim_HsPrimCULong = Prim_HsPrimCULong
   { unwrapPrim_HsPrimCULong :: FC.CULong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -776,8 +758,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCULong "unwrapPrim_HsP
 newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
   { unwrapPrim_HsPrimCLLong :: FC.CLLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -817,8 +798,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCLLong "unwrapPrim_HsP
 newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
   { unwrapPrim_HsPrimCULLong :: FC.CULLong
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -858,8 +838,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCULLong "unwrapPrim_Hs
 newtype Prim_HsPrimCBool = Prim_HsPrimCBool
   { unwrapPrim_HsPrimCBool :: FC.CBool
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -899,8 +878,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCBool "unwrapPrim_HsPr
 newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
   { unwrapPrim_HsPrimCFloat :: FC.CFloat
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -938,8 +916,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Prim_HsPrimCFloat "unwrapPrim_HsP
 newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
   { unwrapPrim_HsPrimCDouble :: FC.CDouble
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/bindingspec.yaml
@@ -86,6 +86,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -114,6 +115,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -140,6 +142,7 @@ hstypes:
   - Eq
   - Floating
   - Fractional
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -166,6 +169,7 @@ hstypes:
   - Eq
   - Floating
   - Fractional
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -194,6 +198,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -222,6 +227,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -250,6 +256,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -278,6 +285,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -306,6 +314,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -334,6 +343,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -362,6 +372,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -390,6 +401,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -418,6 +430,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -446,6 +459,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -474,6 +488,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -502,6 +517,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -530,6 +546,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -558,6 +575,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -586,6 +604,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -614,6 +633,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -642,6 +662,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -670,6 +691,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -698,6 +720,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
@@ -18,8 +18,7 @@ newtype Prim_HsPrimCPtrdiff
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -57,8 +56,7 @@ newtype Prim_HsPrimInt8
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -96,8 +94,7 @@ newtype Prim_HsPrimInt16
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -135,8 +132,7 @@ newtype Prim_HsPrimInt32
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -174,8 +170,7 @@ newtype Prim_HsPrimInt64
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -213,8 +208,7 @@ newtype Prim_HsPrimWord8
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -252,8 +246,7 @@ newtype Prim_HsPrimWord16
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -291,8 +284,7 @@ newtype Prim_HsPrimWord32
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -330,8 +322,7 @@ newtype Prim_HsPrimWord64
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -369,8 +360,7 @@ newtype Prim_HsPrimCChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -408,8 +398,7 @@ newtype Prim_HsPrimCSChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -447,8 +436,7 @@ newtype Prim_HsPrimCUChar
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -486,8 +474,7 @@ newtype Prim_HsPrimCShort
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -525,8 +512,7 @@ newtype Prim_HsPrimCUShort
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -564,8 +550,7 @@ newtype Prim_HsPrimCInt
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -603,8 +588,7 @@ newtype Prim_HsPrimCUInt
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -642,8 +626,7 @@ newtype Prim_HsPrimCLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -681,8 +664,7 @@ newtype Prim_HsPrimCULong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -720,8 +702,7 @@ newtype Prim_HsPrimCLLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -759,8 +740,7 @@ newtype Prim_HsPrimCULLong
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -798,8 +778,7 @@ newtype Prim_HsPrimCBool
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -837,8 +816,7 @@ newtype Prim_HsPrimCFloat
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -874,8 +852,7 @@ newtype Prim_HsPrimCDouble
 
            __exported by:__ @types\/primitives\/primitive_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
@@ -226,8 +226,7 @@ data Primitive = Primitive
          __exported by:__ @types\/primitives\/primitive_types.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Primitive where
 

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/bindingspec.yaml
@@ -42,6 +42,7 @@ hstypes:
       - primitive_d
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
@@ -208,8 +208,7 @@ data Primitive
 
            __exported by:__ @types\/primitives\/primitive_types.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Primitive
     where staticSizeOf = \_ -> 152 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -45,8 +45,7 @@ import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, S
 newtype I = I
   { unwrapI :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -84,8 +83,7 @@ instance HsBindgen.Runtime.HasCField.HasCField I "unwrapI" where
 -}
 data S = S
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S where
 
@@ -135,8 +133,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable U instance F.Storable U
 newtype E = E
   { unwrapE :: FC.CUInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord)
+  deriving stock (GHC.Generics.Generic, Eq, Ord)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
 instance HsBindgen.Runtime.Marshal.StaticSize E where
@@ -234,8 +231,7 @@ pattern Foo = E 0
 newtype TI = TI
   { unwrapTI :: I
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -274,8 +270,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TI "unwrapTI" where
 newtype TS = TS
   { unwrapTS :: S
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -331,8 +326,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TU "unwrapTU" where
 newtype TE = TE
   { unwrapTE :: E
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -362,8 +356,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TE "unwrapTE" where
 newtype TTI = TTI
   { unwrapTTI :: TI
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -402,8 +395,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TTI "unwrapTTI" where
 newtype TTS = TTS
   { unwrapTTS :: TS
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -459,8 +451,7 @@ instance HsBindgen.Runtime.HasCField.HasCField TTU "unwrapTTU" where
 newtype TTE = TTE
   { unwrapTTE :: TE
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
@@ -49,6 +49,7 @@ hstypes:
   instances:
   - CEnum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -74,6 +75,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -96,6 +98,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -109,6 +112,7 @@ hstypes:
       - unwrapTE
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -133,6 +137,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -156,6 +161,7 @@ hstypes:
       - unwrapTS
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -171,6 +177,7 @@ hstypes:
       - unwrapTTE
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -195,6 +202,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -218,6 +226,7 @@ hstypes:
       - unwrapTTS
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -232,6 +241,7 @@ hstypes:
       fields:
       - unwrapTTU
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -245,6 +255,7 @@ hstypes:
       fields:
       - unwrapTU
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -258,6 +269,7 @@ hstypes:
       fields:
       - unwrapU
   instances:
+  - Generic
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -86,8 +86,7 @@ newtype I
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -122,8 +121,7 @@ data S
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -166,8 +164,7 @@ newtype E
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype HasFFIType
 instance StaticSize E
     where staticSizeOf = \_ -> 4 :: Int
@@ -231,8 +228,7 @@ newtype TI
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -267,8 +263,7 @@ newtype TS
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTS" (Ptr TS) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapTS")
@@ -310,8 +305,7 @@ newtype TE
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -337,8 +331,7 @@ newtype TTI
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -373,8 +366,7 @@ newtype TTS
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
 instance HasField "unwrapTTS" (Ptr TTS) (Ptr TS)
     where getField = fromPtr (Proxy @"unwrapTTS")
@@ -416,8 +408,7 @@ newtype TTE
 
            __exported by:__ @types\/qualifiers\/const_typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -37,8 +37,7 @@ data Struct2 = Struct2
          __exported by:__ @types\/special\/parse_failure_long_double.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2 where
 

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - struct2_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
@@ -40,8 +40,7 @@ data Struct2
 
            __exported by:__ @types\/special\/parse_failure_long_double.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct2
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/Example.hs
@@ -38,8 +38,7 @@ import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 newtype Stdlib_CBool = Stdlib_CBool
   { unwrapStdlib_CBool :: FC.CBool
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -79,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CBool "unwrapStdlib_CBool"
 newtype Stdlib_Int8 = Stdlib_Int8
   { unwrapStdlib_Int8 :: HsBindgen.Runtime.LibC.Int8
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -120,8 +118,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int8 "unwrapStdlib_Int8" w
 newtype Stdlib_Int16 = Stdlib_Int16
   { unwrapStdlib_Int16 :: HsBindgen.Runtime.LibC.Int16
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -161,8 +158,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int16 "unwrapStdlib_Int16"
 newtype Stdlib_Int32 = Stdlib_Int32
   { unwrapStdlib_Int32 :: HsBindgen.Runtime.LibC.Int32
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -202,8 +198,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int32 "unwrapStdlib_Int32"
 newtype Stdlib_Int64 = Stdlib_Int64
   { unwrapStdlib_Int64 :: HsBindgen.Runtime.LibC.Int64
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -243,8 +238,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Int64 "unwrapStdlib_Int64"
 newtype Stdlib_Word8 = Stdlib_Word8
   { unwrapStdlib_Word8 :: HsBindgen.Runtime.LibC.Word8
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -284,8 +278,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word8 "unwrapStdlib_Word8"
 newtype Stdlib_Word16 = Stdlib_Word16
   { unwrapStdlib_Word16 :: HsBindgen.Runtime.LibC.Word16
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -325,8 +318,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word16 "unwrapStdlib_Word1
 newtype Stdlib_Word32 = Stdlib_Word32
   { unwrapStdlib_Word32 :: HsBindgen.Runtime.LibC.Word32
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -366,8 +358,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word32 "unwrapStdlib_Word3
 newtype Stdlib_Word64 = Stdlib_Word64
   { unwrapStdlib_Word64 :: HsBindgen.Runtime.LibC.Word64
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -407,8 +398,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_Word64 "unwrapStdlib_Word6
 newtype Stdlib_CIntMax = Stdlib_CIntMax
   { unwrapStdlib_CIntMax :: HsBindgen.Runtime.LibC.CIntMax
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -448,8 +438,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CIntMax "unwrapStdlib_CInt
 newtype Stdlib_CUIntMax = Stdlib_CUIntMax
   { unwrapStdlib_CUIntMax :: HsBindgen.Runtime.LibC.CUIntMax
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -489,8 +478,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CUIntMax "unwrapStdlib_CUI
 newtype Stdlib_CIntPtr = Stdlib_CIntPtr
   { unwrapStdlib_CIntPtr :: HsBindgen.Runtime.LibC.CIntPtr
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -530,8 +518,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CIntPtr "unwrapStdlib_CInt
 newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
   { unwrapStdlib_CUIntPtr :: HsBindgen.Runtime.LibC.CUIntPtr
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -617,8 +604,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFexceptT "unwrapStdlib_CF
 newtype Stdlib_CSize = Stdlib_CSize
   { unwrapStdlib_CSize :: HsBindgen.Runtime.LibC.CSize
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -658,8 +644,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CSize "unwrapStdlib_CSize"
 newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
   { unwrapStdlib_CPtrdiff :: HsBindgen.Runtime.LibC.CPtrdiff
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -722,8 +707,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmp
 newtype Stdlib_CWchar = Stdlib_CWchar
   { unwrapStdlib_CWchar :: HsBindgen.Runtime.LibC.CWchar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -763,8 +747,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWchar "unwrapStdlib_CWcha
 newtype Stdlib_CWintT = Stdlib_CWintT
   { unwrapStdlib_CWintT :: HsBindgen.Runtime.LibC.CWintT
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -827,8 +810,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CMbstateT "unwrapStdlib_CM
 newtype Stdlib_CWctransT = Stdlib_CWctransT
   { unwrapStdlib_CWctransT :: HsBindgen.Runtime.LibC.CWctransT
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -859,8 +841,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWctransT "unwrapStdlib_CW
 newtype Stdlib_CWctypeT = Stdlib_CWctypeT
   { unwrapStdlib_CWctypeT :: HsBindgen.Runtime.LibC.CWctypeT
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -891,8 +872,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CWctypeT "unwrapStdlib_CWc
 newtype Stdlib_CChar16T = Stdlib_CChar16T
   { unwrapStdlib_CChar16T :: HsBindgen.Runtime.LibC.CChar16T
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -932,8 +912,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CChar16T "unwrapStdlib_CCh
 newtype Stdlib_CChar32T = Stdlib_CChar32T
   { unwrapStdlib_CChar32T :: HsBindgen.Runtime.LibC.CChar32T
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -973,8 +952,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CChar32T "unwrapStdlib_CCh
 newtype Stdlib_CTime = Stdlib_CTime
   { unwrapStdlib_CTime :: HsBindgen.Runtime.LibC.CTime
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1007,8 +985,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CTime "unwrapStdlib_CTime"
 newtype Stdlib_CClock = Stdlib_CClock
   { unwrapStdlib_CClock :: HsBindgen.Runtime.LibC.CClock
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1041,8 +1018,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CClock "unwrapStdlib_CCloc
 newtype Stdlib_CTm = Stdlib_CTm
   { unwrapStdlib_CTm :: HsBindgen.Runtime.LibC.CTm
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -1115,8 +1091,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
 newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
   { unwrapStdlib_CSigAtomic :: HsBindgen.Runtime.LibC.CSigAtomic
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/bindingspec.yaml
@@ -110,6 +110,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -138,6 +139,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -166,6 +168,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -190,6 +193,7 @@ hstypes:
   instances:
   - Enum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -209,6 +213,7 @@ hstypes:
       fields:
       - unwrapStdlib_CFenvT
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CFexceptT
@@ -218,6 +223,7 @@ hstypes:
       fields:
       - unwrapStdlib_CFexceptT
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CFile
@@ -227,6 +233,7 @@ hstypes:
       fields:
       - unwrapStdlib_CFile
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CFpos
@@ -236,6 +243,7 @@ hstypes:
       fields:
       - unwrapStdlib_CFpos
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CIntMax
@@ -251,6 +259,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -279,6 +288,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -301,6 +311,7 @@ hstypes:
       fields:
       - unwrapStdlib_CJmpBuf
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CMbstateT
@@ -310,6 +321,7 @@ hstypes:
       fields:
       - unwrapStdlib_CMbstateT
   instances:
+  - Generic
   - HasCField
   - HasField
 - hsname: Stdlib_CPtrdiff
@@ -325,6 +337,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -353,6 +366,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -381,6 +395,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -405,6 +420,7 @@ hstypes:
   instances:
   - Enum
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -425,6 +441,7 @@ hstypes:
       - unwrapStdlib_CTm
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -443,6 +460,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -471,6 +489,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -499,6 +518,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -522,6 +542,7 @@ hstypes:
       - unwrapStdlib_CWctransT
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -539,6 +560,7 @@ hstypes:
       - unwrapStdlib_CWctypeT
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -561,6 +583,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -589,6 +612,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -617,6 +641,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -645,6 +670,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -673,6 +699,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -701,6 +728,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -729,6 +757,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -757,6 +786,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -785,6 +815,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
+++ b/hs-bindgen/fixtures/types/stdlib/stdlib_insts/th.txt
@@ -30,8 +30,7 @@ newtype Stdlib_CBool
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -68,8 +67,7 @@ newtype Stdlib_Int8
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -107,8 +105,7 @@ newtype Stdlib_Int16
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -146,8 +143,7 @@ newtype Stdlib_Int32
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -185,8 +181,7 @@ newtype Stdlib_Int64
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -224,8 +219,7 @@ newtype Stdlib_Word8
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -263,8 +257,7 @@ newtype Stdlib_Word16
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -302,8 +295,7 @@ newtype Stdlib_Word32
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -341,8 +333,7 @@ newtype Stdlib_Word64
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -380,8 +371,7 @@ newtype Stdlib_CIntMax
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -419,8 +409,7 @@ newtype Stdlib_CUIntMax
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -458,8 +447,7 @@ newtype Stdlib_CIntPtr
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -497,8 +485,7 @@ newtype Stdlib_CUIntPtr
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -582,8 +569,7 @@ newtype Stdlib_CSize
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -621,8 +607,7 @@ newtype Stdlib_CPtrdiff
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -683,8 +668,7 @@ newtype Stdlib_CWchar
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -722,8 +706,7 @@ newtype Stdlib_CWintT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -784,8 +767,7 @@ newtype Stdlib_CWctransT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -814,8 +796,7 @@ newtype Stdlib_CWctypeT
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -844,8 +825,7 @@ newtype Stdlib_CChar16T
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -883,8 +863,7 @@ newtype Stdlib_CChar32T
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -922,8 +901,7 @@ newtype Stdlib_CTime
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -954,8 +932,7 @@ newtype Stdlib_CClock
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -986,8 +963,7 @@ newtype Stdlib_CTm
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw)
 instance HasField "unwrapStdlib_CTm"
                   (Ptr Stdlib_CTm)
@@ -1057,8 +1033,7 @@ newtype Stdlib_CSigAtomic
 
            __exported by:__ @types\/stdlib\/stdlib_insts.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
@@ -44,8 +44,7 @@ data S1_c = S1_c
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1_c where
 
@@ -117,8 +116,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
 
@@ -183,8 +181,7 @@ data S2_inner_deep = S2_inner_deep
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_inner_deep where
 
@@ -244,8 +241,7 @@ data S2_inner = S2_inner
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_inner where
 
@@ -318,8 +314,7 @@ data S2 = S2
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2 where
 
@@ -391,8 +386,7 @@ data S3 = S3
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3 where
 
@@ -464,8 +458,7 @@ data S3_c = S3_c
          __exported by:__ @types\/structs\/anonymous.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_c where
 

--- a/hs-bindgen/fixtures/types/structs/anonymous/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/anonymous/bindingspec.yaml
@@ -34,6 +34,7 @@ hstypes:
       - s1_d
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -50,6 +51,7 @@ hstypes:
       - s1_c_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -66,6 +68,7 @@ hstypes:
       - s2_d
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -82,6 +85,7 @@ hstypes:
       - s2_inner_deep
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -97,6 +101,7 @@ hstypes:
       - s2_inner_deep_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -113,6 +118,7 @@ hstypes:
       - s3_d
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -129,6 +135,7 @@ hstypes:
       - s3_c_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/fixtures/types/structs/anonymous/th.txt
@@ -26,8 +26,7 @@ data S1_c
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S1_c
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -75,8 +74,7 @@ data S1
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -117,8 +115,7 @@ data S2_inner_deep
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2_inner_deep
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -160,8 +157,7 @@ data S2_inner
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2_inner
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -211,8 +207,7 @@ data S2
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -260,8 +255,7 @@ data S3
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S3
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -309,8 +303,7 @@ data S3_c
 
            __exported by:__ @types\/structs\/anonymous.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S3_c
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
@@ -74,8 +74,7 @@ data Flags = Flags
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Flags where
 
@@ -220,8 +219,7 @@ data Overflow32 = Overflow32
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32 where
 
@@ -322,8 +320,7 @@ data Overflow32b = Overflow32b
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32b where
 
@@ -424,8 +421,7 @@ data Overflow32c = Overflow32c
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow32c where
 
@@ -519,8 +515,7 @@ data Overflow64 = Overflow64
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Overflow64 where
 
@@ -598,8 +593,7 @@ data AlignA = AlignA
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AlignA where
 
@@ -675,8 +669,7 @@ data AlignB = AlignB
          __exported by:__ @types\/structs\/bitfields.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AlignB where
 

--- a/hs-bindgen/fixtures/types/structs/bitfields/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/bitfields/bindingspec.yaml
@@ -34,6 +34,7 @@ hstypes:
       - alignA_y
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -50,6 +51,7 @@ hstypes:
       - alignB_y
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -70,6 +72,7 @@ hstypes:
       - flags_bits
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasCField
   - HasField
@@ -88,6 +91,7 @@ hstypes:
       - overflow32_z
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -105,6 +109,7 @@ hstypes:
       - overflow32b_z
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -122,6 +127,7 @@ hstypes:
       - overflow32c_z
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw
@@ -138,6 +144,7 @@ hstypes:
       - overflow64_y
   instances:
   - Eq
+  - Generic
   - HasCBitField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/fixtures/types/structs/bitfields/th.txt
@@ -54,8 +54,7 @@ data Flags
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Flags
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -138,8 +137,7 @@ data Overflow32
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Overflow32
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -209,8 +207,7 @@ data Overflow32b
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Overflow32b
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -280,8 +277,7 @@ data Overflow32c
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Overflow32c
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -344,8 +340,7 @@ data Overflow64
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Overflow64
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -399,8 +394,7 @@ data AlignA
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize AlignA
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -450,8 +444,7 @@ data AlignB
 
            __exported by:__ @types\/structs\/bitfields.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize AlignB
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -36,8 +36,7 @@ data B = B
          __exported by:__ @types\/structs\/circular_dependency_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B where
 
@@ -89,8 +88,7 @@ data A = A
          __exported by:__ @types\/structs\/circular_dependency_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where
 

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/bindingspec.yaml
@@ -18,6 +18,7 @@ hstypes:
       - a_toB
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -33,6 +34,7 @@ hstypes:
       - b_toA
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -19,8 +19,7 @@ data B
 
            __exported by:__ @types\/structs\/circular_dependency_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize B
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -55,8 +54,7 @@ data A
 
            __exported by:__ @types\/structs\/circular_dependency_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/structs/named_vs_anon/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/named_vs_anon/Example.hs
@@ -19,8 +19,7 @@ import Prelude (Eq, Int, Show, pure, return)
 -}
 data A = A
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize A where
 
@@ -50,8 +49,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable A instance F.Storable A
 -}
 data Struct1 = Struct1
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct1 where
 
@@ -81,8 +79,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct1 instance F.Storable
 -}
 data B_s = B_s
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize B_s where
 
@@ -112,8 +109,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable B_s instance F.Storable B_s
 -}
 data Struct2_s = Struct2_s
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct2_s where
 
@@ -143,8 +139,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct2_s instance F.Storab
 -}
 data C = C
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize C where
 
@@ -174,8 +169,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable C instance F.Storable C
 -}
 data Struct3 = Struct3
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct3 where
 
@@ -205,8 +199,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct3 instance F.Storable
 -}
 data D = D
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize D where
 
@@ -236,8 +229,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable D instance F.Storable D
 -}
 data Struct4 = Struct4
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct4 where
 
@@ -267,8 +259,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct4 instance F.Storable
 -}
 data E_s = E_s
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize E_s where
 
@@ -298,8 +289,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable E_s instance F.Storable E_s
 -}
 data Struct5_s = Struct5_s
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Struct5_s where
 
@@ -329,8 +319,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Struct5_s instance F.Storab
 -}
 data F = F
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize F where
 
@@ -360,8 +349,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable F instance F.Storable F
 -}
 data Typedef1 = Typedef1
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef1 where
 
@@ -391,8 +379,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Typedef1 instance F.Storabl
 -}
 data G = G
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize G where
 
@@ -422,8 +409,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable G instance F.Storable G
 -}
 data Typedef2 = Typedef2
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef2 where
 
@@ -453,8 +439,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable Typedef2 instance F.Storabl
 -}
 data H = H
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize H where
 
@@ -484,8 +469,7 @@ deriving via HsBindgen.Runtime.Marshal.EquivStorable H instance F.Storable H
 -}
 data Typedef3 = Typedef3
   {}
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Typedef3 where
 

--- a/hs-bindgen/fixtures/types/structs/named_vs_anon/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/named_vs_anon/bindingspec.yaml
@@ -77,6 +77,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -89,6 +90,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -101,6 +103,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -113,6 +116,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -125,6 +129,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -137,6 +142,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -149,6 +155,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -161,6 +168,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -173,6 +181,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -185,6 +194,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -197,6 +207,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -209,6 +220,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -221,6 +233,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -233,6 +246,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -245,6 +259,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -257,6 +272,7 @@ hstypes:
       fields: []
   instances:
   - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/fixtures/types/structs/named_vs_anon/th.txt
+++ b/hs-bindgen/fixtures/types/structs/named_vs_anon/th.txt
@@ -13,8 +13,7 @@ data A
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize A
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -38,8 +37,7 @@ data Struct1
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct1
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -63,8 +61,7 @@ data B_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize B_s
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -88,8 +85,7 @@ data Struct2_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct2_s
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -113,8 +109,7 @@ data C
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize C
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -138,8 +133,7 @@ data Struct3
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct3
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -163,8 +157,7 @@ data D
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize D
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -188,8 +181,7 @@ data Struct4
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct4
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -213,8 +205,7 @@ data E_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize E_s
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -238,8 +229,7 @@ data Struct5_s
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Struct5_s
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -263,8 +253,7 @@ data F
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize F
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -288,8 +277,7 @@ data Typedef1
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Typedef1
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -313,8 +301,7 @@ data G
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize G
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -338,8 +325,7 @@ data Typedef2
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Typedef2
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -363,8 +349,7 @@ data H
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize H
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -388,8 +373,7 @@ data Typedef3
 
            __exported by:__ @types\/structs\/named_vs_anon.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Typedef3
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
@@ -44,8 +44,7 @@ data Linked_list_A_t = Linked_list_A_t
          __exported by:__ @types\/structs\/recursive_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Linked_list_A_t where
 
@@ -119,8 +118,7 @@ data Linked_list_B_t = Linked_list_B_t
          __exported by:__ @types\/structs\/recursive_struct.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Linked_list_B_t where
 

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/bindingspec.yaml
@@ -25,6 +25,7 @@ hstypes:
       - linked_list_A_t_next
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -41,6 +42,7 @@ hstypes:
       - linked_list_B_t_next
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
@@ -26,8 +26,7 @@ data Linked_list_A_t
 
            __exported by:__ @types\/structs\/recursive_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Linked_list_A_t
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -80,8 +79,7 @@ data Linked_list_B_t
 
            __exported by:__ @types\/structs\/recursive_struct.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Linked_list_B_t
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
@@ -47,8 +47,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
 
@@ -127,8 +126,7 @@ data S2_t = S2_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_t where
 
@@ -206,8 +204,7 @@ data S3_t = S3_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_t where
 
@@ -273,8 +270,7 @@ data S4 = S4
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S4 where
 
@@ -359,8 +355,7 @@ data S5 = S5
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S5 where
 
@@ -432,8 +427,7 @@ data S6 = S6
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S6 where
 
@@ -505,8 +499,7 @@ data S7a_Aux = S7a_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7a_Aux where
 
@@ -565,8 +558,7 @@ instance GHC.Records.HasField "b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) where
 newtype S7a = S7a
   { unwrap :: Ptr.Ptr S7a_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -608,8 +600,7 @@ data S7b_Aux = S7b_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7b_Aux where
 
@@ -668,8 +659,7 @@ instance GHC.Records.HasField "b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) where
 newtype S7b = S7b
   { unwrap :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/bindingspec.yaml
@@ -55,6 +55,7 @@ hstypes:
       - b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -72,6 +73,7 @@ hstypes:
       - c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -87,6 +89,7 @@ hstypes:
       - a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -104,6 +107,7 @@ hstypes:
       - c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -120,6 +124,7 @@ hstypes:
       - b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -136,6 +141,7 @@ hstypes:
       - b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -151,6 +157,7 @@ hstypes:
       - unwrap
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -169,6 +176,7 @@ hstypes:
       - b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -184,6 +192,7 @@ hstypes:
       - unwrap
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -202,6 +211,7 @@ hstypes:
       - b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
@@ -26,8 +26,7 @@ data S1
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -82,8 +81,7 @@ data S2_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2_t
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -130,8 +128,7 @@ data S3_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S3_t
     where staticSizeOf = \_ -> 1 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -180,8 +177,7 @@ data S4
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S4
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -235,8 +231,7 @@ data S5
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S5
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -284,8 +279,7 @@ data S6
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S6
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -333,8 +327,7 @@ data S7a_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S7a_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -369,8 +362,7 @@ newtype S7a
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -408,8 +400,7 @@ data S7b_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S7b_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -444,8 +435,7 @@ newtype S7b
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -46,8 +46,7 @@ data S1 = S1
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S1 where
 
@@ -126,8 +125,7 @@ data S2_t = S2_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S2_t where
 
@@ -205,8 +203,7 @@ data S3_t = S3_t
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S3_t where
 
@@ -272,8 +269,7 @@ data S4 = S4
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S4 where
 
@@ -358,8 +354,7 @@ data S5 = S5
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S5 where
 
@@ -431,8 +426,7 @@ data S6 = S6
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S6 where
 
@@ -504,8 +498,7 @@ data S7a_Aux = S7a_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7a_Aux where
 
@@ -564,8 +557,7 @@ instance GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) wh
 newtype S7a = S7a
   { unwrapS7a :: Ptr.Ptr S7a_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -607,8 +599,7 @@ data S7b_Aux = S7b_Aux
          __exported by:__ @types\/structs\/simple_structs.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize S7b_Aux where
 
@@ -667,8 +658,7 @@ instance GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) wh
 newtype S7b = S7b
   { unwrapS7b :: Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux))
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/structs/simple_structs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/bindingspec.yaml
@@ -55,6 +55,7 @@ hstypes:
       - s1_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -72,6 +73,7 @@ hstypes:
       - s2_t_c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -87,6 +89,7 @@ hstypes:
       - s3_t_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -104,6 +107,7 @@ hstypes:
       - s4_c
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -120,6 +124,7 @@ hstypes:
       - s5_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -136,6 +141,7 @@ hstypes:
       - s6_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -151,6 +157,7 @@ hstypes:
       - unwrapS7a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -169,6 +176,7 @@ hstypes:
       - s7a_Aux_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -184,6 +192,7 @@ hstypes:
       - unwrapS7b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -202,6 +211,7 @@ hstypes:
       - s7b_Aux_b
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
@@ -26,8 +26,7 @@ data S1
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S1
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -82,8 +81,7 @@ data S2_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S2_t
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -130,8 +128,7 @@ data S3_t
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S3_t
     where staticSizeOf = \_ -> 1 :: Int
           staticAlignment = \_ -> 1 :: Int
@@ -180,8 +177,7 @@ data S4
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S4
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -235,8 +231,7 @@ data S5
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S5
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -284,8 +279,7 @@ data S6
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S6
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -333,8 +327,7 @@ data S7a_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S7a_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -369,8 +362,7 @@ newtype S7a
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -408,8 +400,7 @@ data S7b_Aux
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize S7b_Aux
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -444,8 +435,7 @@ newtype S7b
 
            __exported by:__ @types\/structs\/simple_structs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
@@ -37,8 +37,7 @@ data Thing = Thing
          __exported by:__ @types\/structs\/struct_arg.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Thing where
 

--- a/hs-bindgen/fixtures/types/structs/struct_arg/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/bindingspec.yaml
@@ -15,6 +15,7 @@ hstypes:
       - thing_x
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
@@ -116,8 +116,7 @@ data Thing
 
            __exported by:__ @types\/structs\/struct_arg.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Thing
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -99,8 +99,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "unwrapF1_Aux" where
 newtype F1 = F1
   { unwrapF1 :: Ptr.FunPtr F1_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -187,8 +186,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F2_Aux "unwrapF2_Aux" where
 newtype F2 = F2
   { unwrapF2 :: Ptr.Ptr (Ptr.FunPtr F2_Aux)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -276,8 +274,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F3_Aux "unwrapF3_Aux" where
 newtype F3 = F3
   { unwrapF3 :: Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux))
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -364,8 +361,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F4_Aux "unwrapF4_Aux" where
 newtype F4 = F4
   { unwrapF4 :: Ptr.Ptr (Ptr.FunPtr F4_Aux)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -452,8 +448,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F5_Aux "unwrapF5_Aux" where
 newtype F5 = F5
   { unwrapF5 :: Ptr.Ptr (Ptr.FunPtr F5_Aux)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -483,8 +478,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F5 "unwrapF5" where
 newtype MyInt = MyInt
   { unwrapMyInt :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -581,8 +575,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F6_Aux "unwrapF6_Aux" where
 newtype F6 = F6
   { unwrapF6 :: Ptr.Ptr (Ptr.FunPtr F6_Aux)
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/bindingspec.yaml
@@ -33,6 +33,7 @@ hstypes:
       - unwrapF1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -50,6 +51,7 @@ hstypes:
       - unwrapF2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -67,6 +69,7 @@ hstypes:
       - unwrapF3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -84,6 +87,7 @@ hstypes:
       - unwrapF4
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -101,6 +105,7 @@ hstypes:
       - unwrapF5
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -118,6 +123,7 @@ hstypes:
       - unwrapF6
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -140,6 +146,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -61,8 +61,7 @@ newtype F1
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -135,8 +134,7 @@ newtype F2
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -209,8 +207,7 @@ newtype F3
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -280,8 +277,7 @@ newtype F4
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -349,8 +345,7 @@ newtype F5
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -375,8 +370,7 @@ newtype MyInt
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -457,8 +451,7 @@ newtype F6
 
            __exported by:__ @types\/typedefs\/multi_level_function_pointer.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -39,8 +39,7 @@ import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, R
 newtype T1 = T1
   { unwrapT1 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -79,8 +78,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T1 "unwrapT1" where
 newtype T2 = T2
   { unwrapT2 :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -119,8 +117,7 @@ instance HsBindgen.Runtime.HasCField.HasCField T2 "unwrapT2" where
 newtype M1 = M1
   { unwrapM1 :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -159,8 +156,7 @@ instance HsBindgen.Runtime.HasCField.HasCField M1 "unwrapM1" where
 newtype M2 = M2
   { unwrapM2 :: FC.CChar
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -199,8 +195,7 @@ instance HsBindgen.Runtime.HasCField.HasCField M2 "unwrapM2" where
 newtype M3 = M3
   { unwrapM3 :: Ptr.Ptr FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -256,8 +251,7 @@ data ExampleStruct = ExampleStruct
          __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize ExampleStruct where
 
@@ -346,8 +340,7 @@ instance GHC.Records.HasField "exampleStruct_m2" (Ptr.Ptr ExampleStruct) (Ptr.Pt
 newtype Uint64_t = Uint64_t
   { unwrapUint64_t :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -392,8 +385,7 @@ data Foo = Foo
          __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Foo where
 

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/bindingspec.yaml
@@ -39,6 +39,7 @@ hstypes:
       - exampleStruct_m2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -54,6 +55,7 @@ hstypes:
       - foo_a
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -74,6 +76,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -102,6 +105,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -125,6 +129,7 @@ hstypes:
       - unwrapM3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -147,6 +152,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -175,6 +181,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -203,6 +210,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -13,8 +13,7 @@ newtype T1
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -49,8 +48,7 @@ newtype T2
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -85,8 +83,7 @@ newtype M1
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -121,8 +118,7 @@ newtype M2
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -157,8 +153,7 @@ newtype M3
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -210,8 +205,7 @@ data ExampleStruct
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize ExampleStruct
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -258,8 +252,7 @@ newtype Uint64_t
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -300,8 +293,7 @@ data Foo
 
            __exported by:__ @types\/typedefs\/typedef_vs_macro.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Foo
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
@@ -41,8 +41,7 @@ import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 newtype Myint = Myint
   { unwrapMyint :: FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -81,8 +80,7 @@ instance HsBindgen.Runtime.HasCField.HasCField Myint "unwrapMyint" where
 newtype Intptr = Intptr
   { unwrapIntptr :: Ptr.Ptr FC.CInt
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -226,8 +224,7 @@ instance HsBindgen.Runtime.HasCField.HasCField FunctionPointer_Function_Aux "unw
 newtype FunctionPointer_Function = FunctionPointer_Function
   { unwrapFunctionPointer_Function :: Ptr.FunPtr FunctionPointer_Function_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -370,8 +367,7 @@ instance HsBindgen.Runtime.HasCField.HasCField F1_Aux "unwrapF1_Aux" where
 newtype F1 = F1
   { unwrapF1 :: Ptr.FunPtr F1_Aux
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -455,8 +451,7 @@ instance HsBindgen.Runtime.HasCField.HasCField G1 "unwrapG1" where
 newtype G2 = G2
   { unwrapG2 :: Ptr.FunPtr G1
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw
@@ -563,8 +558,7 @@ instance HsBindgen.Runtime.HasCField.HasCField H2 "unwrapH2" where
 newtype H3 = H3
   { unwrapH3 :: Ptr.FunPtr H2
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Show)
   deriving newtype
     ( HsBindgen.Runtime.Marshal.StaticSize
     , HsBindgen.Runtime.Marshal.ReadRaw

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/bindingspec.yaml
@@ -45,6 +45,7 @@ hstypes:
       - unwrapF1
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -62,6 +63,7 @@ hstypes:
       - unwrapFunctionPointer_Function
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -79,6 +81,7 @@ hstypes:
       - unwrapG1
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -91,6 +94,7 @@ hstypes:
       - unwrapG2
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -108,6 +112,7 @@ hstypes:
       - unwrapH1
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -119,6 +124,7 @@ hstypes:
       fields:
       - unwrapH2
   instances:
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -130,6 +136,7 @@ hstypes:
       - unwrapH3
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -147,6 +154,7 @@ hstypes:
       - unwrapInt2int
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -159,6 +167,7 @@ hstypes:
       - unwrapIntptr
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -181,6 +190,7 @@ hstypes:
   - Enum
   - Eq
   - FiniteBits
+  - Generic
   - HasCField
   - HasFFIType
   - HasField
@@ -204,6 +214,7 @@ hstypes:
       - unwrapNonFunctionPointer_Function
   instances:
   - FromFunPtr
+  - Generic
   - HasCField
   - HasFFIType
   - HasField

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
@@ -13,8 +13,7 @@ newtype Myint
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Read, Show)
+    deriving stock (Generic, Eq, Ord, Read, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -49,8 +48,7 @@ newtype Intptr
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -166,8 +164,7 @@ newtype FunctionPointer_Function
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -286,8 +283,7 @@ newtype F1
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -351,8 +347,7 @@ newtype G2
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,
@@ -437,8 +432,7 @@ newtype H3
 
            __exported by:__ @types\/typedefs\/typedefs.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Ord, Show)
+    deriving stock (Generic, Eq, Ord, Show)
     deriving newtype (StaticSize,
                       ReadRaw,
                       WriteRaw,

--- a/hs-bindgen/fixtures/types/unions/nested_unions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/bindingspec.yaml
@@ -23,6 +23,7 @@ hstypes:
       fields:
       - exA_fieldA1
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -36,6 +37,7 @@ hstypes:
       fields:
       - exB_fieldB1
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -49,6 +51,7 @@ hstypes:
       fields:
       - unwrapExB_fieldB1
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -62,6 +65,7 @@ hstypes:
       fields:
       - unwrapUnionA
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/unions/Example.hs
@@ -47,8 +47,7 @@ data Dim2 = Dim2
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Dim2 where
 
@@ -127,8 +126,7 @@ data Dim3 = Dim3
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize Dim3 where
 
@@ -547,8 +545,7 @@ data AnonA_xy = AnonA_xy
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AnonA_xy where
 
@@ -620,8 +617,7 @@ data AnonA_polar = AnonA_polar
          __exported by:__ @types\/unions\/unions.h@
     -}
   }
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Show)
 
 instance HsBindgen.Runtime.Marshal.StaticSize AnonA_polar where
 

--- a/hs-bindgen/fixtures/types/unions/unions/bindingspec.yaml
+++ b/hs-bindgen/fixtures/types/unions/unions/bindingspec.yaml
@@ -41,6 +41,7 @@ hstypes:
       fields:
       - unwrapAnonA
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -56,6 +57,7 @@ hstypes:
       - anonA_polar_p
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -72,6 +74,7 @@ hstypes:
       - anonA_xy_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -87,6 +90,7 @@ hstypes:
       - dim_tag
       - dim_payload
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -102,6 +106,7 @@ hstypes:
       - dim2_y
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -119,6 +124,7 @@ hstypes:
       - dim3_z
   instances:
   - Eq
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -134,6 +140,7 @@ hstypes:
       - dimB_tag
       - dimB_payload
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -147,6 +154,7 @@ hstypes:
       fields:
       - unwrapDimPayload
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw
@@ -160,6 +168,7 @@ hstypes:
       fields:
       - unwrapDimPayloadB
   instances:
+  - Generic
   - HasCField
   - HasField
   - ReadRaw

--- a/hs-bindgen/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/unions/th.txt
@@ -26,8 +26,7 @@ data Dim2
 
            __exported by:__ @types\/unions\/unions.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Dim2
     where staticSizeOf = \_ -> 8 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -82,8 +81,7 @@ data Dim3
 
            __exported by:__ @types\/unions\/unions.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize Dim3
     where staticSizeOf = \_ -> 12 :: Int
           staticAlignment = \_ -> 4 :: Int
@@ -427,8 +425,7 @@ data AnonA_xy
 
            __exported by:__ @types\/unions\/unions.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize AnonA_xy
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int
@@ -476,8 +473,7 @@ data AnonA_polar
 
            __exported by:__ @types\/unions\/unions.h@
       -}
-    deriving stock Generic
-    deriving stock (Eq, Show)
+    deriving stock (Generic, Eq, Show)
 instance StaticSize AnonA_polar
     where staticSizeOf = \_ -> 16 :: Int
           staticAlignment = \_ -> 8 :: Int

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -285,10 +285,11 @@ unionDecs fieldNaming haddockConfig info union spec = do
 
         knownInsts :: Set Inst.TypeClass
         knownInsts = Set.fromList $ catMaybes [
+            Just Inst.Generic
           -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
           -- Should correctly detect 'Inst.HasCBitField' and 'Inst.HasCField'
           -- when bit-fields in unions are supported.
-            if null union.fields then Nothing else Just Inst.HasCField
+          , if null union.fields then Nothing else Just Inst.HasCField
           , if null union.fields then Nothing else Just Inst.HasField
           , Just Inst.ReadRaw
           , Just Inst.StaticSize
@@ -305,6 +306,12 @@ unionDecs fieldNaming haddockConfig info union spec = do
         marshalDecls :: [Hs.Decl]
         marshalDecls = [
             Hs.DeclDeriveInstance Hs.DeriveInstance{
+                strategy = Hs.DeriveStock
+              , clss     = Inst.Generic
+              , name     = nt.name
+              , comment  = Nothing
+              }
+          , Hs.DeclDeriveInstance Hs.DeriveInstance{
                 strategy = Hs.DeriveVia sba
               , clss     = Inst.StaticSize
               , name     = nt.name
@@ -551,6 +558,7 @@ enumDecs supInsts fns haddockConfig info enum spec = aux <$> newtypeDec
         knownInsts :: Set Inst.TypeClass
         knownInsts = Set.fromList $ catMaybes [
             Just Inst.CEnum
+          , Just Inst.Generic
           , Just Inst.HasCField
           , Just Inst.HasField
           , Just Inst.Prim
@@ -735,6 +743,7 @@ typedefDecs supInsts haddockConfig sizeofs info mkNewtypeOrigin typedef spec = d
         knownInsts :: Set Inst.TypeClass
         knownInsts = Set.fromList $ catMaybes [
             Inst.FromFunPtr <$ mFunPtr
+          , Just Inst.Generic
           , Just Inst.HasCField
           , Just Inst.HasField
           , Inst.ToFunPtr <$ mFunPtr
@@ -997,7 +1006,7 @@ macroDecsTypedef supInsts haddockConfig info macroType spec = do
         candidateInsts = Hs.getCandidateInsts supInsts
 
         knownInsts :: Set Inst.TypeClass
-        knownInsts = Set.fromList [Inst.HasCField, Inst.HasField]
+        knownInsts = Set.fromList [Inst.HasCField, Inst.HasField, Inst.Generic]
 
     -- everything in aux is state-dependent
     aux :: Hs.Newtype -> [Hs.Decl]

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Instances.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Instances.hs
@@ -187,6 +187,7 @@ getHsPrimTypeInsts = \case
       , Inst.Enum
       , Inst.Eq
       , Inst.FiniteBits
+      , Inst.Generic
       , Inst.HasFFIType
       , Inst.Ix
       , Inst.Ord
@@ -262,6 +263,7 @@ getHsPrimTypeInsts = \case
     unitInsts :: Set Inst.TypeClass
     unitInsts = Set.fromList [
         Inst.Eq
+      , Inst.Generic
       , Inst.HasFFIType
       , Inst.Ord
       , Inst.Read
@@ -275,6 +277,7 @@ getHsPrimTypeInsts = \case
     voidInsts :: Set Inst.TypeClass
     voidInsts = Set.fromList [
         Inst.Eq
+      , Inst.Generic
       , Inst.Ix
       , Inst.Ord
       , Inst.Read

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -61,8 +61,9 @@ getDeclsFieldVec :: forall n.
 getDeclsFieldVec supInsts hCfg spec info struct fieldsVec = do
     insts <-
       getInstances supInsts name struct.fields <$> State.gets (.instanceMap)
-    let (hsStruct, decls) =
-          getDecls supInsts hCfg spec name info struct fieldsVec insts
+    let insts' = Set.insert Inst.Generic insts
+        (hsStruct, decls) =
+          getDecls supInsts hCfg spec name info struct fieldsVec insts'
     State.modify' $ #instanceMap %~ Map.insert name hsStruct.instances
     pure $ Hs.DeclData hsStruct : decls
   where
@@ -82,7 +83,7 @@ getDeclsFieldVecFlam :: forall n.
 getDeclsFieldVecFlam flam supInsts hCfg spec info struct fieldsVec = do
     insts <-
       getInstances supInsts auxName struct.fields <$> State.gets (.instanceMap)
-    let insts' = Set.insert Inst.Flam_Offset insts
+    let insts' = insts <> Set.fromList [Inst.Flam_Offset, Inst.Generic]
         (hsStruct, decls) =
           getDecls supInsts hCfg spec auxName info struct fieldsVec insts'
     State.modify' $ #instanceMap %~ Map.insert auxName hsStruct.instances

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -146,7 +146,7 @@ translateDeclData :: Hs.Struct n -> SDecl
 translateDeclData struct = DRecord Record{
       typ     = struct.name
     , con     = struct.constr
-    , deriv   = [(Hs.DeriveStock, [Generic_class])]
+    , deriv   = []
     , comment = struct.comment
     , origin  = case struct.origin of
                   Just origin -> origin
@@ -174,7 +174,7 @@ translateNewtype n = DNewtype Newtype{
       name    = n.name
     , con     = n.constr
     , origin  = n.origin
-    , deriv   = [(Hs.DeriveStock, [Generic_class])]
+    , deriv   = []
     , comment = n.comment
     , field   = Field {
           name    = n.field.name
@@ -203,6 +203,7 @@ translateTypeClass = \case
     Inst.Floating        -> TGlobal Floating_class
     Inst.Fractional      -> TGlobal Fractional_class
     Inst.FromFunPtr      -> TGlobal FromFunPtr_class
+    Inst.Generic         -> TGlobal Generic_class
     Inst.HasCBitField    -> TGlobal HasCBitfield_class
     Inst.HasCField       -> TGlobal HasCField_class
     Inst.HasFFIType      -> TGlobal HasFFIType_class

--- a/hs-bindgen/src-internal/HsBindgen/Instances.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Instances.hs
@@ -41,6 +41,7 @@ data TypeClass =
   | Floating
   | Fractional
   | FromFunPtr
+  | Generic
   | HasCBitField  -- Indicates instances for all bit fields
   | HasCField     -- Indicates instances for all non-bit fields
   | HasFFIType
@@ -168,10 +169,11 @@ instance Default SupportedInstances where
     SupportedInstances{
         struct = Map.fromList [
             mkDef Eq           Dependent   Stock     []
+          , mkDef Flam_Offset  Independent HsBindgen []
+          , mkDef Generic      Independent Stock     []
           , mkDef HasCBitField Independent HsBindgen []
           , mkDef HasCField    Independent HsBindgen []
           , mkDef HasField     Independent HsBindgen []
-          , mkDef Flam_Offset  Independent HsBindgen []
           , mkOpt Ord          Dependent             [Stock]
           , mkDef ReadRaw      Dependent   HsBindgen []
           , mkDef Show         Dependent   Stock     []
@@ -180,7 +182,8 @@ instance Default SupportedInstances where
           , mkDef WriteRaw     Dependent   HsBindgen []
           ]
       , union = Map.fromList [
-            mkDef HasCBitField Independent HsBindgen []
+            mkDef Generic      Independent Stock     []
+          , mkDef HasCBitField Independent HsBindgen []
           , mkDef HasCField    Independent HsBindgen []
           , mkDef HasField     Independent HsBindgen []
           , mkDef ReadRaw      Independent HsBindgen []
@@ -193,6 +196,7 @@ instance Default SupportedInstances where
           , mkDef CEnum           Independent HsBindgen []
           , mkOpt Enum            Independent           [HsBindgen, Newtype]
           , mkDef Eq              Dependent   Stock     []
+          , mkDef Generic         Independent Stock     []
           , mkDef HasCField       Independent HsBindgen []
           , mkDef HasFFIType      Dependent   Newtype   []
           , mkDef HasField        Independent HsBindgen []
@@ -216,6 +220,7 @@ instance Default SupportedInstances where
           , mkDef Floating   Dependent   Newtype   []
           , mkDef Fractional Dependent   Newtype   []
           , mkDef FromFunPtr Independent HsBindgen []
+          , mkDef Generic    Independent Stock     []
           , mkDef HasCField  Independent HsBindgen []
           , mkDef HasFFIType Dependent   Newtype   []
           , mkDef HasField   Independent HsBindgen []


### PR DESCRIPTION
The hack in #1669 derives instances, but it does not reflect those instances in generated binding specifications.  This commit removes the hack and implements (backend) `Generic` instance resolution.

Note that the hack derived `Generic` instances for `union` types, and this implementation does as well.  This is not a problem, but I mention it in case it was unintentional.

There are two kinds of changes to the fixtures:

* `Generic` is now derived along with the other (`stock`) instances:

```diff
-  deriving stock (GHC.Generics.Generic)
-  deriving stock (Eq, Ord, Read, Show)
+  deriving stock (GHC.Generics.Generic, Eq, Ord, Read, Show)
```

* `Generic` instances are now reflected in generated binding specifications.

I confirmed that there are no other changes.