### PR TITLE
Feature tests (for callbacks)

### DIFF
--- a/.github/actions/examples/feature-tests/action.yml
+++ b/.github/actions/examples/feature-tests/action.yml
@@ -1,0 +1,10 @@
+name: feature-tests example
+description: Build and run the feature-tests example
+
+runs:
+  using: composite
+  steps:
+    - name: Run generation and build script
+      shell: bash
+      working-directory: ./examples/feature-tests
+      run: ./generate-and-run.sh

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -38,7 +38,7 @@ jobs:
         # NOTE: add new example projects here. The example project has to
         # satisfy some requirements for this workflow to work correctly. See
         # ./examples/README.md (with respect to the repository root).
-        example: ['botan', 'bundled-c', 'c-minisat', 'libpcap', 'c-qrcode', 'blocktest', 'c-rogueutil', 'constructor-import-issue', 'c-rpm']
+        example: ['botan', 'bundled-c', 'c-minisat', 'libpcap', 'c-qrcode', 'blocktest', 'c-rogueutil', 'constructor-import-issue', 'c-rpm', 'feature-tests']
 
     env:
       # We assume that the example executable lives in this directory
@@ -84,7 +84,7 @@ jobs:
     - name: 🛠️ Configure (${{ matrix.example }})
       working-directory: ${{ env.hs-project-directory }}
       run: |
-        cabal configure --disable-test --disable-benchmark --disable-documentation --ghc-options="-Werror"
+        cabal configure --enable-test --disable-benchmark --disable-documentation --ghc-options="-Werror"
         cat "cabal.project.local"
 
     - name: 💾 Generate Cabal plan (hs-bindgen-cli)
@@ -182,3 +182,7 @@ jobs:
     - name: 🧪 Build and run c-rpm example
       if: ${{ matrix.example == 'c-rpm' }}
       uses: ./.github/actions/examples/c-rpm
+
+    - name: 🧪 Build and run feature-tests example
+      if: ${{ matrix.example == 'feature-tests' }}
+      uses: ./.github/actions/examples/feature-tests

--- a/examples/feature-tests/.gitignore
+++ b/examples/feature-tests/.gitignore
@@ -1,0 +1,72 @@
+# https://github.com/github/gitignore/blob/main/Haskell.gitignore
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*
+
+# https://github.com/github/gitignore/blob/main/C.gitignore
+## Prerequisites
+*.d
+## Object files
+*.o
+*.ko
+*.obj
+*.elf
+## Linker output
+*.ilk
+*.map
+*.exp
+## Precompiled Headers
+*.gch
+*.pch
+## Libraries
+*.lib
+*.a
+*.la
+*.lo
+## Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+## Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+## Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+## Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+## debug information files
+*.dwo

--- a/examples/feature-tests/c/Makefile
+++ b/examples/feature-tests/c/Makefile
@@ -1,0 +1,30 @@
+default: libfeature-tests.so
+
+.PHONY: clean
+clean:
+	rm -f *.o *.so
+
+libfeature-tests.so: arrays/known_size.o arrays/unknown_size.o basic.o structs.o unions.o
+	gcc -Wall -shared -o libfeature-tests.so \
+		callbacks/arrays/known_size.o \
+		callbacks/arrays/unknown_size.o \
+		callbacks/basic.o \
+		callbacks/structs.o \
+		callbacks/unions.o
+
+# callbacks
+
+arrays/known_size.o: callbacks/arrays/known_size.h callbacks/arrays/known_size.c
+	gcc -Wall -o callbacks/arrays/known_size.o -c -fPIC callbacks/arrays/known_size.c
+
+arrays/unknown_size.o: callbacks/arrays/unknown_size.h callbacks/arrays/unknown_size.c
+	gcc -Wall -o callbacks/arrays/unknown_size.o -c -fPIC callbacks/arrays/unknown_size.c
+
+basic.o: callbacks/basic.h callbacks/basic.c
+	gcc -Wall -o callbacks/basic.o -c -fPIC callbacks/basic.c
+
+structs.o: callbacks/structs.h callbacks/structs.c
+	gcc -Wall -o callbacks/structs.o -c -fPIC callbacks/structs.c
+
+unions.o: callbacks/unions.h callbacks/unions.c
+	gcc -Wall -o callbacks/unions.o -c -fPIC callbacks/unions.c

--- a/examples/feature-tests/c/callbacks/arrays/known_size.c
+++ b/examples/feature-tests/c/callbacks/arrays/known_size.c
@@ -1,0 +1,10 @@
+#include "known_size.h"
+#include "unknown_size.h"
+
+void reverse_vec5 (vec5 xs) {
+  reverse_list(xs, 5);
+};
+
+void apply_vec5_op (vec5_op * f, vec5 xs) {
+  return f(xs);
+};

--- a/examples/feature-tests/c/callbacks/arrays/known_size.h
+++ b/examples/feature-tests/c/callbacks/arrays/known_size.h
@@ -1,0 +1,11 @@
+/* callbacks with arrays of known size (by pointer to their first element) */
+
+#include <stdlib.h>
+
+typedef int vec5[5];
+
+typedef void vec5_op (vec5 xs);
+
+extern void reverse_vec5 (vec5 xs);
+
+extern void apply_vec5_op (vec5_op * f, vec5 xs);

--- a/examples/feature-tests/c/callbacks/arrays/unknown_size.c
+++ b/examples/feature-tests/c/callbacks/arrays/unknown_size.c
@@ -1,0 +1,16 @@
+#include "unknown_size.h"
+
+// https://stackoverflow.com/a/199891
+void reverse_list (list xs, size_t len) {
+    int c, i, j;
+    for (i = 0, j = len - 1; i < j; i++, j--)
+    {
+        c = xs[i];
+        xs[i] = xs[j];
+        xs[j] = c;
+    }
+};
+
+void apply_list_op (list_op * f, list xs, size_t len) {
+  return f(xs, len);
+};

--- a/examples/feature-tests/c/callbacks/arrays/unknown_size.h
+++ b/examples/feature-tests/c/callbacks/arrays/unknown_size.h
@@ -1,0 +1,11 @@
+/* callbacks with arrays of unknown size (by pointer to their first element) */
+
+#include <stdlib.h>
+
+typedef int list[];
+
+typedef void list_op (list xs, size_t len);
+
+extern void reverse_list (list xs, size_t len);
+
+extern void apply_list_op (list_op * f, list xs, size_t len);

--- a/examples/feature-tests/c/callbacks/basic.c
+++ b/examples/feature-tests/c/callbacks/basic.c
@@ -1,0 +1,9 @@
+#include "basic.h"
+
+int square (int x) {
+  return (x * x);
+}
+
+int apply_int_op (int_op * f, int x) {
+  return f(x);
+}

--- a/examples/feature-tests/c/callbacks/basic.h
+++ b/examples/feature-tests/c/callbacks/basic.h
@@ -1,0 +1,7 @@
+/* callbacks with basic types */
+
+typedef int int_op (int);
+
+extern int square(int);
+
+extern int apply_int_op (int_op * f, int x);

--- a/examples/feature-tests/c/callbacks/structs.c
+++ b/examples/feature-tests/c/callbacks/structs.c
@@ -1,0 +1,11 @@
+#include "structs.h"
+
+point scale_2_point (point p) {
+  p.x *= 2;
+  p.y *= 2;
+  return p;
+};
+
+point apply_point_op (point_op * f, point x) {
+  return f(x);
+};

--- a/examples/feature-tests/c/callbacks/structs.h
+++ b/examples/feature-tests/c/callbacks/structs.h
@@ -1,0 +1,12 @@
+/* callbacks with structs (by value) */
+
+typedef struct {
+  int x;
+  int y;
+} point;
+
+typedef point point_op (point p);
+
+extern point scale_2_point (point p);
+
+extern point apply_point_op (point_op * f, point p);

--- a/examples/feature-tests/c/callbacks/unions.c
+++ b/examples/feature-tests/c/callbacks/unions.c
@@ -1,0 +1,17 @@
+#include "unions.h"
+
+Val increment_object (Val v, Typ t) {
+  switch (t) {
+    case LongLong:
+      v.integer++;
+      break;
+    case Float:
+      v.floating++;
+      break;
+  }
+  return v;
+}
+
+Val apply_object_op (object_op * f, Val v, Typ t) {
+  return (*f)(v, t);
+}

--- a/examples/feature-tests/c/callbacks/unions.h
+++ b/examples/feature-tests/c/callbacks/unions.h
@@ -1,0 +1,14 @@
+/* callbacks with unions (by value) */
+
+typedef enum { LongLong, Float } Typ;
+
+typedef union {
+  long long integer;
+  float floating;
+} Val;
+
+typedef Val object_op (Val v, Typ t);
+
+extern Val increment_object (Val v, Typ t);
+
+extern Val apply_object_op (object_op * f, Val v, Typ t);

--- a/examples/feature-tests/generate-and-run.sh
+++ b/examples/feature-tests/generate-and-run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Exit on first error
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+export PROJECT_ROOT
+
+(
+    echo "# "
+    echo "# Building C library"
+    echo "# "
+
+    cd "$SCRIPT_DIR/c"
+    make
+)
+
+C_DIR=$(realpath c)
+echo $C_DIR
+
+echo "# "
+echo "# Generating Haskell bindings"
+echo "# "
+
+GENERATED_DIR=hs-project/src-generated/Generated
+if [ -d "$GENERATED_DIR" ]; then
+  rm -r "$GENERATED_DIR"
+fi
+
+cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Callbacks.Arrays.KnownSize \
+    callbacks/arrays/known_size.h
+
+cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Callbacks.Arrays.UnknownSize \
+    callbacks/arrays/unknown_size.h
+
+cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Callbacks.Basic \
+    callbacks/basic.h
+
+cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Callbacks.Structs \
+    callbacks/structs.h
+
+cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Callbacks.Unions \
+    callbacks/unions.h
+
+echo "# "
+echo "# Updating cabal.project.local"
+echo "# "
+
+LINE=$(cat <<-EOF
+package feature-tests
+    extra-include-dirs: $C_DIR
+    extra-lib-dirs: $C_DIR
+EOF
+)
+
+grep -qxF "$LINE" "$SCRIPT_DIR/hs-project/cabal.project.local" || echo "$LINE" >> "$SCRIPT_DIR/hs-project/cabal.project.local"
+cat "$SCRIPT_DIR/hs-project/cabal.project.local"
+
+echo "# "
+echo "# Done!"
+echo "# "
+
+(
+    echo "# "
+    echo "Running the project"
+    echo "# "
+
+    LD_LIBRARY_PATH="$C_DIR:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH
+    echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+
+    cd "hs-project"
+    cabal build
+    cabal run
+)

--- a/examples/feature-tests/hs-project/LICENSE
+++ b/examples/feature-tests/hs-project/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2024-2026, Well-Typed LLP and Anduril Industries Inc.
+
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/feature-tests/hs-project/cabal.project
+++ b/examples/feature-tests/hs-project/cabal.project
@@ -1,0 +1,4 @@
+import: ../../../cabal.project.base
+packages: .
+          ../../../c-expr-runtime
+          ../../../hs-bindgen-runtime

--- a/examples/feature-tests/hs-project/feature-tests.cabal
+++ b/examples/feature-tests/hs-project/feature-tests.cabal
@@ -1,0 +1,83 @@
+cabal-version: 3.0
+name:          feature-tests
+version:       0.1.0.0
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:        Well-Typed LLP
+maintainer:    info@well-typed.com
+build-type:    Simple
+
+common warnings
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists
+    -Wno-unticked-promoted-constructors -Wunused-packages
+    -Wmissing-deriving-strategies
+
+common language
+  default-language:   GHC2021
+  default-extensions:
+    DerivingStrategies
+    ImportQualifiedPost
+    LambdaCase
+    OverloadedRecordDot
+    PatternSynonyms
+    RecordWildCards
+    RoleAnnotations
+    ViewPatterns
+
+library generated
+  import:          warnings, language
+  visibility:      private
+  hs-source-dirs:  src-generated
+  exposed-modules:
+    Generated.Callbacks.Arrays.KnownSize
+    Generated.Callbacks.Arrays.KnownSize.FunPtr
+    Generated.Callbacks.Arrays.KnownSize.Safe
+    Generated.Callbacks.Arrays.KnownSize.Unsafe
+    Generated.Callbacks.Arrays.UnknownSize
+    Generated.Callbacks.Arrays.UnknownSize.FunPtr
+    Generated.Callbacks.Arrays.UnknownSize.Safe
+    Generated.Callbacks.Arrays.UnknownSize.Unsafe
+    Generated.Callbacks.Basic
+    Generated.Callbacks.Basic.FunPtr
+    Generated.Callbacks.Basic.Safe
+    Generated.Callbacks.Basic.Unsafe
+    Generated.Callbacks.Structs
+    Generated.Callbacks.Structs.FunPtr
+    Generated.Callbacks.Structs.Safe
+    Generated.Callbacks.Structs.Unsafe
+    Generated.Callbacks.Unions
+    Generated.Callbacks.Unions.FunPtr
+    Generated.Callbacks.Unions.Safe
+    Generated.Callbacks.Unions.Unsafe
+
+  build-depends:
+    , base
+    , hs-bindgen-runtime
+
+  extra-libraries: feature-tests
+  ghc-options:     -Wno-missing-export-lists
+
+test-suite feature-tests
+  import:         warnings, language
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Main.hs
+  other-modules:
+    Test.Callbacks.Arrays.KnownSize
+    Test.Callbacks.Arrays.UnknownSize
+    Test.Callbacks.Basic
+    Test.Callbacks.Structs
+    Test.Callbacks.Unions
+    Test.Util
+    Test.Util.Orphans
+
+  build-depends:
+    , base
+    , feature-tests:generated
+    , hs-bindgen-runtime
+    , tasty
+    , tasty-quickcheck
+    , vector

--- a/examples/feature-tests/hs-project/src-generated/.gitignore
+++ b/examples/feature-tests/hs-project/src-generated/.gitignore
@@ -1,0 +1,1 @@
+Generated/

--- a/examples/feature-tests/hs-project/test/Main.hs
+++ b/examples/feature-tests/hs-project/test/Main.hs
@@ -1,0 +1,18 @@
+module Main (main) where
+
+import Test.Tasty
+
+import Test.Callbacks.Arrays.KnownSize qualified
+import Test.Callbacks.Arrays.UnknownSize qualified
+import Test.Callbacks.Basic qualified
+import Test.Callbacks.Structs qualified
+import Test.Callbacks.Unions qualified
+
+main :: IO ()
+main = defaultMain $ testGroup "feature-tests" [
+      Test.Callbacks.Arrays.KnownSize.tests
+    , Test.Callbacks.Arrays.UnknownSize.tests
+    , Test.Callbacks.Basic.tests
+    , Test.Callbacks.Structs.tests
+    , Test.Callbacks.Unions.tests
+    ]

--- a/examples/feature-tests/hs-project/test/Test/Callbacks/Arrays/KnownSize.hs
+++ b/examples/feature-tests/hs-project/test/Test/Callbacks/Arrays/KnownSize.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE DataKinds #-}
+
+module Test.Callbacks.Arrays.KnownSize (
+    tests
+    -- * Properties (exported for haddocks)
+  , prop_reverse_vec5_equiv_toFromFunPtr_reverse_vec5
+  , prop_reverse_vec5_equiv_fromFunPtr_reverse_vec5
+  , prop_apply_vec5_op_reverse_vec5
+  , prop_apply_vec5_op_hsFun
+  ) where
+
+import Control.Monad (forM_)
+import Data.Proxy (Proxy (Proxy))
+import Foreign.C.Types (CInt (CInt))
+import Foreign.Ptr (FunPtr)
+import Foreign.Storable (Storable (peek, peekElemOff, pokeElemOff))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary (..), Fun, Property, applyFun,
+                              ioProperty, testProperty, vector, (===))
+
+import HsBindgen.Runtime.ConstantArray qualified as CA
+import HsBindgen.Runtime.IsArray qualified as IsA
+import HsBindgen.Runtime.Prelude (FromFunPtr (fromFunPtr), IsArray (Elem),
+                                  ToFunPtr (toFunPtr), safeCastFunPtr)
+
+import Generated.Callbacks.Arrays.KnownSize qualified as Types
+import Generated.Callbacks.Arrays.KnownSize.FunPtr qualified as FunPtr
+import Generated.Callbacks.Arrays.KnownSize.Safe qualified as Safe
+import Test.Util.Orphans ()
+
+tests :: TestTree
+tests = testGroup "Test.Callbacks.KnownSize" [
+      testProperty "prop_reverse_vec5_equiv_toFromFunPtr_reverse_vec5"
+        prop_reverse_vec5_equiv_toFromFunPtr_reverse_vec5
+    , testProperty "prop_reverse_vec5_equiv_fromFunPtr_reverse_vec5"
+        prop_reverse_vec5_equiv_fromFunPtr_reverse_vec5
+    , testProperty "prop_apply_vec5_op_reverse_vec5"
+        prop_apply_vec5_op_reverse_vec5
+    , testProperty "prop_apply_vec5_op_hsFun"
+        prop_apply_vec5_op_hsFun
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{Safe.reverse_vec5} ~ xs ~ len
+--    = (\text{fromFunPtr}
+--        ~ (\text{toFunPtr} ~ \text{Safe.reverse_vec5})
+--      ) ~ xs
+--        ~ len
+-- \]
+--
+prop_reverse_vec5_equiv_toFromFunPtr_reverse_vec5 :: Vec5 -> Property
+prop_reverse_vec5_equiv_toFromFunPtr_reverse_vec5 (Vec5 xs) = ioProperty $ do
+    zs1 <- runVec5_op reverse_vec5 xs
+    reverse_vec5' <- fromFunPtr <$> toFunPtr reverse_vec5
+    zs2 <- runVec5_op reverse_vec5' xs
+    pure $ zs1 === zs2
+  where
+    reverse_vec5 :: Types.Vec5_op
+    reverse_vec5 = Types.Vec5_op Safe.reverse_vec5
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{Safe.reverse_vec5} ~ xs ~ len
+--    = (\text{fromFunPtr} ~ \text{FunPtr.reverse_vec5})
+--      ) ~ xs
+--        ~ len
+-- \]
+--
+prop_reverse_vec5_equiv_fromFunPtr_reverse_vec5 :: Vec5 -> Property
+prop_reverse_vec5_equiv_fromFunPtr_reverse_vec5 (Vec5 xs) = ioProperty $ do
+    zs1 <- runVec5_op reverse_vec5 xs
+    zs2 <- runVec5_op reverse_vec5' xs
+    pure $ zs1 === zs2
+  where
+    reverse_vec5 :: Types.Vec5_op
+    reverse_vec5 = Types.Vec5_op Safe.reverse_vec5
+    reverse_vec5Ptr :: FunPtr Types.Vec5_op
+    reverse_vec5Ptr = safeCastFunPtr FunPtr.reverse_vec5
+    reverse_vec5' :: Types.Vec5_op
+    reverse_vec5' = fromFunPtr reverse_vec5Ptr
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{reverseVec5} ~ xs ~ len
+--    = \text{Safe.apply_vec5_op}
+--        ~ \text{FunPtr.reverse_vec5}
+--        ~ xs
+--        ~ len
+-- \]
+--
+prop_apply_vec5_op_reverse_vec5 :: Vec5 -> Property
+prop_apply_vec5_op_reverse_vec5 (Vec5 xs) = ioProperty $ do
+    zs <- apply_vec5_opHelper reverse_vec5Ptr xs
+    pure $ reverseVec5 xs === zs
+  where
+    reverse_vec5Ptr :: FunPtr Types.Vec5_op
+    reverse_vec5Ptr = safeCastFunPtr FunPtr.reverse_vec5
+
+-- |
+-- \[
+--  \forall f, xs, len.
+--      f ~ xs ~ len
+--    = \text{Safe.apply_vec5_op}
+--        ~ (\text{toFunPtr} ~ f)
+--        ~ xs
+--        ~ len
+-- \]
+--
+prop_apply_vec5_op_hsFun :: Vec5Op -> Vec5 -> Property
+prop_apply_vec5_op_hsFun f (Vec5 xs) = ioProperty $ do
+    zs1 <- runVec5_op fOp xs
+    fPtr <- toFunPtr fOp
+    zs2 <- apply_vec5_opHelper fPtr xs
+    pure $ zs1 === zs2
+  where
+    fOp :: Types.Vec5_op
+    fOp = getVec5_op f
+
+{-------------------------------------------------------------------------------
+  Modelled callback function
+-------------------------------------------------------------------------------}
+
+reverseVec5 :: Types.Vec5 -> Types.Vec5
+reverseVec5 (Types.Vec5 xs) = Types.Vec5 (CA.fromList (reverse (CA.toList xs)))
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+runVec5_op :: Types.Vec5_op -> Types.Vec5 -> IO Types.Vec5
+runVec5_op (Types.Vec5_op f) xs = do
+    IsA.withElemPtr xs $ \xsPtr -> do
+        f xsPtr
+        peek (CA.toPtr (Proxy @5) xsPtr)
+
+apply_vec5_opHelper :: FunPtr Types.Vec5_op -> Types.Vec5 -> IO Types.Vec5
+apply_vec5_opHelper fPtr xs = do
+    IsA.withElemPtr xs $ \xsPtr -> do
+        Safe.apply_vec5_op fPtr xsPtr
+        peek (CA.toPtr (Proxy @5) xsPtr)
+
+
+getVec5_op :: Vec5Op -> Types.Vec5_op
+getVec5_op (Vec5Op f) = Types.Vec5_op $ \xsPtr -> do
+    forM_ [0.. 4] $ \i -> do
+      x <- peekElemOff xsPtr i
+      let y = applyFun f x
+      pokeElemOff xsPtr i y
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+newtype Vec5 = Vec5 Types.Vec5
+  deriving stock (Show, Eq)
+
+instance Arbitrary Vec5 where
+  arbitrary = do
+      xs <- vector 5
+      pure (Vec5 (Types.Vec5 (CA.fromList xs)))
+  shrink (Vec5 (Types.Vec5 (CA.toList -> xs))) =
+      [ Vec5 (Types.Vec5 (CA.fromList xs'))
+      | xs' <- shrink xs
+      , length xs' == 5
+      ]
+
+-- Intended to be opaque: use 'getVec5_op' to obtain a 'Types.Vec5_op'
+newtype Vec5Op = Vec5Op (Fun (Elem Types.Vec5) (Elem Types.Vec5))
+
+deriving stock instance Show Vec5Op
+deriving newtype instance Arbitrary Vec5Op

--- a/examples/feature-tests/hs-project/test/Test/Callbacks/Arrays/UnknownSize.hs
+++ b/examples/feature-tests/hs-project/test/Test/Callbacks/Arrays/UnknownSize.hs
@@ -1,0 +1,181 @@
+module Test.Callbacks.Arrays.UnknownSize (
+    tests
+    -- * Properties (exported for haddocks)
+  , prop_reverse_list_equiv_toFromFunPtr_reverse_list
+  , prop_reverse_list_equiv_fromFunPtr_reverse_list
+  , prop_apply_list_op_reverse_list
+  , prop_apply_list_op_hsFun
+  ) where
+
+import Control.Monad (forM_)
+import Data.Vector.Storable qualified as VS
+import Foreign.C.Types (CInt (CInt))
+import Foreign.Ptr (FunPtr)
+import Foreign.Storable (Storable (peekElemOff, pokeElemOff))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary (..), Fun, Property, applyFun,
+                              ioProperty, testProperty, (===))
+
+import HsBindgen.Runtime.IncompleteArray qualified as IA
+import HsBindgen.Runtime.IsArray qualified as IsA
+import HsBindgen.Runtime.Prelude (FromFunPtr (fromFunPtr), IsArray (Elem),
+                                  ToFunPtr (toFunPtr), safeCastFunPtr)
+
+import Generated.Callbacks.Arrays.UnknownSize qualified as Types
+import Generated.Callbacks.Arrays.UnknownSize.FunPtr qualified as FunPtr
+import Generated.Callbacks.Arrays.UnknownSize.Safe qualified as Safe
+import Test.Util.Orphans ()
+
+tests :: TestTree
+tests = testGroup "Test.Callbacks.UnknownSize" [
+      testProperty "prop_reverse_list_equiv_toFromFunPtr_reverse_list"
+        prop_reverse_list_equiv_toFromFunPtr_reverse_list
+    , testProperty "prop_reverse_list_equiv_fromFunPtr_reverse_list"
+        prop_reverse_list_equiv_fromFunPtr_reverse_list
+    , testProperty "prop_apply_list_op_reverse_list"
+        prop_apply_list_op_reverse_list
+    , testProperty "prop_apply_list_op_hsFun"
+        prop_apply_list_op_hsFun
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{Safe.reverse_list} ~ xs ~ len
+--    = (\text{fromFunPtr}
+--        ~ (\text{toFunPtr} ~ \text{Safe.reverse_list})
+--      ) ~ xs
+--        ~ len
+-- \]
+--
+prop_reverse_list_equiv_toFromFunPtr_reverse_list :: List -> Property
+prop_reverse_list_equiv_toFromFunPtr_reverse_list (List xs) = ioProperty $ do
+    zs1 <- runList_op reverse_list xs
+    reverse_list' <- fromFunPtr <$> toFunPtr reverse_list
+    zs2 <- runList_op reverse_list' xs
+    pure $ zs1 === zs2
+  where
+    reverse_list :: Types.List_op
+    reverse_list = Types.List_op Safe.reverse_list
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{Safe.reverse_list} ~ xs ~ len
+--    = (\text{fromFunPtr} ~ \text{FunPtr.reverse_list})
+--      ) ~ xs
+--        ~ len
+-- \]
+--
+prop_reverse_list_equiv_fromFunPtr_reverse_list :: List -> Property
+prop_reverse_list_equiv_fromFunPtr_reverse_list (List xs) = ioProperty $ do
+    zs1 <- runList_op reverse_list xs
+    zs2 <- runList_op reverse_list' xs
+    pure $ zs1 === zs2
+  where
+    reverse_list :: Types.List_op
+    reverse_list = Types.List_op Safe.reverse_list
+    reverse_listPtr :: FunPtr Types.List_op
+    reverse_listPtr = safeCastFunPtr FunPtr.reverse_list
+    reverse_list' :: Types.List_op
+    reverse_list' = fromFunPtr reverse_listPtr
+
+-- |
+-- \[
+--  \forall xs, len.
+--      \text{reverseList} ~ xs ~ len
+--    = \text{Safe.apply_list_op}
+--        ~ \text{FunPtr.reverse_list}
+--        ~ xs
+--        ~ len
+-- \]
+--
+prop_apply_list_op_reverse_list :: List -> Property
+prop_apply_list_op_reverse_list (List xs) = ioProperty $ do
+    zs <- apply_list_opHelper reverse_listPtr xs
+    pure $ reverseList xs === zs
+  where
+    reverse_listPtr :: FunPtr Types.List_op
+    reverse_listPtr = safeCastFunPtr FunPtr.reverse_list
+
+-- |
+-- \[
+--  \forall f, xs, len.
+--      f ~ xs ~ len
+--    = \text{Safe.apply_list_op}
+--        ~ (\text{toFunPtr} ~ f)
+--        ~ xs
+--        ~ len
+-- \]
+--
+prop_apply_list_op_hsFun :: ListOp -> List -> Property
+prop_apply_list_op_hsFun f (List xs) = ioProperty $ do
+    zs1 <- runList_op fOp xs
+    fPtr <- toFunPtr fOp
+    zs2 <- apply_list_opHelper fPtr xs
+    pure $ zs1 === zs2
+  where
+    fOp :: Types.List_op
+    fOp = getList_op f
+
+{-------------------------------------------------------------------------------
+  Modelled callback function
+-------------------------------------------------------------------------------}
+
+reverseList :: Types.List -> Types.List
+reverseList (Types.List xs) = Types.List (IA.fromList (reverse (IA.toList xs)))
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+runList_op :: Types.List_op -> Types.List -> IO Types.List
+runList_op (Types.List_op f) xs = do
+    IsA.withElemPtr xs $ \xsPtr -> do
+        f xsPtr xsLen
+        IA.peekArray xsLen (IA.toPtr xsPtr)
+  where
+    xsLen :: Num a => a
+    xsLen = fromIntegral (VS.length (IA.toVector (Types.unwrapList xs)))
+
+apply_list_opHelper :: FunPtr Types.List_op -> Types.List -> IO Types.List
+apply_list_opHelper fPtr xs = do
+    IsA.withElemPtr xs $ \xsPtr -> do
+        Safe.apply_list_op fPtr xsPtr xsLen
+        IA.peekArray xsLen (IA.toPtr xsPtr)
+  where
+    xsLen :: Num a => a
+    xsLen = fromIntegral (VS.length (IA.toVector (Types.unwrapList xs)))
+
+getList_op :: ListOp -> Types.List_op
+getList_op (ListOp f) = Types.List_op $ \xsPtr xsLen -> do
+    forM_ [0.. fromIntegral xsLen - 1] $ \i -> do
+      x <- peekElemOff xsPtr i
+      let y = applyFun f x
+      pokeElemOff xsPtr i y
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+newtype List = List Types.List
+  deriving stock (Show, Eq)
+
+instance Arbitrary List where
+  arbitrary = do
+      xs <- arbitrary
+      pure (List (Types.List (IA.fromList xs)))
+  shrink (List (Types.List (IA.toList -> xs))) =
+      [ List (Types.List (IA.fromList xs'))
+      | xs' <- shrink xs
+      ]
+
+-- Intended to be opaque: use 'getList_op' to obtain a 'Types.List_op'
+newtype ListOp = ListOp (Fun (Elem Types.List) (Elem Types.List))
+
+deriving stock instance Show ListOp
+deriving newtype instance Arbitrary ListOp

--- a/examples/feature-tests/hs-project/test/Test/Callbacks/Basic.hs
+++ b/examples/feature-tests/hs-project/test/Test/Callbacks/Basic.hs
@@ -1,0 +1,95 @@
+module Test.Callbacks.Basic (
+    tests
+    -- * Properties (exported for haddocks)
+  , prop_square_equiv_toFromFunPtr_square
+  , prop_square_equiv_fromFunPtr_square
+  , prop_apply_int_op_square
+  , prop_apply_int_op_hsFun
+  ) where
+
+import Foreign.C.Types (CInt)
+import Foreign.Ptr (FunPtr)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Fun, Property, applyFun, ioProperty, testProperty,
+                              (===))
+
+import HsBindgen.Runtime.Prelude (FromFunPtr (fromFunPtr), ToFunPtr (toFunPtr),
+                                  safeCastFunPtr)
+
+import Generated.Callbacks.Basic qualified as Types
+import Generated.Callbacks.Basic.FunPtr qualified as FunPtr
+import Generated.Callbacks.Basic.Safe qualified as Safe
+import Test.Util.Orphans ()
+
+tests :: TestTree
+tests = testGroup "Test.Callbacks.Basic" [
+      testProperty "prop_square_equiv_toFromFunPtr_square" prop_square_equiv_toFromFunPtr_square
+    , testProperty "prop_square_equiv_fromFunPtr_square" prop_square_equiv_fromFunPtr_square
+    , testProperty "prop_apply_int_op_square" prop_apply_int_op_square
+    , testProperty "prop_apply_int_op_hsFun" prop_apply_int_op_hsFun
+    ]
+
+-- |
+-- \[
+--  \forall x.
+--      \text{Safe.square} ~ x
+--    = (\text{fromFunPtr}
+--        ~ (\text{toFunPtr} ~ \text{Safe.square})
+--      ) ~ x
+-- \]
+--
+prop_square_equiv_toFromFunPtr_square :: CInt -> Property
+prop_square_equiv_toFromFunPtr_square x = ioProperty $ do
+    z1 <- Safe.square x
+    square' <- fromFunPtr <$> toFunPtr Safe.square
+    z2 <- square' x
+    pure $ z1 === z2
+
+-- |
+-- \[
+--  \forall x.
+--      \text{Safe.square} ~ x
+--    = (\text{fromFunPtr} ~ \text{FunPtr.square}
+--      ) ~ x
+-- \]
+--
+prop_square_equiv_fromFunPtr_square :: CInt -> Property
+prop_square_equiv_fromFunPtr_square x = ioProperty $ do
+    z1 <- Safe.square x
+    z2 <- fromFunPtr FunPtr.square x
+    pure $ z1 === z2
+
+-- |
+-- \[
+--  \forall x.
+--      x * x
+--    = \text{Safe.apply_int_op}
+--        ~ \text{FunPtr.square}
+--        ~ x
+-- \]
+--
+prop_apply_int_op_square :: CInt -> Property
+prop_apply_int_op_square x = ioProperty $ do
+    z <- Safe.apply_int_op squarePtr x
+    pure $ x * x === z
+  where
+    squarePtr :: FunPtr Types.Int_op
+    squarePtr = safeCastFunPtr FunPtr.square
+
+-- |
+-- \[
+--  \forall f, x.
+--      f ~ x
+--    = \text{Safe.apply_int_op}
+--        ~ (\text{toFunPtr} ~ f)
+--        ~ x
+-- \]
+--
+prop_apply_int_op_hsFun :: Fun CInt CInt -> CInt -> Property
+prop_apply_int_op_hsFun f x = ioProperty $ do
+    fPtr <- toFunPtr fOp
+    z <- Safe.apply_int_op fPtr x
+    pure $ applyFun f x === z
+  where
+    fOp :: Types.Int_op
+    fOp = Types.Int_op $ \arg -> pure $ applyFun f arg

--- a/examples/feature-tests/hs-project/test/Test/Callbacks/Structs.hs
+++ b/examples/feature-tests/hs-project/test/Test/Callbacks/Structs.hs
@@ -1,0 +1,61 @@
+module Test.Callbacks.Structs (
+    tests
+    -- * Properties (exported for haddocks)
+  , prop_apply_point_op_scale_2_point
+  ) where
+
+import Foreign.Ptr (FunPtr)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck
+
+import HsBindgen.Runtime.Prelude (safeCastFunPtr)
+
+import Generated.Callbacks.Structs qualified as Types
+import Generated.Callbacks.Structs.FunPtr qualified as FunPtr
+import Generated.Callbacks.Structs.Safe qualified as Safe
+
+tests :: TestTree
+tests = testGroup "Test.Callbacks.Structs" [
+      testProperty "prop_apply_point_op_scale_2_point"
+        prop_apply_point_op_scale_2_point
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- |
+-- \[
+--  \forall p.
+--      \text{scale2Point} ~ p
+--    = \text{Safe.apply_point_op}
+--        ~ \text{FunPtr.scale_2_point}
+--        ~ p
+-- \]
+--
+prop_apply_point_op_scale_2_point :: Point -> Property
+prop_apply_point_op_scale_2_point (Point x) = ioProperty $ do
+    z <- Safe.apply_point_op scale_2_pointPtr x
+    pure $ scale2Point x === z
+  where
+    scale_2_pointPtr :: FunPtr Types.Point_op
+    scale_2_pointPtr = safeCastFunPtr FunPtr.scale_2_point
+
+{-------------------------------------------------------------------------------
+  Modelled callback function
+-------------------------------------------------------------------------------}
+
+scale2Point :: Types.Point -> Types.Point
+scale2Point (Types.Point x y) = Types.Point (2 * x) (2 * y)
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+newtype Point = Point Types.Point
+  deriving stock (Show, Eq)
+
+instance Arbitrary Point where
+  arbitrary = Point <$> (Types.Point <$> arbitrary <*> arbitrary)
+  shrink (Point (Types.Point x y)) =
+      [ Point (Types.Point x' y') | (x', y') <- shrink (x, y) ]

--- a/examples/feature-tests/hs-project/test/Test/Callbacks/Unions.hs
+++ b/examples/feature-tests/hs-project/test/Test/Callbacks/Unions.hs
@@ -1,0 +1,84 @@
+module Test.Callbacks.Unions (
+    tests
+    -- * Properties (exported for haddocks)
+  , prop_apply_object_op_increment_object
+  ) where
+
+import Foreign.C (CFloat, CLLong)
+import Foreign.Ptr (FunPtr)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck
+
+import HsBindgen.Runtime.Prelude (safeCastFunPtr)
+
+import Generated.Callbacks.Unions qualified as Types
+import Generated.Callbacks.Unions.FunPtr qualified as FunPtr
+import Generated.Callbacks.Unions.Safe qualified as Safe
+
+tests :: TestTree
+tests = testGroup "Test.Callbacks.Unions" [
+      testProperty "prop_apply_object_op_increment_object"
+        prop_apply_object_op_increment_object
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- |
+-- \[
+--  \forall obj.
+--      \text{incrementObject}
+--        ~ (\text{getVal} ~ obj)
+--        ~ (\text{getTyp} ~ obj)
+--    = \text{Safe.apply_object_op}
+--        ~ \text{FunPtr.increment_object}
+--        ~ (\text{getVal} ~ obj)
+--        ~ (\text{getTyp} ~ obj)
+-- \]
+--
+prop_apply_object_op_increment_object :: Object -> Property
+prop_apply_object_op_increment_object obj = ioProperty $ do
+    z <- Safe.apply_object_op increment_objectPtr (getVal obj) (getTyp obj)
+    let z' = incrementObject (getVal obj) (getTyp obj)
+    pure $ Types.get_val_integer z' === Types.get_val_integer z .||.
+           Types.get_val_floating z' === Types.get_val_floating z
+  where
+    increment_objectPtr :: FunPtr Types.Object_op
+    increment_objectPtr = safeCastFunPtr FunPtr.increment_object
+
+{-------------------------------------------------------------------------------
+  Modelled callback function
+-------------------------------------------------------------------------------}
+
+incrementObject :: Types.Val -> Types.Typ -> Types.Val
+incrementObject val typ =
+    case typ of
+      Types.LongLong -> Types.set_val_integer  (Types.get_val_integer  val + 1)
+      Types.Float    -> Types.set_val_floating (Types.get_val_floating val + 1)
+      _              -> val
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+data Object =
+    Integer CLLong
+  | Floating CFloat
+  deriving stock (Show, Eq)
+
+getVal :: Object -> Types.Val
+getVal = \case
+    Integer x -> Types.set_val_integer x
+    Floating x -> Types.set_val_floating x
+
+getTyp :: Object -> Types.Typ
+getTyp = \case
+    Integer{}  -> Types.LongLong
+    Floating{} -> Types.Float
+
+instance Arbitrary Object where
+  arbitrary = oneof [ Integer <$> arbitrary, Floating <$> arbitrary ]
+  shrink = \case
+      Integer x -> Integer <$> shrink x
+      Floating x -> Floating <$> shrink x

--- a/examples/feature-tests/hs-project/test/Test/Util.hs
+++ b/examples/feature-tests/hs-project/test/Test/Util.hs
@@ -1,0 +1,33 @@
+module Test.Util (
+    showPowersOf10
+  , showPowersOf
+  , showBucketsOf
+  ) where
+
+import Data.List (find)
+import Data.Maybe (fromJust)
+import Text.Printf
+
+showPowersOf10 :: Int -> String
+showPowersOf10 = showPowersOf 10
+
+showPowersOf :: Int -> Int -> String
+showPowersOf factor n
+  | factor <= 1 = error "showPowersOf: factor must be larger than 1"
+  | n < 0       = "n < 0"
+  | n == 0      = "n == 0"
+  | otherwise   = printf "%d <= n < %d" lb ub
+  where
+    ub = fromJust (find (n <) (iterate (* factor) factor))
+    lb = ub `div` factor
+
+showBucketsOf :: Int -> Int -> String
+showBucketsOf range n
+  | range <= 0 = error "showBucketsOf: range must be larger than 0"
+  | n == 0     = "n == 0"
+  | m == 0     = printf "%d < n < %d" lb ub
+  | otherwise  = printf "%d <= n < %d" lb ub
+  where
+    m = n `div` range
+    lb = m * range
+    ub = (m + 1) * range

--- a/examples/feature-tests/hs-project/test/Test/Util/Orphans.hs
+++ b/examples/feature-tests/hs-project/test/Test/Util/Orphans.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Util.Orphans () where
+
+import Foreign.C.Types (CInt (..))
+import GHC.Generics (Generic)
+import Test.Tasty.QuickCheck (CoArbitrary, Function)
+
+deriving stock instance Generic CInt
+deriving anyclass instance Function CInt
+deriving anyclass instance CoArbitrary CInt


### PR DESCRIPTION
Resolves #1031

We add a new `feature-tests` example aimed at testing `hs-bindgen` features using testing frameworks like `tasty` and `QuickCheck`. The example generates bindings for bespoke C files and puts them into a Haskell project, and the project has a test suite that can be used to test the bindings.

Currently, the test suite is only populated with tests for callbacks: C functions that are passed to other C functions. We use `QuickCheck` to test a number of properties about these callbacks. The tests aim to exercise various scenarios of interplay between C functions and Haskell functions: converting the former to the latter and vice versa, and passing functions to other functions through the Haskell FFI, all while preserving expected semantics.