### PR TITLE
Add `FunctionArg` to C AST

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -123,7 +123,7 @@ scanAllFunctionPointerTypes = foldMap $ \decl ->
       C.DeclUnion union   ->
         foldMap (scanTypeForFunctionPointers . (.typ)) union.fields
       C.DeclFunction fn ->
-        foldMap scanTypeForFunctionPointers (fn.res : map snd fn.args)
+        foldMap scanTypeForFunctionPointers (fn.res : map (.typ) fn.args)
       _ ->
         Set.empty
   where
@@ -193,7 +193,7 @@ generateDecs uniqueId fns haddockConfig moduleName sizeofs (C.Decl info kind spe
       C.DeclFunction function -> do
         let funDeclsWith safety =
               functionDecs safety uniqueId haddockConfig moduleName sizeofs info function spec
-            funType = C.TypeFun (map snd function.args) function.res
+            funType = C.TypeFun (map (.typ) function.args) function.res
             -- Declare a function pointer. We can pass this 'FunPtr' to C
             -- functions that take a function pointer of the appropriate type.
             funPtrDecls = fst $

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -256,10 +256,19 @@ instance (
     , Ann "Function" p ~ Ann "Function" p'
     ) => CoercePass C.Function p p' where
   coercePass function = C.Function{
-        args  = map (bimap id coercePass) function.args
+        args  = map coercePass function.args
       , res   = coercePass function.res
       , attrs = function.attrs
       , ann   = function.ann
+      }
+
+instance (
+      CoercePass C.Type p p'
+    , ScopedName p ~ ScopedName p'
+    ) => CoercePass C.FunctionArg p p' where
+  coercePass functionArg = C.FunctionArg{
+        name = functionArg.name
+      , typ = coercePass functionArg.typ
       }
 
 instance (

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Decl.hs
@@ -21,6 +21,7 @@ module HsBindgen.Frontend.AST.Decl (
   , EnumConstant(..)
   , AnonEnumConstant(..)
   , Function(..)
+  , FunctionArg(..)
   , FunctionAttributes(..)
   , FunctionPurity(..)
   , decideFunctionPurity
@@ -218,12 +219,18 @@ data AnonEnumConstant p = AnonEnumConstant{
   deriving stock (Generic, Show, Eq)
 
 data Function p = Function {
-      args  :: [(Maybe (ScopedName p), C.Type p)]
+      args  :: [FunctionArg p]
     , res   :: C.Type p
     , attrs :: FunctionAttributes
     , ann   :: Ann "Function" p
     }
   deriving stock (Generic)
+
+data FunctionArg p = FunctionArg {
+      name :: Maybe (ScopedName p)
+    , typ  :: C.Type p
+    }
+    deriving stock (Generic)
 
 -- | Function attributes specify properties for C functions.
 --
@@ -348,6 +355,7 @@ deriving stock instance IsPass p => Show (DeclKind         p)
 deriving stock instance IsPass p => Show (Enum             p)
 deriving stock instance IsPass p => Show (EnumConstant     p)
 deriving stock instance IsPass p => Show (Function         p)
+deriving stock instance IsPass p => Show (FunctionArg      p)
 deriving stock instance IsPass p => Show (Struct           p)
 deriving stock instance IsPass p => Show (StructField      p)
 deriving stock instance IsPass p => Show (TranslationUnit  p)
@@ -363,6 +371,7 @@ deriving stock instance IsPass p => Eq (Enum             p)
 deriving stock instance IsPass p => Eq (EnumConstant     p)
 deriving stock instance IsPass p => Eq (FieldInfo        p)
 deriving stock instance IsPass p => Eq (Function         p)
+deriving stock instance IsPass p => Eq (FunctionArg      p)
 deriving stock instance IsPass p => Eq (CommentRef       p)
 deriving stock instance IsPass p => Eq (Struct           p)
 deriving stock instance IsPass p => Eq (StructField      p)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -36,7 +36,7 @@ depsOfDecl (C.DeclMacro _ts) =
     -- having /any/ dependencies, and will rely instead on source ordering.
     []
 depsOfDecl (C.DeclFunction function) =
-    concatMap depsOfType (function.res : map snd function.args)
+    concatMap depsOfType (function.res : map (.typ) function.args)
 depsOfDecl (C.DeclGlobal ty) =
     depsOfType ty
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -275,13 +275,11 @@ instance UpdateUseSites C.Enum where
 instance UpdateUseSites C.Function where
   updateUseSites function =
       reconstruct
-        <$> mapM
-              (\(mName, ty) -> (mName,) <$> updateUseSites ty)
-              function.args
+        <$> mapM updateUseSites function.args
         <*> updateUseSites function.res
     where
       reconstruct ::
-           [(Maybe (C.ScopedName), C.Type AssignAnonIds)]
+           [C.FunctionArg AssignAnonIds]
         -> C.Type AssignAnonIds
         -> C.Function AssignAnonIds
       reconstruct functionArgs' functionRes' = C.Function {
@@ -289,6 +287,21 @@ instance UpdateUseSites C.Function where
           , res   = functionRes'
           , attrs = function.attrs
           , ann   = function.ann
+          }
+
+instance UpdateUseSites C.FunctionArg where
+  updateUseSites functionArg =
+      reconstruct
+        <$> pure functionArg.name
+        <*> updateUseSites functionArg.typ
+    where
+      reconstruct ::
+           Maybe C.ScopedName
+        -> C.Type AssignAnonIds
+        -> C.FunctionArg AssignAnonIds
+      reconstruct name' typ' = C.FunctionArg {
+            name = name'
+          , typ = typ'
           }
 
 instance UpdateUseSites C.Type where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/HandleMacros.hs
@@ -344,7 +344,7 @@ processFunction info function =
           info = info
         , ann  = NoAnn
         , kind = C.DeclFunction C.Function{
-              args  = map (bimap id coercePass) function.args
+              args  = map coercePass function.args
             , res   = coercePass function.res
             , attrs = function.attrs
             , ann   = NoAnn
@@ -358,12 +358,17 @@ processFunction info function =
            info = info
          , ann  = NoAnn
          , kind = C.DeclFunction C.Function{
-               args  = map (first (fmap C.ScopedName)) tys
+               args  = map (uncurry mkFunctionArg) tys
              , res   = ty
              , attrs = function.attrs
              , ann   = NoAnn
              }
          }
+      where
+        mkFunctionArg name typ = C.FunctionArg {
+              name = C.ScopedName <$> name
+            , typ = typ
+            }
 
 -- | Globals (externs or constants)
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -594,7 +594,7 @@ functionDecl info = \curr -> do
       -> ParseDecl (
             Either
               [ParseResult Parse]
-              ([(Maybe C.ScopedName, C.Type Parse)], C.Type Parse)
+              ([C.FunctionArg Parse], C.Type Parse)
           )
     guardTypeFunction curr ty =
         case ty of
@@ -608,7 +608,10 @@ functionDecl info = \curr -> do
                        then Nothing
                        else Just (C.ScopedName argName)
 
-              return (mbArgName, argCType)
+              return C.FunctionArg {
+                  name = mbArgName
+                , typ = argCType
+                }
             pure $ Right (args', res)
           C.TypeTypedef{} ->
             pure $ Left [

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -437,11 +437,11 @@ instance Resolve C.Typedef where
 instance Resolve C.Function where
   resolve ctx function =
     reconstruct
-      <$> mapM (\(mbName, ty) -> (mbName,) <$> resolve ctx ty) function.args
+      <$> mapM (resolve ctx) function.args
       <*> resolve ctx function.res
     where
       reconstruct ::
-           [(Maybe C.ScopedName, C.Type ResolveBindingSpecs)]
+           [C.FunctionArg ResolveBindingSpecs]
         -> C.Type ResolveBindingSpecs
         -> C.Function ResolveBindingSpecs
       reconstruct functionArgs' functionRes' = C.Function {
@@ -450,6 +450,21 @@ instance Resolve C.Function where
         , attrs = function.attrs
         , ann   = function.ann
         }
+
+instance Resolve C.FunctionArg where
+  resolve ctx functionArg =
+    reconstruct
+      <$> pure functionArg.name
+      <*> resolve ctx functionArg.typ
+    where
+      reconstruct ::
+           Maybe C.ScopedName
+        -> C.Type ResolveBindingSpecs
+        -> C.FunctionArg ResolveBindingSpecs
+      reconstruct name' typ' = C.FunctionArg {
+            name = name'
+          , typ = typ'
+          }
 
 instance Resolve CheckedMacro where
   resolve ctx = \case


### PR DESCRIPTION
Function arguments used to be represented by tuples, but this is somewhat unwieldy, so we add a new datatype for function arguments instead.