### PR TITLE
Generalise `HasField` instances by putting the field type in a superclass constraint

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 0.1.0 -- YYYY-mm-dd
 
-* BREAKING: `TyEq` no longer used in generated `HasField` instances
+* BREAKING: occurrences of the `CFieldType`/`CBitfieldType` type families in
+  class instance heads are now replaced by their definition.

--- a/hs-bindgen/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/fixtures/arrays/array/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @triplet@
@@ -42,7 +45,8 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -65,7 +69,8 @@ newtype List = List
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapList")
@@ -94,7 +99,8 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -117,7 +123,8 @@ newtype Tripletlist = Tripletlist
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapTripletlist" (Ptr.Ptr Tripletlist) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+         ) => GHC.Records.HasField "unwrapTripletlist" (Ptr.Ptr Tripletlist) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTripletlist")
@@ -186,7 +193,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example "example_triple" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "example_triple" (Ptr.Ptr Example) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "example_triple" (Ptr.Ptr Example) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_triple")
@@ -198,7 +206,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example "example_sudoku" where
 
   offset# = \_ -> \_ -> 12
 
-instance GHC.Records.HasField "example_sudoku" (Ptr.Ptr Example) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+         ) => GHC.Records.HasField "example_sudoku" (Ptr.Ptr Example) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_sudoku")
@@ -222,7 +231,8 @@ newtype Sudoku = Sudoku
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapSudoku" (Ptr.Ptr Sudoku) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)
+         ) => GHC.Records.HasField "unwrapSudoku" (Ptr.Ptr Sudoku) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSudoku")

--- a/hs-bindgen/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/fixtures/arrays/array/th.txt
@@ -667,9 +667,8 @@ newtype Triplet
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTriplet"
-                  (Ptr Triplet)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -690,9 +689,8 @@ newtype List
            __exported by:__ @arrays\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapList"
-                  (Ptr List)
-                  (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapList" (Ptr List) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt
@@ -713,9 +711,8 @@ newtype Matrix
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapMatrix"
-                  (Ptr Matrix)
-                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
+instance TyEq ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
+         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -737,9 +734,8 @@ newtype Tripletlist
            __exported by:__ @arrays\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapTripletlist"
-                  (Ptr Tripletlist)
-                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
+instance TyEq ty (IncompleteArray (ConstantArray 3 CInt)) =>
+         HasField "unwrapTripletlist" (Ptr Tripletlist) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTripletlist")
 instance HasCField Tripletlist "unwrapTripletlist"
     where type CFieldType Tripletlist
@@ -787,17 +783,15 @@ instance HasCField Example "example_triple"
     where type CFieldType Example "example_triple" = ConstantArray 3
                                                                    CInt
           offset# = \_ -> \_ -> 0
-instance HasField "example_triple"
-                  (Ptr Example)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "example_triple" (Ptr Example) (Ptr ty)
     where getField = fromPtr (Proxy @"example_triple")
 instance HasCField Example "example_sudoku"
     where type CFieldType Example "example_sudoku" = ConstantArray 3
                                                                    (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 12
-instance HasField "example_sudoku"
-                  (Ptr Example)
-                  (Ptr (ConstantArray 3 (ConstantArray 3 CInt)))
+instance TyEq ty (ConstantArray 3 (ConstantArray 3 CInt)) =>
+         HasField "example_sudoku" (Ptr Example) (Ptr ty)
     where getField = fromPtr (Proxy @"example_sudoku")
 {-| Typedef-in-typedef
 
@@ -819,9 +813,8 @@ newtype Sudoku
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapSudoku"
-                  (Ptr Sudoku)
-                  (Ptr (ConstantArray 3 Triplet))
+instance TyEq ty (ConstantArray 3 Triplet) =>
+         HasField "unwrapSudoku" (Ptr Sudoku) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSudoku")
 instance HasCField Sudoku "unwrapSudoku"
     where type CFieldType Sudoku "unwrapSudoku" = ConstantArray 3

--- a/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @S@
@@ -34,7 +37,8 @@ newtype S = S
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS")
@@ -57,7 +61,8 @@ newtype T = T
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")
@@ -86,7 +91,8 @@ newtype U = U
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")
@@ -115,7 +121,8 @@ newtype V = V
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapV" (Ptr.Ptr V) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapV" (Ptr.Ptr V) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapV")
@@ -144,7 +151,8 @@ newtype W = W
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapW" (Ptr.Ptr W) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapW" (Ptr.Ptr W) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapW")
@@ -173,7 +181,8 @@ newtype X = X
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapX" (Ptr.Ptr X) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapX" (Ptr.Ptr X) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapX")

--- a/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/fixtures/arrays/const_qualifier/th.txt
@@ -255,7 +255,8 @@ newtype S
            __exported by:__ @arrays\/const_qualifier.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapS" (Ptr S) (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapS" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = IncompleteArray CInt
@@ -275,7 +276,8 @@ newtype T
            __exported by:__ @arrays\/const_qualifier.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapT" (Ptr T) (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = IncompleteArray CInt
@@ -296,7 +298,8 @@ newtype U
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapU" (Ptr U) (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = ConstantArray 3 CInt
@@ -317,7 +320,8 @@ newtype V
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapV" (Ptr V) (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapV" (Ptr V) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapV")
 instance HasCField V "unwrapV"
     where type CFieldType V "unwrapV" = ConstantArray 3 CInt
@@ -338,7 +342,8 @@ newtype W
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapW" (Ptr W) (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapW" (Ptr W) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapW")
 instance HasCField W "unwrapW"
     where type CFieldType W "unwrapW" = ConstantArray 3 CInt
@@ -359,7 +364,8 @@ newtype X
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapX" (Ptr X) (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapX" (Ptr X) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapX")
 instance HasCField X "unwrapX"
     where type CFieldType X "unwrapX" = ConstantArray 3 CInt

--- a/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/fixtures/arrays/multi_dim/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @matrix@
@@ -40,7 +43,8 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -63,7 +67,8 @@ newtype Triplets = Triplets
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapTriplets" (Ptr.Ptr Triplets) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt))
+         ) => GHC.Records.HasField "unwrapTriplets" (Ptr.Ptr Triplets) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplets")

--- a/hs-bindgen/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/fixtures/arrays/multi_dim/th.txt
@@ -176,9 +176,8 @@ newtype Matrix
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapMatrix"
-                  (Ptr Matrix)
-                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
+instance TyEq ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
+         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -200,9 +199,8 @@ newtype Triplets
            __exported by:__ @arrays\/multi_dim.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapTriplets"
-                  (Ptr Triplets)
-                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
+instance TyEq ty (IncompleteArray (ConstantArray 3 CInt)) =>
+         HasField "unwrapTriplets" (Ptr Triplets) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplets")
 instance HasCField Triplets "unwrapTriplets"
     where type CFieldType Triplets

--- a/hs-bindgen/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/attributes/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, IO, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -79,7 +82,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_c")
@@ -90,7 +94,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_i")
@@ -151,7 +156,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bar_c" (Ptr.Ptr Bar) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "bar_c" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_c")
@@ -162,7 +168,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bar_i" (Ptr.Ptr Bar) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "bar_i" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_i")
@@ -223,7 +230,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Baz "baz_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "baz_c" (Ptr.Ptr Baz) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "baz_c" (Ptr.Ptr Baz) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"baz_c")
@@ -234,7 +242,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Baz "baz_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "baz_i" (Ptr.Ptr Baz) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "baz_i" (Ptr.Ptr Baz) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"baz_i")
@@ -295,7 +304,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Qux "qux_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "qux_c" (Ptr.Ptr Qux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "qux_c" (Ptr.Ptr Qux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"qux_c")
@@ -306,7 +316,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Qux "qux_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "qux_i" (Ptr.Ptr Qux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "qux_i" (Ptr.Ptr Qux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"qux_i")
@@ -376,7 +387,8 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__r" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "fILE__r" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "fILE__r" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__r")
@@ -387,7 +399,8 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__w" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "fILE__w" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "fILE__w" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__w")
@@ -399,7 +412,8 @@ instance HsBindgen.Runtime.HasCField.HasCField FILE "fILE__close" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "fILE__close" (Ptr.Ptr FILE) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Void) -> IO FC.CInt))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Void) -> IO FC.CInt))
+         ) => GHC.Records.HasField "fILE__close" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fILE__close")

--- a/hs-bindgen/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/attributes/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
+instance TyEq ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_c")
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 1
-instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
+instance TyEq ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_i")
 {-| __C declaration:__ @struct bar@
 
@@ -88,12 +88,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_c"
     where type CFieldType Bar "bar_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "bar_c" (Ptr Bar) (Ptr CChar)
+instance TyEq ty CChar => HasField "bar_c" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_c")
 instance HasCField Bar "bar_i"
     where type CFieldType Bar "bar_i" = CInt
           offset# = \_ -> \_ -> 1
-instance HasField "bar_i" (Ptr Bar) (Ptr CInt)
+instance TyEq ty CInt => HasField "bar_i" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_i")
 {-| __C declaration:__ @struct baz@
 
@@ -136,12 +136,12 @@ deriving via (EquivStorable Baz) instance Storable Baz
 instance HasCField Baz "baz_c"
     where type CFieldType Baz "baz_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "baz_c" (Ptr Baz) (Ptr CChar)
+instance TyEq ty CChar => HasField "baz_c" (Ptr Baz) (Ptr ty)
     where getField = fromPtr (Proxy @"baz_c")
 instance HasCField Baz "baz_i"
     where type CFieldType Baz "baz_i" = CInt
           offset# = \_ -> \_ -> 1
-instance HasField "baz_i" (Ptr Baz) (Ptr CInt)
+instance TyEq ty CInt => HasField "baz_i" (Ptr Baz) (Ptr ty)
     where getField = fromPtr (Proxy @"baz_i")
 {-| __C declaration:__ @struct qux@
 
@@ -184,12 +184,12 @@ deriving via (EquivStorable Qux) instance Storable Qux
 instance HasCField Qux "qux_c"
     where type CFieldType Qux "qux_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "qux_c" (Ptr Qux) (Ptr CChar)
+instance TyEq ty CChar => HasField "qux_c" (Ptr Qux) (Ptr ty)
     where getField = fromPtr (Proxy @"qux_c")
 instance HasCField Qux "qux_i"
     where type CFieldType Qux "qux_i" = CInt
           offset# = \_ -> \_ -> 1
-instance HasField "qux_i" (Ptr Qux) (Ptr CInt)
+instance TyEq ty CInt => HasField "qux_i" (Ptr Qux) (Ptr ty)
     where getField = fromPtr (Proxy @"qux_i")
 {-| __C declaration:__ @struct __sFILE@
 
@@ -240,18 +240,17 @@ deriving via (EquivStorable FILE) instance Storable FILE
 instance HasCField FILE "fILE__r"
     where type CFieldType FILE "fILE__r" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "fILE__r" (Ptr FILE) (Ptr CInt)
+instance TyEq ty CInt => HasField "fILE__r" (Ptr FILE) (Ptr ty)
     where getField = fromPtr (Proxy @"fILE__r")
 instance HasCField FILE "fILE__w"
     where type CFieldType FILE "fILE__w" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "fILE__w" (Ptr FILE) (Ptr CInt)
+instance TyEq ty CInt => HasField "fILE__w" (Ptr FILE) (Ptr ty)
     where getField = fromPtr (Proxy @"fILE__w")
 instance HasCField FILE "fILE__close"
     where type CFieldType FILE "fILE__close" = FunPtr (Ptr Void ->
                                                        IO CInt)
           offset# = \_ -> \_ -> 8
-instance HasField "fILE__close"
-                  (Ptr FILE)
-                  (Ptr (FunPtr (Ptr Void -> IO CInt)))
+instance TyEq ty (FunPtr (Ptr Void -> IO CInt)) =>
+         HasField "fILE__close" (Ptr FILE) (Ptr ty)
     where getField = fromPtr (Proxy @"fILE__close")

--- a/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/fixtures/attributes/type_attributes/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -33,6 +35,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -83,7 +86,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S "s_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s_f" (Ptr.Ptr S) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)
+         ) => GHC.Records.HasField "s_f" (Ptr.Ptr S) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s_f")
@@ -116,7 +120,8 @@ newtype More_aligned_int = More_aligned_int
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMore_aligned_int" (Ptr.Ptr More_aligned_int) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMore_aligned_int" (Ptr.Ptr More_aligned_int) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMore_aligned_int")
@@ -176,7 +181,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_f" (Ptr.Ptr S2) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CShort)
+         ) => GHC.Records.HasField "s2_f" (Ptr.Ptr S2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_f")
@@ -238,7 +244,8 @@ instance HsBindgen.Runtime.HasCField.HasCField My_unpacked_struct "my_unpacked_s
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "my_unpacked_struct_c" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "my_unpacked_struct_c" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_unpacked_struct_c")
@@ -250,7 +257,8 @@ instance HsBindgen.Runtime.HasCField.HasCField My_unpacked_struct "my_unpacked_s
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "my_unpacked_struct_i" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "my_unpacked_struct_i" (Ptr.Ptr My_unpacked_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_unpacked_struct_i")
@@ -321,7 +329,8 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "my_packed_struct_c" (Ptr.Ptr My_packed_struct) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "my_packed_struct_c" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_c")
@@ -333,7 +342,8 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "my_packed_struct_i" (Ptr.Ptr My_packed_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "my_packed_struct_i" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_i")
@@ -345,7 +355,8 @@ instance HsBindgen.Runtime.HasCField.HasCField My_packed_struct "my_packed_struc
 
   offset# = \_ -> \_ -> 5
 
-instance GHC.Records.HasField "my_packed_struct_s" (Ptr.Ptr My_packed_struct) (Ptr.Ptr My_unpacked_struct) where
+instance ( TyEq ty My_unpacked_struct
+         ) => GHC.Records.HasField "my_packed_struct_s" (Ptr.Ptr My_packed_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"my_packed_struct_s")
@@ -430,7 +441,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Wait_status_ptr_t "wait_status_pt
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "wait_status_ptr_t___ip" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "wait_status_ptr_t___ip" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"wait_status_ptr_t___ip")
@@ -442,7 +454,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Wait_status_ptr_t "wait_status_pt
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "wait_status_ptr_t___up" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr (Ptr.Ptr Wait)) where
+instance ( TyEq ty (Ptr.Ptr Wait)
+         ) => GHC.Records.HasField "wait_status_ptr_t___up" (Ptr.Ptr Wait_status_ptr_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"wait_status_ptr_t___up")
@@ -483,7 +496,8 @@ newtype T1 = T1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -522,7 +536,8 @@ newtype Short_a = Short_a
     , Real
     )
 
-instance GHC.Records.HasField "unwrapShort_a" (Ptr.Ptr Short_a) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapShort_a" (Ptr.Ptr Short_a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapShort_a")

--- a/hs-bindgen/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/fixtures/attributes/type_attributes/th.txt
@@ -32,7 +32,8 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_f"
     where type CFieldType S "s_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance HasField "s_f" (Ptr S) (Ptr (ConstantArray 3 CShort))
+instance TyEq ty (ConstantArray 3 CShort) =>
+         HasField "s_f" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"s_f")
 {-| __C declaration:__ @more_aligned_int@
 
@@ -64,9 +65,8 @@ newtype More_aligned_int
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMore_aligned_int"
-                  (Ptr More_aligned_int)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMore_aligned_int" (Ptr More_aligned_int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMore_aligned_int")
 instance HasCField More_aligned_int "unwrapMore_aligned_int"
     where type CFieldType More_aligned_int
@@ -105,7 +105,8 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_f"
     where type CFieldType S2 "s2_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance HasField "s2_f" (Ptr S2) (Ptr (ConstantArray 3 CShort))
+instance TyEq ty (ConstantArray 3 CShort) =>
+         HasField "s2_f" (Ptr S2) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_f")
 {-| __C declaration:__ @struct my_unpacked_struct@
 
@@ -149,17 +150,15 @@ instance HasCField My_unpacked_struct "my_unpacked_struct_c"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "my_unpacked_struct_c"
-                  (Ptr My_unpacked_struct)
-                  (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "my_unpacked_struct_c" (Ptr My_unpacked_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"my_unpacked_struct_c")
 instance HasCField My_unpacked_struct "my_unpacked_struct_i"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_i" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "my_unpacked_struct_i"
-                  (Ptr My_unpacked_struct)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "my_unpacked_struct_i" (Ptr My_unpacked_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"my_unpacked_struct_i")
 {-| __C declaration:__ @struct my_packed_struct@
 
@@ -210,24 +209,21 @@ deriving via (EquivStorable My_packed_struct) instance Storable My_packed_struct
 instance HasCField My_packed_struct "my_packed_struct_c"
     where type CFieldType My_packed_struct "my_packed_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "my_packed_struct_c"
-                  (Ptr My_packed_struct)
-                  (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "my_packed_struct_c" (Ptr My_packed_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"my_packed_struct_c")
 instance HasCField My_packed_struct "my_packed_struct_i"
     where type CFieldType My_packed_struct "my_packed_struct_i" = CInt
           offset# = \_ -> \_ -> 1
-instance HasField "my_packed_struct_i"
-                  (Ptr My_packed_struct)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "my_packed_struct_i" (Ptr My_packed_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"my_packed_struct_i")
 instance HasCField My_packed_struct "my_packed_struct_s"
     where type CFieldType My_packed_struct
                           "my_packed_struct_s" = My_unpacked_struct
           offset# = \_ -> \_ -> 5
-instance HasField "my_packed_struct_s"
-                  (Ptr My_packed_struct)
-                  (Ptr My_unpacked_struct)
+instance TyEq ty My_unpacked_struct =>
+         HasField "my_packed_struct_s" (Ptr My_packed_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"my_packed_struct_s")
 {-| __C declaration:__ @union wait_status_ptr_t@
 
@@ -323,17 +319,15 @@ instance HasCField Wait_status_ptr_t "wait_status_ptr_t___ip"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___ip" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance HasField "wait_status_ptr_t___ip"
-                  (Ptr Wait_status_ptr_t)
-                  (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) =>
+         HasField "wait_status_ptr_t___ip" (Ptr Wait_status_ptr_t) (Ptr ty)
     where getField = fromPtr (Proxy @"wait_status_ptr_t___ip")
 instance HasCField Wait_status_ptr_t "wait_status_ptr_t___up"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___up" = Ptr Wait
           offset# = \_ -> \_ -> 0
-instance HasField "wait_status_ptr_t___up"
-                  (Ptr Wait_status_ptr_t)
-                  (Ptr (Ptr Wait))
+instance TyEq ty (Ptr Wait) =>
+         HasField "wait_status_ptr_t___up" (Ptr Wait_status_ptr_t) (Ptr ty)
     where getField = fromPtr (Proxy @"wait_status_ptr_t___up")
 {-| __C declaration:__ @union wait@
 
@@ -372,7 +366,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -407,7 +401,8 @@ newtype Short_a
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapShort_a" (Ptr Short_a) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "unwrapShort_a" (Ptr Short_a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapShort_a")
 instance HasCField Short_a "unwrapShort_a"
     where type CFieldType Short_a "unwrapShort_a" = CShort

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -17,6 +19,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @MyArray@
@@ -30,7 +33,8 @@ newtype MyArray = MyArray
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyArray")
@@ -53,7 +57,8 @@ newtype A = A
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyArray) where
+instance ( TyEq ty MyArray
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -75,7 +80,8 @@ newtype B = B
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -75,9 +75,8 @@ newtype MyArray
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapMyArray"
-                  (Ptr MyArray)
-                  (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray
@@ -98,7 +97,7 @@ newtype A
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
+instance TyEq ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -118,7 +117,7 @@ newtype B
            __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @MyArray@
@@ -39,7 +42,8 @@ newtype MyArray = MyArray
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapMyArray" (Ptr.Ptr MyArray) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyArray")
@@ -68,7 +72,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyArray) where
+instance ( TyEq ty MyArray
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -96,7 +101,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -76,9 +76,8 @@ newtype MyArray
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapMyArray"
-                  (Ptr MyArray)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray "unwrapMyArray" = ConstantArray 3
@@ -100,7 +99,7 @@ newtype A
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
+instance TyEq ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -121,7 +120,7 @@ newtype B
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -108,7 +111,8 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")
@@ -147,7 +151,8 @@ newtype A = A
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyEnum) where
+instance ( TyEq ty MyEnum
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -177,7 +182,8 @@ newtype B = B
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -104,7 +104,8 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -144,7 +145,7 @@ newtype A
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
+instance TyEq ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -170,7 +171,7 @@ newtype B
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified Prelude as P
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @MyFunction@
@@ -68,7 +71,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MyFunction where
 
   fromFunPtr = hs_bindgen_bb71f7e730356103
 
-instance GHC.Records.HasField "unwrapMyFunction" (Ptr.Ptr MyFunction) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapMyFunction" (Ptr.Ptr MyFunction) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunction")
@@ -92,7 +96,8 @@ newtype A = A
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyFunction) where
+instance ( TyEq ty MyFunction
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -115,7 +120,8 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function/th.txt
@@ -161,9 +161,8 @@ instance ToFunPtr MyFunction
     where toFunPtr = hs_bindgen_4e8a459829b269e0
 instance FromFunPtr MyFunction
     where fromFunPtr = hs_bindgen_bb71f7e730356103
-instance HasField "unwrapMyFunction"
-                  (Ptr MyFunction)
-                  (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapMyFunction" (Ptr MyFunction) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyFunction")
 instance HasCField MyFunction "unwrapMyFunction"
     where type CFieldType MyFunction "unwrapMyFunction" = CInt ->
@@ -185,7 +184,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapA" (Ptr A) (Ptr MyFunction)
+instance TyEq ty MyFunction => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunction
@@ -206,7 +205,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,6 +26,7 @@ import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, IO, Ord, Show)
 
 {-| Auxiliary type used by 'MyFunctionPointer'
@@ -72,7 +75,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MyFunctionPointer_Aux wher
 
   fromFunPtr = hs_bindgen_5738272f94a589e2
 
-instance GHC.Records.HasField "unwrapMyFunctionPointer_Aux" (Ptr.Ptr MyFunctionPointer_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapMyFunctionPointer_Aux" (Ptr.Ptr MyFunctionPointer_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunctionPointer_Aux")
@@ -102,7 +106,8 @@ newtype MyFunctionPointer = MyFunctionPointer
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapMyFunctionPointer" (Ptr.Ptr MyFunctionPointer) (Ptr.Ptr (Ptr.FunPtr MyFunctionPointer_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr MyFunctionPointer_Aux)
+         ) => GHC.Records.HasField "unwrapMyFunctionPointer" (Ptr.Ptr MyFunctionPointer) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyFunctionPointer")
@@ -132,7 +137,8 @@ newtype A = A
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyFunctionPointer) where
+instance ( TyEq ty MyFunctionPointer
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -161,7 +167,8 @@ newtype B = B
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -102,9 +102,10 @@ instance ToFunPtr MyFunctionPointer_Aux
     where toFunPtr = hs_bindgen_47dfd04698dd2e6f
 instance FromFunPtr MyFunctionPointer_Aux
     where fromFunPtr = hs_bindgen_5738272f94a589e2
-instance HasField "unwrapMyFunctionPointer_Aux"
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapMyFunctionPointer_Aux"
                   (Ptr MyFunctionPointer_Aux)
-                  (Ptr (CInt -> IO CInt))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer_Aux")
 instance HasCField MyFunctionPointer_Aux
                    "unwrapMyFunctionPointer_Aux"
@@ -131,9 +132,8 @@ newtype MyFunctionPointer
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapMyFunctionPointer"
-                  (Ptr MyFunctionPointer)
-                  (Ptr (FunPtr MyFunctionPointer_Aux))
+instance TyEq ty (FunPtr MyFunctionPointer_Aux) =>
+         HasField "unwrapMyFunctionPointer" (Ptr MyFunctionPointer) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer")
 instance HasCField MyFunctionPointer "unwrapMyFunctionPointer"
     where type CFieldType MyFunctionPointer
@@ -159,7 +159,8 @@ newtype A
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapA" (Ptr A) (Ptr MyFunctionPointer)
+instance TyEq ty MyFunctionPointer =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunctionPointer
@@ -184,7 +185,7 @@ newtype B
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct MyStruct@
@@ -70,7 +73,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -92,7 +96,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyStruct) where
+instance ( TyEq ty MyStruct
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -120,7 +125,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -93,7 +93,8 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @A@
 
@@ -111,7 +112,7 @@ newtype A
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
+instance TyEq ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -132,7 +133,7 @@ newtype B
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,6 +26,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union MyUnion@
 
@@ -77,7 +80,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myUnion_x")
@@ -99,7 +103,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyUnion) where
+instance ( TyEq ty MyUnion
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -127,7 +132,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/union/th.txt
@@ -116,7 +116,8 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
@@ -134,7 +135,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
+instance TyEq ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -155,7 +156,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -18,6 +20,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified M
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @A@
@@ -31,7 +34,8 @@ newtype A = A
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -54,7 +58,8 @@ newtype B = B
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -76,7 +81,8 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -135,7 +135,8 @@ newtype A
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapA" (Ptr A) (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = IncompleteArray CInt
@@ -155,7 +156,7 @@ newtype B
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -175,7 +176,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
       -}
     deriving stock Generic
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @A@
@@ -40,7 +43,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -69,7 +73,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -91,7 +96,8 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -136,7 +136,8 @@ newtype A
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = ConstantArray 3 CInt
@@ -157,7 +158,7 @@ newtype B
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -177,7 +178,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
       -}
     deriving stock Generic
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,6 +31,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -109,7 +112,8 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")
@@ -148,7 +152,8 @@ newtype A = A
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyEnum) where
+instance ( TyEq ty MyEnum
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -178,7 +183,8 @@ newtype B = B
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -201,7 +207,8 @@ newtype E = E
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -164,7 +164,8 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -204,7 +205,7 @@ newtype A
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
+instance TyEq ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -230,7 +231,7 @@ newtype B
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -251,7 +252,7 @@ newtype E
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.Internal.FunPtr
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified M
 import qualified Prelude as P
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @A@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr A where
 
   fromFunPtr = hs_bindgen_0cf9a6d50f563441
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -92,7 +96,8 @@ newtype B = B
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -114,7 +119,8 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function/th.txt
@@ -287,7 +287,8 @@ instance ToFunPtr A
     where toFunPtr = hs_bindgen_0c7d4776a632d026
 instance FromFunPtr A
     where fromFunPtr = hs_bindgen_0cf9a6d50f563441
-instance HasField "unwrapA" (Ptr A) (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt -> IO CInt
@@ -308,7 +309,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -328,7 +329,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
       -}
     deriving stock Generic
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,6 +27,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
 import qualified Prelude as P
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, IO, Ord, Show)
 
 {-| Auxiliary type used by 'A'
@@ -73,7 +76,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr A_Aux where
 
   fromFunPtr = hs_bindgen_cdb12400c6863f15
 
-instance GHC.Records.HasField "unwrapA_Aux" (Ptr.Ptr A_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapA_Aux" (Ptr.Ptr A_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_Aux")
@@ -103,7 +107,8 @@ newtype A = A
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr (Ptr.FunPtr A_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr A_Aux)
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -132,7 +137,8 @@ newtype B = B
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -155,7 +161,8 @@ newtype E = E
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -165,7 +165,8 @@ instance ToFunPtr A_Aux
     where toFunPtr = hs_bindgen_1cabb32c661d9a0e
 instance FromFunPtr A_Aux
     where fromFunPtr = hs_bindgen_cdb12400c6863f15
-instance HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_Aux")
 instance HasCField A_Aux "unwrapA_Aux"
     where type CFieldType A_Aux "unwrapA_Aux" = CInt -> IO CInt
@@ -190,7 +191,8 @@ newtype A
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapA" (Ptr A) (Ptr (FunPtr A_Aux))
+instance TyEq ty (FunPtr A_Aux) =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = FunPtr A_Aux
@@ -215,7 +217,7 @@ newtype B
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -236,7 +238,7 @@ newtype E
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct MyStruct@
@@ -71,7 +74,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -93,7 +97,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyStruct) where
+instance ( TyEq ty MyStruct
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -121,7 +126,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -143,7 +149,8 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -153,7 +153,8 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @A@
 
@@ -171,7 +172,7 @@ newtype A
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
+instance TyEq ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -192,7 +193,7 @@ newtype B
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -212,7 +213,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
       -}
     deriving stock Generic
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,6 +27,7 @@ import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified M
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union MyUnion@
 
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "myUnion_x" (Ptr.Ptr MyUnion) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"myUnion_x")
@@ -100,7 +104,8 @@ newtype A = A
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr MyUnion) where
+instance ( TyEq ty MyUnion
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -128,7 +133,8 @@ newtype B = B
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapB" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapB")
@@ -150,7 +156,8 @@ newtype E = E
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr M.C) where
+instance ( TyEq ty M.C
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/union/th.txt
@@ -176,7 +176,8 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
@@ -194,7 +195,7 @@ newtype A
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
+instance TyEq ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -215,7 +216,7 @@ newtype B
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapB" (Ptr B) (Ptr A)
+instance TyEq ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -235,7 +236,7 @@ newtype E
            __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
       -}
     deriving stock Generic
-instance HasField "unwrapE" (Ptr E) (Ptr M.C)
+instance TyEq ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_x")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_both/th.txt
@@ -40,10 +40,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
+instance TyEq ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
+instance TyEq ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "hoge_x" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_x")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "hoge_y" (Ptr.Ptr Hoge) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_struct/th.txt
@@ -40,10 +40,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
+instance TyEq ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
+instance TyEq ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Piyo "piyo_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "piyo_x" (Ptr.Ptr Piyo) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "piyo_x" (Ptr.Ptr Piyo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"piyo_x")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Piyo "piyo_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "piyo_y" (Ptr.Ptr Piyo) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "piyo_y" (Ptr.Ptr Piyo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"piyo_y")

--- a/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -40,10 +40,10 @@ deriving via (EquivStorable Piyo) instance Storable Piyo
 instance HasCField Piyo "piyo_x"
     where type CFieldType Piyo "piyo_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "piyo_x" (Ptr Piyo) (Ptr CInt)
+instance TyEq ty CInt => HasField "piyo_x" (Ptr Piyo) (Ptr ty)
     where getField = fromPtr (Proxy @"piyo_x")
 instance HasCField Piyo "piyo_y"
     where type CFieldType Piyo "piyo_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "piyo_y" (Ptr Piyo) (Ptr CInt)
+instance TyEq ty CInt => HasField "piyo_y" (Ptr Piyo) (Ptr ty)
     where getField = fromPtr (Proxy @"piyo_y")

--- a/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/name/type/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @sym@
@@ -56,7 +59,8 @@ newtype MySym = MySym
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMySym" (Ptr.Ptr MySym) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapMySym" (Ptr.Ptr MySym) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMySym")

--- a/hs-bindgen/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/name/type/th.txt
@@ -29,7 +29,8 @@ newtype MySym
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMySym" (Ptr MySym) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "unwrapMySym" (Ptr MySym) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMySym")
 instance HasCField MySym "unwrapMySym"
     where type CFieldType MySym "unwrapMySym" = CChar

--- a/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @sym@
@@ -56,7 +59,8 @@ newtype Sym = Sym
     , Real
     )
 
-instance GHC.Records.HasField "unwrapSym" (Ptr.Ptr Sym) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapSym" (Ptr.Ptr Sym) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSym")

--- a/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/omit_type/th.txt
@@ -29,7 +29,7 @@ newtype Sym
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapSym" (Ptr Sym) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapSym" (Ptr Sym) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSym")
 instance HasCField Sym "unwrapSym"
     where type CFieldType Sym "unwrapSym" = CChar

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -77,7 +80,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bar_a" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Foo)) where
+instance ( TyEq ty (Ptr.Ptr Foo)
+         ) => GHC.Records.HasField "bar_a" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_a")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/opaque/th.txt
@@ -39,5 +39,5 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_a"
     where type CFieldType Bar "bar_a" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance HasField "bar_a" (Ptr Bar) (Ptr (Ptr Foo))
+instance TyEq ty (Ptr Foo) => HasField "bar_a" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_a")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/Example.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct rect@
@@ -103,7 +106,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named "named_e" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "named_e" (Ptr.Ptr Named) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "named_e" (Ptr.Ptr Named) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_e")
@@ -114,7 +118,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named "named_f" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "named_f" (Ptr.Ptr Named) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "named_f" (Ptr.Ptr Named) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_f")

--- a/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/rep/emptydata/struct/th.txt
@@ -62,12 +62,12 @@ deriving via (EquivStorable Named) instance Storable Named
 instance HasCField Named "named_e"
     where type CFieldType Named "named_e" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "named_e" (Ptr Named) (Ptr CInt)
+instance TyEq ty CInt => HasField "named_e" (Ptr Named) (Ptr ty)
     where getField = fromPtr (Proxy @"named_e")
 instance HasCField Named "named_f"
     where type CFieldType Named "named_f" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "named_f" (Ptr Named) (Ptr CInt)
+instance TyEq ty CInt => HasField "named_f" (Ptr Named) (Ptr ty)
     where getField = fromPtr (Proxy @"named_f")
 {-| __C declaration:__ @struct oan@
 

--- a/hs-bindgen/fixtures/binding-specs/stdlib/instances/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/stdlib/instances/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @stdlib_CBool@
@@ -56,7 +59,8 @@ newtype Stdlib_CBool = Stdlib_CBool
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CBool" (Ptr.Ptr Stdlib_CBool) (Ptr.Ptr HsBindgen.Runtime.LibC.CBool) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CBool
+         ) => GHC.Records.HasField "unwrapStdlib_CBool" (Ptr.Ptr Stdlib_CBool) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CBool")
@@ -96,7 +100,8 @@ newtype Stdlib_Int8 = Stdlib_Int8
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Int8" (Ptr.Ptr Stdlib_Int8) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int8
+         ) => GHC.Records.HasField "unwrapStdlib_Int8" (Ptr.Ptr Stdlib_Int8) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int8")
@@ -136,7 +141,8 @@ newtype Stdlib_Int16 = Stdlib_Int16
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Int16" (Ptr.Ptr Stdlib_Int16) (Ptr.Ptr HsBindgen.Runtime.LibC.Int16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int16
+         ) => GHC.Records.HasField "unwrapStdlib_Int16" (Ptr.Ptr Stdlib_Int16) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int16")
@@ -176,7 +182,8 @@ newtype Stdlib_Int32 = Stdlib_Int32
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Int32" (Ptr.Ptr Stdlib_Int32) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "unwrapStdlib_Int32" (Ptr.Ptr Stdlib_Int32) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int32")
@@ -216,7 +223,8 @@ newtype Stdlib_Int64 = Stdlib_Int64
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Int64" (Ptr.Ptr Stdlib_Int64) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int64
+         ) => GHC.Records.HasField "unwrapStdlib_Int64" (Ptr.Ptr Stdlib_Int64) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Int64")
@@ -256,7 +264,8 @@ newtype Stdlib_Word8 = Stdlib_Word8
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Word8" (Ptr.Ptr Stdlib_Word8) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "unwrapStdlib_Word8" (Ptr.Ptr Stdlib_Word8) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word8")
@@ -296,7 +305,8 @@ newtype Stdlib_Word16 = Stdlib_Word16
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Word16" (Ptr.Ptr Stdlib_Word16) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "unwrapStdlib_Word16" (Ptr.Ptr Stdlib_Word16) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word16")
@@ -336,7 +346,8 @@ newtype Stdlib_Word32 = Stdlib_Word32
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Word32" (Ptr.Ptr Stdlib_Word32) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapStdlib_Word32" (Ptr.Ptr Stdlib_Word32) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word32")
@@ -376,7 +387,8 @@ newtype Stdlib_Word64 = Stdlib_Word64
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_Word64" (Ptr.Ptr Stdlib_Word64) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word64
+         ) => GHC.Records.HasField "unwrapStdlib_Word64" (Ptr.Ptr Stdlib_Word64) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_Word64")
@@ -416,7 +428,8 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CIntMax" (Ptr.Ptr Stdlib_CIntMax) (Ptr.Ptr HsBindgen.Runtime.LibC.CIntMax) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CIntMax
+         ) => GHC.Records.HasField "unwrapStdlib_CIntMax" (Ptr.Ptr Stdlib_CIntMax) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CIntMax")
@@ -456,7 +469,8 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CUIntMax" (Ptr.Ptr Stdlib_CUIntMax) (Ptr.Ptr HsBindgen.Runtime.LibC.CUIntMax) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CUIntMax
+         ) => GHC.Records.HasField "unwrapStdlib_CUIntMax" (Ptr.Ptr Stdlib_CUIntMax) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CUIntMax")
@@ -496,7 +510,8 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CIntPtr" (Ptr.Ptr Stdlib_CIntPtr) (Ptr.Ptr HsBindgen.Runtime.LibC.CIntPtr) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CIntPtr
+         ) => GHC.Records.HasField "unwrapStdlib_CIntPtr" (Ptr.Ptr Stdlib_CIntPtr) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CIntPtr")
@@ -536,7 +551,8 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CUIntPtr" (Ptr.Ptr Stdlib_CUIntPtr) (Ptr.Ptr HsBindgen.Runtime.LibC.CUIntPtr) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CUIntPtr
+         ) => GHC.Records.HasField "unwrapStdlib_CUIntPtr" (Ptr.Ptr Stdlib_CUIntPtr) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CUIntPtr")
@@ -559,7 +575,8 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CFenvT" (Ptr.Ptr Stdlib_CFenvT) (Ptr.Ptr HsBindgen.Runtime.LibC.CFenvT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CFenvT
+         ) => GHC.Records.HasField "unwrapStdlib_CFenvT" (Ptr.Ptr Stdlib_CFenvT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFenvT")
@@ -582,7 +599,8 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CFexceptT" (Ptr.Ptr Stdlib_CFexceptT) (Ptr.Ptr HsBindgen.Runtime.LibC.CFexceptT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CFexceptT
+         ) => GHC.Records.HasField "unwrapStdlib_CFexceptT" (Ptr.Ptr Stdlib_CFexceptT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFexceptT")
@@ -622,7 +640,8 @@ newtype Stdlib_CSize = Stdlib_CSize
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CSize" (Ptr.Ptr Stdlib_CSize) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSize
+         ) => GHC.Records.HasField "unwrapStdlib_CSize" (Ptr.Ptr Stdlib_CSize) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CSize")
@@ -662,7 +681,8 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CPtrdiff" (Ptr.Ptr Stdlib_CPtrdiff) (Ptr.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CPtrdiff
+         ) => GHC.Records.HasField "unwrapStdlib_CPtrdiff" (Ptr.Ptr Stdlib_CPtrdiff) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CPtrdiff")
@@ -685,7 +705,8 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CJmpBuf" (Ptr.Ptr Stdlib_CJmpBuf) (Ptr.Ptr HsBindgen.Runtime.LibC.CJmpBuf) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CJmpBuf
+         ) => GHC.Records.HasField "unwrapStdlib_CJmpBuf" (Ptr.Ptr Stdlib_CJmpBuf) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CJmpBuf")
@@ -725,7 +746,8 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CWchar" (Ptr.Ptr Stdlib_CWchar) (Ptr.Ptr HsBindgen.Runtime.LibC.CWchar) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CWchar
+         ) => GHC.Records.HasField "unwrapStdlib_CWchar" (Ptr.Ptr Stdlib_CWchar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWchar")
@@ -765,7 +787,8 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CWintT" (Ptr.Ptr Stdlib_CWintT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWintT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CWintT
+         ) => GHC.Records.HasField "unwrapStdlib_CWintT" (Ptr.Ptr Stdlib_CWintT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWintT")
@@ -788,7 +811,8 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CMbstateT" (Ptr.Ptr Stdlib_CMbstateT) (Ptr.Ptr HsBindgen.Runtime.LibC.CMbstateT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CMbstateT
+         ) => GHC.Records.HasField "unwrapStdlib_CMbstateT" (Ptr.Ptr Stdlib_CMbstateT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CMbstateT")
@@ -819,7 +843,8 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CWctransT" (Ptr.Ptr Stdlib_CWctransT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWctransT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CWctransT
+         ) => GHC.Records.HasField "unwrapStdlib_CWctransT" (Ptr.Ptr Stdlib_CWctransT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWctransT")
@@ -850,7 +875,8 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CWctypeT" (Ptr.Ptr Stdlib_CWctypeT) (Ptr.Ptr HsBindgen.Runtime.LibC.CWctypeT) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CWctypeT
+         ) => GHC.Records.HasField "unwrapStdlib_CWctypeT" (Ptr.Ptr Stdlib_CWctypeT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CWctypeT")
@@ -890,7 +916,8 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CChar16T" (Ptr.Ptr Stdlib_CChar16T) (Ptr.Ptr HsBindgen.Runtime.LibC.CChar16T) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CChar16T
+         ) => GHC.Records.HasField "unwrapStdlib_CChar16T" (Ptr.Ptr Stdlib_CChar16T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CChar16T")
@@ -930,7 +957,8 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CChar32T" (Ptr.Ptr Stdlib_CChar32T) (Ptr.Ptr HsBindgen.Runtime.LibC.CChar32T) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CChar32T
+         ) => GHC.Records.HasField "unwrapStdlib_CChar32T" (Ptr.Ptr Stdlib_CChar32T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CChar32T")
@@ -963,7 +991,8 @@ newtype Stdlib_CTime = Stdlib_CTime
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CTime" (Ptr.Ptr Stdlib_CTime) (Ptr.Ptr HsBindgen.Runtime.LibC.CTime) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CTime
+         ) => GHC.Records.HasField "unwrapStdlib_CTime" (Ptr.Ptr Stdlib_CTime) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CTime")
@@ -996,7 +1025,8 @@ newtype Stdlib_CClock = Stdlib_CClock
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CClock" (Ptr.Ptr Stdlib_CClock) (Ptr.Ptr HsBindgen.Runtime.LibC.CClock) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CClock
+         ) => GHC.Records.HasField "unwrapStdlib_CClock" (Ptr.Ptr Stdlib_CClock) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CClock")
@@ -1023,7 +1053,8 @@ newtype Stdlib_CTm = Stdlib_CTm
     , HsBindgen.Runtime.Marshal.ReadRaw
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CTm" (Ptr.Ptr Stdlib_CTm) (Ptr.Ptr HsBindgen.Runtime.LibC.CTm) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CTm
+         ) => GHC.Records.HasField "unwrapStdlib_CTm" (Ptr.Ptr Stdlib_CTm) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CTm")
@@ -1046,7 +1077,8 @@ newtype Stdlib_CFile = Stdlib_CFile
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CFile" (Ptr.Ptr Stdlib_CFile) (Ptr.Ptr HsBindgen.Runtime.LibC.CFile) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CFile
+         ) => GHC.Records.HasField "unwrapStdlib_CFile" (Ptr.Ptr Stdlib_CFile) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFile")
@@ -1069,7 +1101,8 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapStdlib_CFpos" (Ptr.Ptr Stdlib_CFpos) (Ptr.Ptr HsBindgen.Runtime.LibC.CFpos) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CFpos
+         ) => GHC.Records.HasField "unwrapStdlib_CFpos" (Ptr.Ptr Stdlib_CFpos) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CFpos")
@@ -1109,7 +1142,8 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     , Real
     )
 
-instance GHC.Records.HasField "unwrapStdlib_CSigAtomic" (Ptr.Ptr Stdlib_CSigAtomic) (Ptr.Ptr HsBindgen.Runtime.LibC.CSigAtomic) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSigAtomic
+         ) => GHC.Records.HasField "unwrapStdlib_CSigAtomic" (Ptr.Ptr Stdlib_CSigAtomic) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStdlib_CSigAtomic")

--- a/hs-bindgen/fixtures/binding-specs/stdlib/instances/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/stdlib/instances/th.txt
@@ -46,9 +46,8 @@ newtype Stdlib_CBool
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CBool"
-                  (Ptr Stdlib_CBool)
-                  (Ptr HsBindgen.Runtime.LibC.CBool)
+instance TyEq ty HsBindgen.Runtime.LibC.CBool =>
+         HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool
@@ -84,9 +83,8 @@ newtype Stdlib_Int8
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Int8"
-                  (Ptr Stdlib_Int8)
-                  (Ptr HsBindgen.Runtime.LibC.Int8)
+instance TyEq ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
@@ -122,9 +120,8 @@ newtype Stdlib_Int16
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Int16"
-                  (Ptr Stdlib_Int16)
-                  (Ptr HsBindgen.Runtime.LibC.Int16)
+instance TyEq ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
@@ -160,9 +157,8 @@ newtype Stdlib_Int32
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Int32"
-                  (Ptr Stdlib_Int32)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
@@ -198,9 +194,8 @@ newtype Stdlib_Int64
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Int64"
-                  (Ptr Stdlib_Int64)
-                  (Ptr HsBindgen.Runtime.LibC.Int64)
+instance TyEq ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
@@ -236,9 +231,8 @@ newtype Stdlib_Word8
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Word8"
-                  (Ptr Stdlib_Word8)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
@@ -274,9 +268,8 @@ newtype Stdlib_Word16
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Word16"
-                  (Ptr Stdlib_Word16)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
@@ -312,9 +305,8 @@ newtype Stdlib_Word32
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Word32"
-                  (Ptr Stdlib_Word32)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
@@ -350,9 +342,8 @@ newtype Stdlib_Word64
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_Word64"
-                  (Ptr Stdlib_Word64)
-                  (Ptr HsBindgen.Runtime.LibC.Word64)
+instance TyEq ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
@@ -388,9 +379,8 @@ newtype Stdlib_CIntMax
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CIntMax"
-                  (Ptr Stdlib_CIntMax)
-                  (Ptr HsBindgen.Runtime.LibC.CIntMax)
+instance TyEq ty HsBindgen.Runtime.LibC.CIntMax =>
+         HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
@@ -426,9 +416,8 @@ newtype Stdlib_CUIntMax
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CUIntMax"
-                  (Ptr Stdlib_CUIntMax)
-                  (Ptr HsBindgen.Runtime.LibC.CUIntMax)
+instance TyEq ty HsBindgen.Runtime.LibC.CUIntMax =>
+         HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
@@ -464,9 +453,8 @@ newtype Stdlib_CIntPtr
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CIntPtr"
-                  (Ptr Stdlib_CIntPtr)
-                  (Ptr HsBindgen.Runtime.LibC.CIntPtr)
+instance TyEq ty HsBindgen.Runtime.LibC.CIntPtr =>
+         HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
@@ -502,9 +490,8 @@ newtype Stdlib_CUIntPtr
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CUIntPtr"
-                  (Ptr Stdlib_CUIntPtr)
-                  (Ptr HsBindgen.Runtime.LibC.CUIntPtr)
+instance TyEq ty HsBindgen.Runtime.LibC.CUIntPtr =>
+         HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
@@ -525,9 +512,8 @@ newtype Stdlib_CFenvT
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CFenvT"
-                  (Ptr Stdlib_CFenvT)
-                  (Ptr HsBindgen.Runtime.LibC.CFenvT)
+instance TyEq ty HsBindgen.Runtime.LibC.CFenvT =>
+         HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
@@ -548,9 +534,8 @@ newtype Stdlib_CFexceptT
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CFexceptT"
-                  (Ptr Stdlib_CFexceptT)
-                  (Ptr HsBindgen.Runtime.LibC.CFexceptT)
+instance TyEq ty HsBindgen.Runtime.LibC.CFexceptT =>
+         HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
@@ -586,9 +571,8 @@ newtype Stdlib_CSize
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CSize"
-                  (Ptr Stdlib_CSize)
-                  (Ptr HsBindgen.Runtime.LibC.CSize)
+instance TyEq ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
@@ -624,9 +608,8 @@ newtype Stdlib_CPtrdiff
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CPtrdiff"
-                  (Ptr Stdlib_CPtrdiff)
-                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
+instance TyEq ty HsBindgen.Runtime.LibC.CPtrdiff =>
+         HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
@@ -647,9 +630,8 @@ newtype Stdlib_CJmpBuf
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CJmpBuf"
-                  (Ptr Stdlib_CJmpBuf)
-                  (Ptr HsBindgen.Runtime.LibC.CJmpBuf)
+instance TyEq ty HsBindgen.Runtime.LibC.CJmpBuf =>
+         HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
@@ -685,9 +667,8 @@ newtype Stdlib_CWchar
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CWchar"
-                  (Ptr Stdlib_CWchar)
-                  (Ptr HsBindgen.Runtime.LibC.CWchar)
+instance TyEq ty HsBindgen.Runtime.LibC.CWchar =>
+         HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
@@ -723,9 +704,8 @@ newtype Stdlib_CWintT
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CWintT"
-                  (Ptr Stdlib_CWintT)
-                  (Ptr HsBindgen.Runtime.LibC.CWintT)
+instance TyEq ty HsBindgen.Runtime.LibC.CWintT =>
+         HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
@@ -746,9 +726,8 @@ newtype Stdlib_CMbstateT
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CMbstateT"
-                  (Ptr Stdlib_CMbstateT)
-                  (Ptr HsBindgen.Runtime.LibC.CMbstateT)
+instance TyEq ty HsBindgen.Runtime.LibC.CMbstateT =>
+         HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
@@ -775,9 +754,8 @@ newtype Stdlib_CWctransT
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapStdlib_CWctransT"
-                  (Ptr Stdlib_CWctransT)
-                  (Ptr HsBindgen.Runtime.LibC.CWctransT)
+instance TyEq ty HsBindgen.Runtime.LibC.CWctransT =>
+         HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
@@ -804,9 +782,8 @@ newtype Stdlib_CWctypeT
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapStdlib_CWctypeT"
-                  (Ptr Stdlib_CWctypeT)
-                  (Ptr HsBindgen.Runtime.LibC.CWctypeT)
+instance TyEq ty HsBindgen.Runtime.LibC.CWctypeT =>
+         HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
@@ -842,9 +819,8 @@ newtype Stdlib_CChar16T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CChar16T"
-                  (Ptr Stdlib_CChar16T)
-                  (Ptr HsBindgen.Runtime.LibC.CChar16T)
+instance TyEq ty HsBindgen.Runtime.LibC.CChar16T =>
+         HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
@@ -880,9 +856,8 @@ newtype Stdlib_CChar32T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CChar32T"
-                  (Ptr Stdlib_CChar32T)
-                  (Ptr HsBindgen.Runtime.LibC.CChar32T)
+instance TyEq ty HsBindgen.Runtime.LibC.CChar32T =>
+         HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
@@ -911,9 +886,8 @@ newtype Stdlib_CTime
                       Enum,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CTime"
-                  (Ptr Stdlib_CTime)
-                  (Ptr HsBindgen.Runtime.LibC.CTime)
+instance TyEq ty HsBindgen.Runtime.LibC.CTime =>
+         HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
@@ -942,9 +916,8 @@ newtype Stdlib_CClock
                       Enum,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CClock"
-                  (Ptr Stdlib_CClock)
-                  (Ptr HsBindgen.Runtime.LibC.CClock)
+instance TyEq ty HsBindgen.Runtime.LibC.CClock =>
+         HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
@@ -966,9 +939,8 @@ newtype Stdlib_CTm
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw)
-instance HasField "unwrapStdlib_CTm"
-                  (Ptr Stdlib_CTm)
-                  (Ptr HsBindgen.Runtime.LibC.CTm)
+instance TyEq ty HsBindgen.Runtime.LibC.CTm =>
+         HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
@@ -989,9 +961,8 @@ newtype Stdlib_CFile
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CFile"
-                  (Ptr Stdlib_CFile)
-                  (Ptr HsBindgen.Runtime.LibC.CFile)
+instance TyEq ty HsBindgen.Runtime.LibC.CFile =>
+         HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
@@ -1012,9 +983,8 @@ newtype Stdlib_CFpos
            __exported by:__ @binding-specs\/stdlib\/instances.h@
       -}
     deriving stock Generic
-instance HasField "unwrapStdlib_CFpos"
-                  (Ptr Stdlib_CFpos)
-                  (Ptr HsBindgen.Runtime.LibC.CFpos)
+instance TyEq ty HsBindgen.Runtime.LibC.CFpos =>
+         HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
@@ -1050,9 +1020,8 @@ newtype Stdlib_CSigAtomic
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapStdlib_CSigAtomic"
-                  (Ptr Stdlib_CSigAtomic)
-                  (Ptr HsBindgen.Runtime.LibC.CSigAtomic)
+instance TyEq ty HsBindgen.Runtime.LibC.CSigAtomic =>
+         HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @A@
@@ -56,7 +59,8 @@ newtype A = A
     , Real
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSize
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")

--- a/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -52,9 +52,8 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapA"
-                  (Ptr A)
-                  (Ptr HsBindgen.Runtime.LibC.CSize)
+instance TyEq ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = HsBindgen.Runtime.LibC.CSize

--- a/hs-bindgen/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/fixtures/declarations/definitions/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct X@
@@ -72,7 +75,8 @@ instance HsBindgen.Runtime.HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x_n")
@@ -156,7 +160,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_m")
@@ -167,7 +172,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_o")

--- a/hs-bindgen/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/fixtures/declarations/definitions/th.txt
@@ -59,7 +59,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x_n" (Ptr X) (Ptr CInt)
+instance TyEq ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -151,12 +151,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y_m" (Ptr Y) (Ptr CInt)
+instance TyEq ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y_o" (Ptr Y) (Ptr CInt)
+instance TyEq ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsdefinitions_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_9cdc88a6d09442d6" hs_bindgen_9cdc88a6d09442d6_base ::

--- a/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_t "s1_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s1_t_a" (Ptr.Ptr S1_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s1_t_a" (Ptr.Ptr S1_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_t_a")
@@ -121,7 +125,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_a" (Ptr.Ptr S2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s2_a" (Ptr.Ptr S2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_a")

--- a/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/forward_declaration/th.txt
@@ -32,7 +32,7 @@ deriving via (EquivStorable S1_t) instance Storable S1_t
 instance HasCField S1_t "s1_t_a"
     where type CFieldType S1_t "s1_t_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s1_t_a" (Ptr S1_t) (Ptr CInt)
+instance TyEq ty CInt => HasField "s1_t_a" (Ptr S1_t) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_t_a")
 {-| __C declaration:__ @struct S2@
 
@@ -67,5 +67,5 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_a"
     where type CFieldType S2 "s2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s2_a" (Ptr S2) (Ptr CInt)
+instance TyEq ty CInt => HasField "s2_a" (Ptr S2) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_a")

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/Example.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure, return)
 
 {-| __C declaration:__ @struct foo@
@@ -86,7 +89,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_ptrA" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bar_ptrA" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Foo)) where
+instance ( TyEq ty (Ptr.Ptr Foo)
+         ) => GHC.Records.HasField "bar_ptrA" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_ptrA")
@@ -97,7 +101,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_ptrB" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "bar_ptrB" (Ptr.Ptr Bar) (Ptr.Ptr (Ptr.Ptr Bar)) where
+instance ( TyEq ty (Ptr.Ptr Bar)
+         ) => GHC.Records.HasField "bar_ptrB" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_ptrB")

--- a/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/opaque_declaration/th.txt
@@ -47,12 +47,14 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_ptrA"
     where type CFieldType Bar "bar_ptrA" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance HasField "bar_ptrA" (Ptr Bar) (Ptr (Ptr Foo))
+instance TyEq ty (Ptr Foo) =>
+         HasField "bar_ptrA" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_ptrA")
 instance HasCField Bar "bar_ptrB"
     where type CFieldType Bar "bar_ptrB" = Ptr Bar
           offset# = \_ -> \_ -> 8
-instance HasField "bar_ptrB" (Ptr Bar) (Ptr (Ptr Bar))
+instance TyEq ty (Ptr Bar) =>
+         HasField "bar_ptrB" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_ptrB")
 {-| __C declaration:__ @struct baz@
 

--- a/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/fixtures/declarations/redeclaration/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -31,6 +33,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @int_t@
@@ -61,7 +64,8 @@ newtype Int_t = Int_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_t" (Ptr.Ptr Int_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapInt_t" (Ptr.Ptr Int_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_t")
@@ -119,7 +123,8 @@ instance HsBindgen.Runtime.HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x_n" (Ptr.Ptr X) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x_n")
@@ -203,7 +208,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y_m" (Ptr.Ptr Y) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_m")
@@ -214,7 +220,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y_o" (Ptr.Ptr Y) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y_o")

--- a/hs-bindgen/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/fixtures/declarations/redeclaration/th.txt
@@ -36,7 +36,8 @@ newtype Int_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_t" (Ptr Int_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapInt_t" (Ptr Int_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_t")
 instance HasCField Int_t "unwrapInt_t"
     where type CFieldType Int_t "unwrapInt_t" = CInt
@@ -74,7 +75,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x_n" (Ptr X) (Ptr CInt)
+instance TyEq ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -166,12 +167,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y_m" (Ptr Y) (Ptr CInt)
+instance TyEq ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y_o" (Ptr Y) (Ptr CInt)
+instance TyEq ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsredeclaration_Example_get_x@
 foreign import ccall unsafe "hs_bindgen_6f47e5cbb92690b9" hs_bindgen_6f47e5cbb92690b9_base ::

--- a/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/fixtures/declarations/select_scoping/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @ParsedAndSelected1@
@@ -56,7 +59,8 @@ newtype ParsedAndSelected1 = ParsedAndSelected1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapParsedAndSelected1" (Ptr.Ptr ParsedAndSelected1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapParsedAndSelected1" (Ptr.Ptr ParsedAndSelected1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapParsedAndSelected1")

--- a/hs-bindgen/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/fixtures/declarations/select_scoping/th.txt
@@ -30,9 +30,10 @@ newtype ParsedAndSelected1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapParsedAndSelected1"
+instance TyEq ty CInt =>
+         HasField "unwrapParsedAndSelected1"
                   (Ptr ParsedAndSelected1)
-                  (Ptr CInt)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapParsedAndSelected1")
 instance HasCField ParsedAndSelected1 "unwrapParsedAndSelected1"
     where type CFieldType ParsedAndSelected1

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @triplet@
@@ -39,7 +42,8 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")

--- a/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/fixtures/documentation/data_kind_pragma/th.txt
@@ -15,9 +15,8 @@ newtype Triplet
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTriplet"
-                  (Ptr Triplet)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,6 +14,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -47,6 +49,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @MAX_NAME_LENGTH@
@@ -92,7 +95,8 @@ newtype Size_type = Size_type
     , Real
     )
 
-instance GHC.Records.HasField "unwrapSize_type" (Ptr.Ptr Size_type) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSize
+         ) => GHC.Records.HasField "unwrapSize_type" (Ptr.Ptr Size_type) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSize_type")
@@ -215,7 +219,8 @@ instance Read Color_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapColor_enum" (Ptr.Ptr Color_enum) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapColor_enum" (Ptr.Ptr Color_enum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapColor_enum")
@@ -306,7 +311,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Event_callback_t_Aux where
 
   fromFunPtr = hs_bindgen_9e9d478c2d75628c
 
-instance GHC.Records.HasField "unwrapEvent_callback_t_Aux" (Ptr.Ptr Event_callback_t_Aux) (Ptr.Ptr (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapEvent_callback_t_Aux" (Ptr.Ptr Event_callback_t_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEvent_callback_t_Aux")
@@ -346,7 +352,8 @@ newtype Event_callback_t = Event_callback_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapEvent_callback_t" (Ptr.Ptr Event_callback_t) (Ptr.Ptr (Ptr.FunPtr Event_callback_t_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Event_callback_t_Aux)
+         ) => GHC.Records.HasField "unwrapEvent_callback_t" (Ptr.Ptr Event_callback_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEvent_callback_t")
@@ -475,7 +482,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_id" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "config_t_id" (Ptr.Ptr Config_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "config_t_id" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_id")
@@ -487,7 +495,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_name" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "config_t_name" (Ptr.Ptr Config_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 64) FC.CChar)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 64) FC.CChar)
+         ) => GHC.Records.HasField "config_t_name" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_name")
@@ -499,7 +508,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_flags" where
 
   offset# = \_ -> \_ -> 68
 
-instance GHC.Records.HasField "config_t_flags" (Ptr.Ptr Config_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "config_t_flags" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_flags")
@@ -511,7 +521,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_callback" wher
 
   offset# = \_ -> \_ -> 72
 
-instance GHC.Records.HasField "config_t_callback" (Ptr.Ptr Config_t) (Ptr.Ptr Event_callback_t) where
+instance ( TyEq ty Event_callback_t
+         ) => GHC.Records.HasField "config_t_callback" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_callback")
@@ -523,7 +534,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config_t "config_t_user_data" whe
 
   offset# = \_ -> \_ -> 80
 
-instance GHC.Records.HasField "config_t_user_data" (Ptr.Ptr Config_t) (Ptr.Ptr (Ptr.Ptr Void)) where
+instance ( TyEq ty (Ptr.Ptr Void)
+         ) => GHC.Records.HasField "config_t_user_data" (Ptr.Ptr Config_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_t_user_data")
@@ -607,7 +619,8 @@ instance Read Status_code_t where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapStatus_code_t" (Ptr.Ptr Status_code_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapStatus_code_t" (Ptr.Ptr Status_code_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStatus_code_t")
@@ -755,7 +768,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t_as_parts "data_union
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "data_union_t_as_parts_low" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "data_union_t_as_parts_low" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts_low")
@@ -767,7 +781,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t_as_parts "data_union
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "data_union_t_as_parts_high" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "data_union_t_as_parts_high" (Ptr.Ptr Data_union_t_as_parts) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts_high")
@@ -920,7 +935,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_int
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "data_union_t_as_int" (Ptr.Ptr Data_union_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "data_union_t_as_int" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_int")
@@ -932,7 +948,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_flo
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "data_union_t_as_float" (Ptr.Ptr Data_union_t) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "data_union_t_as_float" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_float")
@@ -944,7 +961,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_byt
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "data_union_t_as_bytes" (Ptr.Ptr Data_union_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.LibC.Word8)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) HsBindgen.Runtime.LibC.Word8)
+         ) => GHC.Records.HasField "data_union_t_as_bytes" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_bytes")
@@ -956,7 +974,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Data_union_t "data_union_t_as_par
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "data_union_t_as_parts" (Ptr.Ptr Data_union_t) (Ptr.Ptr Data_union_t_as_parts) where
+instance ( TyEq ty Data_union_t_as_parts
+         ) => GHC.Records.HasField "data_union_t_as_parts" (Ptr.Ptr Data_union_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"data_union_t_as_parts")
@@ -1066,7 +1085,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bitfield_t_flag1" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "bitfield_t_flag1" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_flag1")
@@ -1080,7 +1100,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bitfield_t_flag2" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "bitfield_t_flag2" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_flag2")
@@ -1094,7 +1115,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_coun
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance GHC.Records.HasField "bitfield_t_counter" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "bitfield_t_counter" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_counter")
@@ -1108,7 +1130,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_rese
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "bitfield_t_reserved" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "bitfield_t_reserved" (Ptr.Ptr Bitfield_t) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"bitfield_t_reserved")
@@ -1159,7 +1182,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Processor_fn_t_Aux where
 
   fromFunPtr = hs_bindgen_0d4b3d0461629423
 
-instance GHC.Records.HasField "unwrapProcessor_fn_t_Aux" (Ptr.Ptr Processor_fn_t_Aux) (Ptr.Ptr (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> (Ptr.Ptr Void) -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapProcessor_fn_t_Aux" (Ptr.Ptr Processor_fn_t_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_fn_t_Aux")
@@ -1201,7 +1225,8 @@ newtype Processor_fn_t = Processor_fn_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapProcessor_fn_t" (Ptr.Ptr Processor_fn_t) (Ptr.Ptr (Ptr.FunPtr Processor_fn_t_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Processor_fn_t_Aux)
+         ) => GHC.Records.HasField "unwrapProcessor_fn_t" (Ptr.Ptr Processor_fn_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_fn_t")
@@ -1236,7 +1261,8 @@ newtype Filename_t = Filename_t
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapFilename_t" (Ptr.Ptr Filename_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 256) FC.CChar)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 256) FC.CChar)
+         ) => GHC.Records.HasField "unwrapFilename_t" (Ptr.Ptr Filename_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFilename_t")
@@ -1308,7 +1334,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Flexible_array_Aux "flexible_arra
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "flexible_array_count" (Ptr.Ptr Flexible_array_Aux) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSize
+         ) => GHC.Records.HasField "flexible_array_count" (Ptr.Ptr Flexible_array_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flexible_array_count")

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -400,9 +400,8 @@ newtype Size_type
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapSize_type"
-                  (Ptr Size_type)
-                  (Ptr HsBindgen.Runtime.LibC.CSize)
+instance TyEq ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapSize_type" (Ptr Size_type) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSize_type")
 instance HasCField Size_type "unwrapSize_type"
     where type CFieldType Size_type
@@ -489,7 +488,8 @@ instance Read Color_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapColor_enum")
 instance HasCField Color_enum "unwrapColor_enum"
     where type CFieldType Color_enum "unwrapColor_enum" = CUInt
@@ -591,9 +591,10 @@ instance ToFunPtr Event_callback_t_Aux
     where toFunPtr = hs_bindgen_111918b0aee2a7fb
 instance FromFunPtr Event_callback_t_Aux
     where fromFunPtr = hs_bindgen_9e9d478c2d75628c
-instance HasField "unwrapEvent_callback_t_Aux"
+instance TyEq ty (CInt -> Ptr Void -> IO CInt) =>
+         HasField "unwrapEvent_callback_t_Aux"
                   (Ptr Event_callback_t_Aux)
-                  (Ptr (CInt -> Ptr Void -> IO CInt))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t_Aux")
 instance HasCField Event_callback_t_Aux
                    "unwrapEvent_callback_t_Aux"
@@ -640,9 +641,8 @@ newtype Event_callback_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapEvent_callback_t"
-                  (Ptr Event_callback_t)
-                  (Ptr (FunPtr Event_callback_t_Aux))
+instance TyEq ty (FunPtr Event_callback_t_Aux) =>
+         HasField "unwrapEvent_callback_t" (Ptr Event_callback_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t")
 instance HasCField Event_callback_t "unwrapEvent_callback_t"
     where type CFieldType Event_callback_t
@@ -748,40 +748,35 @@ instance HasCField Config_t "config_t_id"
     where type CFieldType Config_t
                           "config_t_id" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance HasField "config_t_id"
-                  (Ptr Config_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "config_t_id" (Ptr Config_t) (Ptr ty)
     where getField = fromPtr (Proxy @"config_t_id")
 instance HasCField Config_t "config_t_name"
     where type CFieldType Config_t "config_t_name" = ConstantArray 64
                                                                    CChar
           offset# = \_ -> \_ -> 4
-instance HasField "config_t_name"
-                  (Ptr Config_t)
-                  (Ptr (ConstantArray 64 CChar))
+instance TyEq ty (ConstantArray 64 CChar) =>
+         HasField "config_t_name" (Ptr Config_t) (Ptr ty)
     where getField = fromPtr (Proxy @"config_t_name")
 instance HasCField Config_t "config_t_flags"
     where type CFieldType Config_t
                           "config_t_flags" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 68
-instance HasField "config_t_flags"
-                  (Ptr Config_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "config_t_flags" (Ptr Config_t) (Ptr ty)
     where getField = fromPtr (Proxy @"config_t_flags")
 instance HasCField Config_t "config_t_callback"
     where type CFieldType Config_t
                           "config_t_callback" = Event_callback_t
           offset# = \_ -> \_ -> 72
-instance HasField "config_t_callback"
-                  (Ptr Config_t)
-                  (Ptr Event_callback_t)
+instance TyEq ty Event_callback_t =>
+         HasField "config_t_callback" (Ptr Config_t) (Ptr ty)
     where getField = fromPtr (Proxy @"config_t_callback")
 instance HasCField Config_t "config_t_user_data"
     where type CFieldType Config_t "config_t_user_data" = Ptr Void
           offset# = \_ -> \_ -> 80
-instance HasField "config_t_user_data"
-                  (Ptr Config_t)
-                  (Ptr (Ptr Void))
+instance TyEq ty (Ptr Void) =>
+         HasField "config_t_user_data" (Ptr Config_t) (Ptr ty)
     where getField = fromPtr (Proxy @"config_t_user_data")
 {-|
 
@@ -839,9 +834,8 @@ instance Read Status_code_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapStatus_code_t"
-                  (Ptr Status_code_t)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapStatus_code_t" (Ptr Status_code_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStatus_code_t")
 instance HasCField Status_code_t "unwrapStatus_code_t"
     where type CFieldType Status_code_t "unwrapStatus_code_t" = CInt
@@ -1019,18 +1013,20 @@ instance HasCField Data_union_t_as_parts
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_low" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance HasField "data_union_t_as_parts_low"
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "data_union_t_as_parts_low"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_low")
 instance HasCField Data_union_t_as_parts
                    "data_union_t_as_parts_high"
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_high" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance HasField "data_union_t_as_parts_high"
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "data_union_t_as_parts_high"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_high")
 {-|
 
@@ -1224,33 +1220,29 @@ instance HasCField Data_union_t "data_union_t_as_int"
     where type CFieldType Data_union_t
                           "data_union_t_as_int" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance HasField "data_union_t_as_int"
-                  (Ptr Data_union_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "data_union_t_as_int" (Ptr Data_union_t) (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_int")
 instance HasCField Data_union_t "data_union_t_as_float"
     where type CFieldType Data_union_t "data_union_t_as_float" = CFloat
           offset# = \_ -> \_ -> 0
-instance HasField "data_union_t_as_float"
-                  (Ptr Data_union_t)
-                  (Ptr CFloat)
+instance TyEq ty CFloat =>
+         HasField "data_union_t_as_float" (Ptr Data_union_t) (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_float")
 instance HasCField Data_union_t "data_union_t_as_bytes"
     where type CFieldType Data_union_t
                           "data_union_t_as_bytes" = ConstantArray 4
                                                                   HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance HasField "data_union_t_as_bytes"
-                  (Ptr Data_union_t)
-                  (Ptr (ConstantArray 4 HsBindgen.Runtime.LibC.Word8))
+instance TyEq ty (ConstantArray 4 HsBindgen.Runtime.LibC.Word8) =>
+         HasField "data_union_t_as_bytes" (Ptr Data_union_t) (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_bytes")
 instance HasCField Data_union_t "data_union_t_as_parts"
     where type CFieldType Data_union_t
                           "data_union_t_as_parts" = Data_union_t_as_parts
           offset# = \_ -> \_ -> 0
-instance HasField "data_union_t_as_parts"
-                  (Ptr Data_union_t)
-                  (Ptr Data_union_t_as_parts)
+instance TyEq ty Data_union_t_as_parts =>
+         HasField "data_union_t_as_parts" (Ptr Data_union_t) (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_parts")
 {-|
 
@@ -1342,33 +1334,29 @@ instance HasCBitfield Bitfield_t "bitfield_t_flag1"
     where type CBitfieldType Bitfield_t "bitfield_t_flag1" = CUInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "bitfield_t_flag1"
-                  (Ptr Bitfield_t)
-                  (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "bitfield_t_flag1" (Ptr Bitfield_t) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"bitfield_t_flag1")
 instance HasCBitfield Bitfield_t "bitfield_t_flag2"
     where type CBitfieldType Bitfield_t "bitfield_t_flag2" = CUInt
           bitfieldOffset# = \_ -> \_ -> 1
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "bitfield_t_flag2"
-                  (Ptr Bitfield_t)
-                  (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "bitfield_t_flag2" (Ptr Bitfield_t) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"bitfield_t_flag2")
 instance HasCBitfield Bitfield_t "bitfield_t_counter"
     where type CBitfieldType Bitfield_t "bitfield_t_counter" = CUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 6
-instance HasField "bitfield_t_counter"
-                  (Ptr Bitfield_t)
-                  (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "bitfield_t_counter" (Ptr Bitfield_t) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"bitfield_t_counter")
 instance HasCBitfield Bitfield_t "bitfield_t_reserved"
     where type CBitfieldType Bitfield_t "bitfield_t_reserved" = CUInt
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 24
-instance HasField "bitfield_t_reserved"
-                  (Ptr Bitfield_t)
-                  (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "bitfield_t_reserved" (Ptr Bitfield_t) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"bitfield_t_reserved")
 {-| Auxiliary type used by 'Processor_fn_t'
 
@@ -1413,9 +1401,10 @@ instance ToFunPtr Processor_fn_t_Aux
     where toFunPtr = hs_bindgen_d4e16471c82d5df0
 instance FromFunPtr Processor_fn_t_Aux
     where fromFunPtr = hs_bindgen_0d4b3d0461629423
-instance HasField "unwrapProcessor_fn_t_Aux"
+instance TyEq ty (CInt -> Ptr Void -> IO CInt) =>
+         HasField "unwrapProcessor_fn_t_Aux"
                   (Ptr Processor_fn_t_Aux)
-                  (Ptr (CInt -> Ptr Void -> IO CInt))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t_Aux")
 instance HasCField Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux"
     where type CFieldType Processor_fn_t_Aux
@@ -1465,9 +1454,8 @@ newtype Processor_fn_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapProcessor_fn_t"
-                  (Ptr Processor_fn_t)
-                  (Ptr (FunPtr Processor_fn_t_Aux))
+instance TyEq ty (FunPtr Processor_fn_t_Aux) =>
+         HasField "unwrapProcessor_fn_t" (Ptr Processor_fn_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t")
 instance HasCField Processor_fn_t "unwrapProcessor_fn_t"
     where type CFieldType Processor_fn_t
@@ -1501,9 +1489,8 @@ newtype Filename_t
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapFilename_t"
-                  (Ptr Filename_t)
-                  (Ptr (ConstantArray 256 CChar))
+instance TyEq ty (ConstantArray 256 CChar) =>
+         HasField "unwrapFilename_t" (Ptr Filename_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFilename_t")
 instance HasCField Filename_t "unwrapFilename_t"
     where type CFieldType Filename_t
@@ -1549,9 +1536,8 @@ instance HasCField Flexible_array_Aux "flexible_array_count"
     where type CFieldType Flexible_array_Aux
                           "flexible_array_count" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance HasField "flexible_array_count"
-                  (Ptr Flexible_array_Aux)
-                  (Ptr HsBindgen.Runtime.LibC.CSize)
+instance TyEq ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"flexible_array_count")
 instance Offset CInt Flexible_array_Aux
     where offset = \_ty_0 -> 8

--- a/hs-bindgen/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/adios/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @adiós@
@@ -56,7 +59,8 @@ newtype Adio'0301s = Adio'0301s
     , Real
     )
 
-instance GHC.Records.HasField "unwrapAdio'0301s" (Ptr.Ptr Adio'0301s) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapAdio'0301s" (Ptr.Ptr Adio'0301s) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapAdio'0301s")
@@ -96,7 +100,8 @@ newtype C数字 = C数字
     , Real
     )
 
-instance GHC.Records.HasField "unwrapC\25968\23383" (Ptr.Ptr C数字) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapC\25968\23383" (Ptr.Ptr C数字) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapC\25968\23383")

--- a/hs-bindgen/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/adios/th.txt
@@ -98,7 +98,8 @@ newtype Adio'0301s
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapAdio'0301s")
 instance HasCField Adio'0301s "unwrapAdio'0301s"
     where type CFieldType Adio'0301s "unwrapAdio'0301s" = CInt
@@ -133,7 +134,8 @@ newtype C数字
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapC\25968\23383")
 instance HasCField C数字 "unwrapC\25968\23383"
     where type CFieldType C数字 "unwrapC\25968\23383" = CInt

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct \@some_struct_field1@
@@ -79,7 +82,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct_field1 "some_struct_f
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "some_struct_field1_x" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "some_struct_field1_x" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1_x")
@@ -91,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct_field1 "some_struct_f
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "some_struct_field1_y" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "some_struct_field1_y" (Ptr.Ptr Some_struct_field1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1_y")
@@ -162,7 +167,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field1" 
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "some_struct_field1" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
+instance ( TyEq ty Some_struct_field1
+         ) => GHC.Records.HasField "some_struct_field1" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field1")
@@ -174,7 +180,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field2" 
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "some_struct_field2" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
+instance ( TyEq ty Some_struct_field1
+         ) => GHC.Records.HasField "some_struct_field2" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field2")
@@ -186,7 +193,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Some_struct "some_struct_field3" 
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "some_struct_field3" (Ptr.Ptr Some_struct) (Ptr.Ptr Some_struct_field1) where
+instance ( TyEq ty Some_struct_field1
+         ) => GHC.Records.HasField "some_struct_field3" (Ptr.Ptr Some_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"some_struct_field3")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -41,17 +41,15 @@ instance HasCField Some_struct_field1 "some_struct_field1_x"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "some_struct_field1_x"
-                  (Ptr Some_struct_field1)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "some_struct_field1_x" (Ptr Some_struct_field1) (Ptr ty)
     where getField = fromPtr (Proxy @"some_struct_field1_x")
 instance HasCField Some_struct_field1 "some_struct_field1_y"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "some_struct_field1_y"
-                  (Ptr Some_struct_field1)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "some_struct_field1_y" (Ptr Some_struct_field1) (Ptr ty)
     where getField = fromPtr (Proxy @"some_struct_field1_y")
 {-| __C declaration:__ @struct some_struct@
 
@@ -103,23 +101,20 @@ instance HasCField Some_struct "some_struct_field1"
     where type CFieldType Some_struct
                           "some_struct_field1" = Some_struct_field1
           offset# = \_ -> \_ -> 0
-instance HasField "some_struct_field1"
-                  (Ptr Some_struct)
-                  (Ptr Some_struct_field1)
+instance TyEq ty Some_struct_field1 =>
+         HasField "some_struct_field1" (Ptr Some_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"some_struct_field1")
 instance HasCField Some_struct "some_struct_field2"
     where type CFieldType Some_struct
                           "some_struct_field2" = Some_struct_field1
           offset# = \_ -> \_ -> 8
-instance HasField "some_struct_field2"
-                  (Ptr Some_struct)
-                  (Ptr Some_struct_field1)
+instance TyEq ty Some_struct_field1 =>
+         HasField "some_struct_field2" (Ptr Some_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"some_struct_field2")
 instance HasCField Some_struct "some_struct_field3"
     where type CFieldType Some_struct
                           "some_struct_field3" = Some_struct_field1
           offset# = \_ -> \_ -> 16
-instance HasField "some_struct_field3"
-                  (Ptr Some_struct)
-                  (Ptr Some_struct_field1)
+instance TyEq ty Some_struct_field1 =>
+         HasField "some_struct_field3" (Ptr Some_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"some_struct_field3")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct point1a@
@@ -80,7 +83,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point1a "point1a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "point1a_x" (Ptr.Ptr Point1a) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point1a_x" (Ptr.Ptr Point1a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point1a_x")
@@ -91,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point1a "point1a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "point1a_y" (Ptr.Ptr Point1a) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point1a_y" (Ptr.Ptr Point1a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point1a_y")
@@ -113,7 +118,8 @@ newtype Point1b = Point1b
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapPoint1b" (Ptr.Ptr Point1b) (Ptr.Ptr Point1a) where
+instance ( TyEq ty Point1a
+         ) => GHC.Records.HasField "unwrapPoint1b" (Ptr.Ptr Point1b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint1b")
@@ -180,7 +186,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point2a "point2a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "point2a_x" (Ptr.Ptr Point2a) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point2a_x" (Ptr.Ptr Point2a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point2a_x")
@@ -191,7 +198,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point2a "point2a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "point2a_y" (Ptr.Ptr Point2a) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point2a_y" (Ptr.Ptr Point2a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point2a_y")
@@ -214,7 +222,8 @@ newtype Point2b = Point2b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapPoint2b" (Ptr.Ptr Point2b) (Ptr.Ptr (Ptr.Ptr Point2a)) where
+instance ( TyEq ty (Ptr.Ptr Point2a)
+         ) => GHC.Records.HasField "unwrapPoint2b" (Ptr.Ptr Point2b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint2b")
@@ -282,7 +291,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a_Aux "point3a_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "point3a_Aux_x" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point3a_Aux_x" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point3a_Aux_x")
@@ -293,7 +303,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point3a_Aux "point3a_Aux_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "point3a_Aux_y" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point3a_Aux_y" (Ptr.Ptr Point3a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point3a_Aux_y")
@@ -316,7 +327,8 @@ newtype Point3a = Point3a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapPoint3a" (Ptr.Ptr Point3a) (Ptr.Ptr (Ptr.Ptr Point3a_Aux)) where
+instance ( TyEq ty (Ptr.Ptr Point3a_Aux)
+         ) => GHC.Records.HasField "unwrapPoint3a" (Ptr.Ptr Point3a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint3a")
@@ -346,7 +358,8 @@ newtype Point3b = Point3b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapPoint3b" (Ptr.Ptr Point3b) (Ptr.Ptr (Ptr.Ptr Point3a_Aux)) where
+instance ( TyEq ty (Ptr.Ptr Point3a_Aux)
+         ) => GHC.Records.HasField "unwrapPoint3b" (Ptr.Ptr Point3b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPoint3b")

--- a/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -64,12 +64,14 @@ deriving via (EquivStorable Point1a) instance Storable Point1a
 instance HasCField Point1a "point1a_x"
     where type CFieldType Point1a "point1a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "point1a_x" (Ptr Point1a) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point1a_x" (Ptr Point1a) (Ptr ty)
     where getField = fromPtr (Proxy @"point1a_x")
 instance HasCField Point1a "point1a_y"
     where type CFieldType Point1a "point1a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "point1a_y" (Ptr Point1a) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point1a_y" (Ptr Point1a) (Ptr ty)
     where getField = fromPtr (Proxy @"point1a_y")
 {-| __C declaration:__ @point1b@
 
@@ -87,7 +89,8 @@ newtype Point1b
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapPoint1b" (Ptr Point1b) (Ptr Point1a)
+instance TyEq ty Point1a =>
+         HasField "unwrapPoint1b" (Ptr Point1b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint1b")
 instance HasCField Point1b "unwrapPoint1b"
     where type CFieldType Point1b "unwrapPoint1b" = Point1a
@@ -133,12 +136,14 @@ deriving via (EquivStorable Point2a) instance Storable Point2a
 instance HasCField Point2a "point2a_x"
     where type CFieldType Point2a "point2a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "point2a_x" (Ptr Point2a) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point2a_x" (Ptr Point2a) (Ptr ty)
     where getField = fromPtr (Proxy @"point2a_x")
 instance HasCField Point2a "point2a_y"
     where type CFieldType Point2a "point2a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "point2a_y" (Ptr Point2a) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point2a_y" (Ptr Point2a) (Ptr ty)
     where getField = fromPtr (Proxy @"point2a_y")
 {-| __C declaration:__ @point2b@
 
@@ -160,7 +165,8 @@ newtype Point2b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapPoint2b" (Ptr Point2b) (Ptr (Ptr Point2a))
+instance TyEq ty (Ptr Point2a) =>
+         HasField "unwrapPoint2b" (Ptr Point2b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint2b")
 instance HasCField Point2b "unwrapPoint2b"
     where type CFieldType Point2b "unwrapPoint2b" = Ptr Point2a
@@ -206,12 +212,14 @@ deriving via (EquivStorable Point3a_Aux) instance Storable Point3a_Aux
 instance HasCField Point3a_Aux "point3a_Aux_x"
     where type CFieldType Point3a_Aux "point3a_Aux_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"point3a_Aux_x")
 instance HasCField Point3a_Aux "point3a_Aux_y"
     where type CFieldType Point3a_Aux "point3a_Aux_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"point3a_Aux_y")
 {-| __C declaration:__ @point3a@
 
@@ -233,9 +241,8 @@ newtype Point3a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapPoint3a"
-                  (Ptr Point3a)
-                  (Ptr (Ptr Point3a_Aux))
+instance TyEq ty (Ptr Point3a_Aux) =>
+         HasField "unwrapPoint3a" (Ptr Point3a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint3a")
 instance HasCField Point3a "unwrapPoint3a"
     where type CFieldType Point3a "unwrapPoint3a" = Ptr Point3a_Aux
@@ -260,9 +267,8 @@ newtype Point3b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapPoint3b"
-                  (Ptr Point3b)
-                  (Ptr (Ptr Point3a_Aux))
+instance TyEq ty (Ptr Point3a_Aux) =>
+         HasField "unwrapPoint3b" (Ptr Point3b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint3b")
 instance HasCField Point3b "unwrapPoint3b"
     where type CFieldType Point3b "unwrapPoint3b" = Ptr Point3a_Aux

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,6 +13,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -40,6 +42,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @struct another_typedef_struct_t@
@@ -101,7 +104,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Another_typedef_struct_t "another
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "another_typedef_struct_t_foo" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "another_typedef_struct_t_foo" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"another_typedef_struct_t_foo")
@@ -113,7 +117,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Another_typedef_struct_t "another
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "another_typedef_struct_t_bar" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "another_typedef_struct_t_bar" (Ptr.Ptr Another_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"another_typedef_struct_t_bar")
@@ -198,7 +203,8 @@ instance Read Another_typedef_enum_e where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapAnother_typedef_enum_e" (Ptr.Ptr Another_typedef_enum_e) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapAnother_typedef_enum_e" (Ptr.Ptr Another_typedef_enum_e) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapAnother_typedef_enum_e")
@@ -283,7 +289,8 @@ newtype A_type_t = A_type_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapA_type_t" (Ptr.Ptr A_type_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapA_type_t" (Ptr.Ptr A_type_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_type_t")
@@ -322,7 +329,8 @@ newtype Var_t = Var_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapVar_t" (Ptr.Ptr Var_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapVar_t" (Ptr.Ptr Var_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapVar_t")
@@ -482,7 +490,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_0" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_0" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_0")
@@ -494,7 +503,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_1" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_1" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_1")
@@ -506,7 +516,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_2" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_2" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_2")
@@ -518,7 +529,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_3" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_3" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_3")
@@ -530,7 +542,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_4" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr Another_typedef_struct_t) where
+instance ( TyEq ty Another_typedef_struct_t
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_4" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_4")
@@ -542,7 +555,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_5" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr (Ptr.Ptr Another_typedef_struct_t)) where
+instance ( TyEq ty (Ptr.Ptr Another_typedef_struct_t)
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_5" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_5")
@@ -554,7 +568,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_6" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr (Ptr.Ptr Void)) where
+instance ( TyEq ty (Ptr.Ptr Void)
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_6" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_6")
@@ -566,7 +581,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_7" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 7) HsBindgen.Runtime.LibC.Word32)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 7) HsBindgen.Runtime.LibC.Word32)
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_7" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_7")
@@ -578,7 +594,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 60
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_8" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr Another_typedef_enum_e) where
+instance ( TyEq ty Another_typedef_enum_e
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_8" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_8")
@@ -590,7 +607,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 64
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_9" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) Another_typedef_enum_e)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 4) Another_typedef_enum_e)
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_9" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_9")
@@ -602,7 +620,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A_typedef_struct_t "a_typedef_str
 
   offset# = \_ -> \_ -> 80
 
-instance GHC.Records.HasField "a_typedef_struct_t_field_10" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Another_typedef_enum_e))) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Another_typedef_enum_e))
+         ) => GHC.Records.HasField "a_typedef_struct_t_field_10" (Ptr.Ptr A_typedef_struct_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_typedef_struct_t_field_10")
@@ -725,7 +744,8 @@ instance Read A_typedef_enum_e where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapA_typedef_enum_e" (Ptr.Ptr A_typedef_enum_e) (Ptr.Ptr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "unwrapA_typedef_enum_e" (Ptr.Ptr A_typedef_enum_e) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA_typedef_enum_e")
@@ -819,7 +839,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Callback_t_Aux where
 
   fromFunPtr = hs_bindgen_d6debb4b8d5bb869
 
-instance GHC.Records.HasField "unwrapCallback_t_Aux" (Ptr.Ptr Callback_t_Aux) (Ptr.Ptr ((Ptr.Ptr Void) -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)) where
+instance ( TyEq ty ((Ptr.Ptr Void) -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)
+         ) => GHC.Records.HasField "unwrapCallback_t_Aux" (Ptr.Ptr Callback_t_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCallback_t_Aux")
@@ -849,7 +870,8 @@ newtype Callback_t = Callback_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapCallback_t" (Ptr.Ptr Callback_t) (Ptr.Ptr (Ptr.FunPtr Callback_t_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Callback_t_Aux)
+         ) => GHC.Records.HasField "unwrapCallback_t" (Ptr.Ptr Callback_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCallback_t")

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -79,18 +79,20 @@ instance HasCField Another_typedef_struct_t
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_foo" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "another_typedef_struct_t_foo"
+instance TyEq ty CInt =>
+         HasField "another_typedef_struct_t_foo"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr CInt)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_foo")
 instance HasCField Another_typedef_struct_t
                    "another_typedef_struct_t_bar"
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_bar" = CChar
           offset# = \_ -> \_ -> 4
-instance HasField "another_typedef_struct_t_bar"
+instance TyEq ty CChar =>
+         HasField "another_typedef_struct_t_bar"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr CChar)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_bar")
 {-| __C declaration:__ @enum another_typedef_enum_e@
 
@@ -138,9 +140,10 @@ instance Read Another_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapAnother_typedef_enum_e"
+instance TyEq ty CUInt =>
+         HasField "unwrapAnother_typedef_enum_e"
                   (Ptr Another_typedef_enum_e)
-                  (Ptr CUInt)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapAnother_typedef_enum_e")
 instance HasCField Another_typedef_enum_e
                    "unwrapAnother_typedef_enum_e"
@@ -247,7 +250,8 @@ newtype A_type_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_type_t")
 instance HasCField A_type_t "unwrapA_type_t"
     where type CFieldType A_type_t "unwrapA_type_t" = CInt
@@ -282,7 +286,8 @@ newtype Var_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapVar_t" (Ptr Var_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapVar_t" (Ptr Var_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapVar_t")
 instance HasCField Var_t "unwrapVar_t"
     where type CFieldType Var_t "unwrapVar_t" = CInt
@@ -405,83 +410,93 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_0"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_0" = CBool
           offset# = \_ -> \_ -> 0
-instance HasField "a_typedef_struct_t_field_0"
+instance TyEq ty CBool =>
+         HasField "a_typedef_struct_t_field_0"
                   (Ptr A_typedef_struct_t)
-                  (Ptr CBool)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_0")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_1"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_1" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 1
-instance HasField "a_typedef_struct_t_field_1"
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "a_typedef_struct_t_field_1"
                   (Ptr A_typedef_struct_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_1")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_2"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_2" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance HasField "a_typedef_struct_t_field_2"
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "a_typedef_struct_t_field_2"
                   (Ptr A_typedef_struct_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_2")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_3"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_3" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 4
-instance HasField "a_typedef_struct_t_field_3"
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "a_typedef_struct_t_field_3"
                   (Ptr A_typedef_struct_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_3")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_4"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_4" = Another_typedef_struct_t
           offset# = \_ -> \_ -> 8
-instance HasField "a_typedef_struct_t_field_4"
+instance TyEq ty Another_typedef_struct_t =>
+         HasField "a_typedef_struct_t_field_4"
                   (Ptr A_typedef_struct_t)
-                  (Ptr Another_typedef_struct_t)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_4")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_5"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_5" = Ptr Another_typedef_struct_t
           offset# = \_ -> \_ -> 16
-instance HasField "a_typedef_struct_t_field_5"
+instance TyEq ty (Ptr Another_typedef_struct_t) =>
+         HasField "a_typedef_struct_t_field_5"
                   (Ptr A_typedef_struct_t)
-                  (Ptr (Ptr Another_typedef_struct_t))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_5")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_6"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_6" = Ptr Void
           offset# = \_ -> \_ -> 24
-instance HasField "a_typedef_struct_t_field_6"
+instance TyEq ty (Ptr Void) =>
+         HasField "a_typedef_struct_t_field_6"
                   (Ptr A_typedef_struct_t)
-                  (Ptr (Ptr Void))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_6")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_7"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_7" = ConstantArray 7
                                                                        HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 32
-instance HasField "a_typedef_struct_t_field_7"
+instance TyEq ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
+         HasField "a_typedef_struct_t_field_7"
                   (Ptr A_typedef_struct_t)
-                  (Ptr (ConstantArray 7 HsBindgen.Runtime.LibC.Word32))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_7")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_8"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_8" = Another_typedef_enum_e
           offset# = \_ -> \_ -> 60
-instance HasField "a_typedef_struct_t_field_8"
+instance TyEq ty Another_typedef_enum_e =>
+         HasField "a_typedef_struct_t_field_8"
                   (Ptr A_typedef_struct_t)
-                  (Ptr Another_typedef_enum_e)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_8")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_9"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_9" = ConstantArray 4
                                                                        Another_typedef_enum_e
           offset# = \_ -> \_ -> 64
-instance HasField "a_typedef_struct_t_field_9"
+instance TyEq ty (ConstantArray 4 Another_typedef_enum_e) =>
+         HasField "a_typedef_struct_t_field_9"
                   (Ptr A_typedef_struct_t)
-                  (Ptr (ConstantArray 4 Another_typedef_enum_e))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_9")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
     where type CFieldType A_typedef_struct_t
@@ -489,9 +504,11 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
                                                                         (ConstantArray 3
                                                                                        Another_typedef_enum_e)
           offset# = \_ -> \_ -> 80
-instance HasField "a_typedef_struct_t_field_10"
+instance TyEq ty
+              (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)) =>
+         HasField "a_typedef_struct_t_field_10"
                   (Ptr A_typedef_struct_t)
-                  (Ptr (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_10")
 {-| __C declaration:__ @A_DEFINE_0@
 
@@ -597,9 +614,8 @@ instance Read A_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapA_typedef_enum_e"
-                  (Ptr A_typedef_enum_e)
-                  (Ptr CUChar)
+instance TyEq ty CUChar =>
+         HasField "unwrapA_typedef_enum_e" (Ptr A_typedef_enum_e) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_typedef_enum_e")
 instance HasCField A_typedef_enum_e "unwrapA_typedef_enum_e"
     where type CFieldType A_typedef_enum_e
@@ -705,10 +721,11 @@ instance ToFunPtr Callback_t_Aux
     where toFunPtr = hs_bindgen_b6b6922e35047658
 instance FromFunPtr Callback_t_Aux
     where fromFunPtr = hs_bindgen_d6debb4b8d5bb869
-instance HasField "unwrapCallback_t_Aux"
-                  (Ptr Callback_t_Aux)
-                  (Ptr (Ptr Void ->
-                        HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32))
+instance TyEq ty
+              (Ptr Void ->
+               HsBindgen.Runtime.LibC.Word32 ->
+               IO HsBindgen.Runtime.LibC.Word32) =>
+         HasField "unwrapCallback_t_Aux" (Ptr Callback_t_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCallback_t_Aux")
 instance HasCField Callback_t_Aux "unwrapCallback_t_Aux"
     where type CFieldType Callback_t_Aux
@@ -736,9 +753,8 @@ newtype Callback_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapCallback_t"
-                  (Ptr Callback_t)
-                  (Ptr (FunPtr Callback_t_Aux))
+instance TyEq ty (FunPtr Callback_t_Aux) =>
+         HasField "unwrapCallback_t" (Ptr Callback_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCallback_t")
 instance HasCField Callback_t "unwrapCallback_t"
     where type CFieldType Callback_t

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum test@
@@ -110,7 +113,8 @@ instance Read Test where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapTest" (Ptr.Ptr Test) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapTest" (Ptr.Ptr Test) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTest")

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -52,7 +52,7 @@ instance Read Test
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapTest" (Ptr Test) (Ptr CUInt)
+instance TyEq ty CUInt => HasField "unwrapTest" (Ptr Test) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTest")
 instance HasCField Test "unwrapTest"
     where type CFieldType Test "unwrapTest" = CUInt

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.FLAM
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct pascal@
@@ -71,7 +74,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Pascal_Aux "pascal_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "pascal_len" (Ptr.Ptr Pascal_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "pascal_len" (Ptr.Ptr Pascal_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"pascal_len")
@@ -145,7 +149,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_bar "foo_bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_bar_x" (Ptr.Ptr Foo_bar) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "foo_bar_x" (Ptr.Ptr Foo_bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_bar_x")
@@ -156,7 +161,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_bar "foo_bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "foo_bar_y" (Ptr.Ptr Foo_bar) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "foo_bar_y" (Ptr.Ptr Foo_bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_bar_y")
@@ -208,7 +214,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo_Aux "foo_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_len" (Ptr.Ptr Foo_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "foo_len" (Ptr.Ptr Foo_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_len")
@@ -282,7 +289,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Diff_Aux "diff_first" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "diff_first" (Ptr.Ptr Diff_Aux) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "diff_first" (Ptr.Ptr Diff_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"diff_first")
@@ -293,7 +301,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Diff_Aux "diff_second" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "diff_second" (Ptr.Ptr Diff_Aux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "diff_second" (Ptr.Ptr Diff_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"diff_second")
@@ -360,7 +369,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Triplets_Aux "triplets_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "triplets_len" (Ptr.Ptr Triplets_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "triplets_len" (Ptr.Ptr Triplets_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"triplets_len")

--- a/hs-bindgen/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam/th.txt
@@ -26,7 +26,8 @@ deriving via (EquivStorable Pascal_Aux) instance Storable Pascal_Aux
 instance HasCField Pascal_Aux "pascal_len"
     where type CFieldType Pascal_Aux "pascal_len" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "pascal_len" (Ptr Pascal_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"pascal_len")
 instance Offset CChar Pascal_Aux
     where offset = \_ty_0 -> 4
@@ -72,12 +73,14 @@ deriving via (EquivStorable Foo_bar) instance Storable Foo_bar
 instance HasCField Foo_bar "foo_bar_x"
     where type CFieldType Foo_bar "foo_bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "foo_bar_x" (Ptr Foo_bar) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "foo_bar_x" (Ptr Foo_bar) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_bar_x")
 instance HasCField Foo_bar "foo_bar_y"
     where type CFieldType Foo_bar "foo_bar_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "foo_bar_y" (Ptr Foo_bar) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "foo_bar_y" (Ptr Foo_bar) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_bar_y")
 {-| __C declaration:__ @struct foo@
 
@@ -106,7 +109,7 @@ deriving via (EquivStorable Foo_Aux) instance Storable Foo_Aux
 instance HasCField Foo_Aux "foo_len"
     where type CFieldType Foo_Aux "foo_len" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "foo_len" (Ptr Foo_Aux) (Ptr CInt)
+instance TyEq ty CInt => HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_len")
 instance Offset Foo_bar Foo_Aux
     where offset = \_ty_0 -> 4
@@ -146,12 +149,14 @@ deriving via (EquivStorable Diff_Aux) instance Storable Diff_Aux
 instance HasCField Diff_Aux "diff_first"
     where type CFieldType Diff_Aux "diff_first" = CLong
           offset# = \_ -> \_ -> 0
-instance HasField "diff_first" (Ptr Diff_Aux) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "diff_first" (Ptr Diff_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"diff_first")
 instance HasCField Diff_Aux "diff_second"
     where type CFieldType Diff_Aux "diff_second" = CChar
           offset# = \_ -> \_ -> 8
-instance HasField "diff_second" (Ptr Diff_Aux) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"diff_second")
 instance Offset CChar Diff_Aux
     where offset = \_ty_0 -> 9
@@ -185,7 +190,8 @@ deriving via (EquivStorable Triplets_Aux) instance Storable Triplets_Aux
 instance HasCField Triplets_Aux "triplets_len"
     where type CFieldType Triplets_Aux "triplets_len" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "triplets_len" (Ptr Triplets_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"triplets_len")
 instance Offset (ConstantArray 3 CInt) Triplets_Aux
     where offset = \_ty_0 -> 4

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.FLAM
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Vector@
@@ -70,7 +73,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector_Aux "vector_length" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "vector_length" (Ptr.Ptr Vector_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "vector_length" (Ptr.Ptr Vector_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_length")

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
@@ -87,7 +87,8 @@ deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
 instance HasCField Vector_Aux "vector_length"
     where type CFieldType Vector_Aux "vector_length" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "vector_length" (Ptr Vector_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"vector_length")
 instance Offset CLong Vector_Aux
     where offset = \_ty_0 -> 8

--- a/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/iterator/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -19,6 +21,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.Block
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (IO)
 
 {-| __C declaration:__ @Toggle@
@@ -33,7 +36,8 @@ newtype Toggle = Toggle
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapToggle" (Ptr.Ptr Toggle) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (IO FC.CBool))) where
+instance ( TyEq ty (HsBindgen.Runtime.Block.Block (IO FC.CBool))
+         ) => GHC.Records.HasField "unwrapToggle" (Ptr.Ptr Toggle) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapToggle")
@@ -57,7 +61,8 @@ newtype Counter = Counter
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapCounter" (Ptr.Ptr Counter) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (IO FC.CInt))) where
+instance ( TyEq ty (HsBindgen.Runtime.Block.Block (IO FC.CInt))
+         ) => GHC.Records.HasField "unwrapCounter" (Ptr.Ptr Counter) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapCounter")
@@ -81,7 +86,8 @@ newtype VarCounter = VarCounter
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapVarCounter" (Ptr.Ptr VarCounter) (Ptr.Ptr (HsBindgen.Runtime.Block.Block (FC.CInt -> IO FC.CInt))) where
+instance ( TyEq ty (HsBindgen.Runtime.Block.Block (FC.CInt -> IO FC.CInt))
+         ) => GHC.Records.HasField "unwrapVarCounter" (Ptr.Ptr VarCounter) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapVarCounter")

--- a/hs-bindgen/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/iterator/th.txt
@@ -202,9 +202,8 @@ newtype Toggle
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapToggle"
-                  (Ptr Toggle)
-                  (Ptr (Block (IO CBool)))
+instance TyEq ty (Block (IO CBool)) =>
+         HasField "unwrapToggle" (Ptr Toggle) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapToggle")
 instance HasCField Toggle "unwrapToggle"
     where type CFieldType Toggle "unwrapToggle" = Block (IO CBool)
@@ -225,9 +224,8 @@ newtype Counter
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapCounter"
-                  (Ptr Counter)
-                  (Ptr (Block (IO CInt)))
+instance TyEq ty (Block (IO CInt)) =>
+         HasField "unwrapCounter" (Ptr Counter) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCounter")
 instance HasCField Counter "unwrapCounter"
     where type CFieldType Counter "unwrapCounter" = Block (IO CInt)
@@ -248,9 +246,8 @@ newtype VarCounter
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapVarCounter"
-                  (Ptr VarCounter)
-                  (Ptr (Block (CInt -> IO CInt)))
+instance TyEq ty (Block (CInt -> IO CInt)) =>
+         HasField "unwrapVarCounter" (Ptr VarCounter) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapVarCounter")
 instance HasCField VarCounter "unwrapVarCounter"
     where type CFieldType VarCounter

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 
 {-| Examples from the initial specification
@@ -62,7 +65,8 @@ newtype Int16_T = Int16_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt16_T" (Ptr.Ptr Int16_T) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapInt16_T" (Ptr.Ptr Int16_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt16_T")
@@ -101,7 +105,8 @@ newtype Int32_T = Int32_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt32_T" (Ptr.Ptr Int32_T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapInt32_T" (Ptr.Ptr Int32_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt32_T")
@@ -140,7 +145,8 @@ newtype Int64_T = Int64_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt64_T" (Ptr.Ptr Int64_T) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "unwrapInt64_T" (Ptr.Ptr Int64_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt64_T")
@@ -207,7 +213,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Cint16_T "cint16_T_re" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "cint16_T_re" (Ptr.Ptr Cint16_T) (Ptr.Ptr Int16_T) where
+instance ( TyEq ty Int16_T
+         ) => GHC.Records.HasField "cint16_T_re" (Ptr.Ptr Cint16_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"cint16_T_re")
@@ -218,7 +225,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Cint16_T "cint16_T_im" where
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "cint16_T_im" (Ptr.Ptr Cint16_T) (Ptr.Ptr Int16_T) where
+instance ( TyEq ty Int16_T
+         ) => GHC.Records.HasField "cint16_T_im" (Ptr.Ptr Cint16_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"cint16_T_im")
@@ -336,7 +344,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a_x" (Ptr.Ptr A) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "a_x" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_x")
@@ -347,7 +356,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_label" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "a_label" (Ptr.Ptr A) (Ptr.Ptr (Ptr.Ptr FC.CChar)) where
+instance ( TyEq ty (Ptr.Ptr FC.CChar)
+         ) => GHC.Records.HasField "a_label" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_label")
@@ -359,7 +369,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_samples" where
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "a_samples" (Ptr.Ptr A) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 128) FC.CChar)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 128) FC.CChar)
+         ) => GHC.Records.HasField "a_samples" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_samples")
@@ -370,7 +381,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_b" where
 
   offset# = \_ -> \_ -> 144
 
-instance GHC.Records.HasField "a_b" (Ptr.Ptr A) (Ptr.Ptr B) where
+instance ( TyEq ty B
+         ) => GHC.Records.HasField "a_b" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_b")
@@ -381,7 +393,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_c" where
 
   offset# = \_ -> \_ -> 144
 
-instance GHC.Records.HasField "a_c" (Ptr.Ptr A) (Ptr.Ptr (Ptr.Ptr C)) where
+instance ( TyEq ty (Ptr.Ptr C)
+         ) => GHC.Records.HasField "a_c" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_c")

--- a/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/spec_examples/th.txt
@@ -66,7 +66,8 @@ newtype Int16_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt16_T")
 instance HasCField Int16_T "unwrapInt16_T"
     where type CFieldType Int16_T "unwrapInt16_T" = CShort
@@ -101,7 +102,8 @@ newtype Int32_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt32_T")
 instance HasCField Int32_T "unwrapInt32_T"
     where type CFieldType Int32_T "unwrapInt32_T" = CInt
@@ -136,7 +138,8 @@ newtype Int64_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt64_T")
 instance HasCField Int64_T "unwrapInt64_T"
     where type CFieldType Int64_T "unwrapInt64_T" = CLLong
@@ -182,12 +185,14 @@ deriving via (EquivStorable Cint16_T) instance Storable Cint16_T
 instance HasCField Cint16_T "cint16_T_re"
     where type CFieldType Cint16_T "cint16_T_re" = Int16_T
           offset# = \_ -> \_ -> 0
-instance HasField "cint16_T_re" (Ptr Cint16_T) (Ptr Int16_T)
+instance TyEq ty Int16_T =>
+         HasField "cint16_T_re" (Ptr Cint16_T) (Ptr ty)
     where getField = fromPtr (Proxy @"cint16_T_re")
 instance HasCField Cint16_T "cint16_T_im"
     where type CFieldType Cint16_T "cint16_T_im" = Int16_T
           offset# = \_ -> \_ -> 2
-instance HasField "cint16_T_im" (Ptr Cint16_T) (Ptr Int16_T)
+instance TyEq ty Int16_T =>
+         HasField "cint16_T_im" (Ptr Cint16_T) (Ptr ty)
     where getField = fromPtr (Proxy @"cint16_T_im")
 {-| __C declaration:__ @struct B@
 
@@ -278,29 +283,28 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_x"
     where type CFieldType A "a_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "a_x" (Ptr A) (Ptr CDouble)
+instance TyEq ty CDouble => HasField "a_x" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_x")
 instance HasCField A "a_label"
     where type CFieldType A "a_label" = Ptr CChar
           offset# = \_ -> \_ -> 8
-instance HasField "a_label" (Ptr A) (Ptr (Ptr CChar))
+instance TyEq ty (Ptr CChar) => HasField "a_label" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_label")
 instance HasCField A "a_samples"
     where type CFieldType A "a_samples" = ConstantArray 128 CChar
           offset# = \_ -> \_ -> 16
-instance HasField "a_samples"
-                  (Ptr A)
-                  (Ptr (ConstantArray 128 CChar))
+instance TyEq ty (ConstantArray 128 CChar) =>
+         HasField "a_samples" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_samples")
 instance HasCField A "a_b"
     where type CFieldType A "a_b" = B
           offset# = \_ -> \_ -> 144
-instance HasField "a_b" (Ptr A) (Ptr B)
+instance TyEq ty B => HasField "a_b" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_b")
 instance HasCField A "a_c"
     where type CFieldType A "a_c" = Ptr C
           offset# = \_ -> \_ -> 144
-instance HasField "a_c" (Ptr A) (Ptr (Ptr C))
+instance TyEq ty (Ptr C) => HasField "a_c" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_c")
 {-| __C declaration:__ @struct C@
 

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @myInt@
@@ -60,7 +63,8 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -99,7 +103,8 @@ newtype MyUInt = MyUInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyUInt" (Ptr.Ptr MyUInt) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapMyUInt" (Ptr.Ptr MyUInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyUInt")
@@ -138,7 +143,8 @@ newtype MyLong = MyLong
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyLong" (Ptr.Ptr MyLong) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "unwrapMyLong" (Ptr.Ptr MyLong) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyLong")
@@ -216,7 +222,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_x" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyInt) where
+instance ( TyEq ty MyInt
+         ) => GHC.Records.HasField "myStruct_x" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_x")
@@ -229,7 +236,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_y" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "myStruct_y" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyUInt) where
+instance ( TyEq ty MyUInt
+         ) => GHC.Records.HasField "myStruct_y" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_y")
@@ -242,7 +250,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield MyStruct "myStruct_z" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance GHC.Records.HasField "myStruct_z" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr MyLong) where
+instance ( TyEq ty MyLong
+         ) => GHC.Records.HasField "myStruct_z" (Ptr.Ptr MyStruct) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"myStruct_z")

--- a/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -29,7 +29,8 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -64,7 +65,8 @@ newtype MyUInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyUInt")
 instance HasCField MyUInt "unwrapMyUInt"
     where type CFieldType MyUInt "unwrapMyUInt" = CUInt
@@ -99,7 +101,8 @@ newtype MyLong
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyLong" (Ptr MyLong) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "unwrapMyLong" (Ptr MyLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyLong")
 instance HasCField MyLong "unwrapMyLong"
     where type CFieldType MyLong "unwrapMyLong" = CLong
@@ -154,17 +157,20 @@ instance HasCBitfield MyStruct "myStruct_x"
     where type CBitfieldType MyStruct "myStruct_x" = MyInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 2
-instance HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr MyInt)
+instance TyEq ty MyInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"myStruct_x")
 instance HasCBitfield MyStruct "myStruct_y"
     where type CBitfieldType MyStruct "myStruct_y" = MyUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 4
-instance HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr MyUInt)
+instance TyEq ty MyUInt =>
+         HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"myStruct_y")
 instance HasCBitfield MyStruct "myStruct_z"
     where type CBitfieldType MyStruct "myStruct_z" = MyLong
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 3
-instance HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr MyLong)
+instance TyEq ty MyLong =>
+         HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"myStruct_z")

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum MyEnum@
@@ -110,7 +113,8 @@ instance Read MyEnum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapMyEnum" (Ptr.Ptr MyEnum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyEnum")

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
@@ -45,7 +45,8 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,6 +12,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -41,6 +43,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| Auxiliary type used by 'FileOpenedNotification'
@@ -89,7 +92,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr FileOpenedNotification_Aux
 
   fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 
-instance GHC.Records.HasField "unwrapFileOpenedNotification_Aux" (Ptr.Ptr FileOpenedNotification_Aux) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapFileOpenedNotification_Aux" (Ptr.Ptr FileOpenedNotification_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOpenedNotification_Aux")
@@ -119,7 +123,8 @@ newtype FileOpenedNotification = FileOpenedNotification
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFileOpenedNotification" (Ptr.Ptr FileOpenedNotification) (Ptr.Ptr (Ptr.FunPtr FileOpenedNotification_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr FileOpenedNotification_Aux)
+         ) => GHC.Records.HasField "unwrapFileOpenedNotification" (Ptr.Ptr FileOpenedNotification) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOpenedNotification")
@@ -177,7 +182,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr ProgressUpdate_Aux where
 
   fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 
-instance GHC.Records.HasField "unwrapProgressUpdate_Aux" (Ptr.Ptr ProgressUpdate_Aux) (Ptr.Ptr (FC.CInt -> IO ())) where
+instance ( TyEq ty (FC.CInt -> IO ())
+         ) => GHC.Records.HasField "unwrapProgressUpdate_Aux" (Ptr.Ptr ProgressUpdate_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProgressUpdate_Aux")
@@ -207,7 +213,8 @@ newtype ProgressUpdate = ProgressUpdate
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapProgressUpdate" (Ptr.Ptr ProgressUpdate) (Ptr.Ptr (Ptr.FunPtr ProgressUpdate_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr ProgressUpdate_Aux)
+         ) => GHC.Records.HasField "unwrapProgressUpdate" (Ptr.Ptr ProgressUpdate) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProgressUpdate")
@@ -265,7 +272,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr DataValidator_Aux where
 
   fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 
-instance GHC.Records.HasField "unwrapDataValidator_Aux" (Ptr.Ptr DataValidator_Aux) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapDataValidator_Aux" (Ptr.Ptr DataValidator_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapDataValidator_Aux")
@@ -295,7 +303,8 @@ newtype DataValidator = DataValidator
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapDataValidator" (Ptr.Ptr DataValidator) (Ptr.Ptr (Ptr.FunPtr DataValidator_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr DataValidator_Aux)
+         ) => GHC.Records.HasField "unwrapDataValidator" (Ptr.Ptr DataValidator) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapDataValidator")
@@ -364,7 +373,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Measurement "measurement_value" w
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "measurement_value" (Ptr.Ptr Measurement) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "measurement_value" (Ptr.Ptr Measurement) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurement_value")
@@ -376,7 +386,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Measurement "measurement_timestam
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "measurement_timestamp" (Ptr.Ptr Measurement) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "measurement_timestamp" (Ptr.Ptr Measurement) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurement_timestamp")
@@ -427,7 +438,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr MeasurementReceived_Aux wh
 
   fromFunPtr = hs_bindgen_383c36bb22947621
 
-instance GHC.Records.HasField "unwrapMeasurementReceived_Aux" (Ptr.Ptr MeasurementReceived_Aux) (Ptr.Ptr ((Ptr.Ptr Measurement) -> IO ())) where
+instance ( TyEq ty ((Ptr.Ptr Measurement) -> IO ())
+         ) => GHC.Records.HasField "unwrapMeasurementReceived_Aux" (Ptr.Ptr MeasurementReceived_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived_Aux")
@@ -457,7 +469,8 @@ newtype MeasurementReceived = MeasurementReceived
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapMeasurementReceived" (Ptr.Ptr MeasurementReceived) (Ptr.Ptr (Ptr.FunPtr MeasurementReceived_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr MeasurementReceived_Aux)
+         ) => GHC.Records.HasField "unwrapMeasurementReceived" (Ptr.Ptr MeasurementReceived) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived")
@@ -482,7 +495,8 @@ newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapMeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr (Measurement -> IO ())) where
+instance ( TyEq ty (Measurement -> IO ())
+         ) => GHC.Records.HasField "unwrapMeasurementReceived2_Aux" (Ptr.Ptr MeasurementReceived2_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived2_Aux")
@@ -512,7 +526,8 @@ newtype MeasurementReceived2 = MeasurementReceived2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapMeasurementReceived2" (Ptr.Ptr MeasurementReceived2) (Ptr.Ptr (Ptr.FunPtr MeasurementReceived2_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr MeasurementReceived2_Aux)
+         ) => GHC.Records.HasField "unwrapMeasurementReceived2" (Ptr.Ptr MeasurementReceived2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMeasurementReceived2")
@@ -537,7 +552,8 @@ newtype SampleBufferFull_Aux = SampleBufferFull_Aux
   }
   deriving stock (GHC.Generics.Generic)
 
-instance GHC.Records.HasField "unwrapSampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr (((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ())) where
+instance ( TyEq ty (((HsBindgen.Runtime.ConstantArray.ConstantArray 10) FC.CInt) -> IO ())
+         ) => GHC.Records.HasField "unwrapSampleBufferFull_Aux" (Ptr.Ptr SampleBufferFull_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSampleBufferFull_Aux")
@@ -567,7 +583,8 @@ newtype SampleBufferFull = SampleBufferFull
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapSampleBufferFull" (Ptr.Ptr SampleBufferFull) (Ptr.Ptr (Ptr.FunPtr SampleBufferFull_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr SampleBufferFull_Aux)
+         ) => GHC.Records.HasField "unwrapSampleBufferFull" (Ptr.Ptr SampleBufferFull) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSampleBufferFull")
@@ -648,7 +665,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "measurementHandler_onReceived" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))
+         ) => GHC.Records.HasField "measurementHandler_onReceived" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_onReceived")
@@ -660,7 +678,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "measurementHandler_validate" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO FC.CInt))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO FC.CInt))
+         ) => GHC.Records.HasField "measurementHandler_validate" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_validate")
@@ -672,7 +691,8 @@ instance HsBindgen.Runtime.HasCField.HasCField MeasurementHandler "measurementHa
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "measurementHandler_onError" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr (Ptr.FunPtr (FC.CInt -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr (FC.CInt -> IO ()))
+         ) => GHC.Records.HasField "measurementHandler_onError" (Ptr.Ptr MeasurementHandler) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"measurementHandler_onError")
@@ -746,7 +766,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_prePro
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dataPipeline_preProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))
+         ) => GHC.Records.HasField "dataPipeline_preProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_preProcess")
@@ -758,7 +779,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_proces
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "dataPipeline_process" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))
+         ) => GHC.Records.HasField "dataPipeline_process" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_process")
@@ -770,7 +792,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DataPipeline "dataPipeline_postPr
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "dataPipeline_postProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))
+         ) => GHC.Records.HasField "dataPipeline_postProcess" (Ptr.Ptr DataPipeline) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dataPipeline_postProcess")
@@ -882,7 +905,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "processorCallback_simple" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> IO ()))
+         ) => GHC.Records.HasField "processorCallback_simple" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_simple")
@@ -894,7 +918,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "processorCallback_withValidator" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> DataValidator -> IO ()))
+         ) => GHC.Records.HasField "processorCallback_withValidator" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_withValidator")
@@ -906,7 +931,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ProcessorCallback "processorCallb
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "processorCallback_withProgress" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.Ptr Measurement) -> ProgressUpdate -> IO ()))
+         ) => GHC.Records.HasField "processorCallback_withProgress" (Ptr.Ptr ProcessorCallback) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processorCallback_withProgress")
@@ -992,7 +1018,8 @@ instance Read Processor_mode where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapProcessor_mode" (Ptr.Ptr Processor_mode) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapProcessor_mode" (Ptr.Ptr Processor_mode) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapProcessor_mode")
@@ -1088,7 +1115,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Processor "processor_mode" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "processor_mode" (Ptr.Ptr Processor) (Ptr.Ptr Processor_mode) where
+instance ( TyEq ty Processor_mode
+         ) => GHC.Records.HasField "processor_mode" (Ptr.Ptr Processor) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processor_mode")
@@ -1100,7 +1128,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Processor "processor_callback" wh
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "processor_callback" (Ptr.Ptr Processor) (Ptr.Ptr ProcessorCallback) where
+instance ( TyEq ty ProcessorCallback
+         ) => GHC.Records.HasField "processor_callback" (Ptr.Ptr Processor) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"processor_callback")
@@ -1133,7 +1162,8 @@ newtype Foo = Foo
     , Real
     )
 
-instance GHC.Records.HasField "unwrapFoo" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapFoo" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo")
@@ -1172,7 +1202,8 @@ newtype Foo2 = Foo2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapFoo2" (Ptr.Ptr Foo2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapFoo2" (Ptr.Ptr Foo2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo2")

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -462,9 +462,10 @@ instance ToFunPtr FileOpenedNotification_Aux
     where toFunPtr = hs_bindgen_b3b8b1fad168671a
 instance FromFunPtr FileOpenedNotification_Aux
     where fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
-instance HasField "unwrapFileOpenedNotification_Aux"
+instance TyEq ty (IO Unit) =>
+         HasField "unwrapFileOpenedNotification_Aux"
                   (Ptr FileOpenedNotification_Aux)
-                  (Ptr (IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification_Aux")
 instance HasCField FileOpenedNotification_Aux
                    "unwrapFileOpenedNotification_Aux"
@@ -491,9 +492,10 @@ newtype FileOpenedNotification
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFileOpenedNotification"
+instance TyEq ty (FunPtr FileOpenedNotification_Aux) =>
+         HasField "unwrapFileOpenedNotification"
                   (Ptr FileOpenedNotification)
-                  (Ptr (FunPtr FileOpenedNotification_Aux))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification")
 instance HasCField FileOpenedNotification
                    "unwrapFileOpenedNotification"
@@ -542,9 +544,10 @@ instance ToFunPtr ProgressUpdate_Aux
     where toFunPtr = hs_bindgen_d551f31556ffa727
 instance FromFunPtr ProgressUpdate_Aux
     where fromFunPtr = hs_bindgen_ccf7f4b62a839a04
-instance HasField "unwrapProgressUpdate_Aux"
+instance TyEq ty (CInt -> IO Unit) =>
+         HasField "unwrapProgressUpdate_Aux"
                   (Ptr ProgressUpdate_Aux)
-                  (Ptr (CInt -> IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProgressUpdate_Aux")
 instance HasCField ProgressUpdate_Aux "unwrapProgressUpdate_Aux"
     where type CFieldType ProgressUpdate_Aux
@@ -570,9 +573,8 @@ newtype ProgressUpdate
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapProgressUpdate"
-                  (Ptr ProgressUpdate)
-                  (Ptr (FunPtr ProgressUpdate_Aux))
+instance TyEq ty (FunPtr ProgressUpdate_Aux) =>
+         HasField "unwrapProgressUpdate" (Ptr ProgressUpdate) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProgressUpdate")
 instance HasCField ProgressUpdate "unwrapProgressUpdate"
     where type CFieldType ProgressUpdate
@@ -619,9 +621,8 @@ instance ToFunPtr DataValidator_Aux
     where toFunPtr = hs_bindgen_c656ca21e63343d6
 instance FromFunPtr DataValidator_Aux
     where fromFunPtr = hs_bindgen_c1e79a4c11ca4033
-instance HasField "unwrapDataValidator_Aux"
-                  (Ptr DataValidator_Aux)
-                  (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapDataValidator_Aux" (Ptr DataValidator_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapDataValidator_Aux")
 instance HasCField DataValidator_Aux "unwrapDataValidator_Aux"
     where type CFieldType DataValidator_Aux
@@ -647,9 +648,8 @@ newtype DataValidator
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapDataValidator"
-                  (Ptr DataValidator)
-                  (Ptr (FunPtr DataValidator_Aux))
+instance TyEq ty (FunPtr DataValidator_Aux) =>
+         HasField "unwrapDataValidator" (Ptr DataValidator) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapDataValidator")
 instance HasCField DataValidator "unwrapDataValidator"
     where type CFieldType DataValidator
@@ -696,16 +696,14 @@ deriving via (EquivStorable Measurement) instance Storable Measurement
 instance HasCField Measurement "measurement_value"
     where type CFieldType Measurement "measurement_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "measurement_value"
-                  (Ptr Measurement)
-                  (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "measurement_value" (Ptr Measurement) (Ptr ty)
     where getField = fromPtr (Proxy @"measurement_value")
 instance HasCField Measurement "measurement_timestamp"
     where type CFieldType Measurement "measurement_timestamp" = CDouble
           offset# = \_ -> \_ -> 8
-instance HasField "measurement_timestamp"
-                  (Ptr Measurement)
-                  (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "measurement_timestamp" (Ptr Measurement) (Ptr ty)
     where getField = fromPtr (Proxy @"measurement_timestamp")
 {-| Auxiliary type used by 'MeasurementReceived'
 
@@ -749,9 +747,10 @@ instance ToFunPtr MeasurementReceived_Aux
     where toFunPtr = hs_bindgen_9259654df9d40f5b
 instance FromFunPtr MeasurementReceived_Aux
     where fromFunPtr = hs_bindgen_383c36bb22947621
-instance HasField "unwrapMeasurementReceived_Aux"
+instance TyEq ty (Ptr Measurement -> IO Unit) =>
+         HasField "unwrapMeasurementReceived_Aux"
                   (Ptr MeasurementReceived_Aux)
-                  (Ptr (Ptr Measurement -> IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived_Aux")
 instance HasCField MeasurementReceived_Aux
                    "unwrapMeasurementReceived_Aux"
@@ -778,9 +777,10 @@ newtype MeasurementReceived
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapMeasurementReceived"
+instance TyEq ty (FunPtr MeasurementReceived_Aux) =>
+         HasField "unwrapMeasurementReceived"
                   (Ptr MeasurementReceived)
-                  (Ptr (FunPtr MeasurementReceived_Aux))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived")
 instance HasCField MeasurementReceived "unwrapMeasurementReceived"
     where type CFieldType MeasurementReceived
@@ -806,9 +806,10 @@ newtype MeasurementReceived2_Aux
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving stock Generic
-instance HasField "unwrapMeasurementReceived2_Aux"
+instance TyEq ty (Measurement -> IO Unit) =>
+         HasField "unwrapMeasurementReceived2_Aux"
                   (Ptr MeasurementReceived2_Aux)
-                  (Ptr (Measurement -> IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2_Aux")
 instance HasCField MeasurementReceived2_Aux
                    "unwrapMeasurementReceived2_Aux"
@@ -835,9 +836,10 @@ newtype MeasurementReceived2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapMeasurementReceived2"
+instance TyEq ty (FunPtr MeasurementReceived2_Aux) =>
+         HasField "unwrapMeasurementReceived2"
                   (Ptr MeasurementReceived2)
-                  (Ptr (FunPtr MeasurementReceived2_Aux))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2")
 instance HasCField MeasurementReceived2
                    "unwrapMeasurementReceived2"
@@ -865,9 +867,10 @@ newtype SampleBufferFull_Aux
       __exported by:__ @functions\/callbacks.h@
       -}
     deriving stock Generic
-instance HasField "unwrapSampleBufferFull_Aux"
+instance TyEq ty (ConstantArray 10 CInt -> IO Unit) =>
+         HasField "unwrapSampleBufferFull_Aux"
                   (Ptr SampleBufferFull_Aux)
-                  (Ptr (ConstantArray 10 CInt -> IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull_Aux")
 instance HasCField SampleBufferFull_Aux
                    "unwrapSampleBufferFull_Aux"
@@ -894,9 +897,8 @@ newtype SampleBufferFull
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapSampleBufferFull"
-                  (Ptr SampleBufferFull)
-                  (Ptr (FunPtr SampleBufferFull_Aux))
+instance TyEq ty (FunPtr SampleBufferFull_Aux) =>
+         HasField "unwrapSampleBufferFull" (Ptr SampleBufferFull) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull")
 instance HasCField SampleBufferFull "unwrapSampleBufferFull"
     where type CFieldType SampleBufferFull
@@ -956,25 +958,28 @@ instance HasCField MeasurementHandler
                           "measurementHandler_onReceived" = FunPtr (Ptr Measurement ->
                                                                     IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "measurementHandler_onReceived"
+instance TyEq ty (FunPtr (Ptr Measurement -> IO Unit)) =>
+         HasField "measurementHandler_onReceived"
                   (Ptr MeasurementHandler)
-                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"measurementHandler_onReceived")
 instance HasCField MeasurementHandler "measurementHandler_validate"
     where type CFieldType MeasurementHandler
                           "measurementHandler_validate" = FunPtr (Ptr Measurement -> IO CInt)
           offset# = \_ -> \_ -> 8
-instance HasField "measurementHandler_validate"
+instance TyEq ty (FunPtr (Ptr Measurement -> IO CInt)) =>
+         HasField "measurementHandler_validate"
                   (Ptr MeasurementHandler)
-                  (Ptr (FunPtr (Ptr Measurement -> IO CInt)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"measurementHandler_validate")
 instance HasCField MeasurementHandler "measurementHandler_onError"
     where type CFieldType MeasurementHandler
                           "measurementHandler_onError" = FunPtr (CInt -> IO Unit)
           offset# = \_ -> \_ -> 16
-instance HasField "measurementHandler_onError"
+instance TyEq ty (FunPtr (CInt -> IO Unit)) =>
+         HasField "measurementHandler_onError"
                   (Ptr MeasurementHandler)
-                  (Ptr (FunPtr (CInt -> IO Unit)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"measurementHandler_onError")
 {-| __C declaration:__ @struct DataPipeline@
 
@@ -1029,26 +1034,25 @@ instance HasCField DataPipeline "dataPipeline_preProcess"
                           "dataPipeline_preProcess" = FunPtr (Ptr Measurement ->
                                                               DataValidator -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "dataPipeline_preProcess"
-                  (Ptr DataPipeline)
-                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)))
+instance TyEq ty
+              (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)) =>
+         HasField "dataPipeline_preProcess" (Ptr DataPipeline) (Ptr ty)
     where getField = fromPtr (Proxy @"dataPipeline_preProcess")
 instance HasCField DataPipeline "dataPipeline_process"
     where type CFieldType DataPipeline
                           "dataPipeline_process" = FunPtr (Ptr Measurement -> IO Unit)
           offset# = \_ -> \_ -> 8
-instance HasField "dataPipeline_process"
-                  (Ptr DataPipeline)
-                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
+instance TyEq ty (FunPtr (Ptr Measurement -> IO Unit)) =>
+         HasField "dataPipeline_process" (Ptr DataPipeline) (Ptr ty)
     where getField = fromPtr (Proxy @"dataPipeline_process")
 instance HasCField DataPipeline "dataPipeline_postProcess"
     where type CFieldType DataPipeline
                           "dataPipeline_postProcess" = FunPtr (Ptr Measurement ->
                                                                ProgressUpdate -> IO Unit)
           offset# = \_ -> \_ -> 16
-instance HasField "dataPipeline_postProcess"
-                  (Ptr DataPipeline)
-                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)))
+instance TyEq ty
+              (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)) =>
+         HasField "dataPipeline_postProcess" (Ptr DataPipeline) (Ptr ty)
     where getField = fromPtr (Proxy @"dataPipeline_postProcess")
 {-| __C declaration:__ @union ProcessorCallback@
 
@@ -1187,9 +1191,10 @@ instance HasCField ProcessorCallback "processorCallback_simple"
     where type CFieldType ProcessorCallback
                           "processorCallback_simple" = FunPtr (Ptr Measurement -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "processorCallback_simple"
+instance TyEq ty (FunPtr (Ptr Measurement -> IO Unit)) =>
+         HasField "processorCallback_simple"
                   (Ptr ProcessorCallback)
-                  (Ptr (FunPtr (Ptr Measurement -> IO Unit)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_simple")
 instance HasCField ProcessorCallback
                    "processorCallback_withValidator"
@@ -1197,9 +1202,11 @@ instance HasCField ProcessorCallback
                           "processorCallback_withValidator" = FunPtr (Ptr Measurement ->
                                                                       DataValidator -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "processorCallback_withValidator"
+instance TyEq ty
+              (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)) =>
+         HasField "processorCallback_withValidator"
                   (Ptr ProcessorCallback)
-                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO Unit)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_withValidator")
 instance HasCField ProcessorCallback
                    "processorCallback_withProgress"
@@ -1207,9 +1214,11 @@ instance HasCField ProcessorCallback
                           "processorCallback_withProgress" = FunPtr (Ptr Measurement ->
                                                                      ProgressUpdate -> IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "processorCallback_withProgress"
+instance TyEq ty
+              (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)) =>
+         HasField "processorCallback_withProgress"
                   (Ptr ProcessorCallback)
-                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO Unit)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_withProgress")
 {-| __C declaration:__ @enum \@Processor_mode@
 
@@ -1258,9 +1267,8 @@ instance Read Processor_mode
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapProcessor_mode"
-                  (Ptr Processor_mode)
-                  (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapProcessor_mode" (Ptr Processor_mode) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProcessor_mode")
 instance HasCField Processor_mode "unwrapProcessor_mode"
     where type CFieldType Processor_mode "unwrapProcessor_mode" = CUInt
@@ -1348,17 +1356,15 @@ deriving via (EquivStorable Processor) instance Storable Processor
 instance HasCField Processor "processor_mode"
     where type CFieldType Processor "processor_mode" = Processor_mode
           offset# = \_ -> \_ -> 0
-instance HasField "processor_mode"
-                  (Ptr Processor)
-                  (Ptr Processor_mode)
+instance TyEq ty Processor_mode =>
+         HasField "processor_mode" (Ptr Processor) (Ptr ty)
     where getField = fromPtr (Proxy @"processor_mode")
 instance HasCField Processor "processor_callback"
     where type CFieldType Processor
                           "processor_callback" = ProcessorCallback
           offset# = \_ -> \_ -> 8
-instance HasField "processor_callback"
-                  (Ptr Processor)
-                  (Ptr ProcessorCallback)
+instance TyEq ty ProcessorCallback =>
+         HasField "processor_callback" (Ptr Processor) (Ptr ty)
     where getField = fromPtr (Proxy @"processor_callback")
 {-| __C declaration:__ @foo@
 
@@ -1390,7 +1396,7 @@ newtype Foo
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapFoo" (Ptr Foo) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = CInt
@@ -1425,7 +1431,7 @@ newtype Foo2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapFoo2" (Ptr Foo2) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapFoo2" (Ptr Foo2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo2")
 instance HasCField Foo2 "unwrapFoo2"
     where type CFieldType Foo2 "unwrapFoo2" = CInt

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -25,6 +27,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, IO, Int, Ord, Show, pure)
 
 {-| Auxiliary type used by 'Fun_ptr'
@@ -73,7 +76,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Fun_ptr_Aux where
 
   fromFunPtr = hs_bindgen_f8391e85af67fcb6
 
-instance GHC.Records.HasField "unwrapFun_ptr_Aux" (Ptr.Ptr Fun_ptr_Aux) (Ptr.Ptr ((Ptr.Ptr Forward_declaration) -> IO ())) where
+instance ( TyEq ty ((Ptr.Ptr Forward_declaration) -> IO ())
+         ) => GHC.Records.HasField "unwrapFun_ptr_Aux" (Ptr.Ptr Fun_ptr_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFun_ptr_Aux")
@@ -103,7 +107,8 @@ newtype Fun_ptr = Fun_ptr
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFun_ptr" (Ptr.Ptr Fun_ptr) (Ptr.Ptr (Ptr.FunPtr Fun_ptr_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Fun_ptr_Aux)
+         ) => GHC.Records.HasField "unwrapFun_ptr" (Ptr.Ptr Fun_ptr) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFun_ptr")
@@ -163,7 +168,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Forward_declaration "forward_decl
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "forward_declaration_f" (Ptr.Ptr Forward_declaration) (Ptr.Ptr Fun_ptr) where
+instance ( TyEq ty Fun_ptr
+         ) => GHC.Records.HasField "forward_declaration_f" (Ptr.Ptr Forward_declaration) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"forward_declaration_f")

--- a/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/fixtures/functions/circular_dependency_fun/th.txt
@@ -40,9 +40,8 @@ instance ToFunPtr Fun_ptr_Aux
     where toFunPtr = hs_bindgen_5964bbadb359ee4a
 instance FromFunPtr Fun_ptr_Aux
     where fromFunPtr = hs_bindgen_f8391e85af67fcb6
-instance HasField "unwrapFun_ptr_Aux"
-                  (Ptr Fun_ptr_Aux)
-                  (Ptr (Ptr Forward_declaration -> IO Unit))
+instance TyEq ty (Ptr Forward_declaration -> IO Unit) =>
+         HasField "unwrapFun_ptr_Aux" (Ptr Fun_ptr_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFun_ptr_Aux")
 instance HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux"
     where type CFieldType Fun_ptr_Aux
@@ -68,9 +67,8 @@ newtype Fun_ptr
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFun_ptr"
-                  (Ptr Fun_ptr)
-                  (Ptr (FunPtr Fun_ptr_Aux))
+instance TyEq ty (FunPtr Fun_ptr_Aux) =>
+         HasField "unwrapFun_ptr" (Ptr Fun_ptr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFun_ptr")
 instance HasCField Fun_ptr "unwrapFun_ptr"
     where type CFieldType Fun_ptr "unwrapFun_ptr" = FunPtr Fun_ptr_Aux
@@ -109,7 +107,6 @@ instance HasCField Forward_declaration "forward_declaration_f"
     where type CFieldType Forward_declaration
                           "forward_declaration_f" = Fun_ptr
           offset# = \_ -> \_ -> 0
-instance HasField "forward_declaration_f"
-                  (Ptr Forward_declaration)
-                  (Ptr Fun_ptr)
+instance TyEq ty Fun_ptr =>
+         HasField "forward_declaration_f" (Ptr Forward_declaration) (Ptr ty)
     where getField = fromPtr (Proxy @"forward_declaration_f")

--- a/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/Example.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,6 +26,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct opaque@
@@ -90,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Outside "outside_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "outside_x" (Ptr.Ptr Outside) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "outside_x" (Ptr.Ptr Outside) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"outside_x")
@@ -101,7 +105,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Outside "outside_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "outside_y" (Ptr.Ptr Outside) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "outside_y" (Ptr.Ptr Outside) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"outside_y")
@@ -167,7 +172,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_struct "named_struct_x" whe
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "named_struct_x" (Ptr.Ptr Named_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "named_struct_x" (Ptr.Ptr Named_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_struct_x")
@@ -179,7 +185,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_struct "named_struct_y" whe
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "named_struct_y" (Ptr.Ptr Named_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "named_struct_y" (Ptr.Ptr Named_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_struct_y")
@@ -263,7 +270,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_union "named_union_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "named_union_x" (Ptr.Ptr Named_union) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "named_union_x" (Ptr.Ptr Named_union) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_union_x")
@@ -275,7 +283,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Named_union "named_union_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "named_union_y" (Ptr.Ptr Named_union) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "named_union_y" (Ptr.Ptr Named_union) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"named_union_y")

--- a/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/fixtures/functions/decls_in_signature/th.txt
@@ -114,12 +114,14 @@ deriving via (EquivStorable Outside) instance Storable Outside
 instance HasCField Outside "outside_x"
     where type CFieldType Outside "outside_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "outside_x" (Ptr Outside) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "outside_x" (Ptr Outside) (Ptr ty)
     where getField = fromPtr (Proxy @"outside_x")
 instance HasCField Outside "outside_y"
     where type CFieldType Outside "outside_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "outside_y" (Ptr Outside) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "outside_y" (Ptr Outside) (Ptr ty)
     where getField = fromPtr (Proxy @"outside_y")
 {-| Error cases
 
@@ -170,12 +172,14 @@ deriving via (EquivStorable Named_struct) instance Storable Named_struct
 instance HasCField Named_struct "named_struct_x"
     where type CFieldType Named_struct "named_struct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "named_struct_x" (Ptr Named_struct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "named_struct_x" (Ptr Named_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"named_struct_x")
 instance HasCField Named_struct "named_struct_y"
     where type CFieldType Named_struct "named_struct_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "named_struct_y" (Ptr Named_struct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "named_struct_y" (Ptr Named_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"named_struct_y")
 {-| __C declaration:__ @union named_union@
 
@@ -267,12 +271,14 @@ set_named_union_y = setUnionPayload
 instance HasCField Named_union "named_union_x"
     where type CFieldType Named_union "named_union_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "named_union_x" (Ptr Named_union) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "named_union_x" (Ptr Named_union) (Ptr ty)
     where getField = fromPtr (Proxy @"named_union_x")
 instance HasCField Named_union "named_union_y"
     where type CFieldType Named_union "named_union_y" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "named_union_y" (Ptr Named_union) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "named_union_y" (Ptr Named_union) (Ptr ty)
     where getField = fromPtr (Proxy @"named_union_y")
 -- __unique:__ @test_functionsdecls_in_signature_Example_Safe_normal@
 foreign import ccall safe "hs_bindgen_920e5c20f770432b" hs_bindgen_920e5c20f770432b_base ::

--- a/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/fixtures/functions/fun_attributes/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return)
 
 {-| Attributes on functions
@@ -92,7 +95,8 @@ newtype Size_t = Size_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapSize_t" (Ptr.Ptr Size_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapSize_t" (Ptr.Ptr Size_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSize_t")

--- a/hs-bindgen/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/fixtures/functions/fun_attributes/th.txt
@@ -491,7 +491,8 @@ newtype Size_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapSize_t" (Ptr Size_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapSize_t" (Ptr Size_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSize_t")
 instance HasCField Size_t "unwrapSize_t"
     where type CFieldType Size_t "unwrapSize_t" = CInt

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
@@ -55,7 +55,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_a5d53f538e59b1fc" hs_bindgen_a5d53f538e59b1fc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const/th.txt
@@ -55,7 +55,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -55,7 +55,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct S@
@@ -70,7 +73,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S "s_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s_x" (Ptr.Ptr S) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s_x" (Ptr.Ptr S) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s_x")
@@ -92,7 +96,8 @@ newtype T = T
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr S) where
+instance ( TyEq ty S
+         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")

--- a/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -55,7 +55,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_x"
     where type CFieldType S "s_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s_x" (Ptr S) (Ptr CInt)
+instance TyEq ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"s_x")
 {-| __C declaration:__ @T@
 
@@ -73,7 +73,7 @@ newtype T
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapT" (Ptr T) (Ptr S)
+instance TyEq ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S

--- a/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -76,7 +79,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union/th.txt
@@ -78,7 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_9fc5746860ab93cb" hs_bindgen_9fc5746860ab93cb_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -76,7 +79,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const/th.txt
@@ -78,7 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -76,7 +79,8 @@ instance HsBindgen.Runtime.HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "t_x" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"t_x")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_member/th.txt
@@ -78,7 +78,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "t_x" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -24,6 +26,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 
 {-| __C declaration:__ @union U@
 
@@ -77,7 +80,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U "u_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "u_x" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "u_x" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"u_x")
@@ -99,7 +103,8 @@ newtype T = T
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr U) where
+instance ( TyEq ty U
+         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")

--- a/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -78,7 +78,7 @@ set_u_x = setUnionPayload
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "u_x" (Ptr U) (Ptr CInt)
+instance TyEq ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @T@
 
@@ -96,7 +96,7 @@ newtype T
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapT" (Ptr T) (Ptr U)
+instance TyEq ty U => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = U

--- a/hs-bindgen/fixtures/functions/typedef_funptr/Example.hs
+++ b/hs-bindgen/fixtures/functions/typedef_funptr/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -27,6 +29,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, IO, Int, Ord, Show, pure)
 
 {-| Auxiliary type used by 'RunDriver'
@@ -75,7 +78,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr RunDriver_Aux where
 
   fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 
-instance GHC.Records.HasField "unwrapRunDriver_Aux" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ((Ptr.Ptr Driver) -> IO FC.CInt)) where
+instance ( TyEq ty ((Ptr.Ptr Driver) -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapRunDriver_Aux" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapRunDriver_Aux")
@@ -105,7 +109,8 @@ newtype RunDriver = RunDriver
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapRunDriver" (Ptr.Ptr RunDriver) (Ptr.Ptr (Ptr.FunPtr RunDriver_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr RunDriver_Aux)
+         ) => GHC.Records.HasField "unwrapRunDriver" (Ptr.Ptr RunDriver) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapRunDriver")
@@ -164,7 +169,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Driver "driver_run" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "driver_run" (Ptr.Ptr Driver) (Ptr.Ptr RunDriver) where
+instance ( TyEq ty RunDriver
+         ) => GHC.Records.HasField "driver_run" (Ptr.Ptr Driver) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"driver_run")
@@ -217,7 +223,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bare "bare_callback" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bare_callback" (Ptr.Ptr Bare) (Ptr.Ptr (Ptr.FunPtr (FC.CInt -> IO ()))) where
+instance ( TyEq ty (Ptr.FunPtr (FC.CInt -> IO ()))
+         ) => GHC.Records.HasField "bare_callback" (Ptr.Ptr Bare) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bare_callback")

--- a/hs-bindgen/fixtures/functions/typedef_funptr/th.txt
+++ b/hs-bindgen/fixtures/functions/typedef_funptr/th.txt
@@ -40,9 +40,8 @@ instance ToFunPtr RunDriver_Aux
     where toFunPtr = hs_bindgen_d86ecf261d7044c6
 instance FromFunPtr RunDriver_Aux
     where fromFunPtr = hs_bindgen_6520ae39b50ffb4e
-instance HasField "unwrapRunDriver_Aux"
-                  (Ptr RunDriver_Aux)
-                  (Ptr (Ptr Driver -> IO CInt))
+instance TyEq ty (Ptr Driver -> IO CInt) =>
+         HasField "unwrapRunDriver_Aux" (Ptr RunDriver_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapRunDriver_Aux")
 instance HasCField RunDriver_Aux "unwrapRunDriver_Aux"
     where type CFieldType RunDriver_Aux
@@ -68,9 +67,8 @@ newtype RunDriver
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapRunDriver"
-                  (Ptr RunDriver)
-                  (Ptr (FunPtr RunDriver_Aux))
+instance TyEq ty (FunPtr RunDriver_Aux) =>
+         HasField "unwrapRunDriver" (Ptr RunDriver) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapRunDriver")
 instance HasCField RunDriver "unwrapRunDriver"
     where type CFieldType RunDriver
@@ -109,7 +107,8 @@ deriving via (EquivStorable Driver) instance Storable Driver
 instance HasCField Driver "driver_run"
     where type CFieldType Driver "driver_run" = RunDriver
           offset# = \_ -> \_ -> 0
-instance HasField "driver_run" (Ptr Driver) (Ptr RunDriver)
+instance TyEq ty RunDriver =>
+         HasField "driver_run" (Ptr Driver) (Ptr ty)
     where getField = fromPtr (Proxy @"driver_run")
 {-| __C declaration:__ @struct Bare@
 
@@ -145,7 +144,6 @@ instance HasCField Bare "bare_callback"
     where type CFieldType Bare "bare_callback" = FunPtr (CInt ->
                                                          IO Unit)
           offset# = \_ -> \_ -> 0
-instance HasField "bare_callback"
-                  (Ptr Bare)
-                  (Ptr (FunPtr (CInt -> IO Unit)))
+instance TyEq ty (FunPtr (CInt -> IO Unit)) =>
+         HasField "bare_callback" (Ptr Bare) (Ptr ty)
     where getField = fromPtr (Proxy @"bare_callback")

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct config@
@@ -79,7 +82,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config "config_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "config_x" (Ptr.Ptr Config) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "config_x" (Ptr.Ptr Config) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_x")
@@ -90,7 +94,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Config "config_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "config_y" (Ptr.Ptr Config) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "config_y" (Ptr.Ptr Config) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"config_y")
@@ -152,7 +157,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Inline_struct "inline_struct_x" w
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "inline_struct_x" (Ptr.Ptr Inline_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "inline_struct_x" (Ptr.Ptr Inline_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"inline_struct_x")
@@ -164,7 +170,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Inline_struct "inline_struct_y" w
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "inline_struct_y" (Ptr.Ptr Inline_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "inline_struct_y" (Ptr.Ptr Inline_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"inline_struct_y")
@@ -235,7 +242,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_major" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "version_t_major" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "version_t_major" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_major")
@@ -247,7 +255,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_minor" where
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "version_t_minor" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "version_t_minor" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_minor")
@@ -259,7 +268,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Version_t "version_t_patch" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "version_t_patch" (Ptr.Ptr Version_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "version_t_patch" (Ptr.Ptr Version_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"version_t_patch")
@@ -330,7 +340,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct1_t_x" (Ptr.Ptr Struct1_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "struct1_t_x" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_x")
@@ -341,7 +352,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_y" where
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "struct1_t_y" (Ptr.Ptr Struct1_t) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "struct1_t_y" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_y")
@@ -353,7 +365,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1_t "struct1_t_version" whe
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "struct1_t_version" (Ptr.Ptr Struct1_t) (Ptr.Ptr Version_t) where
+instance ( TyEq ty Version_t
+         ) => GHC.Records.HasField "struct1_t_version" (Ptr.Ptr Struct1_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_t_version")
@@ -406,7 +419,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2_t "struct2_t_field1" wher
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct2_t_field1" (Ptr.Ptr Struct2_t) (Ptr.Ptr Struct1_t) where
+instance ( TyEq ty Struct1_t
+         ) => GHC.Records.HasField "struct2_t_field1" (Ptr.Ptr Struct2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_t_field1")

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -159,12 +159,12 @@ deriving via (EquivStorable Config) instance Storable Config
 instance HasCField Config "config_x"
     where type CFieldType Config "config_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "config_x" (Ptr Config) (Ptr CInt)
+instance TyEq ty CInt => HasField "config_x" (Ptr Config) (Ptr ty)
     where getField = fromPtr (Proxy @"config_x")
 instance HasCField Config "config_y"
     where type CFieldType Config "config_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "config_y" (Ptr Config) (Ptr CInt)
+instance TyEq ty CInt => HasField "config_y" (Ptr Config) (Ptr ty)
     where getField = fromPtr (Proxy @"config_y")
 {-| __C declaration:__ @struct inline_struct@
 
@@ -207,12 +207,14 @@ deriving via (EquivStorable Inline_struct) instance Storable Inline_struct
 instance HasCField Inline_struct "inline_struct_x"
     where type CFieldType Inline_struct "inline_struct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "inline_struct_x" (Ptr Inline_struct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "inline_struct_x" (Ptr Inline_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"inline_struct_x")
 instance HasCField Inline_struct "inline_struct_y"
     where type CFieldType Inline_struct "inline_struct_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "inline_struct_y" (Ptr Inline_struct) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "inline_struct_y" (Ptr Inline_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"inline_struct_y")
 {-| __C declaration:__ @struct version_t@
 
@@ -264,25 +266,22 @@ instance HasCField Version_t "version_t_major"
     where type CFieldType Version_t
                           "version_t_major" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance HasField "version_t_major"
-                  (Ptr Version_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "version_t_major" (Ptr Version_t) (Ptr ty)
     where getField = fromPtr (Proxy @"version_t_major")
 instance HasCField Version_t "version_t_minor"
     where type CFieldType Version_t
                           "version_t_minor" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance HasField "version_t_minor"
-                  (Ptr Version_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "version_t_minor" (Ptr Version_t) (Ptr ty)
     where getField = fromPtr (Proxy @"version_t_minor")
 instance HasCField Version_t "version_t_patch"
     where type CFieldType Version_t
                           "version_t_patch" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 4
-instance HasField "version_t_patch"
-                  (Ptr Version_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "version_t_patch" (Ptr Version_t) (Ptr ty)
     where getField = fromPtr (Proxy @"version_t_patch")
 {-| __C declaration:__ @struct struct1_t@
 
@@ -334,21 +333,20 @@ instance HasCField Struct1_t "struct1_t_x"
     where type CFieldType Struct1_t
                           "struct1_t_x" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance HasField "struct1_t_x"
-                  (Ptr Struct1_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "struct1_t_x" (Ptr Struct1_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct1_t_x")
 instance HasCField Struct1_t "struct1_t_y"
     where type CFieldType Struct1_t "struct1_t_y" = CBool
           offset# = \_ -> \_ -> 2
-instance HasField "struct1_t_y" (Ptr Struct1_t) (Ptr CBool)
+instance TyEq ty CBool =>
+         HasField "struct1_t_y" (Ptr Struct1_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct1_t_y")
 instance HasCField Struct1_t "struct1_t_version"
     where type CFieldType Struct1_t "struct1_t_version" = Version_t
           offset# = \_ -> \_ -> 4
-instance HasField "struct1_t_version"
-                  (Ptr Struct1_t)
-                  (Ptr Version_t)
+instance TyEq ty Version_t =>
+         HasField "struct1_t_version" (Ptr Struct1_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct1_t_version")
 {-| __C declaration:__ @struct struct2_t@
 
@@ -383,9 +381,8 @@ deriving via (EquivStorable Struct2_t) instance Storable Struct2_t
 instance HasCField Struct2_t "struct2_t_field1"
     where type CFieldType Struct2_t "struct2_t_field1" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance HasField "struct2_t_field1"
-                  (Ptr Struct2_t)
-                  (Ptr Struct1_t)
+instance TyEq ty Struct1_t =>
+         HasField "struct2_t_field1" (Ptr Struct2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct2_t_field1")
 -- __unique:__ @test_globalsglobals_Example_get_simpleGlobal@
 foreign import ccall unsafe "hs_bindgen_4f8e7b3d91414aa8" hs_bindgen_4f8e7b3d91414aa8_base ::

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, IO, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @I@
@@ -60,7 +63,8 @@ newtype I = I
     , Real
     )
 
-instance GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapI")
@@ -99,7 +103,8 @@ newtype C = C
     , Real
     )
 
-instance GHC.Records.HasField "unwrapC" (Ptr.Ptr C) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapC" (Ptr.Ptr C) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapC")
@@ -136,7 +141,8 @@ newtype F = F
     , RealFrac
     )
 
-instance GHC.Records.HasField "unwrapF" (Ptr.Ptr F) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "unwrapF" (Ptr.Ptr F) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF")
@@ -175,7 +181,8 @@ newtype L = L
     , Real
     )
 
-instance GHC.Records.HasField "unwrapL" (Ptr.Ptr L) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "unwrapL" (Ptr.Ptr L) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapL")
@@ -214,7 +221,8 @@ newtype S = S
     , Real
     )
 
-instance GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapS" (Ptr.Ptr S) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS")

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl/th.txt
@@ -341,7 +341,7 @@ newtype I
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapI" (Ptr I) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -376,7 +376,7 @@ newtype C
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapC" (Ptr C) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapC" (Ptr C) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapC")
 instance HasCField C "unwrapC"
     where type CFieldType C "unwrapC" = CChar
@@ -409,7 +409,7 @@ newtype F
                       Real,
                       RealFloat,
                       RealFrac)
-instance HasField "unwrapF" (Ptr F) (Ptr CFloat)
+instance TyEq ty CFloat => HasField "unwrapF" (Ptr F) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF")
 instance HasCField F "unwrapF"
     where type CFieldType F "unwrapF" = CFloat
@@ -444,7 +444,7 @@ newtype L
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapL" (Ptr L) (Ptr CLong)
+instance TyEq ty CLong => HasField "unwrapL" (Ptr L) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapL")
 instance HasCField L "unwrapL"
     where type CFieldType L "unwrapL" = CLong
@@ -479,7 +479,7 @@ newtype S
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapS" (Ptr S) (Ptr CShort)
+instance TyEq ty CShort => HasField "unwrapS" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = CShort

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @MC@
@@ -58,7 +61,8 @@ newtype MC = MC
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMC" (Ptr.Ptr MC) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapMC" (Ptr.Ptr MC) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMC")
@@ -97,7 +101,8 @@ newtype TC = TC
     , Real
     )
 
-instance GHC.Records.HasField "unwrapTC" (Ptr.Ptr TC) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapTC" (Ptr.Ptr TC) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTC")
@@ -155,7 +160,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct1 "struct1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct1_a" (Ptr.Ptr Struct1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct1_a" (Ptr.Ptr Struct1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct1_a")
@@ -207,7 +213,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2 "struct2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct2_a" (Ptr.Ptr Struct2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct2_a" (Ptr.Ptr Struct2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_a")
@@ -259,7 +266,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct3 "struct3_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct3_a" (Ptr.Ptr Struct3) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct3_a" (Ptr.Ptr Struct3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct3_a")
@@ -281,7 +289,8 @@ newtype Struct3_t = Struct3_t
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct3_t" (Ptr.Ptr Struct3_t) (Ptr.Ptr Struct3) where
+instance ( TyEq ty Struct3
+         ) => GHC.Records.HasField "unwrapStruct3_t" (Ptr.Ptr Struct3_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct3_t")
@@ -339,7 +348,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct4 "struct4_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct4_a" (Ptr.Ptr Struct4) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct4_a" (Ptr.Ptr Struct4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct4_a")

--- a/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -260,7 +260,7 @@ newtype MC
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMC" (Ptr MC) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapMC" (Ptr MC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMC")
 instance HasCField MC "unwrapMC"
     where type CFieldType MC "unwrapMC" = CChar
@@ -295,7 +295,7 @@ newtype TC
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapTC" (Ptr TC) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapTC" (Ptr TC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTC")
 instance HasCField TC "unwrapTC"
     where type CFieldType TC "unwrapTC" = CChar
@@ -333,7 +333,8 @@ deriving via (EquivStorable Struct1) instance Storable Struct1
 instance HasCField Struct1 "struct1_a"
     where type CFieldType Struct1 "struct1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct1_a" (Ptr Struct1) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct1_a" (Ptr Struct1) (Ptr ty)
     where getField = fromPtr (Proxy @"struct1_a")
 {-| __C declaration:__ @struct struct2@
 
@@ -368,7 +369,8 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_a"
     where type CFieldType Struct2 "struct2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct2_a" (Ptr Struct2) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct2_a" (Ptr Struct2) (Ptr ty)
     where getField = fromPtr (Proxy @"struct2_a")
 {-| __C declaration:__ @struct struct3@
 
@@ -403,7 +405,8 @@ deriving via (EquivStorable Struct3) instance Storable Struct3
 instance HasCField Struct3 "struct3_a"
     where type CFieldType Struct3 "struct3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct3_a" (Ptr Struct3) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct3_a" (Ptr Struct3) (Ptr ty)
     where getField = fromPtr (Proxy @"struct3_a")
 {-| __C declaration:__ @struct3_t@
 
@@ -421,7 +424,8 @@ newtype Struct3_t
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr Struct3)
+instance TyEq ty Struct3 =>
+         HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct3_t")
 instance HasCField Struct3_t "unwrapStruct3_t"
     where type CFieldType Struct3_t "unwrapStruct3_t" = Struct3
@@ -459,7 +463,8 @@ deriving via (EquivStorable Struct4) instance Storable Struct4
 instance HasCField Struct4 "struct4_a"
     where type CFieldType Struct4 "struct4_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct4_a" (Ptr Struct4) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct4_a" (Ptr Struct4) (Ptr ty)
     where getField = fromPtr (Proxy @"struct4_a")
 -- __unique:__ @test_macrosmacro_in_fundecl_vs_typ_Example_Safe_quux1@
 foreign import ccall safe "hs_bindgen_02e0e3b28d470fd4" hs_bindgen_02e0e3b28d470fd4_base ::

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @FILE@
@@ -56,7 +59,8 @@ newtype FILE = FILE
     , Real
     )
 
-instance GHC.Records.HasField "unwrapFILE" (Ptr.Ptr FILE) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapFILE" (Ptr.Ptr FILE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFILE")

--- a/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_redefines_global/th.txt
@@ -29,7 +29,7 @@ newtype FILE
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapFILE" (Ptr FILE) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapFILE" (Ptr FILE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFILE")
 instance HasCField FILE "unwrapFILE"
     where type CFieldType FILE "unwrapFILE" = CInt

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @T1@
@@ -56,7 +59,8 @@ newtype T1 = T1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -95,7 +99,8 @@ newtype T2 = T2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr T1) where
+instance ( TyEq ty T1
+         ) => GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT2")
@@ -134,7 +139,8 @@ newtype T3 = T3
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT3" (Ptr.Ptr T3) (Ptr.Ptr T2) where
+instance ( TyEq ty T2
+         ) => GHC.Records.HasField "unwrapT3" (Ptr.Ptr T3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT3")
@@ -173,7 +179,8 @@ newtype T4 = T4
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT4" (Ptr.Ptr T4) (Ptr.Ptr T3) where
+instance ( TyEq ty T3
+         ) => GHC.Records.HasField "unwrapT4" (Ptr.Ptr T4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT4")

--- a/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_scope/th.txt
@@ -29,7 +29,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -64,7 +64,7 @@ newtype T2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT2" (Ptr T2) (Ptr T1)
+instance TyEq ty T1 => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = T1
@@ -99,7 +99,7 @@ newtype T3
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT3" (Ptr T3) (Ptr T2)
+instance TyEq ty T2 => HasField "unwrapT3" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = T2
@@ -134,7 +134,7 @@ newtype T4
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT4" (Ptr T4) (Ptr T3)
+instance TyEq ty T3 => HasField "unwrapT4" (Ptr T4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = T3

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @MY_TYPE@
@@ -58,7 +61,8 @@ newtype MY_TYPE = MY_TYPE
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMY_TYPE" (Ptr.Ptr MY_TYPE) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMY_TYPE" (Ptr.Ptr MY_TYPE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMY_TYPE")
@@ -125,7 +129,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bar_x" (Ptr.Ptr Bar) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "bar_x" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_x")
@@ -136,7 +141,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "bar_y" (Ptr.Ptr Bar) (Ptr.Ptr MY_TYPE) where
+instance ( TyEq ty MY_TYPE
+         ) => GHC.Records.HasField "bar_y" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_y")

--- a/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_typedef_struct/th.txt
@@ -29,7 +29,8 @@ newtype MY_TYPE
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMY_TYPE")
 instance HasCField MY_TYPE "unwrapMY_TYPE"
     where type CFieldType MY_TYPE "unwrapMY_TYPE" = CInt
@@ -75,10 +76,10 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_x"
     where type CFieldType Bar "bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "bar_x" (Ptr Bar) (Ptr CInt)
+instance TyEq ty CInt => HasField "bar_x" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_x")
 instance HasCField Bar "bar_y"
     where type CFieldType Bar "bar_y" = MY_TYPE
           offset# = \_ -> \_ -> 4
-instance HasField "bar_y" (Ptr Bar) (Ptr MY_TYPE)
+instance TyEq ty MY_TYPE => HasField "bar_y" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_y")

--- a/hs-bindgen/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_types/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @PtrInt@
@@ -46,7 +49,8 @@ newtype PtrInt = PtrInt
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapPtrInt" (Ptr.Ptr PtrInt) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "unwrapPtrInt" (Ptr.Ptr PtrInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPtrInt")
@@ -86,7 +90,8 @@ newtype ShortInt = ShortInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapShortInt" (Ptr.Ptr ShortInt) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapShortInt" (Ptr.Ptr ShortInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapShortInt")
@@ -125,7 +130,8 @@ newtype SignedShortInt = SignedShortInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapSignedShortInt" (Ptr.Ptr SignedShortInt) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapSignedShortInt" (Ptr.Ptr SignedShortInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSignedShortInt")
@@ -165,7 +171,8 @@ newtype UnsignedShortInt = UnsignedShortInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUnsignedShortInt" (Ptr.Ptr UnsignedShortInt) (Ptr.Ptr FC.CUShort) where
+instance ( TyEq ty FC.CUShort
+         ) => GHC.Records.HasField "unwrapUnsignedShortInt" (Ptr.Ptr UnsignedShortInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUnsignedShortInt")
@@ -195,7 +202,8 @@ newtype PtrPtrChar = PtrPtrChar
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapPtrPtrChar" (Ptr.Ptr PtrPtrChar) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr FC.CChar))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr FC.CChar))
+         ) => GHC.Records.HasField "unwrapPtrPtrChar" (Ptr.Ptr PtrPtrChar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPtrPtrChar")
@@ -233,7 +241,8 @@ newtype MTy = MTy
     , RealFrac
     )
 
-instance GHC.Records.HasField "unwrapMTy" (Ptr.Ptr MTy) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "unwrapMTy" (Ptr.Ptr MTy) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMTy")
@@ -270,7 +279,8 @@ newtype Tty = Tty
     , RealFrac
     )
 
-instance GHC.Records.HasField "unwrapTty" (Ptr.Ptr Tty) (Ptr.Ptr MTy) where
+instance ( TyEq ty MTy
+         ) => GHC.Records.HasField "unwrapTty" (Ptr.Ptr Tty) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTty")
@@ -309,7 +319,8 @@ newtype UINT8_T = UINT8_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUINT8_T" (Ptr.Ptr UINT8_T) (Ptr.Ptr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "unwrapUINT8_T" (Ptr.Ptr UINT8_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUINT8_T")
@@ -348,7 +359,8 @@ newtype BOOLEAN_T = BOOLEAN_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapBOOLEAN_T" (Ptr.Ptr BOOLEAN_T) (Ptr.Ptr UINT8_T) where
+instance ( TyEq ty UINT8_T
+         ) => GHC.Records.HasField "unwrapBOOLEAN_T" (Ptr.Ptr BOOLEAN_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOLEAN_T")
@@ -387,7 +399,8 @@ newtype Boolean_T = Boolean_T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapBoolean_T" (Ptr.Ptr Boolean_T) (Ptr.Ptr BOOLEAN_T) where
+instance ( TyEq ty BOOLEAN_T
+         ) => GHC.Records.HasField "unwrapBoolean_T" (Ptr.Ptr Boolean_T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBoolean_T")

--- a/hs-bindgen/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_types/th.txt
@@ -19,7 +19,8 @@ newtype PtrInt
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) =>
+         HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrInt")
 instance HasCField PtrInt "unwrapPtrInt"
     where type CFieldType PtrInt "unwrapPtrInt" = Ptr CInt
@@ -54,7 +55,8 @@ newtype ShortInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapShortInt" (Ptr ShortInt) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "unwrapShortInt" (Ptr ShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapShortInt")
 instance HasCField ShortInt "unwrapShortInt"
     where type CFieldType ShortInt "unwrapShortInt" = CShort
@@ -89,9 +91,8 @@ newtype SignedShortInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapSignedShortInt"
-                  (Ptr SignedShortInt)
-                  (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "unwrapSignedShortInt" (Ptr SignedShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSignedShortInt")
 instance HasCField SignedShortInt "unwrapSignedShortInt"
     where type CFieldType SignedShortInt
@@ -127,9 +128,8 @@ newtype UnsignedShortInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUnsignedShortInt"
-                  (Ptr UnsignedShortInt)
-                  (Ptr CUShort)
+instance TyEq ty CUShort =>
+         HasField "unwrapUnsignedShortInt" (Ptr UnsignedShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUnsignedShortInt")
 instance HasCField UnsignedShortInt "unwrapUnsignedShortInt"
     where type CFieldType UnsignedShortInt
@@ -155,9 +155,8 @@ newtype PtrPtrChar
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapPtrPtrChar"
-                  (Ptr PtrPtrChar)
-                  (Ptr (Ptr (Ptr CChar)))
+instance TyEq ty (Ptr (Ptr CChar)) =>
+         HasField "unwrapPtrPtrChar" (Ptr PtrPtrChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrPtrChar")
 instance HasCField PtrPtrChar "unwrapPtrPtrChar"
     where type CFieldType PtrPtrChar
@@ -191,7 +190,7 @@ newtype MTy
                       Real,
                       RealFloat,
                       RealFrac)
-instance HasField "unwrapMTy" (Ptr MTy) (Ptr CFloat)
+instance TyEq ty CFloat => HasField "unwrapMTy" (Ptr MTy) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMTy")
 instance HasCField MTy "unwrapMTy"
     where type CFieldType MTy "unwrapMTy" = CFloat
@@ -224,7 +223,7 @@ newtype Tty
                       Real,
                       RealFloat,
                       RealFrac)
-instance HasField "unwrapTty" (Ptr Tty) (Ptr MTy)
+instance TyEq ty MTy => HasField "unwrapTty" (Ptr Tty) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTty")
 instance HasCField Tty "unwrapTty"
     where type CFieldType Tty "unwrapTty" = MTy
@@ -259,7 +258,8 @@ newtype UINT8_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr CUChar)
+instance TyEq ty CUChar =>
+         HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUINT8_T")
 instance HasCField UINT8_T "unwrapUINT8_T"
     where type CFieldType UINT8_T "unwrapUINT8_T" = CUChar
@@ -294,7 +294,8 @@ newtype BOOLEAN_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr UINT8_T)
+instance TyEq ty UINT8_T =>
+         HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOLEAN_T")
 instance HasCField BOOLEAN_T "unwrapBOOLEAN_T"
     where type CFieldType BOOLEAN_T "unwrapBOOLEAN_T" = UINT8_T
@@ -329,7 +330,8 @@ newtype Boolean_T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr BOOLEAN_T)
+instance TyEq ty BOOLEAN_T =>
+         HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBoolean_T")
 instance HasCField Boolean_T "unwrapBoolean_T"
     where type CFieldType Boolean_T "unwrapBoolean_T" = BOOLEAN_T

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -11,6 +12,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -42,6 +44,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Double, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, return, showsPrec)
 
 {-| __C declaration:__ @A@
@@ -72,7 +75,8 @@ newtype A = A
     , Real
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")
@@ -210,7 +214,8 @@ instance Read Some_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapSome_enum" (Ptr.Ptr Some_enum) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapSome_enum" (Ptr.Ptr Some_enum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSome_enum")
@@ -242,7 +247,8 @@ newtype Arr_typedef1 = Arr_typedef1
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapArr_typedef1" (Ptr.Ptr Arr_typedef1) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray A)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray A)
+         ) => GHC.Records.HasField "unwrapArr_typedef1" (Ptr.Ptr Arr_typedef1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef1")
@@ -265,7 +271,8 @@ newtype Arr_typedef2 = Arr_typedef2
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapArr_typedef2" (Ptr.Ptr Arr_typedef2) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A))) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapArr_typedef2" (Ptr.Ptr Arr_typedef2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef2")
@@ -294,7 +301,8 @@ newtype Arr_typedef3 = Arr_typedef3
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapArr_typedef3" (Ptr.Ptr Arr_typedef3) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) A)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) A)
+         ) => GHC.Records.HasField "unwrapArr_typedef3" (Ptr.Ptr Arr_typedef3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef3")
@@ -323,7 +331,8 @@ newtype Arr_typedef4 = Arr_typedef4
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapArr_typedef4" (Ptr.Ptr Arr_typedef4) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A))) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 5) (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapArr_typedef4" (Ptr.Ptr Arr_typedef4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapArr_typedef4")
@@ -365,7 +374,8 @@ newtype Typedef1 = Typedef1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapTypedef1" (Ptr.Ptr Typedef1) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapTypedef1" (Ptr.Ptr Typedef1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef1")
@@ -394,7 +404,8 @@ newtype Typedef2 = Typedef2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapTypedef2" (Ptr.Ptr Typedef2) (Ptr.Ptr (Ptr.Ptr A)) where
+instance ( TyEq ty (Ptr.Ptr A)
+         ) => GHC.Records.HasField "unwrapTypedef2" (Ptr.Ptr Typedef2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef2")
@@ -423,7 +434,8 @@ newtype Typedef3 = Typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapTypedef3" (Ptr.Ptr Typedef3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr A))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapTypedef3" (Ptr.Ptr Typedef3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTypedef3")
@@ -481,7 +493,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef1_Aux where
 
   fromFunPtr = hs_bindgen_806a46dc418a062c
 
-instance GHC.Records.HasField "unwrapFunptr_typedef1_Aux" (Ptr.Ptr Funptr_typedef1_Aux) (Ptr.Ptr (IO A)) where
+instance ( TyEq ty (IO A)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef1_Aux" (Ptr.Ptr Funptr_typedef1_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef1_Aux")
@@ -511,7 +524,8 @@ newtype Funptr_typedef1 = Funptr_typedef1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunptr_typedef1" (Ptr.Ptr Funptr_typedef1) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef1_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Funptr_typedef1_Aux)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef1" (Ptr.Ptr Funptr_typedef1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef1")
@@ -569,7 +583,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef2_Aux where
 
   fromFunPtr = hs_bindgen_323d07dff85b802c
 
-instance GHC.Records.HasField "unwrapFunptr_typedef2_Aux" (Ptr.Ptr Funptr_typedef2_Aux) (Ptr.Ptr (IO (Ptr.Ptr A))) where
+instance ( TyEq ty (IO (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapFunptr_typedef2_Aux" (Ptr.Ptr Funptr_typedef2_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef2_Aux")
@@ -599,7 +614,8 @@ newtype Funptr_typedef2 = Funptr_typedef2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunptr_typedef2" (Ptr.Ptr Funptr_typedef2) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef2_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Funptr_typedef2_Aux)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef2" (Ptr.Ptr Funptr_typedef2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef2")
@@ -657,7 +673,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef3_Aux where
 
   fromFunPtr = hs_bindgen_82dc7b932974117e
 
-instance GHC.Records.HasField "unwrapFunptr_typedef3_Aux" (Ptr.Ptr Funptr_typedef3_Aux) (Ptr.Ptr (IO (Ptr.Ptr (Ptr.Ptr A)))) where
+instance ( TyEq ty (IO (Ptr.Ptr (Ptr.Ptr A)))
+         ) => GHC.Records.HasField "unwrapFunptr_typedef3_Aux" (Ptr.Ptr Funptr_typedef3_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef3_Aux")
@@ -687,7 +704,8 @@ newtype Funptr_typedef3 = Funptr_typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunptr_typedef3" (Ptr.Ptr Funptr_typedef3) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef3_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Funptr_typedef3_Aux)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef3" (Ptr.Ptr Funptr_typedef3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef3")
@@ -745,7 +763,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef4_Aux where
 
   fromFunPtr = hs_bindgen_d4a97954476da161
 
-instance GHC.Records.HasField "unwrapFunptr_typedef4_Aux" (Ptr.Ptr Funptr_typedef4_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO A)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef4_Aux" (Ptr.Ptr Funptr_typedef4_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef4_Aux")
@@ -775,7 +794,8 @@ newtype Funptr_typedef4 = Funptr_typedef4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunptr_typedef4" (Ptr.Ptr Funptr_typedef4) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef4_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Funptr_typedef4_Aux)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef4" (Ptr.Ptr Funptr_typedef4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef4")
@@ -833,7 +853,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Funptr_typedef5_Aux where
 
   fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 
-instance GHC.Records.HasField "unwrapFunptr_typedef5_Aux" (Ptr.Ptr Funptr_typedef5_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapFunptr_typedef5_Aux" (Ptr.Ptr Funptr_typedef5_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef5_Aux")
@@ -863,7 +884,8 @@ newtype Funptr_typedef5 = Funptr_typedef5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunptr_typedef5" (Ptr.Ptr Funptr_typedef5) (Ptr.Ptr (Ptr.FunPtr Funptr_typedef5_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Funptr_typedef5_Aux)
+         ) => GHC.Records.HasField "unwrapFunptr_typedef5" (Ptr.Ptr Funptr_typedef5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunptr_typedef5")
@@ -903,7 +925,8 @@ newtype Comments2 = Comments2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapComments2" (Ptr.Ptr Comments2) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapComments2" (Ptr.Ptr Comments2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapComments2")
@@ -985,7 +1008,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "example_struct_field1" (Ptr.Ptr Example_struct) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "example_struct_field1" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field1")
@@ -997,7 +1021,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "example_struct_field2" (Ptr.Ptr Example_struct) (Ptr.Ptr (Ptr.Ptr A)) where
+instance ( TyEq ty (Ptr.Ptr A)
+         ) => GHC.Records.HasField "example_struct_field2" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field2")
@@ -1009,7 +1034,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct "example_struct_fi
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "example_struct_field3" (Ptr.Ptr Example_struct) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr A))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr A))
+         ) => GHC.Records.HasField "example_struct_field3" (Ptr.Ptr Example_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_field3")
@@ -1042,7 +1068,8 @@ newtype Const_typedef1 = Const_typedef1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef1" (Ptr.Ptr Const_typedef1) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapConst_typedef1" (Ptr.Ptr Const_typedef1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef1")
@@ -1082,7 +1109,8 @@ newtype Const_typedef2 = Const_typedef2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef2" (Ptr.Ptr Const_typedef2) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "unwrapConst_typedef2" (Ptr.Ptr Const_typedef2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef2")
@@ -1112,7 +1140,8 @@ newtype Const_typedef3 = Const_typedef3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef3" (Ptr.Ptr Const_typedef3) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "unwrapConst_typedef3" (Ptr.Ptr Const_typedef3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef3")
@@ -1142,7 +1171,8 @@ newtype Const_typedef4 = Const_typedef4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef4" (Ptr.Ptr Const_typedef4) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "unwrapConst_typedef4" (Ptr.Ptr Const_typedef4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef4")
@@ -1172,7 +1202,8 @@ newtype Const_typedef5 = Const_typedef5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef5" (Ptr.Ptr Const_typedef5) (Ptr.Ptr (Ptr.Ptr A)) where
+instance ( TyEq ty (Ptr.Ptr A)
+         ) => GHC.Records.HasField "unwrapConst_typedef5" (Ptr.Ptr Const_typedef5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef5")
@@ -1202,7 +1233,8 @@ newtype Const_typedef6 = Const_typedef6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef6" (Ptr.Ptr Const_typedef6) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "unwrapConst_typedef6" (Ptr.Ptr Const_typedef6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef6")
@@ -1232,7 +1264,8 @@ newtype Const_typedef7 = Const_typedef7
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_typedef7" (Ptr.Ptr Const_typedef7) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "unwrapConst_typedef7" (Ptr.Ptr Const_typedef7) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_typedef7")
@@ -1353,7 +1386,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "example_struct_with_const_const_field1" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "example_struct_with_const_const_field1" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field1")
@@ -1365,7 +1399,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "example_struct_with_const_const_field2" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr A) where
+instance ( TyEq ty A
+         ) => GHC.Records.HasField "example_struct_with_const_const_field2" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field2")
@@ -1377,7 +1412,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "example_struct_with_const_const_field3" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "example_struct_with_const_const_field3" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field3")
@@ -1389,7 +1425,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "example_struct_with_const_const_field4" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "example_struct_with_const_const_field4" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field4")
@@ -1401,7 +1438,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "example_struct_with_const_const_field5" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (Ptr.Ptr A)) where
+instance ( TyEq ty (Ptr.Ptr A)
+         ) => GHC.Records.HasField "example_struct_with_const_const_field5" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field5")
@@ -1413,7 +1451,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "example_struct_with_const_const_field6" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "example_struct_with_const_const_field6" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field6")
@@ -1425,7 +1464,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Example_struct_with_const "exampl
 
   offset# = \_ -> \_ -> 40
 
-instance GHC.Records.HasField "example_struct_with_const_const_field7" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst A)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst A)
+         ) => GHC.Records.HasField "example_struct_with_const_const_field7" (Ptr.Ptr Example_struct_with_const) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"example_struct_with_const_const_field7")
@@ -1476,7 +1516,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr1_Aux where
 
   fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 
-instance GHC.Records.HasField "unwrapConst_funptr1_Aux" (Ptr.Ptr Const_funptr1_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO A)
+         ) => GHC.Records.HasField "unwrapConst_funptr1_Aux" (Ptr.Ptr Const_funptr1_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr1_Aux")
@@ -1506,7 +1547,8 @@ newtype Const_funptr1 = Const_funptr1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr1" (Ptr.Ptr Const_funptr1) (Ptr.Ptr (Ptr.FunPtr Const_funptr1_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr1_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr1" (Ptr.Ptr Const_funptr1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr1")
@@ -1564,7 +1606,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr2_Aux where
 
   fromFunPtr = hs_bindgen_352cebf463125ca9
 
-instance GHC.Records.HasField "unwrapConst_funptr2_Aux" (Ptr.Ptr Const_funptr2_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO A)) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO A)
+         ) => GHC.Records.HasField "unwrapConst_funptr2_Aux" (Ptr.Ptr Const_funptr2_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr2_Aux")
@@ -1594,7 +1637,8 @@ newtype Const_funptr2 = Const_funptr2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr2" (Ptr.Ptr Const_funptr2) (Ptr.Ptr (Ptr.FunPtr Const_funptr2_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr2_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr2" (Ptr.Ptr Const_funptr2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr2")
@@ -1652,7 +1696,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr3_Aux where
 
   fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 
-instance GHC.Records.HasField "unwrapConst_funptr3_Aux" (Ptr.Ptr Const_funptr3_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))
+         ) => GHC.Records.HasField "unwrapConst_funptr3_Aux" (Ptr.Ptr Const_funptr3_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr3_Aux")
@@ -1682,7 +1727,8 @@ newtype Const_funptr3 = Const_funptr3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr3" (Ptr.Ptr Const_funptr3) (Ptr.Ptr (Ptr.FunPtr Const_funptr3_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr3_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr3" (Ptr.Ptr Const_funptr3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr3")
@@ -1740,7 +1786,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr4_Aux where
 
   fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 
-instance GHC.Records.HasField "unwrapConst_funptr4_Aux" (Ptr.Ptr Const_funptr4_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))
+         ) => GHC.Records.HasField "unwrapConst_funptr4_Aux" (Ptr.Ptr Const_funptr4_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr4_Aux")
@@ -1770,7 +1817,8 @@ newtype Const_funptr4 = Const_funptr4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr4" (Ptr.Ptr Const_funptr4) (Ptr.Ptr (Ptr.FunPtr Const_funptr4_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr4_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr4" (Ptr.Ptr Const_funptr4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr4")
@@ -1828,7 +1876,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr5_Aux where
 
   fromFunPtr = hs_bindgen_38a21d84bb7115b5
 
-instance GHC.Records.HasField "unwrapConst_funptr5_Aux" (Ptr.Ptr Const_funptr5_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (Ptr.Ptr A))
+         ) => GHC.Records.HasField "unwrapConst_funptr5_Aux" (Ptr.Ptr Const_funptr5_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr5_Aux")
@@ -1858,7 +1907,8 @@ newtype Const_funptr5 = Const_funptr5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr5" (Ptr.Ptr Const_funptr5) (Ptr.Ptr (Ptr.FunPtr Const_funptr5_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr5_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr5" (Ptr.Ptr Const_funptr5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr5")
@@ -1916,7 +1966,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr6_Aux where
 
   fromFunPtr = hs_bindgen_45251216b04aa8b5
 
-instance GHC.Records.HasField "unwrapConst_funptr6_Aux" (Ptr.Ptr Const_funptr6_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))
+         ) => GHC.Records.HasField "unwrapConst_funptr6_Aux" (Ptr.Ptr Const_funptr6_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr6_Aux")
@@ -1946,7 +1997,8 @@ newtype Const_funptr6 = Const_funptr6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr6" (Ptr.Ptr Const_funptr6) (Ptr.Ptr (Ptr.FunPtr Const_funptr6_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr6_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr6" (Ptr.Ptr Const_funptr6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr6")
@@ -2004,7 +2056,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Const_funptr7_Aux where
 
   fromFunPtr = hs_bindgen_42fbcebf75a973ba
 
-instance GHC.Records.HasField "unwrapConst_funptr7_Aux" (Ptr.Ptr Const_funptr7_Aux) (Ptr.Ptr (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))) where
+instance ( TyEq ty (FC.CInt -> FC.CDouble -> IO (HsBindgen.Runtime.PtrConst.PtrConst A))
+         ) => GHC.Records.HasField "unwrapConst_funptr7_Aux" (Ptr.Ptr Const_funptr7_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr7_Aux")
@@ -2034,7 +2087,8 @@ newtype Const_funptr7 = Const_funptr7
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapConst_funptr7" (Ptr.Ptr Const_funptr7) (Ptr.Ptr (Ptr.FunPtr Const_funptr7_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr Const_funptr7_Aux)
+         ) => GHC.Records.HasField "unwrapConst_funptr7" (Ptr.Ptr Const_funptr7) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConst_funptr7")
@@ -2074,7 +2128,8 @@ newtype BOOL = BOOL
     , Real
     )
 
-instance GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOL")
@@ -2113,7 +2168,8 @@ newtype INT = INT
     , Real
     )
 
-instance GHC.Records.HasField "unwrapINT" (Ptr.Ptr INT) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapINT" (Ptr.Ptr INT) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINT")
@@ -2142,7 +2198,8 @@ newtype INTP = INTP
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapINTP" (Ptr.Ptr INTP) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "unwrapINTP" (Ptr.Ptr INTP) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINTP")
@@ -2171,7 +2228,8 @@ newtype INTCP = INTCP
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapINTCP" (Ptr.Ptr INTCP) (Ptr.Ptr (HsBindgen.Runtime.PtrConst.PtrConst FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.PtrConst.PtrConst FC.CInt)
+         ) => GHC.Records.HasField "unwrapINTCP" (Ptr.Ptr INTCP) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapINTCP")

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2503,7 +2503,7 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapA" (Ptr A) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
@@ -2596,7 +2596,8 @@ instance Read Some_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSome_enum")
 instance HasCField Some_enum "unwrapSome_enum"
     where type CFieldType Some_enum "unwrapSome_enum" = CUInt
@@ -2630,9 +2631,8 @@ newtype Arr_typedef1
            __exported by:__ @macros\/reparse.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapArr_typedef1"
-                  (Ptr Arr_typedef1)
-                  (Ptr (IncompleteArray A))
+instance TyEq ty (IncompleteArray A) =>
+         HasField "unwrapArr_typedef1" (Ptr Arr_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef1")
 instance HasCField Arr_typedef1 "unwrapArr_typedef1"
     where type CFieldType Arr_typedef1
@@ -2653,9 +2653,8 @@ newtype Arr_typedef2
            __exported by:__ @macros\/reparse.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapArr_typedef2"
-                  (Ptr Arr_typedef2)
-                  (Ptr (IncompleteArray (Ptr A)))
+instance TyEq ty (IncompleteArray (Ptr A)) =>
+         HasField "unwrapArr_typedef2" (Ptr Arr_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef2")
 instance HasCField Arr_typedef2 "unwrapArr_typedef2"
     where type CFieldType Arr_typedef2
@@ -2677,9 +2676,8 @@ newtype Arr_typedef3
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapArr_typedef3"
-                  (Ptr Arr_typedef3)
-                  (Ptr (ConstantArray 5 A))
+instance TyEq ty (ConstantArray 5 A) =>
+         HasField "unwrapArr_typedef3" (Ptr Arr_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef3")
 instance HasCField Arr_typedef3 "unwrapArr_typedef3"
     where type CFieldType Arr_typedef3
@@ -2701,9 +2699,8 @@ newtype Arr_typedef4
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapArr_typedef4"
-                  (Ptr Arr_typedef4)
-                  (Ptr (ConstantArray 5 (Ptr A)))
+instance TyEq ty (ConstantArray 5 (Ptr A)) =>
+         HasField "unwrapArr_typedef4" (Ptr Arr_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef4")
 instance HasCField Arr_typedef4 "unwrapArr_typedef4"
     where type CFieldType Arr_typedef4
@@ -2743,7 +2740,8 @@ newtype Typedef1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr A)
+instance TyEq ty A =>
+         HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef1")
 instance HasCField Typedef1 "unwrapTypedef1"
     where type CFieldType Typedef1 "unwrapTypedef1" = A
@@ -2768,7 +2766,8 @@ newtype Typedef2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr (Ptr A))
+instance TyEq ty (Ptr A) =>
+         HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef2")
 instance HasCField Typedef2 "unwrapTypedef2"
     where type CFieldType Typedef2 "unwrapTypedef2" = Ptr A
@@ -2793,9 +2792,8 @@ newtype Typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapTypedef3"
-                  (Ptr Typedef3)
-                  (Ptr (Ptr (Ptr A)))
+instance TyEq ty (Ptr (Ptr A)) =>
+         HasField "unwrapTypedef3" (Ptr Typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef3")
 instance HasCField Typedef3 "unwrapTypedef3"
     where type CFieldType Typedef3 "unwrapTypedef3" = Ptr (Ptr A)
@@ -2840,9 +2838,10 @@ instance ToFunPtr Funptr_typedef1_Aux
     where toFunPtr = hs_bindgen_c584d0f839fd43de
 instance FromFunPtr Funptr_typedef1_Aux
     where fromFunPtr = hs_bindgen_806a46dc418a062c
-instance HasField "unwrapFunptr_typedef1_Aux"
+instance TyEq ty (IO A) =>
+         HasField "unwrapFunptr_typedef1_Aux"
                   (Ptr Funptr_typedef1_Aux)
-                  (Ptr (IO A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1_Aux")
 instance HasCField Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux"
     where type CFieldType Funptr_typedef1_Aux
@@ -2868,9 +2867,8 @@ newtype Funptr_typedef1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunptr_typedef1"
-                  (Ptr Funptr_typedef1)
-                  (Ptr (FunPtr Funptr_typedef1_Aux))
+instance TyEq ty (FunPtr Funptr_typedef1_Aux) =>
+         HasField "unwrapFunptr_typedef1" (Ptr Funptr_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1")
 instance HasCField Funptr_typedef1 "unwrapFunptr_typedef1"
     where type CFieldType Funptr_typedef1
@@ -2916,9 +2914,10 @@ instance ToFunPtr Funptr_typedef2_Aux
     where toFunPtr = hs_bindgen_f174457a161ac5a0
 instance FromFunPtr Funptr_typedef2_Aux
     where fromFunPtr = hs_bindgen_323d07dff85b802c
-instance HasField "unwrapFunptr_typedef2_Aux"
+instance TyEq ty (IO (Ptr A)) =>
+         HasField "unwrapFunptr_typedef2_Aux"
                   (Ptr Funptr_typedef2_Aux)
-                  (Ptr (IO (Ptr A)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2_Aux")
 instance HasCField Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux"
     where type CFieldType Funptr_typedef2_Aux
@@ -2944,9 +2943,8 @@ newtype Funptr_typedef2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunptr_typedef2"
-                  (Ptr Funptr_typedef2)
-                  (Ptr (FunPtr Funptr_typedef2_Aux))
+instance TyEq ty (FunPtr Funptr_typedef2_Aux) =>
+         HasField "unwrapFunptr_typedef2" (Ptr Funptr_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2")
 instance HasCField Funptr_typedef2 "unwrapFunptr_typedef2"
     where type CFieldType Funptr_typedef2
@@ -2992,9 +2990,10 @@ instance ToFunPtr Funptr_typedef3_Aux
     where toFunPtr = hs_bindgen_031d1a7decd790d8
 instance FromFunPtr Funptr_typedef3_Aux
     where fromFunPtr = hs_bindgen_82dc7b932974117e
-instance HasField "unwrapFunptr_typedef3_Aux"
+instance TyEq ty (IO (Ptr (Ptr A))) =>
+         HasField "unwrapFunptr_typedef3_Aux"
                   (Ptr Funptr_typedef3_Aux)
-                  (Ptr (IO (Ptr (Ptr A))))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3_Aux")
 instance HasCField Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux"
     where type CFieldType Funptr_typedef3_Aux
@@ -3020,9 +3019,8 @@ newtype Funptr_typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunptr_typedef3"
-                  (Ptr Funptr_typedef3)
-                  (Ptr (FunPtr Funptr_typedef3_Aux))
+instance TyEq ty (FunPtr Funptr_typedef3_Aux) =>
+         HasField "unwrapFunptr_typedef3" (Ptr Funptr_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3")
 instance HasCField Funptr_typedef3 "unwrapFunptr_typedef3"
     where type CFieldType Funptr_typedef3
@@ -3071,9 +3069,10 @@ instance ToFunPtr Funptr_typedef4_Aux
     where toFunPtr = hs_bindgen_da2336d254667386
 instance FromFunPtr Funptr_typedef4_Aux
     where fromFunPtr = hs_bindgen_d4a97954476da161
-instance HasField "unwrapFunptr_typedef4_Aux"
+instance TyEq ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapFunptr_typedef4_Aux"
                   (Ptr Funptr_typedef4_Aux)
-                  (Ptr (CInt -> CDouble -> IO A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4_Aux")
 instance HasCField Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux"
     where type CFieldType Funptr_typedef4_Aux
@@ -3099,9 +3098,8 @@ newtype Funptr_typedef4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunptr_typedef4"
-                  (Ptr Funptr_typedef4)
-                  (Ptr (FunPtr Funptr_typedef4_Aux))
+instance TyEq ty (FunPtr Funptr_typedef4_Aux) =>
+         HasField "unwrapFunptr_typedef4" (Ptr Funptr_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4")
 instance HasCField Funptr_typedef4 "unwrapFunptr_typedef4"
     where type CFieldType Funptr_typedef4
@@ -3150,9 +3148,10 @@ instance ToFunPtr Funptr_typedef5_Aux
     where toFunPtr = hs_bindgen_1f45632f07742a46
 instance FromFunPtr Funptr_typedef5_Aux
     where fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
-instance HasField "unwrapFunptr_typedef5_Aux"
+instance TyEq ty (CInt -> CDouble -> IO (Ptr A)) =>
+         HasField "unwrapFunptr_typedef5_Aux"
                   (Ptr Funptr_typedef5_Aux)
-                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5_Aux")
 instance HasCField Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux"
     where type CFieldType Funptr_typedef5_Aux
@@ -3178,9 +3177,8 @@ newtype Funptr_typedef5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunptr_typedef5"
-                  (Ptr Funptr_typedef5)
-                  (Ptr (FunPtr Funptr_typedef5_Aux))
+instance TyEq ty (FunPtr Funptr_typedef5_Aux) =>
+         HasField "unwrapFunptr_typedef5" (Ptr Funptr_typedef5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5")
 instance HasCField Funptr_typedef5 "unwrapFunptr_typedef5"
     where type CFieldType Funptr_typedef5
@@ -3216,7 +3214,8 @@ newtype Comments2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapComments2" (Ptr Comments2) (Ptr A)
+instance TyEq ty A =>
+         HasField "unwrapComments2" (Ptr Comments2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapComments2")
 instance HasCField Comments2 "unwrapComments2"
     where type CFieldType Comments2 "unwrapComments2" = A
@@ -3274,25 +3273,22 @@ deriving via (EquivStorable Example_struct) instance Storable Example_struct
 instance HasCField Example_struct "example_struct_field1"
     where type CFieldType Example_struct "example_struct_field1" = A
           offset# = \_ -> \_ -> 0
-instance HasField "example_struct_field1"
-                  (Ptr Example_struct)
-                  (Ptr A)
+instance TyEq ty A =>
+         HasField "example_struct_field1" (Ptr Example_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_field1")
 instance HasCField Example_struct "example_struct_field2"
     where type CFieldType Example_struct
                           "example_struct_field2" = Ptr A
           offset# = \_ -> \_ -> 8
-instance HasField "example_struct_field2"
-                  (Ptr Example_struct)
-                  (Ptr (Ptr A))
+instance TyEq ty (Ptr A) =>
+         HasField "example_struct_field2" (Ptr Example_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_field2")
 instance HasCField Example_struct "example_struct_field3"
     where type CFieldType Example_struct
                           "example_struct_field3" = Ptr (Ptr A)
           offset# = \_ -> \_ -> 16
-instance HasField "example_struct_field3"
-                  (Ptr Example_struct)
-                  (Ptr (Ptr (Ptr A)))
+instance TyEq ty (Ptr (Ptr A)) =>
+         HasField "example_struct_field3" (Ptr Example_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_field3")
 {-| __C declaration:__ @const_typedef1@
 
@@ -3324,9 +3320,8 @@ newtype Const_typedef1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapConst_typedef1"
-                  (Ptr Const_typedef1)
-                  (Ptr A)
+instance TyEq ty A =>
+         HasField "unwrapConst_typedef1" (Ptr Const_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef1")
 instance HasCField Const_typedef1 "unwrapConst_typedef1"
     where type CFieldType Const_typedef1 "unwrapConst_typedef1" = A
@@ -3361,9 +3356,8 @@ newtype Const_typedef2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapConst_typedef2"
-                  (Ptr Const_typedef2)
-                  (Ptr A)
+instance TyEq ty A =>
+         HasField "unwrapConst_typedef2" (Ptr Const_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef2")
 instance HasCField Const_typedef2 "unwrapConst_typedef2"
     where type CFieldType Const_typedef2 "unwrapConst_typedef2" = A
@@ -3388,9 +3382,8 @@ newtype Const_typedef3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_typedef3"
-                  (Ptr Const_typedef3)
-                  (Ptr (PtrConst A))
+instance TyEq ty (PtrConst A) =>
+         HasField "unwrapConst_typedef3" (Ptr Const_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef3")
 instance HasCField Const_typedef3 "unwrapConst_typedef3"
     where type CFieldType Const_typedef3
@@ -3416,9 +3409,8 @@ newtype Const_typedef4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_typedef4"
-                  (Ptr Const_typedef4)
-                  (Ptr (PtrConst A))
+instance TyEq ty (PtrConst A) =>
+         HasField "unwrapConst_typedef4" (Ptr Const_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef4")
 instance HasCField Const_typedef4 "unwrapConst_typedef4"
     where type CFieldType Const_typedef4
@@ -3444,9 +3436,8 @@ newtype Const_typedef5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_typedef5"
-                  (Ptr Const_typedef5)
-                  (Ptr (Ptr A))
+instance TyEq ty (Ptr A) =>
+         HasField "unwrapConst_typedef5" (Ptr Const_typedef5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef5")
 instance HasCField Const_typedef5 "unwrapConst_typedef5"
     where type CFieldType Const_typedef5 "unwrapConst_typedef5" = Ptr A
@@ -3471,9 +3462,8 @@ newtype Const_typedef6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_typedef6"
-                  (Ptr Const_typedef6)
-                  (Ptr (PtrConst A))
+instance TyEq ty (PtrConst A) =>
+         HasField "unwrapConst_typedef6" (Ptr Const_typedef6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef6")
 instance HasCField Const_typedef6 "unwrapConst_typedef6"
     where type CFieldType Const_typedef6
@@ -3499,9 +3489,8 @@ newtype Const_typedef7
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_typedef7"
-                  (Ptr Const_typedef7)
-                  (Ptr (PtrConst A))
+instance TyEq ty (PtrConst A) =>
+         HasField "unwrapConst_typedef7" (Ptr Const_typedef7) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef7")
 instance HasCField Const_typedef7 "unwrapConst_typedef7"
     where type CFieldType Const_typedef7
@@ -3590,63 +3579,70 @@ instance HasCField Example_struct_with_const
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field1" = A
           offset# = \_ -> \_ -> 0
-instance HasField "example_struct_with_const_const_field1"
+instance TyEq ty A =>
+         HasField "example_struct_with_const_const_field1"
                   (Ptr Example_struct_with_const)
-                  (Ptr A)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field1")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field2"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field2" = A
           offset# = \_ -> \_ -> 4
-instance HasField "example_struct_with_const_const_field2"
+instance TyEq ty A =>
+         HasField "example_struct_with_const_const_field2"
                   (Ptr Example_struct_with_const)
-                  (Ptr A)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field2")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field3"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field3" = PtrConst A
           offset# = \_ -> \_ -> 8
-instance HasField "example_struct_with_const_const_field3"
+instance TyEq ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field3"
                   (Ptr Example_struct_with_const)
-                  (Ptr (PtrConst A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field3")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field4"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field4" = PtrConst A
           offset# = \_ -> \_ -> 16
-instance HasField "example_struct_with_const_const_field4"
+instance TyEq ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field4"
                   (Ptr Example_struct_with_const)
-                  (Ptr (PtrConst A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field4")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field5"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field5" = Ptr A
           offset# = \_ -> \_ -> 24
-instance HasField "example_struct_with_const_const_field5"
+instance TyEq ty (Ptr A) =>
+         HasField "example_struct_with_const_const_field5"
                   (Ptr Example_struct_with_const)
-                  (Ptr (Ptr A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field5")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field6"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field6" = PtrConst A
           offset# = \_ -> \_ -> 32
-instance HasField "example_struct_with_const_const_field6"
+instance TyEq ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field6"
                   (Ptr Example_struct_with_const)
-                  (Ptr (PtrConst A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field6")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field7"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field7" = PtrConst A
           offset# = \_ -> \_ -> 40
-instance HasField "example_struct_with_const_const_field7"
+instance TyEq ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field7"
                   (Ptr Example_struct_with_const)
-                  (Ptr (PtrConst A))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field7")
 {-| Auxiliary type used by 'Const_funptr1'
 
@@ -3691,9 +3687,8 @@ instance ToFunPtr Const_funptr1_Aux
     where toFunPtr = hs_bindgen_7f125e20a9d4075b
 instance FromFunPtr Const_funptr1_Aux
     where fromFunPtr = hs_bindgen_ac4bd8d789bba94b
-instance HasField "unwrapConst_funptr1_Aux"
-                  (Ptr Const_funptr1_Aux)
-                  (Ptr (CInt -> CDouble -> IO A))
+instance TyEq ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapConst_funptr1_Aux" (Ptr Const_funptr1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr1_Aux")
 instance HasCField Const_funptr1_Aux "unwrapConst_funptr1_Aux"
     where type CFieldType Const_funptr1_Aux
@@ -3719,9 +3714,8 @@ newtype Const_funptr1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr1"
-                  (Ptr Const_funptr1)
-                  (Ptr (FunPtr Const_funptr1_Aux))
+instance TyEq ty (FunPtr Const_funptr1_Aux) =>
+         HasField "unwrapConst_funptr1" (Ptr Const_funptr1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr1")
 instance HasCField Const_funptr1 "unwrapConst_funptr1"
     where type CFieldType Const_funptr1
@@ -3770,9 +3764,8 @@ instance ToFunPtr Const_funptr2_Aux
     where toFunPtr = hs_bindgen_c7b1e36d845634fb
 instance FromFunPtr Const_funptr2_Aux
     where fromFunPtr = hs_bindgen_352cebf463125ca9
-instance HasField "unwrapConst_funptr2_Aux"
-                  (Ptr Const_funptr2_Aux)
-                  (Ptr (CInt -> CDouble -> IO A))
+instance TyEq ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapConst_funptr2_Aux" (Ptr Const_funptr2_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr2_Aux")
 instance HasCField Const_funptr2_Aux "unwrapConst_funptr2_Aux"
     where type CFieldType Const_funptr2_Aux
@@ -3798,9 +3791,8 @@ newtype Const_funptr2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr2"
-                  (Ptr Const_funptr2)
-                  (Ptr (FunPtr Const_funptr2_Aux))
+instance TyEq ty (FunPtr Const_funptr2_Aux) =>
+         HasField "unwrapConst_funptr2" (Ptr Const_funptr2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr2")
 instance HasCField Const_funptr2 "unwrapConst_funptr2"
     where type CFieldType Const_funptr2
@@ -3849,9 +3841,8 @@ instance ToFunPtr Const_funptr3_Aux
     where toFunPtr = hs_bindgen_2dcbfe1c2502178c
 instance FromFunPtr Const_funptr3_Aux
     where fromFunPtr = hs_bindgen_86738dcfd7c9d33c
-instance HasField "unwrapConst_funptr3_Aux"
-                  (Ptr Const_funptr3_Aux)
-                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
+instance TyEq ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr3_Aux" (Ptr Const_funptr3_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr3_Aux")
 instance HasCField Const_funptr3_Aux "unwrapConst_funptr3_Aux"
     where type CFieldType Const_funptr3_Aux
@@ -3877,9 +3868,8 @@ newtype Const_funptr3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr3"
-                  (Ptr Const_funptr3)
-                  (Ptr (FunPtr Const_funptr3_Aux))
+instance TyEq ty (FunPtr Const_funptr3_Aux) =>
+         HasField "unwrapConst_funptr3" (Ptr Const_funptr3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr3")
 instance HasCField Const_funptr3 "unwrapConst_funptr3"
     where type CFieldType Const_funptr3
@@ -3928,9 +3918,8 @@ instance ToFunPtr Const_funptr4_Aux
     where toFunPtr = hs_bindgen_5461deeda491de0b
 instance FromFunPtr Const_funptr4_Aux
     where fromFunPtr = hs_bindgen_de7846fca3bfd1b6
-instance HasField "unwrapConst_funptr4_Aux"
-                  (Ptr Const_funptr4_Aux)
-                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
+instance TyEq ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr4_Aux" (Ptr Const_funptr4_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr4_Aux")
 instance HasCField Const_funptr4_Aux "unwrapConst_funptr4_Aux"
     where type CFieldType Const_funptr4_Aux
@@ -3956,9 +3945,8 @@ newtype Const_funptr4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr4"
-                  (Ptr Const_funptr4)
-                  (Ptr (FunPtr Const_funptr4_Aux))
+instance TyEq ty (FunPtr Const_funptr4_Aux) =>
+         HasField "unwrapConst_funptr4" (Ptr Const_funptr4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr4")
 instance HasCField Const_funptr4 "unwrapConst_funptr4"
     where type CFieldType Const_funptr4
@@ -4007,9 +3995,8 @@ instance ToFunPtr Const_funptr5_Aux
     where toFunPtr = hs_bindgen_7b0174fc978a1ce1
 instance FromFunPtr Const_funptr5_Aux
     where fromFunPtr = hs_bindgen_38a21d84bb7115b5
-instance HasField "unwrapConst_funptr5_Aux"
-                  (Ptr Const_funptr5_Aux)
-                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
+instance TyEq ty (CInt -> CDouble -> IO (Ptr A)) =>
+         HasField "unwrapConst_funptr5_Aux" (Ptr Const_funptr5_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr5_Aux")
 instance HasCField Const_funptr5_Aux "unwrapConst_funptr5_Aux"
     where type CFieldType Const_funptr5_Aux
@@ -4035,9 +4022,8 @@ newtype Const_funptr5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr5"
-                  (Ptr Const_funptr5)
-                  (Ptr (FunPtr Const_funptr5_Aux))
+instance TyEq ty (FunPtr Const_funptr5_Aux) =>
+         HasField "unwrapConst_funptr5" (Ptr Const_funptr5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr5")
 instance HasCField Const_funptr5 "unwrapConst_funptr5"
     where type CFieldType Const_funptr5
@@ -4086,9 +4072,8 @@ instance ToFunPtr Const_funptr6_Aux
     where toFunPtr = hs_bindgen_4e32721222f4df9f
 instance FromFunPtr Const_funptr6_Aux
     where fromFunPtr = hs_bindgen_45251216b04aa8b5
-instance HasField "unwrapConst_funptr6_Aux"
-                  (Ptr Const_funptr6_Aux)
-                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
+instance TyEq ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr6_Aux" (Ptr Const_funptr6_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr6_Aux")
 instance HasCField Const_funptr6_Aux "unwrapConst_funptr6_Aux"
     where type CFieldType Const_funptr6_Aux
@@ -4114,9 +4099,8 @@ newtype Const_funptr6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr6"
-                  (Ptr Const_funptr6)
-                  (Ptr (FunPtr Const_funptr6_Aux))
+instance TyEq ty (FunPtr Const_funptr6_Aux) =>
+         HasField "unwrapConst_funptr6" (Ptr Const_funptr6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr6")
 instance HasCField Const_funptr6 "unwrapConst_funptr6"
     where type CFieldType Const_funptr6
@@ -4165,9 +4149,8 @@ instance ToFunPtr Const_funptr7_Aux
     where toFunPtr = hs_bindgen_0d04fc96ffb9de06
 instance FromFunPtr Const_funptr7_Aux
     where fromFunPtr = hs_bindgen_42fbcebf75a973ba
-instance HasField "unwrapConst_funptr7_Aux"
-                  (Ptr Const_funptr7_Aux)
-                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
+instance TyEq ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr7_Aux" (Ptr Const_funptr7_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr7_Aux")
 instance HasCField Const_funptr7_Aux "unwrapConst_funptr7_Aux"
     where type CFieldType Const_funptr7_Aux
@@ -4193,9 +4176,8 @@ newtype Const_funptr7
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapConst_funptr7"
-                  (Ptr Const_funptr7)
-                  (Ptr (FunPtr Const_funptr7_Aux))
+instance TyEq ty (FunPtr Const_funptr7_Aux) =>
+         HasField "unwrapConst_funptr7" (Ptr Const_funptr7) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr7")
 instance HasCField Const_funptr7 "unwrapConst_funptr7"
     where type CFieldType Const_funptr7
@@ -4231,7 +4213,7 @@ newtype BOOL
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
+instance TyEq ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -4266,7 +4248,7 @@ newtype INT
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapINT" (Ptr INT) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapINT" (Ptr INT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINT")
 instance HasCField INT "unwrapINT"
     where type CFieldType INT "unwrapINT" = CInt
@@ -4291,7 +4273,8 @@ newtype INTP
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapINTP" (Ptr INTP) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) =>
+         HasField "unwrapINTP" (Ptr INTP) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINTP")
 instance HasCField INTP "unwrapINTP"
     where type CFieldType INTP "unwrapINTP" = Ptr CInt
@@ -4316,7 +4299,8 @@ newtype INTCP
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapINTCP" (Ptr INTCP) (Ptr (PtrConst CInt))
+instance TyEq ty (PtrConst CInt) =>
+         HasField "unwrapINTCP" (Ptr INTCP) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINTCP")
 instance HasCField INTCP "unwrapINTCP"
     where type CFieldType INTCP "unwrapINTCP" = PtrConst CInt

--- a/hs-bindgen/fixtures/manual/arrays/Example.hs
+++ b/hs-bindgen/fixtures/manual/arrays/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified HsBindgen.Runtime.ConstantArray
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.IncompleteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Eq, Show)
 
 {-| __C declaration:__ @triplet@
@@ -40,7 +43,8 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -69,7 +73,8 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)
+         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")
@@ -94,7 +99,8 @@ newtype Triplet_ptrs = Triplet_ptrs
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapTriplet_ptrs" (Ptr.Ptr Triplet_ptrs) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)))
+         ) => GHC.Records.HasField "unwrapTriplet_ptrs" (Ptr.Ptr Triplet_ptrs) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet_ptrs")

--- a/hs-bindgen/fixtures/manual/arrays/th.txt
+++ b/hs-bindgen/fixtures/manual/arrays/th.txt
@@ -95,9 +95,8 @@ newtype Triplet
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTriplet"
-                  (Ptr Triplet)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -119,9 +118,8 @@ newtype Matrix
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapMatrix"
-                  (Ptr Matrix)
-                  (Ptr (ConstantArray 3 Triplet))
+instance TyEq ty (ConstantArray 3 Triplet) =>
+         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 3
@@ -147,9 +145,8 @@ newtype Triplet_ptrs
       __exported by:__ @manual\/arrays.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapTriplet_ptrs"
-                  (Ptr Triplet_ptrs)
-                  (Ptr (IncompleteArray (Ptr (ConstantArray 3 CInt))))
+instance TyEq ty (IncompleteArray (Ptr (ConstantArray 3 CInt))) =>
+         HasField "unwrapTriplet_ptrs" (Ptr Triplet_ptrs) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet_ptrs")
 instance HasCField Triplet_ptrs "unwrapTriplet_ptrs"
     where type CFieldType Triplet_ptrs

--- a/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/Example.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,6 +14,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -42,6 +44,7 @@ import qualified Prelude as P
 import qualified Text.Read
 import Data.Bits (FiniteBits)
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, IO, Int, Integral, Num, Ord, Read, Real, Show, pure, showsPrec)
 
 {-| __C declaration:__ @struct Point@
@@ -100,7 +103,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x" (Ptr.Ptr Point) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -111,7 +115,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "y" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y" (Ptr.Ptr Point) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -172,7 +177,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Size "width" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "width" (Ptr.Ptr Size) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "width" (Ptr.Ptr Size) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"width")
@@ -183,7 +189,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Size "height" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "height" (Ptr.Ptr Size) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "height" (Ptr.Ptr Size) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"height")
@@ -262,7 +269,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -273,7 +281,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "y" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -284,7 +293,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "width" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "width" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "width" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"width")
@@ -295,7 +305,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rect "height" where
 
   offset# = \_ -> \_ -> 12
 
-instance GHC.Records.HasField "height" (Ptr.Ptr Rect) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "height" (Ptr.Ptr Rect) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"height")
@@ -378,7 +389,8 @@ instance Read E where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr E) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -435,7 +447,8 @@ newtype Value = Value
     , Real
     )
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr Value) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr Value) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -525,7 +538,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U1 "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x" (Ptr.Ptr U1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x" (Ptr.Ptr U1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -536,7 +550,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U1 "y" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y" (Ptr.Ptr U1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y" (Ptr.Ptr U1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -620,7 +635,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr U2_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr U2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -631,7 +647,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U2_t "b" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "b" (Ptr.Ptr U2_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr U2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -715,7 +732,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U3 "p" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "p" (Ptr.Ptr U3) (Ptr.Ptr Point) where
+instance ( TyEq ty Point
+         ) => GHC.Records.HasField "p" (Ptr.Ptr U3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"p")
@@ -726,7 +744,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U3 "s" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s" (Ptr.Ptr U3) (Ptr.Ptr Size) where
+instance ( TyEq ty Size
+         ) => GHC.Records.HasField "s" (Ptr.Ptr U3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s")
@@ -810,7 +829,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U4 "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "x" (Ptr.Ptr U4) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "x" (Ptr.Ptr U4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"x")
@@ -821,7 +841,8 @@ instance HsBindgen.Runtime.HasCField.HasCField U4 "y" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "y" (Ptr.Ptr U4) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "y" (Ptr.Ptr U4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"y")
@@ -880,7 +901,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr RunDriver_Aux where
 
   fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ((Ptr.Ptr Driver) -> IO FC.CInt)) where
+instance ( TyEq ty ((Ptr.Ptr Driver) -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -910,7 +932,8 @@ newtype RunDriver = RunDriver
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver) (Ptr.Ptr (Ptr.FunPtr RunDriver_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr RunDriver_Aux)
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr RunDriver) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")

--- a/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/manual/enable_record_dot/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable Point) instance Storable Point
 instance HasCField Point "x"
     where type CFieldType Point "x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x" (Ptr Point) (Ptr CInt)
+instance TyEq ty CInt => HasField "x" (Ptr Point) (Ptr ty)
     where getField = fromPtr (Proxy @"x")
 instance HasCField Point "y"
     where type CFieldType Point "y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "y" (Ptr Point) (Ptr CInt)
+instance TyEq ty CInt => HasField "y" (Ptr Point) (Ptr ty)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @struct Size@
 
@@ -88,12 +88,12 @@ deriving via (EquivStorable Size) instance Storable Size
 instance HasCField Size "width"
     where type CFieldType Size "width" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "width" (Ptr Size) (Ptr CInt)
+instance TyEq ty CInt => HasField "width" (Ptr Size) (Ptr ty)
     where getField = fromPtr (Proxy @"width")
 instance HasCField Size "height"
     where type CFieldType Size "height" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "height" (Ptr Size) (Ptr CInt)
+instance TyEq ty CInt => HasField "height" (Ptr Size) (Ptr ty)
     where getField = fromPtr (Proxy @"height")
 {-| __C declaration:__ @struct Rect@
 
@@ -152,22 +152,22 @@ deriving via (EquivStorable Rect) instance Storable Rect
 instance HasCField Rect "x"
     where type CFieldType Rect "x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x" (Ptr Rect) (Ptr CInt)
+instance TyEq ty CInt => HasField "x" (Ptr Rect) (Ptr ty)
     where getField = fromPtr (Proxy @"x")
 instance HasCField Rect "y"
     where type CFieldType Rect "y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "y" (Ptr Rect) (Ptr CInt)
+instance TyEq ty CInt => HasField "y" (Ptr Rect) (Ptr ty)
     where getField = fromPtr (Proxy @"y")
 instance HasCField Rect "width"
     where type CFieldType Rect "width" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "width" (Ptr Rect) (Ptr CInt)
+instance TyEq ty CInt => HasField "width" (Ptr Rect) (Ptr ty)
     where getField = fromPtr (Proxy @"width")
 instance HasCField Rect "height"
     where type CFieldType Rect "height" = CInt
           offset# = \_ -> \_ -> 12
-instance HasField "height" (Ptr Rect) (Ptr CInt)
+instance TyEq ty CInt => HasField "height" (Ptr Rect) (Ptr ty)
     where getField = fromPtr (Proxy @"height")
 {-| __C declaration:__ @enum E@
 
@@ -214,7 +214,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrap" (Ptr E) (Ptr CUInt)
+instance TyEq ty CUInt => HasField "unwrap" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField E "unwrap"
     where type CFieldType E "unwrap" = CUInt
@@ -277,7 +277,7 @@ newtype Value
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrap" (Ptr Value) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrap" (Ptr Value) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Value "unwrap"
     where type CFieldType Value "unwrap" = CInt
@@ -372,12 +372,12 @@ set_u1_y = setUnionPayload
 instance HasCField U1 "x"
     where type CFieldType U1 "x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x" (Ptr U1) (Ptr CInt)
+instance TyEq ty CInt => HasField "x" (Ptr U1) (Ptr ty)
     where getField = fromPtr (Proxy @"x")
 instance HasCField U1 "y"
     where type CFieldType U1 "y" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y" (Ptr U1) (Ptr CInt)
+instance TyEq ty CInt => HasField "y" (Ptr U1) (Ptr ty)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @union U2@
 
@@ -469,12 +469,12 @@ set_u2_t_b = setUnionPayload
 instance HasCField U2_t "a"
     where type CFieldType U2_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr U2_t) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr U2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField U2_t "b"
     where type CFieldType U2_t "b" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "b" (Ptr U2_t) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr U2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @union U3@
 
@@ -566,12 +566,12 @@ set_u3_s = setUnionPayload
 instance HasCField U3 "p"
     where type CFieldType U3 "p" = Point
           offset# = \_ -> \_ -> 0
-instance HasField "p" (Ptr U3) (Ptr Point)
+instance TyEq ty Point => HasField "p" (Ptr U3) (Ptr ty)
     where getField = fromPtr (Proxy @"p")
 instance HasCField U3 "s"
     where type CFieldType U3 "s" = Size
           offset# = \_ -> \_ -> 0
-instance HasField "s" (Ptr U3) (Ptr Size)
+instance TyEq ty Size => HasField "s" (Ptr U3) (Ptr ty)
     where getField = fromPtr (Proxy @"s")
 {-| __C declaration:__ @union U4@
 
@@ -663,12 +663,12 @@ set_u4_y = setUnionPayload
 instance HasCField U4 "x"
     where type CFieldType U4 "x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "x" (Ptr U4) (Ptr CInt)
+instance TyEq ty CInt => HasField "x" (Ptr U4) (Ptr ty)
     where getField = fromPtr (Proxy @"x")
 instance HasCField U4 "y"
     where type CFieldType U4 "y" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "y" (Ptr U4) (Ptr CInt)
+instance TyEq ty CInt => HasField "y" (Ptr U4) (Ptr ty)
     where getField = fromPtr (Proxy @"y")
 {-| __C declaration:__ @struct Driver@
 
@@ -718,9 +718,8 @@ instance ToFunPtr RunDriver_Aux
     where toFunPtr = hs_bindgen_d86ecf261d7044c6
 instance FromFunPtr RunDriver_Aux
     where fromFunPtr = hs_bindgen_6520ae39b50ffb4e
-instance HasField "unwrap"
-                  (Ptr RunDriver_Aux)
-                  (Ptr (Ptr Driver -> IO CInt))
+instance TyEq ty (Ptr Driver -> IO CInt) =>
+         HasField "unwrap" (Ptr RunDriver_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField RunDriver_Aux "unwrap"
     where type CFieldType RunDriver_Aux "unwrap" = Ptr Driver ->
@@ -746,9 +745,8 @@ newtype RunDriver
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrap"
-                  (Ptr RunDriver)
-                  (Ptr (FunPtr RunDriver_Aux))
+instance TyEq ty (FunPtr RunDriver_Aux) =>
+         HasField "unwrap" (Ptr RunDriver) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField RunDriver "unwrap"
     where type CFieldType RunDriver "unwrap" = FunPtr RunDriver_Aux

--- a/hs-bindgen/fixtures/manual/function_pointers/Example.hs
+++ b/hs-bindgen/fixtures/manual/function_pointers/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Void (Void)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, IO, Int, Show, pure)
 
 {-| __C declaration:__ @int2int@
@@ -76,7 +79,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Int2int where
 
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
-instance GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt2int")
@@ -138,7 +142,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Apply1Struct "apply1Struct_apply1
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "apply1Struct_apply1_nopointer_struct_field" (Ptr.Ptr Apply1Struct) (Ptr.Ptr (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))
+         ) => GHC.Records.HasField "apply1Struct_apply1_nopointer_struct_field" (Ptr.Ptr Apply1Struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"apply1Struct_apply1_nopointer_struct_field")
@@ -198,7 +203,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Apply1Union "apply1Union_apply1_n
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "apply1Union_apply1_nopointer_union_field" (Ptr.Ptr Apply1Union) (Ptr.Ptr (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))) where
+instance ( TyEq ty (Ptr.FunPtr ((Ptr.FunPtr Int2int) -> FC.CInt -> IO FC.CInt))
+         ) => GHC.Records.HasField "apply1Union_apply1_nopointer_union_field" (Ptr.Ptr Apply1Union) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"apply1Union_apply1_nopointer_union_field")

--- a/hs-bindgen/fixtures/manual/function_pointers/th.txt
+++ b/hs-bindgen/fixtures/manual/function_pointers/th.txt
@@ -232,9 +232,8 @@ instance ToFunPtr Int2int
     where toFunPtr = hs_bindgen_a6c7dd49f5b9d470
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
-instance HasField "unwrapInt2int"
-                  (Ptr Int2int)
-                  (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
@@ -280,9 +279,10 @@ instance HasCField Apply1Struct
                           "apply1Struct_apply1_nopointer_struct_field" = FunPtr (FunPtr Int2int ->
                                                                                  CInt -> IO CInt)
           offset# = \_ -> \_ -> 0
-instance HasField "apply1Struct_apply1_nopointer_struct_field"
+instance TyEq ty (FunPtr (FunPtr Int2int -> CInt -> IO CInt)) =>
+         HasField "apply1Struct_apply1_nopointer_struct_field"
                   (Ptr Apply1Struct)
-                  (Ptr (FunPtr (FunPtr Int2int -> CInt -> IO CInt)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"apply1Struct_apply1_nopointer_struct_field")
 {-| A union field pointing to a function like apply1_nopointer().
 
@@ -350,9 +350,10 @@ instance HasCField Apply1Union
                           "apply1Union_apply1_nopointer_union_field" = FunPtr (FunPtr Int2int ->
                                                                                CInt -> IO CInt)
           offset# = \_ -> \_ -> 0
-instance HasField "apply1Union_apply1_nopointer_union_field"
+instance TyEq ty (FunPtr (FunPtr Int2int -> CInt -> IO CInt)) =>
+         HasField "apply1Union_apply1_nopointer_union_field"
                   (Ptr Apply1Union)
-                  (Ptr (FunPtr (FunPtr Int2int -> CInt -> IO CInt)))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"apply1Union_apply1_nopointer_union_field")
 foreign import ccall safe "wrapper" hs_bindgen_fe02c1e534fc52ea_base ::
     FunPtr Void -> Int32 -> IO Int32

--- a/hs-bindgen/fixtures/manual/globals/Example.hs
+++ b/hs-bindgen/fixtures/manual/globals/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct globalConfig@
@@ -89,7 +92,8 @@ instance HsBindgen.Runtime.HasCField.HasCField GlobalConfig "globalConfig_numThr
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "globalConfig_numThreads" (Ptr.Ptr GlobalConfig) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "globalConfig_numThreads" (Ptr.Ptr GlobalConfig) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"globalConfig_numThreads")
@@ -101,7 +105,8 @@ instance HsBindgen.Runtime.HasCField.HasCField GlobalConfig "globalConfig_numWor
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "globalConfig_numWorkers" (Ptr.Ptr GlobalConfig) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "globalConfig_numWorkers" (Ptr.Ptr GlobalConfig) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"globalConfig_numWorkers")
@@ -134,7 +139,8 @@ newtype ConstInt = ConstInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapConstInt" (Ptr.Ptr ConstInt) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapConstInt" (Ptr.Ptr ConstInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapConstInt")
@@ -201,7 +207,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Tuple "tuple_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "tuple_x" (Ptr.Ptr Tuple) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "tuple_x" (Ptr.Ptr Tuple) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tuple_x")
@@ -212,7 +219,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Tuple "tuple_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "tuple_y" (Ptr.Ptr Tuple) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "tuple_y" (Ptr.Ptr Tuple) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tuple_y")
@@ -234,7 +242,8 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -257,7 +266,8 @@ newtype List = List
   }
   deriving stock (GHC.Generics.Generic, Eq, Show)
 
-instance GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)) where
+instance ( TyEq ty (HsBindgen.Runtime.IncompleteArray.IncompleteArray FC.CInt)
+         ) => GHC.Records.HasField "unwrapList" (Ptr.Ptr List) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapList")

--- a/hs-bindgen/fixtures/manual/globals/th.txt
+++ b/hs-bindgen/fixtures/manual/globals/th.txt
@@ -173,16 +173,14 @@ deriving via (EquivStorable GlobalConfig) instance Storable GlobalConfig
 instance HasCField GlobalConfig "globalConfig_numThreads"
     where type CFieldType GlobalConfig "globalConfig_numThreads" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "globalConfig_numThreads"
-                  (Ptr GlobalConfig)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "globalConfig_numThreads" (Ptr GlobalConfig) (Ptr ty)
     where getField = fromPtr (Proxy @"globalConfig_numThreads")
 instance HasCField GlobalConfig "globalConfig_numWorkers"
     where type CFieldType GlobalConfig "globalConfig_numWorkers" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "globalConfig_numWorkers"
-                  (Ptr GlobalConfig)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "globalConfig_numWorkers" (Ptr GlobalConfig) (Ptr ty)
     where getField = fromPtr (Proxy @"globalConfig_numWorkers")
 {-| __C declaration:__ @ConstInt@
 
@@ -214,7 +212,8 @@ newtype ConstInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapConstInt" (Ptr ConstInt) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapConstInt" (Ptr ConstInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConstInt")
 instance HasCField ConstInt "unwrapConstInt"
     where type CFieldType ConstInt "unwrapConstInt" = CInt
@@ -260,12 +259,12 @@ deriving via (EquivStorable Tuple) instance Storable Tuple
 instance HasCField Tuple "tuple_x"
     where type CFieldType Tuple "tuple_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "tuple_x" (Ptr Tuple) (Ptr CInt)
+instance TyEq ty CInt => HasField "tuple_x" (Ptr Tuple) (Ptr ty)
     where getField = fromPtr (Proxy @"tuple_x")
 instance HasCField Tuple "tuple_y"
     where type CFieldType Tuple "tuple_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "tuple_y" (Ptr Tuple) (Ptr CInt)
+instance TyEq ty CInt => HasField "tuple_y" (Ptr Tuple) (Ptr ty)
     where getField = fromPtr (Proxy @"tuple_y")
 {-| __C declaration:__ @triplet@
 
@@ -283,9 +282,8 @@ newtype Triplet
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTriplet"
-                  (Ptr Triplet)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -306,9 +304,8 @@ newtype List
            __exported by:__ @manual\/globals.h@
       -}
     deriving stock (Generic, Eq, Show)
-instance HasField "unwrapList"
-                  (Ptr List)
-                  (Ptr (IncompleteArray CInt))
+instance TyEq ty (IncompleteArray CInt) =>
+         HasField "unwrapList" (Ptr List) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt

--- a/hs-bindgen/fixtures/manual/zero_copy/Example.hs
+++ b/hs-bindgen/fixtures/manual/zero_copy/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -35,6 +37,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct point@
@@ -93,7 +96,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "point_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "point_x" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point_x" (Ptr.Ptr Point) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point_x")
@@ -104,7 +108,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Point "point_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "point_y" (Ptr.Ptr Point) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "point_y" (Ptr.Ptr Point) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"point_y")
@@ -165,7 +170,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rectangle "rectangle_topleft" whe
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "rectangle_topleft" (Ptr.Ptr Rectangle) (Ptr.Ptr Point) where
+instance ( TyEq ty Point
+         ) => GHC.Records.HasField "rectangle_topleft" (Ptr.Ptr Rectangle) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"rectangle_topleft")
@@ -177,7 +183,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Rectangle "rectangle_bottomright"
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "rectangle_bottomright" (Ptr.Ptr Rectangle) (Ptr.Ptr Point) where
+instance ( TyEq ty Point
+         ) => GHC.Records.HasField "rectangle_bottomright" (Ptr.Ptr Rectangle) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"rectangle_bottomright")
@@ -238,7 +245,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Circle "circle_midpoint" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "circle_midpoint" (Ptr.Ptr Circle) (Ptr.Ptr Point) where
+instance ( TyEq ty Point
+         ) => GHC.Records.HasField "circle_midpoint" (Ptr.Ptr Circle) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"circle_midpoint")
@@ -249,7 +257,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Circle "circle_radius" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "circle_radius" (Ptr.Ptr Circle) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "circle_radius" (Ptr.Ptr Circle) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"circle_radius")
@@ -333,7 +342,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Shape "shape_rectangle" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "shape_rectangle" (Ptr.Ptr Shape) (Ptr.Ptr Rectangle) where
+instance ( TyEq ty Rectangle
+         ) => GHC.Records.HasField "shape_rectangle" (Ptr.Ptr Shape) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"shape_rectangle")
@@ -344,7 +354,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Shape "shape_circle" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "shape_circle" (Ptr.Ptr Shape) (Ptr.Ptr Circle) where
+instance ( TyEq ty Circle
+         ) => GHC.Records.HasField "shape_circle" (Ptr.Ptr Shape) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"shape_circle")
@@ -439,7 +450,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_opacity" whe
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "colour_opacity" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "colour_opacity" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_opacity")
@@ -453,7 +465,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_brightness" 
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance GHC.Records.HasField "colour_brightness" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "colour_brightness" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_brightness")
@@ -466,7 +479,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_red" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "colour_red" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "colour_red" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_red")
@@ -479,7 +493,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_green" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "colour_green" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "colour_green" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_green")
@@ -492,7 +507,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Colour "colour_blue" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "colour_blue" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "colour_blue" (Ptr.Ptr Colour) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"colour_blue")
@@ -525,7 +541,8 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -593,7 +610,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Drawing "drawing_shape" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "drawing_shape" (Ptr.Ptr Drawing) (Ptr.Ptr (Ptr.Ptr Shape)) where
+instance ( TyEq ty (Ptr.Ptr Shape)
+         ) => GHC.Records.HasField "drawing_shape" (Ptr.Ptr Drawing) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"drawing_shape")
@@ -605,7 +623,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Drawing "drawing_colour" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "drawing_colour" (Ptr.Ptr Drawing) (Ptr.Ptr (Ptr.Ptr Colour)) where
+instance ( TyEq ty (Ptr.Ptr Colour)
+         ) => GHC.Records.HasField "drawing_colour" (Ptr.Ptr Drawing) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"drawing_colour")
@@ -676,7 +695,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row1" wh
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "tic_tac_toe_row1" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "tic_tac_toe_row1" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row1")
@@ -688,7 +708,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row2" wh
 
   offset# = \_ -> \_ -> 12
 
-instance GHC.Records.HasField "tic_tac_toe_row2" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "tic_tac_toe_row2" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row2")
@@ -700,7 +721,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Tic_tac_toe "tic_tac_toe_row3" wh
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "tic_tac_toe_row3" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "tic_tac_toe_row3" (Ptr.Ptr Tic_tac_toe) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"tic_tac_toe_row3")
@@ -752,7 +774,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector_Aux "vector_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "vector_len" (Ptr.Ptr Vector_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "vector_len" (Ptr.Ptr Vector_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_len")
@@ -787,7 +810,8 @@ newtype Triplet = Triplet
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) FC.CInt)
+         ) => GHC.Records.HasField "unwrapTriplet" (Ptr.Ptr Triplet) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTriplet")
@@ -816,7 +840,8 @@ newtype Matrix = Matrix
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)) where
+instance ( TyEq ty ((HsBindgen.Runtime.ConstantArray.ConstantArray 3) Triplet)
+         ) => GHC.Records.HasField "unwrapMatrix" (Ptr.Ptr Matrix) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMatrix")

--- a/hs-bindgen/fixtures/manual/zero_copy/th.txt
+++ b/hs-bindgen/fixtures/manual/zero_copy/th.txt
@@ -90,12 +90,12 @@ deriving via (EquivStorable Point) instance Storable Point
 instance HasCField Point "point_x"
     where type CFieldType Point "point_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "point_x" (Ptr Point) (Ptr CInt)
+instance TyEq ty CInt => HasField "point_x" (Ptr Point) (Ptr ty)
     where getField = fromPtr (Proxy @"point_x")
 instance HasCField Point "point_y"
     where type CFieldType Point "point_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "point_y" (Ptr Point) (Ptr CInt)
+instance TyEq ty CInt => HasField "point_y" (Ptr Point) (Ptr ty)
     where getField = fromPtr (Proxy @"point_y")
 {-| __C declaration:__ @struct rectangle@
 
@@ -138,14 +138,14 @@ deriving via (EquivStorable Rectangle) instance Storable Rectangle
 instance HasCField Rectangle "rectangle_topleft"
     where type CFieldType Rectangle "rectangle_topleft" = Point
           offset# = \_ -> \_ -> 0
-instance HasField "rectangle_topleft" (Ptr Rectangle) (Ptr Point)
+instance TyEq ty Point =>
+         HasField "rectangle_topleft" (Ptr Rectangle) (Ptr ty)
     where getField = fromPtr (Proxy @"rectangle_topleft")
 instance HasCField Rectangle "rectangle_bottomright"
     where type CFieldType Rectangle "rectangle_bottomright" = Point
           offset# = \_ -> \_ -> 8
-instance HasField "rectangle_bottomright"
-                  (Ptr Rectangle)
-                  (Ptr Point)
+instance TyEq ty Point =>
+         HasField "rectangle_bottomright" (Ptr Rectangle) (Ptr ty)
     where getField = fromPtr (Proxy @"rectangle_bottomright")
 {-| __C declaration:__ @struct circle@
 
@@ -188,12 +188,14 @@ deriving via (EquivStorable Circle) instance Storable Circle
 instance HasCField Circle "circle_midpoint"
     where type CFieldType Circle "circle_midpoint" = Point
           offset# = \_ -> \_ -> 0
-instance HasField "circle_midpoint" (Ptr Circle) (Ptr Point)
+instance TyEq ty Point =>
+         HasField "circle_midpoint" (Ptr Circle) (Ptr ty)
     where getField = fromPtr (Proxy @"circle_midpoint")
 instance HasCField Circle "circle_radius"
     where type CFieldType Circle "circle_radius" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "circle_radius" (Ptr Circle) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "circle_radius" (Ptr Circle) (Ptr ty)
     where getField = fromPtr (Proxy @"circle_radius")
 {-| __C declaration:__ @union shape@
 
@@ -285,12 +287,14 @@ set_shape_circle = setUnionPayload
 instance HasCField Shape "shape_rectangle"
     where type CFieldType Shape "shape_rectangle" = Rectangle
           offset# = \_ -> \_ -> 0
-instance HasField "shape_rectangle" (Ptr Shape) (Ptr Rectangle)
+instance TyEq ty Rectangle =>
+         HasField "shape_rectangle" (Ptr Shape) (Ptr ty)
     where getField = fromPtr (Proxy @"shape_rectangle")
 instance HasCField Shape "shape_circle"
     where type CFieldType Shape "shape_circle" = Circle
           offset# = \_ -> \_ -> 0
-instance HasField "shape_circle" (Ptr Shape) (Ptr Circle)
+instance TyEq ty Circle =>
+         HasField "shape_circle" (Ptr Shape) (Ptr ty)
     where getField = fromPtr (Proxy @"shape_circle")
 {-| __C declaration:__ @struct colour@
 
@@ -358,33 +362,36 @@ instance HasCBitfield Colour "colour_opacity"
     where type CBitfieldType Colour "colour_opacity" = CUInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 2
-instance HasField "colour_opacity" (Ptr Colour) (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "colour_opacity" (Ptr Colour) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"colour_opacity")
 instance HasCBitfield Colour "colour_brightness"
     where type CBitfieldType Colour "colour_brightness" = CUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 3
-instance HasField "colour_brightness"
-                  (Ptr Colour)
-                  (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "colour_brightness" (Ptr Colour) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"colour_brightness")
 instance HasCBitfield Colour "colour_red"
     where type CBitfieldType Colour "colour_red" = CUInt
           bitfieldOffset# = \_ -> \_ -> 5
           bitfieldWidth# = \_ -> \_ -> 8
-instance HasField "colour_red" (Ptr Colour) (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "colour_red" (Ptr Colour) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"colour_red")
 instance HasCBitfield Colour "colour_green"
     where type CBitfieldType Colour "colour_green" = CUInt
           bitfieldOffset# = \_ -> \_ -> 13
           bitfieldWidth# = \_ -> \_ -> 8
-instance HasField "colour_green" (Ptr Colour) (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "colour_green" (Ptr Colour) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"colour_green")
 instance HasCBitfield Colour "colour_blue"
     where type CBitfieldType Colour "colour_blue" = CUInt
           bitfieldOffset# = \_ -> \_ -> 21
           bitfieldWidth# = \_ -> \_ -> 8
-instance HasField "colour_blue" (Ptr Colour) (BitfieldPtr CUInt)
+instance TyEq ty CUInt =>
+         HasField "colour_blue" (Ptr Colour) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"colour_blue")
 {-| __C declaration:__ @myInt@
 
@@ -416,7 +423,8 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -462,12 +470,14 @@ deriving via (EquivStorable Drawing) instance Storable Drawing
 instance HasCField Drawing "drawing_shape"
     where type CFieldType Drawing "drawing_shape" = Ptr Shape
           offset# = \_ -> \_ -> 0
-instance HasField "drawing_shape" (Ptr Drawing) (Ptr (Ptr Shape))
+instance TyEq ty (Ptr Shape) =>
+         HasField "drawing_shape" (Ptr Drawing) (Ptr ty)
     where getField = fromPtr (Proxy @"drawing_shape")
 instance HasCField Drawing "drawing_colour"
     where type CFieldType Drawing "drawing_colour" = Ptr Colour
           offset# = \_ -> \_ -> 8
-instance HasField "drawing_colour" (Ptr Drawing) (Ptr (Ptr Colour))
+instance TyEq ty (Ptr Colour) =>
+         HasField "drawing_colour" (Ptr Drawing) (Ptr ty)
     where getField = fromPtr (Proxy @"drawing_colour")
 {-| __C declaration:__ @struct tic_tac_toe@
 
@@ -519,25 +529,22 @@ instance HasCField Tic_tac_toe "tic_tac_toe_row1"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row1" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance HasField "tic_tac_toe_row1"
-                  (Ptr Tic_tac_toe)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "tic_tac_toe_row1" (Ptr Tic_tac_toe) (Ptr ty)
     where getField = fromPtr (Proxy @"tic_tac_toe_row1")
 instance HasCField Tic_tac_toe "tic_tac_toe_row2"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row2" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 12
-instance HasField "tic_tac_toe_row2"
-                  (Ptr Tic_tac_toe)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "tic_tac_toe_row2" (Ptr Tic_tac_toe) (Ptr ty)
     where getField = fromPtr (Proxy @"tic_tac_toe_row2")
 instance HasCField Tic_tac_toe "tic_tac_toe_row3"
     where type CFieldType Tic_tac_toe
                           "tic_tac_toe_row3" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 24
-instance HasField "tic_tac_toe_row3"
-                  (Ptr Tic_tac_toe)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "tic_tac_toe_row3" (Ptr Tic_tac_toe) (Ptr ty)
     where getField = fromPtr (Proxy @"tic_tac_toe_row3")
 {-| __C declaration:__ @struct vector@
 
@@ -566,7 +573,8 @@ deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
 instance HasCField Vector_Aux "vector_len"
     where type CFieldType Vector_Aux "vector_len" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "vector_len" (Ptr Vector_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "vector_len" (Ptr Vector_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"vector_len")
 instance Offset CChar Vector_Aux
     where offset = \_ty_0 -> 4
@@ -587,9 +595,8 @@ newtype Triplet
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTriplet"
-                  (Ptr Triplet)
-                  (Ptr (ConstantArray 3 CInt))
+instance TyEq ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -611,9 +618,8 @@ newtype Matrix
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapMatrix"
-                  (Ptr Matrix)
-                  (Ptr (ConstantArray 3 Triplet))
+instance TyEq ty (ConstantArray 3 Triplet) =>
+         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 3

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -56,7 +59,8 @@ newtype U = U
     , Real
     )
 
-instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_selected/th.txt
@@ -71,7 +71,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapU" (Ptr U) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -56,7 +59,8 @@ newtype U = U
     , Real
     )
 
-instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
@@ -71,7 +71,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapU" (Ptr U) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @T@
@@ -56,7 +59,8 @@ newtype T = T
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapT" (Ptr.Ptr T) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT")
@@ -95,7 +99,8 @@ newtype U = U
     , Real
     )
 
-instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
@@ -71,7 +71,7 @@ newtype T
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT" (Ptr T) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
@@ -106,7 +106,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapU" (Ptr U) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @U@
@@ -56,7 +59,8 @@ newtype U = U
     , Real
     )
 
-instance GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapU" (Ptr.Ptr U) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapU")

--- a/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
@@ -51,7 +51,7 @@ newtype U
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapU" (Ptr U) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,6 +31,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum FileOperationStatus@
@@ -105,7 +108,8 @@ instance Read FileOperationStatus where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapFileOperationStatus" (Ptr.Ptr FileOperationStatus) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapFileOperationStatus" (Ptr.Ptr FileOperationStatus) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFileOperationStatus")
@@ -230,7 +234,8 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOperationRecord "fileOperatio
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "fileOperationRecord_status" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr FileOperationStatus) where
+instance ( TyEq ty FileOperationStatus
+         ) => GHC.Records.HasField "fileOperationRecord_status" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fileOperationRecord_status")
@@ -242,7 +247,8 @@ instance HsBindgen.Runtime.HasCField.HasCField FileOperationRecord "fileOperatio
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "fileOperationRecord_bytes_processed" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr HsBindgen.Runtime.LibC.CSize) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CSize
+         ) => GHC.Records.HasField "fileOperationRecord_bytes_processed" (Ptr.Ptr FileOperationRecord) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"fileOperationRecord_bytes_processed")

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -80,9 +80,10 @@ instance Read FileOperationStatus
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapFileOperationStatus"
+instance TyEq ty CInt =>
+         HasField "unwrapFileOperationStatus"
                   (Ptr FileOperationStatus)
-                  (Ptr CInt)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFileOperationStatus")
 instance HasCField FileOperationStatus "unwrapFileOperationStatus"
     where type CFieldType FileOperationStatus
@@ -214,18 +215,20 @@ instance HasCField FileOperationRecord "fileOperationRecord_status"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_status" = FileOperationStatus
           offset# = \_ -> \_ -> 0
-instance HasField "fileOperationRecord_status"
+instance TyEq ty FileOperationStatus =>
+         HasField "fileOperationRecord_status"
                   (Ptr FileOperationRecord)
-                  (Ptr FileOperationStatus)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"fileOperationRecord_status")
 instance HasCField FileOperationRecord
                    "fileOperationRecord_bytes_processed"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_bytes_processed" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 8
-instance HasField "fileOperationRecord_bytes_processed"
+instance TyEq ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "fileOperationRecord_bytes_processed"
                   (Ptr FileOperationRecord)
-                  (Ptr HsBindgen.Runtime.LibC.CSize)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"fileOperationRecord_bytes_processed")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_read_file_chunk@
 foreign import ccall safe "hs_bindgen_b2a91b3b7edf2ad3" hs_bindgen_b2a91b3b7edf2ad3_base ::

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -27,6 +29,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @uint32_t@
@@ -57,7 +60,8 @@ newtype Uint32_t = Uint32_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint32_t" (Ptr.Ptr Uint32_t) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapUint32_t" (Ptr.Ptr Uint32_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint32_t")
@@ -118,7 +122,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr Foreign.Word64) where
+instance ( TyEq ty Foreign.Word64
+         ) => GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_sixty_four")
@@ -129,7 +134,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr Uint32_t) where
+instance ( TyEq ty Uint32_t
+         ) => GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -56,7 +56,8 @@ newtype Uint32_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint32_t")
 instance HasCField Uint32_t "unwrapUint32_t"
     where type CFieldType Uint32_t "unwrapUint32_t" = CUInt
@@ -99,12 +100,14 @@ instance Storable Foo
 instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo "foo_sixty_four" = Foreign.Word64
           offset# = \_ -> \_ -> 0
-instance HasField "foo_sixty_four" (Ptr Foo) (Ptr Foreign.Word64)
+instance TyEq ty Foreign.Word64 =>
+         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo "foo_thirty_two" = Uint32_t
           offset# = \_ -> \_ -> 8
-instance HasField "foo_thirty_two" (Ptr Foo) (Ptr Uint32_t)
+instance TyEq ty Uint32_t =>
+         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_thirty_two")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_48dbbf4b09b5b3c1" hs_bindgen_48dbbf4b09b5b3c1_base ::

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @A@
@@ -56,7 +59,8 @@ newtype A = A
     , Real
     )
 
-instance GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapA" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapA")

--- a/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_bad/th.txt
@@ -30,7 +30,7 @@ newtype A
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapA" (Ptr A) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -121,7 +125,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -32,7 +32,8 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -67,5 +68,6 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -121,7 +125,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -32,7 +32,8 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -67,5 +68,6 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -32,5 +32,6 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
     where getField = fromPtr (Proxy @"okBefore_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct OkBefore@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okBefore_x" (Ptr.Ptr OkBefore) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okBefore_x")
@@ -121,7 +125,8 @@ instance HsBindgen.Runtime.HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "okAfter_x" (Ptr.Ptr OkAfter) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_fail/th.txt
@@ -32,7 +32,8 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -67,5 +68,6 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct StructWithAssignedHaskellNameByPrescriptiveBindingSpecs@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField NewName "newName_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "newName_x" (Ptr.Ptr NewName) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "newName_x" (Ptr.Ptr NewName) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"newName_x")

--- a/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -47,7 +47,8 @@ deriving via (EquivStorable NewName) instance Storable NewName
 instance HasCField NewName "newName_x"
     where type CFieldType NewName "newName_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "newName_x" (Ptr NewName) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "newName_x" (Ptr NewName) (Ptr ty)
     where getField = fromPtr (Proxy @"newName_x")
 -- __unique:__ @test_programanalysisselection_mat_Example_Safe_FunctionWithAssignedHaskellNameByNameMangler@
 foreign import ccall safe "hs_bindgen_c9b1dc5577fd8ced" hs_bindgen_c9b1dc5577fd8ced_base ::

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct UnrelatedDeclaration@
@@ -70,7 +73,8 @@ instance HsBindgen.Runtime.HasCField.HasCField UnrelatedDeclaration "unrelatedDe
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "unrelatedDeclaration_m" (Ptr.Ptr UnrelatedDeclaration) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unrelatedDeclaration_m" (Ptr.Ptr UnrelatedDeclaration) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -34,7 +34,8 @@ instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
     where type CFieldType UnrelatedDeclaration
                           "unrelatedDeclaration_m" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "unrelatedDeclaration_m"
+instance TyEq ty CInt =>
+         HasField "unrelatedDeclaration_m"
                   (Ptr UnrelatedDeclaration)
-                  (Ptr CInt)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Omitted@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Omitted "omitted_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "omitted_n" (Ptr.Ptr Omitted) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "omitted_n" (Ptr.Ptr Omitted) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"omitted_n")
@@ -122,7 +126,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DirectlyDependsOnOmitted "directl
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "directlyDependsOnOmitted_o" (Ptr.Ptr DirectlyDependsOnOmitted) (Ptr.Ptr Omitted) where
+instance ( TyEq ty Omitted
+         ) => GHC.Records.HasField "directlyDependsOnOmitted_o" (Ptr.Ptr DirectlyDependsOnOmitted) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"directlyDependsOnOmitted_o")
@@ -175,7 +180,8 @@ instance HsBindgen.Runtime.HasCField.HasCField IndirectlyDependsOnOmitted "indir
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "indirectlyDependsOnOmitted_d" (Ptr.Ptr IndirectlyDependsOnOmitted) (Ptr.Ptr DirectlyDependsOnOmitted) where
+instance ( TyEq ty DirectlyDependsOnOmitted
+         ) => GHC.Records.HasField "indirectlyDependsOnOmitted_d" (Ptr.Ptr IndirectlyDependsOnOmitted) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -33,7 +33,8 @@ deriving via (EquivStorable Omitted) instance Storable Omitted
 instance HasCField Omitted "omitted_n"
     where type CFieldType Omitted "omitted_n" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "omitted_n" (Ptr Omitted) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "omitted_n" (Ptr Omitted) (Ptr ty)
     where getField = fromPtr (Proxy @"omitted_n")
 {-| __C declaration:__ @struct DirectlyDependsOnOmitted@
 
@@ -70,9 +71,10 @@ instance HasCField DirectlyDependsOnOmitted
     where type CFieldType DirectlyDependsOnOmitted
                           "directlyDependsOnOmitted_o" = Omitted
           offset# = \_ -> \_ -> 0
-instance HasField "directlyDependsOnOmitted_o"
+instance TyEq ty Omitted =>
+         HasField "directlyDependsOnOmitted_o"
                   (Ptr DirectlyDependsOnOmitted)
-                  (Ptr Omitted)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"directlyDependsOnOmitted_o")
 {-| __C declaration:__ @struct IndirectlyDependsOnOmitted@
 
@@ -109,7 +111,8 @@ instance HasCField IndirectlyDependsOnOmitted
     where type CFieldType IndirectlyDependsOnOmitted
                           "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
           offset# = \_ -> \_ -> 0
-instance HasField "indirectlyDependsOnOmitted_d"
+instance TyEq ty DirectlyDependsOnOmitted =>
+         HasField "indirectlyDependsOnOmitted_d"
                   (Ptr IndirectlyDependsOnOmitted)
-                  (Ptr DirectlyDependsOnOmitted)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure, return)
 
 {-| Examples for the various cases in by `HsBindgen.Frontend.Analysis.Typedefs`
@@ -151,7 +154,8 @@ newtype Struct5_t = Struct5_t
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapStruct5_t" (Ptr.Ptr Struct5_t) (Ptr.Ptr (Ptr.Ptr Struct5)) where
+instance ( TyEq ty (Ptr.Ptr Struct5)
+         ) => GHC.Records.HasField "unwrapStruct5_t" (Ptr.Ptr Struct5_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct5_t")
@@ -211,7 +215,8 @@ newtype Struct6 = Struct6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapStruct6" (Ptr.Ptr Struct6) (Ptr.Ptr (Ptr.Ptr Struct6_Aux)) where
+instance ( TyEq ty (Ptr.Ptr Struct6_Aux)
+         ) => GHC.Records.HasField "unwrapStruct6" (Ptr.Ptr Struct6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct6")
@@ -270,7 +275,8 @@ newtype Struct7a = Struct7a
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct7a" (Ptr.Ptr Struct7a) (Ptr.Ptr Struct7) where
+instance ( TyEq ty Struct7
+         ) => GHC.Records.HasField "unwrapStruct7a" (Ptr.Ptr Struct7a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct7a")
@@ -298,7 +304,8 @@ newtype Struct7b = Struct7b
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct7b" (Ptr.Ptr Struct7b) (Ptr.Ptr Struct7) where
+instance ( TyEq ty Struct7
+         ) => GHC.Records.HasField "unwrapStruct7b" (Ptr.Ptr Struct7b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct7b")
@@ -356,7 +363,8 @@ newtype Struct8b = Struct8b
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct8b" (Ptr.Ptr Struct8b) (Ptr.Ptr Struct8) where
+instance ( TyEq ty Struct8
+         ) => GHC.Records.HasField "unwrapStruct8b" (Ptr.Ptr Struct8b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct8b")
@@ -414,7 +422,8 @@ newtype Struct9_t = Struct9_t
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct9_t" (Ptr.Ptr Struct9_t) (Ptr.Ptr Struct9) where
+instance ( TyEq ty Struct9
+         ) => GHC.Records.HasField "unwrapStruct9_t" (Ptr.Ptr Struct9_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct9_t")
@@ -472,7 +481,8 @@ newtype Struct10_t_t = Struct10_t_t
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapStruct10_t_t" (Ptr.Ptr Struct10_t_t) (Ptr.Ptr Struct10_t) where
+instance ( TyEq ty Struct10_t
+         ) => GHC.Records.HasField "unwrapStruct10_t_t" (Ptr.Ptr Struct10_t_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapStruct10_t_t")
@@ -540,7 +550,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct11_t "struct11_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct11_t_x" (Ptr.Ptr Struct11_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct11_t_x" (Ptr.Ptr Struct11_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct11_t_x")
@@ -552,7 +563,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct11_t "struct11_t_self" wher
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "struct11_t_self" (Ptr.Ptr Struct11_t) (Ptr.Ptr (Ptr.Ptr Struct11_t)) where
+instance ( TyEq ty (Ptr.Ptr Struct11_t)
+         ) => GHC.Records.HasField "struct11_t_self" (Ptr.Ptr Struct11_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct11_t_self")
@@ -613,7 +625,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct12_t "struct12_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct12_t_x" (Ptr.Ptr Struct12_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct12_t_x" (Ptr.Ptr Struct12_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct12_t_x")
@@ -625,7 +638,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct12_t "struct12_t_self" wher
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "struct12_t_self" (Ptr.Ptr Struct12_t) (Ptr.Ptr (Ptr.Ptr Struct12_t)) where
+instance ( TyEq ty (Ptr.Ptr Struct12_t)
+         ) => GHC.Records.HasField "struct12_t_self" (Ptr.Ptr Struct12_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct12_t_self")
@@ -849,7 +863,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct1_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct1_t) where
+instance ( TyEq ty Struct1_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct1_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct1_t")
@@ -861,7 +876,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct2_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct2_t) where
+instance ( TyEq ty Struct2_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct2_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct2_t")
@@ -873,7 +889,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct3_t" (Ptr.Ptr Use_sites) (Ptr.Ptr (Ptr.Ptr Struct3_t)) where
+instance ( TyEq ty (Ptr.Ptr Struct3_t)
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct3_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct3_t")
@@ -885,7 +902,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct4_t" (Ptr.Ptr Use_sites) (Ptr.Ptr (Ptr.Ptr Struct4_t)) where
+instance ( TyEq ty (Ptr.Ptr Struct4_t)
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct4_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct4_t")
@@ -897,7 +915,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useStruct_st
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "use_sites_useStruct_struct5" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct5) where
+instance ( TyEq ty Struct5
+         ) => GHC.Records.HasField "use_sites_useStruct_struct5" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useStruct_struct5")
@@ -909,7 +928,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct5_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct5_t) where
+instance ( TyEq ty Struct5_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct5_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct5_t")
@@ -921,7 +941,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useStruct_st
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "use_sites_useStruct_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct6_Aux) where
+instance ( TyEq ty Struct6_Aux
+         ) => GHC.Records.HasField "use_sites_useStruct_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useStruct_struct6")
@@ -933,7 +954,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct6) where
+instance ( TyEq ty Struct6
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct6" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct6")
@@ -945,7 +967,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct7a" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct7a) where
+instance ( TyEq ty Struct7a
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct7a" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct7a")
@@ -957,7 +980,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct7b" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct7b) where
+instance ( TyEq ty Struct7b
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct7b" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct7b")
@@ -969,7 +993,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct8" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct8) where
+instance ( TyEq ty Struct8
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct8" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct8")
@@ -981,7 +1006,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct8b" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct8b) where
+instance ( TyEq ty Struct8b
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct8b" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct8b")
@@ -993,7 +1019,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct9" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct9) where
+instance ( TyEq ty Struct9
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct9" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct9")
@@ -1005,7 +1032,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct9_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct9_t) where
+instance ( TyEq ty Struct9_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct9_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct9_t")
@@ -1017,7 +1045,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct10_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct10_t) where
+instance ( TyEq ty Struct10_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct10_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct10_t")
@@ -1029,7 +1058,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct10_t_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct10_t_t) where
+instance ( TyEq ty Struct10_t_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct10_t_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct10_t_t")
@@ -1041,7 +1071,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct11_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct11_t) where
+instance ( TyEq ty Struct11_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct11_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct11_t")
@@ -1053,7 +1084,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Use_sites "use_sites_useTypedef_s
 
   offset# = \_ -> \_ -> 48
 
-instance GHC.Records.HasField "use_sites_useTypedef_struct12_t" (Ptr.Ptr Use_sites) (Ptr.Ptr Struct12_t) where
+instance ( TyEq ty Struct12_t
+         ) => GHC.Records.HasField "use_sites_useTypedef_struct12_t" (Ptr.Ptr Use_sites) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/typedef_analysis/th.txt
@@ -109,9 +109,8 @@ newtype Struct5_t
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapStruct5_t"
-                  (Ptr Struct5_t)
-                  (Ptr (Ptr Struct5))
+instance TyEq ty (Ptr Struct5) =>
+         HasField "unwrapStruct5_t" (Ptr Struct5_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct5_t")
 instance HasCField Struct5_t "unwrapStruct5_t"
     where type CFieldType Struct5_t "unwrapStruct5_t" = Ptr Struct5
@@ -160,9 +159,8 @@ newtype Struct6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapStruct6"
-                  (Ptr Struct6)
-                  (Ptr (Ptr Struct6_Aux))
+instance TyEq ty (Ptr Struct6_Aux) =>
+         HasField "unwrapStruct6" (Ptr Struct6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct6")
 instance HasCField Struct6 "unwrapStruct6"
     where type CFieldType Struct6 "unwrapStruct6" = Ptr Struct6_Aux
@@ -207,7 +205,8 @@ newtype Struct7a
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr Struct7)
+instance TyEq ty Struct7 =>
+         HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct7a")
 instance HasCField Struct7a "unwrapStruct7a"
     where type CFieldType Struct7a "unwrapStruct7a" = Struct7
@@ -228,7 +227,8 @@ newtype Struct7b
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr Struct7)
+instance TyEq ty Struct7 =>
+         HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct7b")
 instance HasCField Struct7b "unwrapStruct7b"
     where type CFieldType Struct7b "unwrapStruct7b" = Struct7
@@ -273,7 +273,8 @@ newtype Struct8b
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr Struct8)
+instance TyEq ty Struct8 =>
+         HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct8b")
 instance HasCField Struct8b "unwrapStruct8b"
     where type CFieldType Struct8b "unwrapStruct8b" = Struct8
@@ -318,7 +319,8 @@ newtype Struct9_t
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr Struct9)
+instance TyEq ty Struct9 =>
+         HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct9_t")
 instance HasCField Struct9_t "unwrapStruct9_t"
     where type CFieldType Struct9_t "unwrapStruct9_t" = Struct9
@@ -363,9 +365,8 @@ newtype Struct10_t_t
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapStruct10_t_t"
-                  (Ptr Struct10_t_t)
-                  (Ptr Struct10_t)
+instance TyEq ty Struct10_t =>
+         HasField "unwrapStruct10_t_t" (Ptr Struct10_t_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct10_t_t")
 instance HasCField Struct10_t_t "unwrapStruct10_t_t"
     where type CFieldType Struct10_t_t
@@ -412,14 +413,14 @@ deriving via (EquivStorable Struct11_t) instance Storable Struct11_t
 instance HasCField Struct11_t "struct11_t_x"
     where type CFieldType Struct11_t "struct11_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct11_t_x" (Ptr Struct11_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct11_t_x" (Ptr Struct11_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct11_t_x")
 instance HasCField Struct11_t "struct11_t_self"
     where type CFieldType Struct11_t "struct11_t_self" = Ptr Struct11_t
           offset# = \_ -> \_ -> 8
-instance HasField "struct11_t_self"
-                  (Ptr Struct11_t)
-                  (Ptr (Ptr Struct11_t))
+instance TyEq ty (Ptr Struct11_t) =>
+         HasField "struct11_t_self" (Ptr Struct11_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct11_t_self")
 {-| __C declaration:__ @struct struct12@
 
@@ -462,14 +463,14 @@ deriving via (EquivStorable Struct12_t) instance Storable Struct12_t
 instance HasCField Struct12_t "struct12_t_x"
     where type CFieldType Struct12_t "struct12_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct12_t_x" (Ptr Struct12_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct12_t_x" (Ptr Struct12_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct12_t_x")
 instance HasCField Struct12_t "struct12_t_self"
     where type CFieldType Struct12_t "struct12_t_self" = Ptr Struct12_t
           offset# = \_ -> \_ -> 8
-instance HasField "struct12_t_self"
-                  (Ptr Struct12_t)
-                  (Ptr (Ptr Struct12_t))
+instance TyEq ty (Ptr Struct12_t) =>
+         HasField "struct12_t_self" (Ptr Struct12_t) (Ptr ty)
     where getField = fromPtr (Proxy @"struct12_t_self")
 {-| __C declaration:__ @struct use_sites@
 
@@ -641,143 +642,127 @@ instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct1_t" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance HasField "use_sites_useTypedef_struct1_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct1_t)
+instance TyEq ty Struct1_t =>
+         HasField "use_sites_useTypedef_struct1_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct1_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct2_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct2_t" = Struct2_t
           offset# = \_ -> \_ -> 0
-instance HasField "use_sites_useTypedef_struct2_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct2_t)
+instance TyEq ty Struct2_t =>
+         HasField "use_sites_useTypedef_struct2_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct2_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct3_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct3_t" = Ptr Struct3_t
           offset# = \_ -> \_ -> 0
-instance HasField "use_sites_useTypedef_struct3_t"
-                  (Ptr Use_sites)
-                  (Ptr (Ptr Struct3_t))
+instance TyEq ty (Ptr Struct3_t) =>
+         HasField "use_sites_useTypedef_struct3_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct3_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct4_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct4_t" = Ptr Struct4_t
           offset# = \_ -> \_ -> 8
-instance HasField "use_sites_useTypedef_struct4_t"
-                  (Ptr Use_sites)
-                  (Ptr (Ptr Struct4_t))
+instance TyEq ty (Ptr Struct4_t) =>
+         HasField "use_sites_useTypedef_struct4_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct4_t")
 instance HasCField Use_sites "use_sites_useStruct_struct5"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct5" = Struct5
           offset# = \_ -> \_ -> 16
-instance HasField "use_sites_useStruct_struct5"
-                  (Ptr Use_sites)
-                  (Ptr Struct5)
+instance TyEq ty Struct5 =>
+         HasField "use_sites_useStruct_struct5" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct5")
 instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct5_t" = Struct5_t
           offset# = \_ -> \_ -> 16
-instance HasField "use_sites_useTypedef_struct5_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct5_t)
+instance TyEq ty Struct5_t =>
+         HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
 instance HasCField Use_sites "use_sites_useStruct_struct6"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct6" = Struct6_Aux
           offset# = \_ -> \_ -> 24
-instance HasField "use_sites_useStruct_struct6"
-                  (Ptr Use_sites)
-                  (Ptr Struct6_Aux)
+instance TyEq ty Struct6_Aux =>
+         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct6"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct6" = Struct6
           offset# = \_ -> \_ -> 24
-instance HasField "use_sites_useTypedef_struct6"
-                  (Ptr Use_sites)
-                  (Ptr Struct6)
+instance TyEq ty Struct6 =>
+         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct7a"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7a" = Struct7a
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct7a"
-                  (Ptr Use_sites)
-                  (Ptr Struct7a)
+instance TyEq ty Struct7a =>
+         HasField "use_sites_useTypedef_struct7a" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7a")
 instance HasCField Use_sites "use_sites_useTypedef_struct7b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7b" = Struct7b
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct7b"
-                  (Ptr Use_sites)
-                  (Ptr Struct7b)
+instance TyEq ty Struct7b =>
+         HasField "use_sites_useTypedef_struct7b" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7b")
 instance HasCField Use_sites "use_sites_useTypedef_struct8"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8" = Struct8
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct8"
-                  (Ptr Use_sites)
-                  (Ptr Struct8)
+instance TyEq ty Struct8 =>
+         HasField "use_sites_useTypedef_struct8" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8")
 instance HasCField Use_sites "use_sites_useTypedef_struct8b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8b" = Struct8b
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct8b"
-                  (Ptr Use_sites)
-                  (Ptr Struct8b)
+instance TyEq ty Struct8b =>
+         HasField "use_sites_useTypedef_struct8b" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8b")
 instance HasCField Use_sites "use_sites_useTypedef_struct9"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9" = Struct9
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct9"
-                  (Ptr Use_sites)
-                  (Ptr Struct9)
+instance TyEq ty Struct9 =>
+         HasField "use_sites_useTypedef_struct9" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9")
 instance HasCField Use_sites "use_sites_useTypedef_struct9_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9_t" = Struct9_t
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct9_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct9_t)
+instance TyEq ty Struct9_t =>
+         HasField "use_sites_useTypedef_struct9_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t" = Struct10_t
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct10_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct10_t)
+instance TyEq ty Struct10_t =>
+         HasField "use_sites_useTypedef_struct10_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t_t" = Struct10_t_t
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct10_t_t"
+instance TyEq ty Struct10_t_t =>
+         HasField "use_sites_useTypedef_struct10_t_t"
                   (Ptr Use_sites)
-                  (Ptr Struct10_t_t)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct11_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct11_t" = Struct11_t
           offset# = \_ -> \_ -> 32
-instance HasField "use_sites_useTypedef_struct11_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct11_t)
+instance TyEq ty Struct11_t =>
+         HasField "use_sites_useTypedef_struct11_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct11_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct12_t" = Struct12_t
           offset# = \_ -> \_ -> 48
-instance HasField "use_sites_useTypedef_struct12_t"
-                  (Ptr Use_sites)
-                  (Ptr Struct12_t)
+instance TyEq ty Struct12_t =>
+         HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -21,6 +23,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct complex_object_t@
@@ -92,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "complex_object_t_velocity" (Ptr.Ptr Complex_object_t) (Ptr.Ptr (Data.Complex.Complex FC.CFloat)) where
+instance ( TyEq ty (Data.Complex.Complex FC.CFloat)
+         ) => GHC.Records.HasField "complex_object_t_velocity" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_velocity")
@@ -104,7 +108,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "complex_object_t_position" (Ptr.Ptr Complex_object_t) (Ptr.Ptr (Data.Complex.Complex FC.CDouble)) where
+instance ( TyEq ty (Data.Complex.Complex FC.CDouble)
+         ) => GHC.Records.HasField "complex_object_t_position" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_position")
@@ -116,7 +121,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Complex_object_t "complex_object_
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "complex_object_t_id" (Ptr.Ptr Complex_object_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "complex_object_t_id" (Ptr.Ptr Complex_object_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"complex_object_t_id")

--- a/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/hsb_complex_test/th.txt
@@ -185,24 +185,25 @@ instance HasCField Complex_object_t "complex_object_t_velocity"
     where type CFieldType Complex_object_t
                           "complex_object_t_velocity" = Complex CFloat
           offset# = \_ -> \_ -> 0
-instance HasField "complex_object_t_velocity"
+instance TyEq ty (Complex CFloat) =>
+         HasField "complex_object_t_velocity"
                   (Ptr Complex_object_t)
-                  (Ptr (Complex CFloat))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"complex_object_t_velocity")
 instance HasCField Complex_object_t "complex_object_t_position"
     where type CFieldType Complex_object_t
                           "complex_object_t_position" = Complex CDouble
           offset# = \_ -> \_ -> 8
-instance HasField "complex_object_t_position"
+instance TyEq ty (Complex CDouble) =>
+         HasField "complex_object_t_position"
                   (Ptr Complex_object_t)
-                  (Ptr (Complex CDouble))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"complex_object_t_position")
 instance HasCField Complex_object_t "complex_object_t_id"
     where type CFieldType Complex_object_t "complex_object_t_id" = CInt
           offset# = \_ -> \_ -> 24
-instance HasField "complex_object_t_id"
-                  (Ptr Complex_object_t)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "complex_object_t_id" (Ptr Complex_object_t) (Ptr ty)
     where getField = fromPtr (Proxy @"complex_object_t_id")
 -- __unique:__ @test_typescomplexhsb_complex_test_Example_Safe_multiply_complex_f@
 foreign import ccall safe "hs_bindgen_687af703c95fba0e" hs_bindgen_687af703c95fba0e_base ::

--- a/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/fixtures/types/complex/vector_test/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct vector@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector "vector_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "vector_x" (Ptr.Ptr Vector) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "vector_x" (Ptr.Ptr Vector) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_x")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Vector "vector_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "vector_y" (Ptr.Ptr Vector) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "vector_y" (Ptr.Ptr Vector) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"vector_y")

--- a/hs-bindgen/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/fixtures/types/complex/vector_test/th.txt
@@ -64,12 +64,14 @@ deriving via (EquivStorable Vector) instance Storable Vector
 instance HasCField Vector "vector_x"
     where type CFieldType Vector "vector_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "vector_x" (Ptr Vector) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "vector_x" (Ptr Vector) (Ptr ty)
     where getField = fromPtr (Proxy @"vector_x")
 instance HasCField Vector "vector_y"
     where type CFieldType Vector "vector_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance HasField "vector_y" (Ptr Vector) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "vector_y" (Ptr Vector) (Ptr ty)
     where getField = fromPtr (Proxy @"vector_y")
 -- __unique:__ @test_typescomplexvector_test_Example_Safe_new_vector@
 foreign import ccall safe "hs_bindgen_cd5f566bc96dcba0" hs_bindgen_cd5f566bc96dcba0_base ::

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum foo_enum@
@@ -111,7 +114,8 @@ instance Read Foo_enum where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapFoo_enum" (Ptr.Ptr Foo_enum) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapFoo_enum" (Ptr.Ptr Foo_enum) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFoo_enum")

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -48,9 +48,8 @@ instance Read Foo_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapFoo_enum"
-                  (Ptr Foo_enum)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapFoo_enum" (Ptr Foo_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo_enum")
 instance HasCField Foo_enum "unwrapFoo_enum"
     where type CFieldType Foo_enum

--- a/hs-bindgen/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enums/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum first@
@@ -110,7 +113,8 @@ instance Read First where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapFirst" (Ptr.Ptr First) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapFirst" (Ptr.Ptr First) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFirst")
@@ -220,7 +224,8 @@ instance Read Second where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapSecond" (Ptr.Ptr Second) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapSecond" (Ptr.Ptr Second) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSecond")
@@ -336,7 +341,8 @@ instance Read Same where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapSame" (Ptr.Ptr Same) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapSame" (Ptr.Ptr Same) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapSame")
@@ -436,7 +442,8 @@ instance Read Nonseq where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapNonseq" (Ptr.Ptr Nonseq) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapNonseq" (Ptr.Ptr Nonseq) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapNonseq")
@@ -555,7 +562,8 @@ instance Read Packed where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapPacked" (Ptr.Ptr Packed) (Ptr.Ptr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "unwrapPacked" (Ptr.Ptr Packed) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPacked")
@@ -673,7 +681,8 @@ instance Read EnumA where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumA")
@@ -782,7 +791,8 @@ instance Read EnumB where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapEnumB" (Ptr.Ptr EnumB) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapEnumB" (Ptr.Ptr EnumB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumB")
@@ -891,7 +901,8 @@ instance Read EnumC where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapEnumC" (Ptr.Ptr EnumC) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapEnumC" (Ptr.Ptr EnumC) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumC")
@@ -1000,7 +1011,8 @@ instance Read EnumD_t where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapEnumD_t" (Ptr.Ptr EnumD_t) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapEnumD_t" (Ptr.Ptr EnumD_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumD_t")

--- a/hs-bindgen/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enums/th.txt
@@ -45,7 +45,8 @@ instance Read First
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapFirst" (Ptr First) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapFirst" (Ptr First) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFirst")
 instance HasCField First "unwrapFirst"
     where type CFieldType First "unwrapFirst" = CUInt
@@ -125,7 +126,8 @@ instance Read Second
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapSecond" (Ptr Second) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapSecond" (Ptr Second) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSecond")
 instance HasCField Second "unwrapSecond"
     where type CFieldType Second "unwrapSecond" = CInt
@@ -217,7 +219,7 @@ instance Read Same
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapSame" (Ptr Same) (Ptr CUInt)
+instance TyEq ty CUInt => HasField "unwrapSame" (Ptr Same) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSame")
 instance HasCField Same "unwrapSame"
     where type CFieldType Same "unwrapSame" = CUInt
@@ -292,7 +294,8 @@ instance Read Nonseq
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapNonseq" (Ptr Nonseq) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapNonseq" (Ptr Nonseq) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapNonseq")
 instance HasCField Nonseq "unwrapNonseq"
     where type CFieldType Nonseq "unwrapNonseq" = CUInt
@@ -386,7 +389,8 @@ instance Read Packed
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapPacked" (Ptr Packed) (Ptr CUChar)
+instance TyEq ty CUChar =>
+         HasField "unwrapPacked" (Ptr Packed) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPacked")
 instance HasCField Packed "unwrapPacked"
     where type CFieldType Packed "unwrapPacked" = CUChar
@@ -479,7 +483,8 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -558,7 +563,8 @@ instance Read EnumB
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapEnumB" (Ptr EnumB) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapEnumB" (Ptr EnumB) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumB")
 instance HasCField EnumB "unwrapEnumB"
     where type CFieldType EnumB "unwrapEnumB" = CUInt
@@ -637,7 +643,8 @@ instance Read EnumC
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapEnumC" (Ptr EnumC) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapEnumC" (Ptr EnumC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumC")
 instance HasCField EnumC "unwrapEnumC"
     where type CFieldType EnumC "unwrapEnumC" = CUInt
@@ -716,7 +723,8 @@ instance Read EnumD_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumD_t")
 instance HasCField EnumD_t "unwrapEnumD_t"
     where type CFieldType EnumD_t "unwrapEnumD_t" = CUInt

--- a/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Ord, Read, Show, pure, showsPrec)
 
 {-| __C declaration:__ @enum enumA@
@@ -110,7 +113,8 @@ instance Read EnumA where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapEnumA" (Ptr.Ptr EnumA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapEnumA")
@@ -186,7 +190,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr EnumA) where
+instance ( TyEq ty EnumA
+         ) => GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exA_fieldA1")
@@ -271,7 +276,8 @@ instance Read ExB_fieldB1 where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapExB_fieldB1" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapExB_fieldB1" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapExB_fieldB1")
@@ -348,7 +354,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ExB_fieldB1) where
+instance ( TyEq ty ExB_fieldB1
+         ) => GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
@@ -45,7 +45,8 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -111,7 +112,7 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = EnumA
           offset# = \_ -> \_ -> 0
-instance HasField "exA_fieldA1" (Ptr ExA) (Ptr EnumA)
+instance TyEq ty EnumA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @enum \@exB_fieldB1@
 
@@ -159,7 +160,8 @@ instance Read ExB_fieldB1
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapExB_fieldB1")
 instance HasCField ExB_fieldB1 "unwrapExB_fieldB1"
     where type CFieldType ExB_fieldB1 "unwrapExB_fieldB1" = CUInt
@@ -225,5 +227,6 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
+instance TyEq ty ExB_fieldB1 =>
+         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/fixtures/types/nested/nested_types/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "foo_i" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_i")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "foo_c" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_c")
@@ -150,7 +155,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_foo1" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bar_foo1" (Ptr.Ptr Bar) (Ptr.Ptr Foo) where
+instance ( TyEq ty Foo
+         ) => GHC.Records.HasField "bar_foo1" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_foo1")
@@ -161,7 +167,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bar "bar_foo2" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "bar_foo2" (Ptr.Ptr Bar) (Ptr.Ptr Foo) where
+instance ( TyEq ty Foo
+         ) => GHC.Records.HasField "bar_foo2" (Ptr.Ptr Bar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bar_foo2")
@@ -223,7 +230,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "ex3_ex3_struct_ex3_a" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "ex3_ex3_struct_ex3_a" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct_ex3_a")
@@ -235,7 +243,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "ex3_ex3_struct_ex3_b" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "ex3_ex3_struct_ex3_b" (Ptr.Ptr Ex3_ex3_struct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct_ex3_b")
@@ -296,7 +305,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3 "ex3_ex3_struct" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "ex3_ex3_struct" (Ptr.Ptr Ex3) (Ptr.Ptr Ex3_ex3_struct) where
+instance ( TyEq ty Ex3_ex3_struct
+         ) => GHC.Records.HasField "ex3_ex3_struct" (Ptr.Ptr Ex3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_struct")
@@ -307,7 +317,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex3 "ex3_ex3_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "ex3_ex3_c" (Ptr.Ptr Ex3) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "ex3_ex3_c" (Ptr.Ptr Ex3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex3_ex3_c")
@@ -368,7 +379,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_odd "ex4_odd_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "ex4_odd_value" (Ptr.Ptr Ex4_odd) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "ex4_odd_value" (Ptr.Ptr Ex4_odd) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_odd_value")
@@ -380,7 +392,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_odd "ex4_odd_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "ex4_odd_next" (Ptr.Ptr Ex4_odd) (Ptr.Ptr (Ptr.Ptr Ex4_even)) where
+instance ( TyEq ty (Ptr.Ptr Ex4_even)
+         ) => GHC.Records.HasField "ex4_odd_next" (Ptr.Ptr Ex4_odd) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_odd_next")
@@ -442,7 +455,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_even "ex4_even_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "ex4_even_value" (Ptr.Ptr Ex4_even) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "ex4_even_value" (Ptr.Ptr Ex4_even) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_even_value")
@@ -454,7 +468,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Ex4_even "ex4_even_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "ex4_even_next" (Ptr.Ptr Ex4_even) (Ptr.Ptr (Ptr.Ptr Ex4_odd)) where
+instance ( TyEq ty (Ptr.Ptr Ex4_odd)
+         ) => GHC.Records.HasField "ex4_even_next" (Ptr.Ptr Ex4_even) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"ex4_even_next")

--- a/hs-bindgen/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/fixtures/types/nested/nested_types/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
+instance TyEq ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_i")
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 4
-instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
+instance TyEq ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_c")
 {-| __C declaration:__ @struct bar@
 
@@ -88,12 +88,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_foo1"
     where type CFieldType Bar "bar_foo1" = Foo
           offset# = \_ -> \_ -> 0
-instance HasField "bar_foo1" (Ptr Bar) (Ptr Foo)
+instance TyEq ty Foo => HasField "bar_foo1" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_foo1")
 instance HasCField Bar "bar_foo2"
     where type CFieldType Bar "bar_foo2" = Foo
           offset# = \_ -> \_ -> 8
-instance HasField "bar_foo2" (Ptr Bar) (Ptr Foo)
+instance TyEq ty Foo => HasField "bar_foo2" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"bar_foo2")
 {-| __C declaration:__ @struct \@ex3_ex3_struct@
 
@@ -136,16 +136,14 @@ deriving via (EquivStorable Ex3_ex3_struct) instance Storable Ex3_ex3_struct
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "ex3_ex3_struct_ex3_a"
-                  (Ptr Ex3_ex3_struct)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "ex3_ex3_struct_ex3_a" (Ptr Ex3_ex3_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_a")
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" = CChar
           offset# = \_ -> \_ -> 4
-instance HasField "ex3_ex3_struct_ex3_b"
-                  (Ptr Ex3_ex3_struct)
-                  (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "ex3_ex3_struct_ex3_b" (Ptr Ex3_ex3_struct) (Ptr ty)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_b")
 {-| __C declaration:__ @struct ex3@
 
@@ -188,12 +186,13 @@ deriving via (EquivStorable Ex3) instance Storable Ex3
 instance HasCField Ex3 "ex3_ex3_struct"
     where type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
           offset# = \_ -> \_ -> 0
-instance HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr Ex3_ex3_struct)
+instance TyEq ty Ex3_ex3_struct =>
+         HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr ty)
     where getField = fromPtr (Proxy @"ex3_ex3_struct")
 instance HasCField Ex3 "ex3_ex3_c"
     where type CFieldType Ex3 "ex3_ex3_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance HasField "ex3_ex3_c" (Ptr Ex3) (Ptr CFloat)
+instance TyEq ty CFloat => HasField "ex3_ex3_c" (Ptr Ex3) (Ptr ty)
     where getField = fromPtr (Proxy @"ex3_ex3_c")
 {-| __C declaration:__ @struct ex4_odd@
 
@@ -236,12 +235,14 @@ deriving via (EquivStorable Ex4_odd) instance Storable Ex4_odd
 instance HasCField Ex4_odd "ex4_odd_value"
     where type CFieldType Ex4_odd "ex4_odd_value" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr ty)
     where getField = fromPtr (Proxy @"ex4_odd_value")
 instance HasCField Ex4_odd "ex4_odd_next"
     where type CFieldType Ex4_odd "ex4_odd_next" = Ptr Ex4_even
           offset# = \_ -> \_ -> 8
-instance HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr (Ptr Ex4_even))
+instance TyEq ty (Ptr Ex4_even) =>
+         HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr ty)
     where getField = fromPtr (Proxy @"ex4_odd_next")
 {-| __C declaration:__ @struct ex4_even@
 
@@ -284,12 +285,12 @@ deriving via (EquivStorable Ex4_even) instance Storable Ex4_even
 instance HasCField Ex4_even "ex4_even_value"
     where type CFieldType Ex4_even "ex4_even_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "ex4_even_value" (Ptr Ex4_even) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "ex4_even_value" (Ptr Ex4_even) (Ptr ty)
     where getField = fromPtr (Proxy @"ex4_even_value")
 instance HasCField Ex4_even "ex4_even_next"
     where type CFieldType Ex4_even "ex4_even_next" = Ptr Ex4_odd
           offset# = \_ -> \_ -> 8
-instance HasField "ex4_even_next"
-                  (Ptr Ex4_even)
-                  (Ptr (Ptr Ex4_odd))
+instance TyEq ty (Ptr Ex4_odd) =>
+         HasField "ex4_even_next" (Ptr Ex4_even) (Ptr ty)
     where getField = fromPtr (Proxy @"ex4_even_next")

--- a/hs-bindgen/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/bool/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @struct bools1@
@@ -86,7 +89,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools1 "bools1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bools1_x" (Ptr.Ptr Bools1) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "bools1_x" (Ptr.Ptr Bools1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools1_x")
@@ -97,7 +101,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools1 "bools1_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bools1_y" (Ptr.Ptr Bools1) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "bools1_y" (Ptr.Ptr Bools1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools1_y")
@@ -158,7 +163,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools2 "bools2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bools2_x" (Ptr.Ptr Bools2) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "bools2_x" (Ptr.Ptr Bools2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools2_x")
@@ -169,7 +175,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools2 "bools2_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bools2_y" (Ptr.Ptr Bools2) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "bools2_y" (Ptr.Ptr Bools2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools2_y")
@@ -202,7 +209,8 @@ newtype BOOL = BOOL
     , Real
     )
 
-instance GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "unwrapBOOL" (Ptr.Ptr BOOL) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapBOOL")
@@ -269,7 +277,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools3 "bools3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "bools3_x" (Ptr.Ptr Bools3) (Ptr.Ptr BOOL) where
+instance ( TyEq ty BOOL
+         ) => GHC.Records.HasField "bools3_x" (Ptr.Ptr Bools3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools3_x")
@@ -280,7 +289,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Bools3 "bools3_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "bools3_y" (Ptr.Ptr Bools3) (Ptr.Ptr BOOL) where
+instance ( TyEq ty BOOL
+         ) => GHC.Records.HasField "bools3_y" (Ptr.Ptr Bools3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"bools3_y")

--- a/hs-bindgen/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/bool/th.txt
@@ -41,12 +41,12 @@ deriving via (EquivStorable Bools1) instance Storable Bools1
 instance HasCField Bools1 "bools1_x"
     where type CFieldType Bools1 "bools1_x" = CBool
           offset# = \_ -> \_ -> 0
-instance HasField "bools1_x" (Ptr Bools1) (Ptr CBool)
+instance TyEq ty CBool => HasField "bools1_x" (Ptr Bools1) (Ptr ty)
     where getField = fromPtr (Proxy @"bools1_x")
 instance HasCField Bools1 "bools1_y"
     where type CFieldType Bools1 "bools1_y" = CBool
           offset# = \_ -> \_ -> 1
-instance HasField "bools1_y" (Ptr Bools1) (Ptr CBool)
+instance TyEq ty CBool => HasField "bools1_y" (Ptr Bools1) (Ptr ty)
     where getField = fromPtr (Proxy @"bools1_y")
 {-| __C declaration:__ @struct bools2@
 
@@ -89,12 +89,12 @@ deriving via (EquivStorable Bools2) instance Storable Bools2
 instance HasCField Bools2 "bools2_x"
     where type CFieldType Bools2 "bools2_x" = CBool
           offset# = \_ -> \_ -> 0
-instance HasField "bools2_x" (Ptr Bools2) (Ptr CBool)
+instance TyEq ty CBool => HasField "bools2_x" (Ptr Bools2) (Ptr ty)
     where getField = fromPtr (Proxy @"bools2_x")
 instance HasCField Bools2 "bools2_y"
     where type CFieldType Bools2 "bools2_y" = CBool
           offset# = \_ -> \_ -> 1
-instance HasField "bools2_y" (Ptr Bools2) (Ptr CBool)
+instance TyEq ty CBool => HasField "bools2_y" (Ptr Bools2) (Ptr ty)
     where getField = fromPtr (Proxy @"bools2_y")
 {-| __C declaration:__ @BOOL@
 
@@ -126,7 +126,7 @@ newtype BOOL
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
+instance TyEq ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -172,10 +172,10 @@ deriving via (EquivStorable Bools3) instance Storable Bools3
 instance HasCField Bools3 "bools3_x"
     where type CFieldType Bools3 "bools3_x" = BOOL
           offset# = \_ -> \_ -> 0
-instance HasField "bools3_x" (Ptr Bools3) (Ptr BOOL)
+instance TyEq ty BOOL => HasField "bools3_x" (Ptr Bools3) (Ptr ty)
     where getField = fromPtr (Proxy @"bools3_x")
 instance HasCField Bools3 "bools3_y"
     where type CFieldType Bools3 "bools3_y" = BOOL
           offset# = \_ -> \_ -> 1
-instance HasField "bools3_y" (Ptr Bools3) (Ptr BOOL)
+instance TyEq ty BOOL => HasField "bools3_y" (Ptr Bools3) (Ptr ty)
     where getField = fromPtr (Proxy @"bools3_y")

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct foo@
@@ -79,7 +82,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word64
+         ) => GHC.Records.HasField "foo_sixty_four" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_sixty_four")
@@ -91,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "foo_thirty_two" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/fixedwidth/th.txt
@@ -44,15 +44,13 @@ instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo
                           "foo_sixty_four" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance HasField "foo_sixty_four"
-                  (Ptr Foo)
-                  (Ptr HsBindgen.Runtime.LibC.Word64)
+instance TyEq ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo
                           "foo_thirty_two" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 8
-instance HasField "foo_thirty_two"
-                  (Ptr Foo)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_thirty_two")

--- a/hs-bindgen/fixtures/types/primitives/least_fast/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/least_fast/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,6 +28,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @int_fast16_t@
@@ -56,7 +59,8 @@ newtype Int_fast16_t = Int_fast16_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_fast16_t" (Ptr.Ptr Int_fast16_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "unwrapInt_fast16_t" (Ptr.Ptr Int_fast16_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_fast16_t")
@@ -96,7 +100,8 @@ newtype Int_fast32_t = Int_fast32_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_fast32_t" (Ptr.Ptr Int_fast32_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "unwrapInt_fast32_t" (Ptr.Ptr Int_fast32_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_fast32_t")
@@ -136,7 +141,8 @@ newtype Uint_fast16_t = Uint_fast16_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_fast16_t" (Ptr.Ptr Uint_fast16_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapUint_fast16_t" (Ptr.Ptr Uint_fast16_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_fast16_t")
@@ -176,7 +182,8 @@ newtype Uint_fast32_t = Uint_fast32_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_fast32_t" (Ptr.Ptr Uint_fast32_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapUint_fast32_t" (Ptr.Ptr Uint_fast32_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_fast32_t")
@@ -216,7 +223,8 @@ newtype Int_fast8_t = Int_fast8_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_fast8_t" (Ptr.Ptr Int_fast8_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int8
+         ) => GHC.Records.HasField "unwrapInt_fast8_t" (Ptr.Ptr Int_fast8_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_fast8_t")
@@ -256,7 +264,8 @@ newtype Int_fast64_t = Int_fast64_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_fast64_t" (Ptr.Ptr Int_fast64_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int64
+         ) => GHC.Records.HasField "unwrapInt_fast64_t" (Ptr.Ptr Int_fast64_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_fast64_t")
@@ -296,7 +305,8 @@ newtype Int_least8_t = Int_least8_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_least8_t" (Ptr.Ptr Int_least8_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int8
+         ) => GHC.Records.HasField "unwrapInt_least8_t" (Ptr.Ptr Int_least8_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_least8_t")
@@ -336,7 +346,8 @@ newtype Int_least16_t = Int_least16_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_least16_t" (Ptr.Ptr Int_least16_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int16
+         ) => GHC.Records.HasField "unwrapInt_least16_t" (Ptr.Ptr Int_least16_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_least16_t")
@@ -376,7 +387,8 @@ newtype Int_least32_t = Int_least32_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_least32_t" (Ptr.Ptr Int_least32_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "unwrapInt_least32_t" (Ptr.Ptr Int_least32_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_least32_t")
@@ -416,7 +428,8 @@ newtype Int_least64_t = Int_least64_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapInt_least64_t" (Ptr.Ptr Int_least64_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int64
+         ) => GHC.Records.HasField "unwrapInt_least64_t" (Ptr.Ptr Int_least64_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt_least64_t")
@@ -456,7 +469,8 @@ newtype Uint_fast8_t = Uint_fast8_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_fast8_t" (Ptr.Ptr Uint_fast8_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "unwrapUint_fast8_t" (Ptr.Ptr Uint_fast8_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_fast8_t")
@@ -496,7 +510,8 @@ newtype Uint_fast64_t = Uint_fast64_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_fast64_t" (Ptr.Ptr Uint_fast64_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word64
+         ) => GHC.Records.HasField "unwrapUint_fast64_t" (Ptr.Ptr Uint_fast64_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_fast64_t")
@@ -536,7 +551,8 @@ newtype Uint_least8_t = Uint_least8_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_least8_t" (Ptr.Ptr Uint_least8_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "unwrapUint_least8_t" (Ptr.Ptr Uint_least8_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_least8_t")
@@ -576,7 +592,8 @@ newtype Uint_least16_t = Uint_least16_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_least16_t" (Ptr.Ptr Uint_least16_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "unwrapUint_least16_t" (Ptr.Ptr Uint_least16_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_least16_t")
@@ -616,7 +633,8 @@ newtype Uint_least32_t = Uint_least32_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_least32_t" (Ptr.Ptr Uint_least32_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapUint_least32_t" (Ptr.Ptr Uint_least32_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_least32_t")
@@ -656,7 +674,8 @@ newtype Uint_least64_t = Uint_least64_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint_least64_t" (Ptr.Ptr Uint_least64_t) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word64
+         ) => GHC.Records.HasField "unwrapUint_least64_t" (Ptr.Ptr Uint_least64_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint_least64_t")

--- a/hs-bindgen/fixtures/types/primitives/least_fast/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/least_fast/th.txt
@@ -257,9 +257,8 @@ newtype Int_fast16_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_fast16_t"
-                  (Ptr Int_fast16_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_fast16_t" (Ptr Int_fast16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast16_t")
 instance HasCField Int_fast16_t "unwrapInt_fast16_t"
     where type CFieldType Int_fast16_t
@@ -295,9 +294,8 @@ newtype Int_fast32_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_fast32_t"
-                  (Ptr Int_fast32_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_fast32_t" (Ptr Int_fast32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast32_t")
 instance HasCField Int_fast32_t "unwrapInt_fast32_t"
     where type CFieldType Int_fast32_t
@@ -333,9 +331,8 @@ newtype Uint_fast16_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_fast16_t"
-                  (Ptr Uint_fast16_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_fast16_t" (Ptr Uint_fast16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast16_t")
 instance HasCField Uint_fast16_t "unwrapUint_fast16_t"
     where type CFieldType Uint_fast16_t
@@ -371,9 +368,8 @@ newtype Uint_fast32_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_fast32_t"
-                  (Ptr Uint_fast32_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_fast32_t" (Ptr Uint_fast32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast32_t")
 instance HasCField Uint_fast32_t "unwrapUint_fast32_t"
     where type CFieldType Uint_fast32_t
@@ -409,9 +405,8 @@ newtype Int_fast8_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_fast8_t"
-                  (Ptr Int_fast8_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int8)
+instance TyEq ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapInt_fast8_t" (Ptr Int_fast8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast8_t")
 instance HasCField Int_fast8_t "unwrapInt_fast8_t"
     where type CFieldType Int_fast8_t
@@ -447,9 +442,8 @@ newtype Int_fast64_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_fast64_t"
-                  (Ptr Int_fast64_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int64)
+instance TyEq ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapInt_fast64_t" (Ptr Int_fast64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast64_t")
 instance HasCField Int_fast64_t "unwrapInt_fast64_t"
     where type CFieldType Int_fast64_t
@@ -485,9 +479,8 @@ newtype Int_least8_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_least8_t"
-                  (Ptr Int_least8_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int8)
+instance TyEq ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapInt_least8_t" (Ptr Int_least8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least8_t")
 instance HasCField Int_least8_t "unwrapInt_least8_t"
     where type CFieldType Int_least8_t
@@ -523,9 +516,8 @@ newtype Int_least16_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_least16_t"
-                  (Ptr Int_least16_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int16)
+instance TyEq ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapInt_least16_t" (Ptr Int_least16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least16_t")
 instance HasCField Int_least16_t "unwrapInt_least16_t"
     where type CFieldType Int_least16_t
@@ -561,9 +553,8 @@ newtype Int_least32_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_least32_t"
-                  (Ptr Int_least32_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_least32_t" (Ptr Int_least32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least32_t")
 instance HasCField Int_least32_t "unwrapInt_least32_t"
     where type CFieldType Int_least32_t
@@ -599,9 +590,8 @@ newtype Int_least64_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapInt_least64_t"
-                  (Ptr Int_least64_t)
-                  (Ptr HsBindgen.Runtime.LibC.Int64)
+instance TyEq ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapInt_least64_t" (Ptr Int_least64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least64_t")
 instance HasCField Int_least64_t "unwrapInt_least64_t"
     where type CFieldType Int_least64_t
@@ -637,9 +627,8 @@ newtype Uint_fast8_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_fast8_t"
-                  (Ptr Uint_fast8_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapUint_fast8_t" (Ptr Uint_fast8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast8_t")
 instance HasCField Uint_fast8_t "unwrapUint_fast8_t"
     where type CFieldType Uint_fast8_t
@@ -675,9 +664,8 @@ newtype Uint_fast64_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_fast64_t"
-                  (Ptr Uint_fast64_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word64)
+instance TyEq ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapUint_fast64_t" (Ptr Uint_fast64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast64_t")
 instance HasCField Uint_fast64_t "unwrapUint_fast64_t"
     where type CFieldType Uint_fast64_t
@@ -713,9 +701,8 @@ newtype Uint_least8_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_least8_t"
-                  (Ptr Uint_least8_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapUint_least8_t" (Ptr Uint_least8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least8_t")
 instance HasCField Uint_least8_t "unwrapUint_least8_t"
     where type CFieldType Uint_least8_t
@@ -751,9 +738,8 @@ newtype Uint_least16_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_least16_t"
-                  (Ptr Uint_least16_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapUint_least16_t" (Ptr Uint_least16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least16_t")
 instance HasCField Uint_least16_t "unwrapUint_least16_t"
     where type CFieldType Uint_least16_t
@@ -789,9 +775,8 @@ newtype Uint_least32_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_least32_t"
-                  (Ptr Uint_least32_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_least32_t" (Ptr Uint_least32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least32_t")
 instance HasCField Uint_least32_t "unwrapUint_least32_t"
     where type CFieldType Uint_least32_t
@@ -827,9 +812,8 @@ newtype Uint_least64_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint_least64_t"
-                  (Ptr Uint_least64_t)
-                  (Ptr HsBindgen.Runtime.LibC.Word64)
+instance TyEq ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapUint_least64_t" (Ptr Uint_least64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least64_t")
 instance HasCField Uint_least64_t "unwrapUint_least64_t"
     where type CFieldType Uint_least64_t

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/Example.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -27,6 +29,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.LibC
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, Floating, Fractional, Integral, Num, Ord, Read, Real, RealFloat, RealFrac, Show)
 
 {-| __C declaration:__ @prim_HsPrimCPtrdiff@
@@ -57,7 +60,8 @@ newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCPtrdiff" (Ptr.Ptr Prim_HsPrimCPtrdiff) (Ptr.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.CPtrdiff
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCPtrdiff" (Ptr.Ptr Prim_HsPrimCPtrdiff) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCPtrdiff")
@@ -97,7 +101,8 @@ newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimInt8" (Ptr.Ptr Prim_HsPrimInt8) (Ptr.Ptr HsBindgen.Runtime.LibC.Int8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int8
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt8" (Ptr.Ptr Prim_HsPrimInt8) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt8")
@@ -137,7 +142,8 @@ newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimInt16" (Ptr.Ptr Prim_HsPrimInt16) (Ptr.Ptr HsBindgen.Runtime.LibC.Int16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int16
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt16" (Ptr.Ptr Prim_HsPrimInt16) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt16")
@@ -177,7 +183,8 @@ newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimInt32" (Ptr.Ptr Prim_HsPrimInt32) (Ptr.Ptr HsBindgen.Runtime.LibC.Int32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int32
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt32" (Ptr.Ptr Prim_HsPrimInt32) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt32")
@@ -217,7 +224,8 @@ newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimInt64" (Ptr.Ptr Prim_HsPrimInt64) (Ptr.Ptr HsBindgen.Runtime.LibC.Int64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Int64
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimInt64" (Ptr.Ptr Prim_HsPrimInt64) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimInt64")
@@ -257,7 +265,8 @@ newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimWord8" (Ptr.Ptr Prim_HsPrimWord8) (Ptr.Ptr HsBindgen.Runtime.LibC.Word8) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word8
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord8" (Ptr.Ptr Prim_HsPrimWord8) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord8")
@@ -297,7 +306,8 @@ newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimWord16" (Ptr.Ptr Prim_HsPrimWord16) (Ptr.Ptr HsBindgen.Runtime.LibC.Word16) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word16
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord16" (Ptr.Ptr Prim_HsPrimWord16) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord16")
@@ -337,7 +347,8 @@ newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimWord32" (Ptr.Ptr Prim_HsPrimWord32) (Ptr.Ptr HsBindgen.Runtime.LibC.Word32) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word32
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord32" (Ptr.Ptr Prim_HsPrimWord32) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord32")
@@ -377,7 +388,8 @@ newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimWord64" (Ptr.Ptr Prim_HsPrimWord64) (Ptr.Ptr HsBindgen.Runtime.LibC.Word64) where
+instance ( TyEq ty HsBindgen.Runtime.LibC.Word64
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimWord64" (Ptr.Ptr Prim_HsPrimWord64) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimWord64")
@@ -417,7 +429,8 @@ newtype Prim_HsPrimCChar = Prim_HsPrimCChar
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCChar" (Ptr.Ptr Prim_HsPrimCChar) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCChar" (Ptr.Ptr Prim_HsPrimCChar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCChar")
@@ -457,7 +470,8 @@ newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCSChar" (Ptr.Ptr Prim_HsPrimCSChar) (Ptr.Ptr FC.CSChar) where
+instance ( TyEq ty FC.CSChar
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCSChar" (Ptr.Ptr Prim_HsPrimCSChar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCSChar")
@@ -497,7 +511,8 @@ newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCUChar" (Ptr.Ptr Prim_HsPrimCUChar) (Ptr.Ptr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUChar" (Ptr.Ptr Prim_HsPrimCUChar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUChar")
@@ -537,7 +552,8 @@ newtype Prim_HsPrimCShort = Prim_HsPrimCShort
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCShort" (Ptr.Ptr Prim_HsPrimCShort) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCShort" (Ptr.Ptr Prim_HsPrimCShort) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCShort")
@@ -577,7 +593,8 @@ newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCUShort" (Ptr.Ptr Prim_HsPrimCUShort) (Ptr.Ptr FC.CUShort) where
+instance ( TyEq ty FC.CUShort
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUShort" (Ptr.Ptr Prim_HsPrimCUShort) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUShort")
@@ -617,7 +634,8 @@ newtype Prim_HsPrimCInt = Prim_HsPrimCInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCInt" (Ptr.Ptr Prim_HsPrimCInt) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCInt" (Ptr.Ptr Prim_HsPrimCInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCInt")
@@ -657,7 +675,8 @@ newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCUInt" (Ptr.Ptr Prim_HsPrimCUInt) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCUInt" (Ptr.Ptr Prim_HsPrimCUInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCUInt")
@@ -697,7 +716,8 @@ newtype Prim_HsPrimCLong = Prim_HsPrimCLong
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCLong" (Ptr.Ptr Prim_HsPrimCLong) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCLong" (Ptr.Ptr Prim_HsPrimCLong) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCLong")
@@ -737,7 +757,8 @@ newtype Prim_HsPrimCULong = Prim_HsPrimCULong
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCULong" (Ptr.Ptr Prim_HsPrimCULong) (Ptr.Ptr FC.CULong) where
+instance ( TyEq ty FC.CULong
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCULong" (Ptr.Ptr Prim_HsPrimCULong) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCULong")
@@ -777,7 +798,8 @@ newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCLLong" (Ptr.Ptr Prim_HsPrimCLLong) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCLLong" (Ptr.Ptr Prim_HsPrimCLLong) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCLLong")
@@ -817,7 +839,8 @@ newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCULLong" (Ptr.Ptr Prim_HsPrimCULLong) (Ptr.Ptr FC.CULLong) where
+instance ( TyEq ty FC.CULLong
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCULLong" (Ptr.Ptr Prim_HsPrimCULLong) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCULLong")
@@ -857,7 +880,8 @@ newtype Prim_HsPrimCBool = Prim_HsPrimCBool
     , Real
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCBool" (Ptr.Ptr Prim_HsPrimCBool) (Ptr.Ptr FC.CBool) where
+instance ( TyEq ty FC.CBool
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCBool" (Ptr.Ptr Prim_HsPrimCBool) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCBool")
@@ -895,7 +919,8 @@ newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
     , RealFrac
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCFloat" (Ptr.Ptr Prim_HsPrimCFloat) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCFloat" (Ptr.Ptr Prim_HsPrimCFloat) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCFloat")
@@ -933,7 +958,8 @@ newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
     , RealFrac
     )
 
-instance GHC.Records.HasField "unwrapPrim_HsPrimCDouble" (Ptr.Ptr Prim_HsPrimCDouble) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "unwrapPrim_HsPrimCDouble" (Ptr.Ptr Prim_HsPrimCDouble) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapPrim_HsPrimCDouble")

--- a/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_insts/th.txt
@@ -34,9 +34,10 @@ newtype Prim_HsPrimCPtrdiff
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCPtrdiff"
+instance TyEq ty HsBindgen.Runtime.LibC.CPtrdiff =>
+         HasField "unwrapPrim_HsPrimCPtrdiff"
                   (Ptr Prim_HsPrimCPtrdiff)
-                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCPtrdiff")
 instance HasCField Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff"
     where type CFieldType Prim_HsPrimCPtrdiff
@@ -72,9 +73,8 @@ newtype Prim_HsPrimInt8
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimInt8"
-                  (Ptr Prim_HsPrimInt8)
-                  (Ptr HsBindgen.Runtime.LibC.Int8)
+instance TyEq ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapPrim_HsPrimInt8" (Ptr Prim_HsPrimInt8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt8")
 instance HasCField Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8"
     where type CFieldType Prim_HsPrimInt8
@@ -110,9 +110,8 @@ newtype Prim_HsPrimInt16
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimInt16"
-                  (Ptr Prim_HsPrimInt16)
-                  (Ptr HsBindgen.Runtime.LibC.Int16)
+instance TyEq ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapPrim_HsPrimInt16" (Ptr Prim_HsPrimInt16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt16")
 instance HasCField Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16"
     where type CFieldType Prim_HsPrimInt16
@@ -148,9 +147,8 @@ newtype Prim_HsPrimInt32
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimInt32"
-                  (Ptr Prim_HsPrimInt32)
-                  (Ptr HsBindgen.Runtime.LibC.Int32)
+instance TyEq ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapPrim_HsPrimInt32" (Ptr Prim_HsPrimInt32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt32")
 instance HasCField Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32"
     where type CFieldType Prim_HsPrimInt32
@@ -186,9 +184,8 @@ newtype Prim_HsPrimInt64
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimInt64"
-                  (Ptr Prim_HsPrimInt64)
-                  (Ptr HsBindgen.Runtime.LibC.Int64)
+instance TyEq ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapPrim_HsPrimInt64" (Ptr Prim_HsPrimInt64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt64")
 instance HasCField Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64"
     where type CFieldType Prim_HsPrimInt64
@@ -224,9 +221,8 @@ newtype Prim_HsPrimWord8
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimWord8"
-                  (Ptr Prim_HsPrimWord8)
-                  (Ptr HsBindgen.Runtime.LibC.Word8)
+instance TyEq ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapPrim_HsPrimWord8" (Ptr Prim_HsPrimWord8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord8")
 instance HasCField Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8"
     where type CFieldType Prim_HsPrimWord8
@@ -262,9 +258,8 @@ newtype Prim_HsPrimWord16
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimWord16"
-                  (Ptr Prim_HsPrimWord16)
-                  (Ptr HsBindgen.Runtime.LibC.Word16)
+instance TyEq ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapPrim_HsPrimWord16" (Ptr Prim_HsPrimWord16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord16")
 instance HasCField Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16"
     where type CFieldType Prim_HsPrimWord16
@@ -300,9 +295,8 @@ newtype Prim_HsPrimWord32
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimWord32"
-                  (Ptr Prim_HsPrimWord32)
-                  (Ptr HsBindgen.Runtime.LibC.Word32)
+instance TyEq ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapPrim_HsPrimWord32" (Ptr Prim_HsPrimWord32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord32")
 instance HasCField Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32"
     where type CFieldType Prim_HsPrimWord32
@@ -338,9 +332,8 @@ newtype Prim_HsPrimWord64
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimWord64"
-                  (Ptr Prim_HsPrimWord64)
-                  (Ptr HsBindgen.Runtime.LibC.Word64)
+instance TyEq ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapPrim_HsPrimWord64" (Ptr Prim_HsPrimWord64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord64")
 instance HasCField Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64"
     where type CFieldType Prim_HsPrimWord64
@@ -376,9 +369,8 @@ newtype Prim_HsPrimCChar
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCChar"
-                  (Ptr Prim_HsPrimCChar)
-                  (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "unwrapPrim_HsPrimCChar" (Ptr Prim_HsPrimCChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCChar")
 instance HasCField Prim_HsPrimCChar "unwrapPrim_HsPrimCChar"
     where type CFieldType Prim_HsPrimCChar
@@ -414,9 +406,8 @@ newtype Prim_HsPrimCSChar
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCSChar"
-                  (Ptr Prim_HsPrimCSChar)
-                  (Ptr CSChar)
+instance TyEq ty CSChar =>
+         HasField "unwrapPrim_HsPrimCSChar" (Ptr Prim_HsPrimCSChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCSChar")
 instance HasCField Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar"
     where type CFieldType Prim_HsPrimCSChar
@@ -452,9 +443,8 @@ newtype Prim_HsPrimCUChar
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCUChar"
-                  (Ptr Prim_HsPrimCUChar)
-                  (Ptr CUChar)
+instance TyEq ty CUChar =>
+         HasField "unwrapPrim_HsPrimCUChar" (Ptr Prim_HsPrimCUChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUChar")
 instance HasCField Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar"
     where type CFieldType Prim_HsPrimCUChar
@@ -490,9 +480,8 @@ newtype Prim_HsPrimCShort
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCShort"
-                  (Ptr Prim_HsPrimCShort)
-                  (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "unwrapPrim_HsPrimCShort" (Ptr Prim_HsPrimCShort) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCShort")
 instance HasCField Prim_HsPrimCShort "unwrapPrim_HsPrimCShort"
     where type CFieldType Prim_HsPrimCShort
@@ -528,9 +517,10 @@ newtype Prim_HsPrimCUShort
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCUShort"
+instance TyEq ty CUShort =>
+         HasField "unwrapPrim_HsPrimCUShort"
                   (Ptr Prim_HsPrimCUShort)
-                  (Ptr CUShort)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUShort")
 instance HasCField Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort"
     where type CFieldType Prim_HsPrimCUShort
@@ -566,9 +556,8 @@ newtype Prim_HsPrimCInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCInt"
-                  (Ptr Prim_HsPrimCInt)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapPrim_HsPrimCInt" (Ptr Prim_HsPrimCInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCInt")
 instance HasCField Prim_HsPrimCInt "unwrapPrim_HsPrimCInt"
     where type CFieldType Prim_HsPrimCInt
@@ -604,9 +593,8 @@ newtype Prim_HsPrimCUInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCUInt"
-                  (Ptr Prim_HsPrimCUInt)
-                  (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "unwrapPrim_HsPrimCUInt" (Ptr Prim_HsPrimCUInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUInt")
 instance HasCField Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt"
     where type CFieldType Prim_HsPrimCUInt
@@ -642,9 +630,8 @@ newtype Prim_HsPrimCLong
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCLong"
-                  (Ptr Prim_HsPrimCLong)
-                  (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "unwrapPrim_HsPrimCLong" (Ptr Prim_HsPrimCLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLong")
 instance HasCField Prim_HsPrimCLong "unwrapPrim_HsPrimCLong"
     where type CFieldType Prim_HsPrimCLong
@@ -680,9 +667,8 @@ newtype Prim_HsPrimCULong
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCULong"
-                  (Ptr Prim_HsPrimCULong)
-                  (Ptr CULong)
+instance TyEq ty CULong =>
+         HasField "unwrapPrim_HsPrimCULong" (Ptr Prim_HsPrimCULong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULong")
 instance HasCField Prim_HsPrimCULong "unwrapPrim_HsPrimCULong"
     where type CFieldType Prim_HsPrimCULong
@@ -718,9 +704,8 @@ newtype Prim_HsPrimCLLong
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCLLong"
-                  (Ptr Prim_HsPrimCLLong)
-                  (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "unwrapPrim_HsPrimCLLong" (Ptr Prim_HsPrimCLLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLLong")
 instance HasCField Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong"
     where type CFieldType Prim_HsPrimCLLong
@@ -756,9 +741,10 @@ newtype Prim_HsPrimCULLong
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCULLong"
+instance TyEq ty CULLong =>
+         HasField "unwrapPrim_HsPrimCULLong"
                   (Ptr Prim_HsPrimCULLong)
-                  (Ptr CULLong)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULLong")
 instance HasCField Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong"
     where type CFieldType Prim_HsPrimCULLong
@@ -794,9 +780,8 @@ newtype Prim_HsPrimCBool
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapPrim_HsPrimCBool"
-                  (Ptr Prim_HsPrimCBool)
-                  (Ptr CBool)
+instance TyEq ty CBool =>
+         HasField "unwrapPrim_HsPrimCBool" (Ptr Prim_HsPrimCBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCBool")
 instance HasCField Prim_HsPrimCBool "unwrapPrim_HsPrimCBool"
     where type CFieldType Prim_HsPrimCBool
@@ -830,9 +815,8 @@ newtype Prim_HsPrimCFloat
                       Real,
                       RealFloat,
                       RealFrac)
-instance HasField "unwrapPrim_HsPrimCFloat"
-                  (Ptr Prim_HsPrimCFloat)
-                  (Ptr CFloat)
+instance TyEq ty CFloat =>
+         HasField "unwrapPrim_HsPrimCFloat" (Ptr Prim_HsPrimCFloat) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCFloat")
 instance HasCField Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat"
     where type CFieldType Prim_HsPrimCFloat
@@ -866,9 +850,10 @@ newtype Prim_HsPrimCDouble
                       Real,
                       RealFloat,
                       RealFrac)
-instance HasField "unwrapPrim_HsPrimCDouble"
+instance TyEq ty CDouble =>
+         HasField "unwrapPrim_HsPrimCDouble"
                   (Ptr Prim_HsPrimCDouble)
-                  (Ptr CDouble)
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCDouble")
 instance HasCField Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble"
     where type CFieldType Prim_HsPrimCDouble

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct primitive@
@@ -340,7 +343,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "primitive_c" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "primitive_c" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_c")
@@ -351,7 +355,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sc" where
 
   offset# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "primitive_sc" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CSChar) where
+instance ( TyEq ty FC.CSChar
+         ) => GHC.Records.HasField "primitive_sc" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sc")
@@ -362,7 +367,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_uc" where
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "primitive_uc" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "primitive_uc" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_uc")
@@ -373,7 +379,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_s" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "primitive_s" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "primitive_s" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_s")
@@ -384,7 +391,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_si" where
 
   offset# = \_ -> \_ -> 6
 
-instance GHC.Records.HasField "primitive_si" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "primitive_si" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_si")
@@ -395,7 +403,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ss" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "primitive_ss" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "primitive_ss" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ss")
@@ -406,7 +415,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ssi" where
 
   offset# = \_ -> \_ -> 10
 
-instance GHC.Records.HasField "primitive_ssi" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CShort) where
+instance ( TyEq ty FC.CShort
+         ) => GHC.Records.HasField "primitive_ssi" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ssi")
@@ -417,7 +427,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_us" where
 
   offset# = \_ -> \_ -> 12
 
-instance GHC.Records.HasField "primitive_us" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUShort) where
+instance ( TyEq ty FC.CUShort
+         ) => GHC.Records.HasField "primitive_us" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_us")
@@ -429,7 +440,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_usi" where
 
   offset# = \_ -> \_ -> 14
 
-instance GHC.Records.HasField "primitive_usi" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUShort) where
+instance ( TyEq ty FC.CUShort
+         ) => GHC.Records.HasField "primitive_usi" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_usi")
@@ -440,7 +452,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_i" where
 
   offset# = \_ -> \_ -> 16
 
-instance GHC.Records.HasField "primitive_i" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "primitive_i" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_i")
@@ -451,7 +464,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_s2" where
 
   offset# = \_ -> \_ -> 20
 
-instance GHC.Records.HasField "primitive_s2" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "primitive_s2" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_s2")
@@ -462,7 +476,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_si2" where
 
   offset# = \_ -> \_ -> 24
 
-instance GHC.Records.HasField "primitive_si2" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "primitive_si2" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_si2")
@@ -473,7 +488,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_u" where
 
   offset# = \_ -> \_ -> 28
 
-instance GHC.Records.HasField "primitive_u" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "primitive_u" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_u")
@@ -484,7 +500,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ui" where
 
   offset# = \_ -> \_ -> 32
 
-instance GHC.Records.HasField "primitive_ui" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "primitive_ui" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ui")
@@ -495,7 +512,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_l" where
 
   offset# = \_ -> \_ -> 40
 
-instance GHC.Records.HasField "primitive_l" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "primitive_l" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_l")
@@ -506,7 +524,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_li" where
 
   offset# = \_ -> \_ -> 48
 
-instance GHC.Records.HasField "primitive_li" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "primitive_li" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_li")
@@ -517,7 +536,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sl" where
 
   offset# = \_ -> \_ -> 56
 
-instance GHC.Records.HasField "primitive_sl" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "primitive_sl" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sl")
@@ -528,7 +548,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sli" where
 
   offset# = \_ -> \_ -> 64
 
-instance GHC.Records.HasField "primitive_sli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "primitive_sli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sli")
@@ -539,7 +560,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ul" where
 
   offset# = \_ -> \_ -> 72
 
-instance GHC.Records.HasField "primitive_ul" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULong) where
+instance ( TyEq ty FC.CULong
+         ) => GHC.Records.HasField "primitive_ul" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ul")
@@ -550,7 +572,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_uli" where
 
   offset# = \_ -> \_ -> 80
 
-instance GHC.Records.HasField "primitive_uli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULong) where
+instance ( TyEq ty FC.CULong
+         ) => GHC.Records.HasField "primitive_uli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_uli")
@@ -561,7 +584,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ll" where
 
   offset# = \_ -> \_ -> 88
 
-instance GHC.Records.HasField "primitive_ll" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "primitive_ll" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ll")
@@ -572,7 +596,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_lli" where
 
   offset# = \_ -> \_ -> 96
 
-instance GHC.Records.HasField "primitive_lli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "primitive_lli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_lli")
@@ -583,7 +608,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_sll" where
 
   offset# = \_ -> \_ -> 104
 
-instance GHC.Records.HasField "primitive_sll" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "primitive_sll" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_sll")
@@ -595,7 +621,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_slli" where
 
   offset# = \_ -> \_ -> 112
 
-instance GHC.Records.HasField "primitive_slli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CLLong) where
+instance ( TyEq ty FC.CLLong
+         ) => GHC.Records.HasField "primitive_slli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_slli")
@@ -607,7 +634,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ull" where
 
   offset# = \_ -> \_ -> 120
 
-instance GHC.Records.HasField "primitive_ull" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULLong) where
+instance ( TyEq ty FC.CULLong
+         ) => GHC.Records.HasField "primitive_ull" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ull")
@@ -619,7 +647,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_ulli" where
 
   offset# = \_ -> \_ -> 128
 
-instance GHC.Records.HasField "primitive_ulli" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CULLong) where
+instance ( TyEq ty FC.CULLong
+         ) => GHC.Records.HasField "primitive_ulli" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_ulli")
@@ -630,7 +659,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_f" where
 
   offset# = \_ -> \_ -> 136
 
-instance GHC.Records.HasField "primitive_f" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "primitive_f" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_f")
@@ -641,7 +671,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Primitive "primitive_d" where
 
   offset# = \_ -> \_ -> 144
 
-instance GHC.Records.HasField "primitive_d" (Ptr.Ptr Primitive) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "primitive_d" (Ptr.Ptr Primitive) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"primitive_d")

--- a/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/fixtures/types/primitives/primitive_types/th.txt
@@ -248,140 +248,168 @@ deriving via (EquivStorable Primitive) instance Storable Primitive
 instance HasCField Primitive "primitive_c"
     where type CFieldType Primitive "primitive_c" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "primitive_c" (Ptr Primitive) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "primitive_c" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_c")
 instance HasCField Primitive "primitive_sc"
     where type CFieldType Primitive "primitive_sc" = CSChar
           offset# = \_ -> \_ -> 1
-instance HasField "primitive_sc" (Ptr Primitive) (Ptr CSChar)
+instance TyEq ty CSChar =>
+         HasField "primitive_sc" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_sc")
 instance HasCField Primitive "primitive_uc"
     where type CFieldType Primitive "primitive_uc" = CUChar
           offset# = \_ -> \_ -> 2
-instance HasField "primitive_uc" (Ptr Primitive) (Ptr CUChar)
+instance TyEq ty CUChar =>
+         HasField "primitive_uc" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_uc")
 instance HasCField Primitive "primitive_s"
     where type CFieldType Primitive "primitive_s" = CShort
           offset# = \_ -> \_ -> 4
-instance HasField "primitive_s" (Ptr Primitive) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "primitive_s" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_s")
 instance HasCField Primitive "primitive_si"
     where type CFieldType Primitive "primitive_si" = CShort
           offset# = \_ -> \_ -> 6
-instance HasField "primitive_si" (Ptr Primitive) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "primitive_si" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_si")
 instance HasCField Primitive "primitive_ss"
     where type CFieldType Primitive "primitive_ss" = CShort
           offset# = \_ -> \_ -> 8
-instance HasField "primitive_ss" (Ptr Primitive) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "primitive_ss" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ss")
 instance HasCField Primitive "primitive_ssi"
     where type CFieldType Primitive "primitive_ssi" = CShort
           offset# = \_ -> \_ -> 10
-instance HasField "primitive_ssi" (Ptr Primitive) (Ptr CShort)
+instance TyEq ty CShort =>
+         HasField "primitive_ssi" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ssi")
 instance HasCField Primitive "primitive_us"
     where type CFieldType Primitive "primitive_us" = CUShort
           offset# = \_ -> \_ -> 12
-instance HasField "primitive_us" (Ptr Primitive) (Ptr CUShort)
+instance TyEq ty CUShort =>
+         HasField "primitive_us" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_us")
 instance HasCField Primitive "primitive_usi"
     where type CFieldType Primitive "primitive_usi" = CUShort
           offset# = \_ -> \_ -> 14
-instance HasField "primitive_usi" (Ptr Primitive) (Ptr CUShort)
+instance TyEq ty CUShort =>
+         HasField "primitive_usi" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_usi")
 instance HasCField Primitive "primitive_i"
     where type CFieldType Primitive "primitive_i" = CInt
           offset# = \_ -> \_ -> 16
-instance HasField "primitive_i" (Ptr Primitive) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "primitive_i" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_i")
 instance HasCField Primitive "primitive_s2"
     where type CFieldType Primitive "primitive_s2" = CInt
           offset# = \_ -> \_ -> 20
-instance HasField "primitive_s2" (Ptr Primitive) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "primitive_s2" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_s2")
 instance HasCField Primitive "primitive_si2"
     where type CFieldType Primitive "primitive_si2" = CInt
           offset# = \_ -> \_ -> 24
-instance HasField "primitive_si2" (Ptr Primitive) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "primitive_si2" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_si2")
 instance HasCField Primitive "primitive_u"
     where type CFieldType Primitive "primitive_u" = CUInt
           offset# = \_ -> \_ -> 28
-instance HasField "primitive_u" (Ptr Primitive) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "primitive_u" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_u")
 instance HasCField Primitive "primitive_ui"
     where type CFieldType Primitive "primitive_ui" = CUInt
           offset# = \_ -> \_ -> 32
-instance HasField "primitive_ui" (Ptr Primitive) (Ptr CUInt)
+instance TyEq ty CUInt =>
+         HasField "primitive_ui" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ui")
 instance HasCField Primitive "primitive_l"
     where type CFieldType Primitive "primitive_l" = CLong
           offset# = \_ -> \_ -> 40
-instance HasField "primitive_l" (Ptr Primitive) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "primitive_l" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_l")
 instance HasCField Primitive "primitive_li"
     where type CFieldType Primitive "primitive_li" = CLong
           offset# = \_ -> \_ -> 48
-instance HasField "primitive_li" (Ptr Primitive) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "primitive_li" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_li")
 instance HasCField Primitive "primitive_sl"
     where type CFieldType Primitive "primitive_sl" = CLong
           offset# = \_ -> \_ -> 56
-instance HasField "primitive_sl" (Ptr Primitive) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "primitive_sl" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_sl")
 instance HasCField Primitive "primitive_sli"
     where type CFieldType Primitive "primitive_sli" = CLong
           offset# = \_ -> \_ -> 64
-instance HasField "primitive_sli" (Ptr Primitive) (Ptr CLong)
+instance TyEq ty CLong =>
+         HasField "primitive_sli" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_sli")
 instance HasCField Primitive "primitive_ul"
     where type CFieldType Primitive "primitive_ul" = CULong
           offset# = \_ -> \_ -> 72
-instance HasField "primitive_ul" (Ptr Primitive) (Ptr CULong)
+instance TyEq ty CULong =>
+         HasField "primitive_ul" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ul")
 instance HasCField Primitive "primitive_uli"
     where type CFieldType Primitive "primitive_uli" = CULong
           offset# = \_ -> \_ -> 80
-instance HasField "primitive_uli" (Ptr Primitive) (Ptr CULong)
+instance TyEq ty CULong =>
+         HasField "primitive_uli" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_uli")
 instance HasCField Primitive "primitive_ll"
     where type CFieldType Primitive "primitive_ll" = CLLong
           offset# = \_ -> \_ -> 88
-instance HasField "primitive_ll" (Ptr Primitive) (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "primitive_ll" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ll")
 instance HasCField Primitive "primitive_lli"
     where type CFieldType Primitive "primitive_lli" = CLLong
           offset# = \_ -> \_ -> 96
-instance HasField "primitive_lli" (Ptr Primitive) (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "primitive_lli" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_lli")
 instance HasCField Primitive "primitive_sll"
     where type CFieldType Primitive "primitive_sll" = CLLong
           offset# = \_ -> \_ -> 104
-instance HasField "primitive_sll" (Ptr Primitive) (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "primitive_sll" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_sll")
 instance HasCField Primitive "primitive_slli"
     where type CFieldType Primitive "primitive_slli" = CLLong
           offset# = \_ -> \_ -> 112
-instance HasField "primitive_slli" (Ptr Primitive) (Ptr CLLong)
+instance TyEq ty CLLong =>
+         HasField "primitive_slli" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_slli")
 instance HasCField Primitive "primitive_ull"
     where type CFieldType Primitive "primitive_ull" = CULLong
           offset# = \_ -> \_ -> 120
-instance HasField "primitive_ull" (Ptr Primitive) (Ptr CULLong)
+instance TyEq ty CULLong =>
+         HasField "primitive_ull" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ull")
 instance HasCField Primitive "primitive_ulli"
     where type CFieldType Primitive "primitive_ulli" = CULLong
           offset# = \_ -> \_ -> 128
-instance HasField "primitive_ulli" (Ptr Primitive) (Ptr CULLong)
+instance TyEq ty CULLong =>
+         HasField "primitive_ulli" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_ulli")
 instance HasCField Primitive "primitive_f"
     where type CFieldType Primitive "primitive_f" = CFloat
           offset# = \_ -> \_ -> 136
-instance HasField "primitive_f" (Ptr Primitive) (Ptr CFloat)
+instance TyEq ty CFloat =>
+         HasField "primitive_f" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_f")
 instance HasCField Primitive "primitive_d"
     where type CFieldType Primitive "primitive_d" = CDouble
           offset# = \_ -> \_ -> 144
-instance HasField "primitive_d" (Ptr Primitive) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "primitive_d" (Ptr Primitive) (Ptr ty)
     where getField = fromPtr (Proxy @"primitive_d")

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -34,6 +36,7 @@ import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
 import qualified Text.Read
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure, return, showsPrec)
 
 {-| __C declaration:__ @I@
@@ -64,7 +67,8 @@ newtype I = I
     , Real
     )
 
-instance GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapI" (Ptr.Ptr I) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapI")
@@ -202,7 +206,8 @@ instance Read E where
 
   readListPrec = Text.Read.readListPrecDefault
 
-instance GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr FC.CUInt) where
+instance ( TyEq ty FC.CUInt
+         ) => GHC.Records.HasField "unwrapE" (Ptr.Ptr E) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapE")
@@ -250,7 +255,8 @@ newtype TI = TI
     , Real
     )
 
-instance GHC.Records.HasField "unwrapTI" (Ptr.Ptr TI) (Ptr.Ptr I) where
+instance ( TyEq ty I
+         ) => GHC.Records.HasField "unwrapTI" (Ptr.Ptr TI) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTI")
@@ -278,7 +284,8 @@ newtype TS = TS
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTS" (Ptr.Ptr TS) (Ptr.Ptr S) where
+instance ( TyEq ty S
+         ) => GHC.Records.HasField "unwrapTS" (Ptr.Ptr TS) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTS")
@@ -306,7 +313,8 @@ newtype TU = TU
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTU" (Ptr.Ptr TU) (Ptr.Ptr U) where
+instance ( TyEq ty U
+         ) => GHC.Records.HasField "unwrapTU" (Ptr.Ptr TU) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTU")
@@ -336,7 +344,8 @@ newtype TE = TE
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapTE" (Ptr.Ptr TE) (Ptr.Ptr E) where
+instance ( TyEq ty E
+         ) => GHC.Records.HasField "unwrapTE" (Ptr.Ptr TE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTE")
@@ -375,7 +384,8 @@ newtype TTI = TTI
     , Real
     )
 
-instance GHC.Records.HasField "unwrapTTI" (Ptr.Ptr TTI) (Ptr.Ptr TI) where
+instance ( TyEq ty TI
+         ) => GHC.Records.HasField "unwrapTTI" (Ptr.Ptr TTI) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTI")
@@ -403,7 +413,8 @@ newtype TTS = TTS
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTTS" (Ptr.Ptr TTS) (Ptr.Ptr TS) where
+instance ( TyEq ty TS
+         ) => GHC.Records.HasField "unwrapTTS" (Ptr.Ptr TTS) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTS")
@@ -431,7 +442,8 @@ newtype TTU = TTU
     , F.Storable
     )
 
-instance GHC.Records.HasField "unwrapTTU" (Ptr.Ptr TTU) (Ptr.Ptr TU) where
+instance ( TyEq ty TU
+         ) => GHC.Records.HasField "unwrapTTU" (Ptr.Ptr TTU) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTU")
@@ -461,7 +473,8 @@ newtype TTE = TTE
     , Data.Primitive.Types.Prim
     )
 
-instance GHC.Records.HasField "unwrapTTE" (Ptr.Ptr TTE) (Ptr.Ptr TE) where
+instance ( TyEq ty TE
+         ) => GHC.Records.HasField "unwrapTTE" (Ptr.Ptr TTE) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapTTE")

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -102,7 +102,7 @@ newtype I
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapI" (Ptr I) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -195,7 +195,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance HasField "unwrapE" (Ptr E) (Ptr CUInt)
+instance TyEq ty CUInt => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = CUInt
@@ -244,7 +244,7 @@ newtype TI
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapTI" (Ptr TI) (Ptr I)
+instance TyEq ty I => HasField "unwrapTI" (Ptr TI) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTI")
 instance HasCField TI "unwrapTI"
     where type CFieldType TI "unwrapTI" = I
@@ -265,7 +265,7 @@ newtype TS
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTS" (Ptr TS) (Ptr S)
+instance TyEq ty S => HasField "unwrapTS" (Ptr TS) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTS")
 instance HasCField TS "unwrapTS"
     where type CFieldType TS "unwrapTS" = S
@@ -286,7 +286,7 @@ newtype TU
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTU" (Ptr TU) (Ptr U)
+instance TyEq ty U => HasField "unwrapTU" (Ptr TU) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTU")
 instance HasCField TU "unwrapTU"
     where type CFieldType TU "unwrapTU" = U
@@ -312,7 +312,7 @@ newtype TE
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapTE" (Ptr TE) (Ptr E)
+instance TyEq ty E => HasField "unwrapTE" (Ptr TE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTE")
 instance HasCField TE "unwrapTE"
     where type CFieldType TE "unwrapTE" = E
@@ -347,7 +347,7 @@ newtype TTI
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapTTI" (Ptr TTI) (Ptr TI)
+instance TyEq ty TI => HasField "unwrapTTI" (Ptr TTI) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTI")
 instance HasCField TTI "unwrapTTI"
     where type CFieldType TTI "unwrapTTI" = TI
@@ -368,7 +368,7 @@ newtype TTS
       -}
     deriving stock (Generic, Eq, Show)
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTTS" (Ptr TTS) (Ptr TS)
+instance TyEq ty TS => HasField "unwrapTTS" (Ptr TTS) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTS")
 instance HasCField TTS "unwrapTTS"
     where type CFieldType TTS "unwrapTTS" = TS
@@ -389,7 +389,7 @@ newtype TTU
       -}
     deriving stock Generic
     deriving newtype (StaticSize, ReadRaw, WriteRaw, Storable)
-instance HasField "unwrapTTU" (Ptr TTU) (Ptr TU)
+instance TyEq ty TU => HasField "unwrapTTU" (Ptr TTU) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTU")
 instance HasCField TTU "unwrapTTU"
     where type CFieldType TTU "unwrapTTU" = TU
@@ -415,7 +415,7 @@ newtype TTE
                       Storable,
                       HasFFIType,
                       Prim)
-instance HasField "unwrapTTE" (Ptr TTE) (Ptr TE)
+instance TyEq ty TE => HasField "unwrapTTE" (Ptr TTE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTE")
 instance HasCField TTE "unwrapTTE"
     where type CFieldType TTE "unwrapTTE" = TE

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct struct2@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Struct2 "struct2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "struct2_x" (Ptr.Ptr Struct2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "struct2_x" (Ptr.Ptr Struct2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"struct2_x")

--- a/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/fixtures/types/special/parse_failure_long_double/th.txt
@@ -53,7 +53,8 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_x"
     where type CFieldType Struct2 "struct2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "struct2_x" (Ptr Struct2) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "struct2_x" (Ptr Struct2) (Ptr ty)
     where getField = fromPtr (Proxy @"struct2_x")
 -- __unique:__ @test_typesspecialparse_failure_lo_Example_Safe_fun2@
 foreign import ccall safe "hs_bindgen_a1252a3becef09a6" hs_bindgen_a1252a3becef09a6_base ::

--- a/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/anonymous/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct \@S1_c@
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_c "s1_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s1_c_a" (Ptr.Ptr S1_c) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s1_c_a" (Ptr.Ptr S1_c) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c_a")
@@ -89,7 +93,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1_c "s1_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s1_c_b" (Ptr.Ptr S1_c) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s1_c_b" (Ptr.Ptr S1_c) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c_b")
@@ -150,7 +155,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s1_c" (Ptr.Ptr S1) (Ptr.Ptr S1_c) where
+instance ( TyEq ty S1_c
+         ) => GHC.Records.HasField "s1_c" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_c")
@@ -161,7 +167,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "s1_d" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s1_d" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_d")
@@ -214,7 +221,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner_deep "s2_inner_deep_b" w
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_inner_deep_b" (Ptr.Ptr S2_inner_deep) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s2_inner_deep_b" (Ptr.Ptr S2_inner_deep) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_deep_b")
@@ -275,7 +283,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner "s2_inner_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_inner_a" (Ptr.Ptr S2_inner) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s2_inner_a" (Ptr.Ptr S2_inner) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_a")
@@ -287,7 +296,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_inner "s2_inner_deep" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s2_inner_deep" (Ptr.Ptr S2_inner) (Ptr.Ptr S2_inner_deep) where
+instance ( TyEq ty S2_inner_deep
+         ) => GHC.Records.HasField "s2_inner_deep" (Ptr.Ptr S2_inner) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner_deep")
@@ -348,7 +358,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_inner" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_inner" (Ptr.Ptr S2) (Ptr.Ptr S2_inner) where
+instance ( TyEq ty S2_inner
+         ) => GHC.Records.HasField "s2_inner" (Ptr.Ptr S2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_inner")
@@ -359,7 +370,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2 "s2_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "s2_d" (Ptr.Ptr S2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s2_d" (Ptr.Ptr S2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_d")
@@ -420,7 +432,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3 "s3_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s3_c" (Ptr.Ptr S3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S3_c))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr S3_c))
+         ) => GHC.Records.HasField "s3_c" (Ptr.Ptr S3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c")
@@ -431,7 +444,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3 "s3_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "s3_d" (Ptr.Ptr S3) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s3_d" (Ptr.Ptr S3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_d")
@@ -492,7 +506,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_c "s3_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s3_c_a" (Ptr.Ptr S3_c) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s3_c_a" (Ptr.Ptr S3_c) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c_a")
@@ -503,7 +518,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_c "s3_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s3_c_b" (Ptr.Ptr S3_c) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s3_c_b" (Ptr.Ptr S3_c) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_c_b")

--- a/hs-bindgen/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/fixtures/types/structs/anonymous/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable S1_c) instance Storable S1_c
 instance HasCField S1_c "s1_c_a"
     where type CFieldType S1_c "s1_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s1_c_a" (Ptr S1_c) (Ptr CInt)
+instance TyEq ty CInt => HasField "s1_c_a" (Ptr S1_c) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_c_a")
 instance HasCField S1_c "s1_c_b"
     where type CFieldType S1_c "s1_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s1_c_b" (Ptr S1_c) (Ptr CInt)
+instance TyEq ty CInt => HasField "s1_c_b" (Ptr S1_c) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_c_b")
 {-| __C declaration:__ @struct S1@
 
@@ -88,12 +88,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_c"
     where type CFieldType S1 "s1_c" = S1_c
           offset# = \_ -> \_ -> 0
-instance HasField "s1_c" (Ptr S1) (Ptr S1_c)
+instance TyEq ty S1_c => HasField "s1_c" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_c")
 instance HasCField S1 "s1_d"
     where type CFieldType S1 "s1_d" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "s1_d" (Ptr S1) (Ptr CInt)
+instance TyEq ty CInt => HasField "s1_d" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_d")
 {-| __C declaration:__ @struct \@S2_inner_deep@
 
@@ -128,7 +128,8 @@ deriving via (EquivStorable S2_inner_deep) instance Storable S2_inner_deep
 instance HasCField S2_inner_deep "s2_inner_deep_b"
     where type CFieldType S2_inner_deep "s2_inner_deep_b" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_inner_deep_b")
 {-| __C declaration:__ @struct \@S2_inner@
 
@@ -171,14 +172,14 @@ deriving via (EquivStorable S2_inner) instance Storable S2_inner
 instance HasCField S2_inner "s2_inner_a"
     where type CFieldType S2_inner "s2_inner_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s2_inner_a" (Ptr S2_inner) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "s2_inner_a" (Ptr S2_inner) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_inner_a")
 instance HasCField S2_inner "s2_inner_deep"
     where type CFieldType S2_inner "s2_inner_deep" = S2_inner_deep
           offset# = \_ -> \_ -> 4
-instance HasField "s2_inner_deep"
-                  (Ptr S2_inner)
-                  (Ptr S2_inner_deep)
+instance TyEq ty S2_inner_deep =>
+         HasField "s2_inner_deep" (Ptr S2_inner) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_inner_deep")
 {-| __C declaration:__ @struct S2@
 
@@ -221,12 +222,12 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_inner"
     where type CFieldType S2 "s2_inner" = S2_inner
           offset# = \_ -> \_ -> 0
-instance HasField "s2_inner" (Ptr S2) (Ptr S2_inner)
+instance TyEq ty S2_inner => HasField "s2_inner" (Ptr S2) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_inner")
 instance HasCField S2 "s2_d"
     where type CFieldType S2 "s2_d" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "s2_d" (Ptr S2) (Ptr CInt)
+instance TyEq ty CInt => HasField "s2_d" (Ptr S2) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_d")
 {-| __C declaration:__ @struct S3@
 
@@ -269,12 +270,13 @@ deriving via (EquivStorable S3) instance Storable S3
 instance HasCField S3 "s3_c"
     where type CFieldType S3 "s3_c" = Ptr (Ptr S3_c)
           offset# = \_ -> \_ -> 0
-instance HasField "s3_c" (Ptr S3) (Ptr (Ptr (Ptr S3_c)))
+instance TyEq ty (Ptr (Ptr S3_c)) =>
+         HasField "s3_c" (Ptr S3) (Ptr ty)
     where getField = fromPtr (Proxy @"s3_c")
 instance HasCField S3 "s3_d"
     where type CFieldType S3 "s3_d" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "s3_d" (Ptr S3) (Ptr CInt)
+instance TyEq ty CInt => HasField "s3_d" (Ptr S3) (Ptr ty)
     where getField = fromPtr (Proxy @"s3_d")
 {-| __C declaration:__ @struct \@S3_c@
 
@@ -317,10 +319,10 @@ deriving via (EquivStorable S3_c) instance Storable S3_c
 instance HasCField S3_c "s3_c_a"
     where type CFieldType S3_c "s3_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s3_c_a" (Ptr S3_c) (Ptr CInt)
+instance TyEq ty CInt => HasField "s3_c_a" (Ptr S3_c) (Ptr ty)
     where getField = fromPtr (Proxy @"s3_c_a")
 instance HasCField S3_c "s3_c_b"
     where type CFieldType S3_c "s3_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s3_c_b" (Ptr S3_c) (Ptr CInt)
+instance TyEq ty CInt => HasField "s3_c_b" (Ptr S3_c) (Ptr ty)
     where getField = fromPtr (Proxy @"s3_c_b")

--- a/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/bitfields/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified HsBindgen.Runtime.BitfieldPtr
 import qualified HsBindgen.Runtime.HasCBitfield
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct flags@
@@ -122,7 +125,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Flags "flags_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "flags_fieldX" (Ptr.Ptr Flags) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "flags_fieldX" (Ptr.Ptr Flags) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flags_fieldX")
@@ -135,7 +139,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagA" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "flags_flagA" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "flags_flagA" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagA")
@@ -148,7 +153,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagB" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "flags_flagB" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "flags_flagB" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagB")
@@ -161,7 +167,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_flagC" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "flags_flagC" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "flags_flagC" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_flagC")
@@ -172,7 +179,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Flags "flags_fieldY" where
 
   offset# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "flags_fieldY" (Ptr.Ptr Flags) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "flags_fieldY" (Ptr.Ptr Flags) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"flags_fieldY")
@@ -185,7 +193,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Flags "flags_bits" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance GHC.Records.HasField "flags_bits" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "flags_bits" (Ptr.Ptr Flags) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"flags_bits")
@@ -258,7 +267,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_x" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32_x" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "overflow32_x" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_x")
@@ -272,7 +282,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_y" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32_y" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "overflow32_y" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_y")
@@ -286,7 +297,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32 "overflow32_z" w
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32_z" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "overflow32_z" (Ptr.Ptr Overflow32) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32_z")
@@ -359,7 +371,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_x"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32b_x" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow32b_x" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_x")
@@ -373,7 +386,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_y"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32b_y" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow32b_y" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_y")
@@ -387,7 +401,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32b "overflow32b_z"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32b_z" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow32b_z" (Ptr.Ptr Overflow32b) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32b_z")
@@ -460,7 +475,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_x"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32c_x" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow32c_x" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_x")
@@ -474,7 +490,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_y"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32c_y" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "overflow32c_y" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_y")
@@ -488,7 +505,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow32c "overflow32c_z"
 
   bitfieldWidth# = \_ -> \_ -> 17
 
-instance GHC.Records.HasField "overflow32c_z" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow32c_z" (Ptr.Ptr Overflow32c) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow32c_z")
@@ -552,7 +570,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow64 "overflow64_x" w
 
   bitfieldWidth# = \_ -> \_ -> 33
 
-instance GHC.Records.HasField "overflow64_x" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow64_x" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow64_x")
@@ -566,7 +585,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield Overflow64 "overflow64_y" w
 
   bitfieldWidth# = \_ -> \_ -> 33
 
-instance GHC.Records.HasField "overflow64_y" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CLong) where
+instance ( TyEq ty FC.CLong
+         ) => GHC.Records.HasField "overflow64_y" (Ptr.Ptr Overflow64) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"overflow64_y")
@@ -629,7 +649,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignA "alignA_x" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance GHC.Records.HasField "alignA_x" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "alignA_x" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignA_x")
@@ -642,7 +663,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignA "alignA_y" where
 
   bitfieldWidth# = \_ -> \_ -> 10
 
-instance GHC.Records.HasField "alignA_y" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "alignA_y" (Ptr.Ptr AlignA) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignA_y")
@@ -705,7 +727,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignB "alignB_x" where
 
   bitfieldWidth# = \_ -> \_ -> 7
 
-instance GHC.Records.HasField "alignB_x" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CUChar) where
+instance ( TyEq ty FC.CUChar
+         ) => GHC.Records.HasField "alignB_x" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignB_x")
@@ -718,7 +741,8 @@ instance HsBindgen.Runtime.HasCBitfield.HasCBitfield AlignB "alignB_y" where
 
   bitfieldWidth# = \_ -> \_ -> 31
 
-instance GHC.Records.HasField "alignB_y" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "alignB_y" (Ptr.Ptr AlignB) (HsBindgen.Runtime.BitfieldPtr.BitfieldPtr ty) where
 
   getField =
     HsBindgen.Runtime.HasCBitfield.toPtr (Data.Proxy.Proxy @"alignB_y")

--- a/hs-bindgen/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/fixtures/types/structs/bitfields/th.txt
@@ -72,36 +72,42 @@ deriving via (EquivStorable Flags) instance Storable Flags
 instance HasCField Flags "flags_fieldX"
     where type CFieldType Flags "flags_fieldX" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "flags_fieldX" (Ptr Flags) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "flags_fieldX" (Ptr Flags) (Ptr ty)
     where getField = fromPtr (Proxy @"flags_fieldX")
 instance HasCBitfield Flags "flags_flagA"
     where type CBitfieldType Flags "flags_flagA" = CInt
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "flags_flagA" (Ptr Flags) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "flags_flagA" (Ptr Flags) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"flags_flagA")
 instance HasCBitfield Flags "flags_flagB"
     where type CBitfieldType Flags "flags_flagB" = CInt
           bitfieldOffset# = \_ -> \_ -> 9
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "flags_flagB" (Ptr Flags) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "flags_flagB" (Ptr Flags) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"flags_flagB")
 instance HasCBitfield Flags "flags_flagC"
     where type CBitfieldType Flags "flags_flagC" = CInt
           bitfieldOffset# = \_ -> \_ -> 10
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "flags_flagC" (Ptr Flags) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "flags_flagC" (Ptr Flags) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"flags_flagC")
 instance HasCField Flags "flags_fieldY"
     where type CFieldType Flags "flags_fieldY" = CChar
           offset# = \_ -> \_ -> 2
-instance HasField "flags_fieldY" (Ptr Flags) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "flags_fieldY" (Ptr Flags) (Ptr ty)
     where getField = fromPtr (Proxy @"flags_fieldY")
 instance HasCBitfield Flags "flags_bits"
     where type CBitfieldType Flags "flags_bits" = CInt
           bitfieldOffset# = \_ -> \_ -> 24
           bitfieldWidth# = \_ -> \_ -> 2
-instance HasField "flags_bits" (Ptr Flags) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "flags_bits" (Ptr Flags) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"flags_bits")
 {-| __C declaration:__ @struct overflow32@
 
@@ -153,25 +159,22 @@ instance HasCBitfield Overflow32 "overflow32_x"
     where type CBitfieldType Overflow32 "overflow32_x" = CInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32_x"
-                  (Ptr Overflow32)
-                  (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "overflow32_x" (Ptr Overflow32) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32_x")
 instance HasCBitfield Overflow32 "overflow32_y"
     where type CBitfieldType Overflow32 "overflow32_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32_y"
-                  (Ptr Overflow32)
-                  (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "overflow32_y" (Ptr Overflow32) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32_y")
 instance HasCBitfield Overflow32 "overflow32_z"
     where type CBitfieldType Overflow32 "overflow32_z" = CInt
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32_z"
-                  (Ptr Overflow32)
-                  (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "overflow32_z" (Ptr Overflow32) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32_z")
 {-| __C declaration:__ @struct overflow32b@
 
@@ -223,25 +226,22 @@ instance HasCBitfield Overflow32b "overflow32b_x"
     where type CBitfieldType Overflow32b "overflow32b_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32b_x"
-                  (Ptr Overflow32b)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow32b_x" (Ptr Overflow32b) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32b_x")
 instance HasCBitfield Overflow32b "overflow32b_y"
     where type CBitfieldType Overflow32b "overflow32b_y" = CLong
           bitfieldOffset# = \_ -> \_ -> 17
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32b_y"
-                  (Ptr Overflow32b)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow32b_y" (Ptr Overflow32b) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32b_y")
 instance HasCBitfield Overflow32b "overflow32b_z"
     where type CBitfieldType Overflow32b "overflow32b_z" = CLong
           bitfieldOffset# = \_ -> \_ -> 34
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32b_z"
-                  (Ptr Overflow32b)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow32b_z" (Ptr Overflow32b) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32b_z")
 {-| __C declaration:__ @struct overflow32c@
 
@@ -293,25 +293,22 @@ instance HasCBitfield Overflow32c "overflow32c_x"
     where type CBitfieldType Overflow32c "overflow32c_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32c_x"
-                  (Ptr Overflow32c)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow32c_x" (Ptr Overflow32c) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32c_x")
 instance HasCBitfield Overflow32c "overflow32c_y"
     where type CBitfieldType Overflow32c "overflow32c_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32c_y"
-                  (Ptr Overflow32c)
-                  (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "overflow32c_y" (Ptr Overflow32c) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32c_y")
 instance HasCBitfield Overflow32c "overflow32c_z"
     where type CBitfieldType Overflow32c "overflow32c_z" = CLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 17
-instance HasField "overflow32c_z"
-                  (Ptr Overflow32c)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow32c_z" (Ptr Overflow32c) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow32c_z")
 {-| __C declaration:__ @struct overflow64@
 
@@ -355,17 +352,15 @@ instance HasCBitfield Overflow64 "overflow64_x"
     where type CBitfieldType Overflow64 "overflow64_x" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 33
-instance HasField "overflow64_x"
-                  (Ptr Overflow64)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow64_x" (Ptr Overflow64) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow64_x")
 instance HasCBitfield Overflow64 "overflow64_y"
     where type CBitfieldType Overflow64 "overflow64_y" = CLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 33
-instance HasField "overflow64_y"
-                  (Ptr Overflow64)
-                  (BitfieldPtr CLong)
+instance TyEq ty CLong =>
+         HasField "overflow64_y" (Ptr Overflow64) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"overflow64_y")
 {-| __C declaration:__ @struct alignA@
 
@@ -409,13 +404,15 @@ instance HasCBitfield AlignA "alignA_x"
     where type CBitfieldType AlignA "alignA_x" = CUChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 1
-instance HasField "alignA_x" (Ptr AlignA) (BitfieldPtr CUChar)
+instance TyEq ty CUChar =>
+         HasField "alignA_x" (Ptr AlignA) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"alignA_x")
 instance HasCBitfield AlignA "alignA_y"
     where type CBitfieldType AlignA "alignA_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 1
           bitfieldWidth# = \_ -> \_ -> 10
-instance HasField "alignA_y" (Ptr AlignA) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "alignA_y" (Ptr AlignA) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"alignA_y")
 {-| __C declaration:__ @struct alignB@
 
@@ -459,11 +456,13 @@ instance HasCBitfield AlignB "alignB_x"
     where type CBitfieldType AlignB "alignB_x" = CUChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 7
-instance HasField "alignB_x" (Ptr AlignB) (BitfieldPtr CUChar)
+instance TyEq ty CUChar =>
+         HasField "alignB_x" (Ptr AlignB) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"alignB_x")
 instance HasCBitfield AlignB "alignB_y"
     where type CBitfieldType AlignB "alignB_y" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 31
-instance HasField "alignB_y" (Ptr AlignB) (BitfieldPtr CInt)
+instance TyEq ty CInt =>
+         HasField "alignB_y" (Ptr AlignB) (BitfieldPtr ty)
     where getField = toPtr (Proxy @"alignB_y")

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -19,6 +21,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct b@
@@ -68,7 +71,8 @@ instance HsBindgen.Runtime.HasCField.HasCField B "b_toA" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "b_toA" (Ptr.Ptr B) (Ptr.Ptr (Ptr.Ptr A)) where
+instance ( TyEq ty (Ptr.Ptr A)
+         ) => GHC.Records.HasField "b_toA" (Ptr.Ptr B) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b_toA")
@@ -120,7 +124,8 @@ instance HsBindgen.Runtime.HasCField.HasCField A "a_toB" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a_toB" (Ptr.Ptr A) (Ptr.Ptr B) where
+instance ( TyEq ty B
+         ) => GHC.Records.HasField "a_toB" (Ptr.Ptr A) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a_toB")

--- a/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -32,7 +32,7 @@ deriving via (EquivStorable B) instance Storable B
 instance HasCField B "b_toA"
     where type CFieldType B "b_toA" = Ptr A
           offset# = \_ -> \_ -> 0
-instance HasField "b_toA" (Ptr B) (Ptr (Ptr A))
+instance TyEq ty (Ptr A) => HasField "b_toA" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"b_toA")
 {-| __C declaration:__ @struct a@
 
@@ -67,5 +67,5 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_toB"
     where type CFieldType A "a_toB" = B
           offset# = \_ -> \_ -> 0
-instance HasField "a_toB" (Ptr A) (Ptr B)
+instance TyEq ty B => HasField "a_toB" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"a_toB")

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct linked_list_A_s@
@@ -79,7 +82,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_A_t "linked_list_A_t_
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "linked_list_A_t_x" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "linked_list_A_t_x" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_A_t_x")
@@ -91,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_A_t "linked_list_A_t_
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "linked_list_A_t_next" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr (Ptr.Ptr Linked_list_A_t)) where
+instance ( TyEq ty (Ptr.Ptr Linked_list_A_t)
+         ) => GHC.Records.HasField "linked_list_A_t_next" (Ptr.Ptr Linked_list_A_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_A_t_next")
@@ -153,7 +158,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_B_t "linked_list_B_t_
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "linked_list_B_t_x" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "linked_list_B_t_x" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_B_t_x")
@@ -165,7 +171,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Linked_list_B_t "linked_list_B_t_
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "linked_list_B_t_next" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr (Ptr.Ptr Linked_list_B_t)) where
+instance ( TyEq ty (Ptr.Ptr Linked_list_B_t)
+         ) => GHC.Records.HasField "linked_list_B_t_next" (Ptr.Ptr Linked_list_B_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/fixtures/types/structs/recursive_struct/th.txt
@@ -40,17 +40,15 @@ deriving via (EquivStorable Linked_list_A_t) instance Storable Linked_list_A_t
 instance HasCField Linked_list_A_t "linked_list_A_t_x"
     where type CFieldType Linked_list_A_t "linked_list_A_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "linked_list_A_t_x"
-                  (Ptr Linked_list_A_t)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "linked_list_A_t_x" (Ptr Linked_list_A_t) (Ptr ty)
     where getField = fromPtr (Proxy @"linked_list_A_t_x")
 instance HasCField Linked_list_A_t "linked_list_A_t_next"
     where type CFieldType Linked_list_A_t
                           "linked_list_A_t_next" = Ptr Linked_list_A_t
           offset# = \_ -> \_ -> 8
-instance HasField "linked_list_A_t_next"
-                  (Ptr Linked_list_A_t)
-                  (Ptr (Ptr Linked_list_A_t))
+instance TyEq ty (Ptr Linked_list_A_t) =>
+         HasField "linked_list_A_t_next" (Ptr Linked_list_A_t) (Ptr ty)
     where getField = fromPtr (Proxy @"linked_list_A_t_next")
 {-| __C declaration:__ @struct linked_list_B_t@
 
@@ -93,15 +91,13 @@ deriving via (EquivStorable Linked_list_B_t) instance Storable Linked_list_B_t
 instance HasCField Linked_list_B_t "linked_list_B_t_x"
     where type CFieldType Linked_list_B_t "linked_list_B_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "linked_list_B_t_x"
-                  (Ptr Linked_list_B_t)
-                  (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "linked_list_B_t_x" (Ptr Linked_list_B_t) (Ptr ty)
     where getField = fromPtr (Proxy @"linked_list_B_t_x")
 instance HasCField Linked_list_B_t "linked_list_B_t_next"
     where type CFieldType Linked_list_B_t
                           "linked_list_B_t_next" = Ptr Linked_list_B_t
           offset# = \_ -> \_ -> 8
-instance HasField "linked_list_B_t_next"
-                  (Ptr Linked_list_B_t)
-                  (Ptr (Ptr Linked_list_B_t))
+instance TyEq ty (Ptr Linked_list_B_t) =>
+         HasField "linked_list_B_t_next" (Ptr Linked_list_B_t) (Ptr ty)
     where getField = fromPtr (Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/Example.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -81,7 +84,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -92,7 +96,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S1) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -162,7 +167,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -173,7 +179,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -184,7 +191,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "c" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "c" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"c")
@@ -236,7 +244,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S3_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S3_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -306,7 +315,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "b" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S4) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -317,7 +327,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "a" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S4) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -328,7 +339,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "c" (Ptr.Ptr S4) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "c" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"c")
@@ -389,7 +401,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S5) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -400,7 +413,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S5) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -461,7 +475,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S6) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -472,7 +487,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S6) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -533,7 +549,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -544,7 +561,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -567,7 +585,8 @@ newtype S7a = S7a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr S7a) (Ptr.Ptr (Ptr.Ptr S7a_Aux)) where
+instance ( TyEq ty (Ptr.Ptr S7a_Aux)
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr S7a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")
@@ -634,7 +653,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"a")
@@ -645,7 +665,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"b")
@@ -668,7 +689,8 @@ newtype S7b = S7b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrap" (Ptr.Ptr S7b) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))
+         ) => GHC.Records.HasField "unwrap" (Ptr.Ptr S7b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrap")

--- a/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs.enable_record_dot/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "a"
     where type CFieldType S1 "a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S1) (Ptr CInt)
+instance TyEq ty CInt => HasField "a" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S1 "b"
     where type CFieldType S1 "b" = CChar
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S1) (Ptr CChar)
+instance TyEq ty CChar => HasField "b" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S2@
 
@@ -96,17 +96,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "a"
     where type CFieldType S2_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S2_t) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S2_t "b"
     where type CFieldType S2_t "b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S2_t) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S2_t "c"
     where type CFieldType S2_t "c" = CFloat
           offset# = \_ -> \_ -> 8
-instance HasField "c" (Ptr S2_t) (Ptr CFloat)
+instance TyEq ty CFloat => HasField "c" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -141,7 +141,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "a"
     where type CFieldType S3_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S3_t) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S3_t) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 {-| __C declaration:__ @struct S4@
 
@@ -192,17 +192,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "b"
     where type CFieldType S4 "b" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "b" (Ptr S4) (Ptr CChar)
+instance TyEq ty CChar => HasField "b" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S4 "a"
     where type CFieldType S4 "a" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "a" (Ptr S4) (Ptr CInt)
+instance TyEq ty CInt => HasField "a" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S4 "c"
     where type CFieldType S4 "c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance HasField "c" (Ptr S4) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) => HasField "c" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S5@
 
@@ -245,12 +245,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "a"
     where type CFieldType S5 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S5) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S5) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S5 "b"
     where type CFieldType S5 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S5) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr S5) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S6@
 
@@ -293,12 +293,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "a"
     where type CFieldType S6 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S6) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S6) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S6 "b"
     where type CFieldType S6 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S6) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr S6) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -341,12 +341,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "a"
     where type CFieldType S7a_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S7a_Aux) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S7a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7a_Aux "b"
     where type CFieldType S7a_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S7a_Aux) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr S7a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7a@
 
@@ -368,7 +368,8 @@ newtype S7a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrap" (Ptr S7a) (Ptr (Ptr S7a_Aux))
+instance TyEq ty (Ptr S7a_Aux) =>
+         HasField "unwrap" (Ptr S7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7a "unwrap"
     where type CFieldType S7a "unwrap" = Ptr S7a_Aux
@@ -414,12 +415,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "a"
     where type CFieldType S7b_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "a" (Ptr S7b_Aux) (Ptr CChar)
+instance TyEq ty CChar => HasField "a" (Ptr S7b_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7b_Aux "b"
     where type CFieldType S7b_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "b" (Ptr S7b_Aux) (Ptr CInt)
+instance TyEq ty CInt => HasField "b" (Ptr S7b_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7b@
 
@@ -441,9 +442,8 @@ newtype S7b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrap"
-                  (Ptr S7b)
-                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
+instance TyEq ty (Ptr (Ptr (Ptr S7b_Aux))) =>
+         HasField "unwrap" (Ptr S7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7b "unwrap"
     where type CFieldType S7b "unwrap" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -22,6 +24,7 @@ import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Ord, Show, pure)
 
 {-| __C declaration:__ @struct S1@
@@ -80,7 +83,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s1_a" (Ptr.Ptr S1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s1_a" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_a")
@@ -91,7 +95,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S1 "s1_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s1_b" (Ptr.Ptr S1) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s1_b" (Ptr.Ptr S1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s1_b")
@@ -161,7 +166,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s2_t_a" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s2_t_a" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_a")
@@ -172,7 +178,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s2_t_b" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s2_t_b" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_b")
@@ -183,7 +190,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S2_t "s2_t_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "s2_t_c" (Ptr.Ptr S2_t) (Ptr.Ptr FC.CFloat) where
+instance ( TyEq ty FC.CFloat
+         ) => GHC.Records.HasField "s2_t_c" (Ptr.Ptr S2_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s2_t_c")
@@ -235,7 +243,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S3_t "s3_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s3_t_a" (Ptr.Ptr S3_t) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s3_t_a" (Ptr.Ptr S3_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s3_t_a")
@@ -305,7 +314,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s4_b" (Ptr.Ptr S4) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s4_b" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_b")
@@ -316,7 +326,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_a" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s4_a" (Ptr.Ptr S4) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s4_a" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_a")
@@ -327,7 +338,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S4 "s4_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "s4_c" (Ptr.Ptr S4) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "s4_c" (Ptr.Ptr S4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s4_c")
@@ -388,7 +400,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "s5_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s5_a" (Ptr.Ptr S5) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s5_a" (Ptr.Ptr S5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s5_a")
@@ -399,7 +412,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S5 "s5_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s5_b" (Ptr.Ptr S5) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s5_b" (Ptr.Ptr S5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s5_b")
@@ -460,7 +474,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "s6_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s6_a" (Ptr.Ptr S6) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s6_a" (Ptr.Ptr S6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s6_a")
@@ -471,7 +486,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S6 "s6_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s6_b" (Ptr.Ptr S6) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s6_b" (Ptr.Ptr S6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s6_b")
@@ -532,7 +548,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s7a_Aux_a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s7a_Aux_a" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7a_Aux_a")
@@ -543,7 +560,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7a_Aux "s7a_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s7a_Aux_b" (Ptr.Ptr S7a_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7a_Aux_b")
@@ -566,7 +584,8 @@ newtype S7a = S7a
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapS7a" (Ptr.Ptr S7a) (Ptr.Ptr (Ptr.Ptr S7a_Aux)) where
+instance ( TyEq ty (Ptr.Ptr S7a_Aux)
+         ) => GHC.Records.HasField "unwrapS7a" (Ptr.Ptr S7a) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS7a")
@@ -633,7 +652,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "s7b_Aux_a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "s7b_Aux_a" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7b_Aux_a")
@@ -644,7 +664,8 @@ instance HsBindgen.Runtime.HasCField.HasCField S7b_Aux "s7b_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "s7b_Aux_b" (Ptr.Ptr S7b_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"s7b_Aux_b")
@@ -667,7 +688,8 @@ newtype S7b = S7b
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapS7b" (Ptr.Ptr S7b) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr S7b_Aux)))
+         ) => GHC.Records.HasField "unwrapS7b" (Ptr.Ptr S7b) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapS7b")

--- a/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/fixtures/types/structs/simple_structs/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_a"
     where type CFieldType S1 "s1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "s1_a" (Ptr S1) (Ptr CInt)
+instance TyEq ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_a")
 instance HasCField S1 "s1_b"
     where type CFieldType S1 "s1_b" = CChar
           offset# = \_ -> \_ -> 4
-instance HasField "s1_b" (Ptr S1) (Ptr CChar)
+instance TyEq ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_b")
 {-| __C declaration:__ @struct S2@
 
@@ -96,17 +96,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "s2_t_a"
     where type CFieldType S2_t "s2_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s2_t_a" (Ptr S2_t) (Ptr CChar)
+instance TyEq ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_t_a")
 instance HasCField S2_t "s2_t_b"
     where type CFieldType S2_t "s2_t_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s2_t_b" (Ptr S2_t) (Ptr CInt)
+instance TyEq ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_t_b")
 instance HasCField S2_t "s2_t_c"
     where type CFieldType S2_t "s2_t_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance HasField "s2_t_c" (Ptr S2_t) (Ptr CFloat)
+instance TyEq ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_t_c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -141,7 +141,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "s3_t_a"
     where type CFieldType S3_t "s3_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s3_t_a" (Ptr S3_t) (Ptr CChar)
+instance TyEq ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
     where getField = fromPtr (Proxy @"s3_t_a")
 {-| __C declaration:__ @struct S4@
 
@@ -192,17 +192,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "s4_b"
     where type CFieldType S4 "s4_b" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s4_b" (Ptr S4) (Ptr CChar)
+instance TyEq ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"s4_b")
 instance HasCField S4 "s4_a"
     where type CFieldType S4 "s4_a" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s4_a" (Ptr S4) (Ptr CInt)
+instance TyEq ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"s4_a")
 instance HasCField S4 "s4_c"
     where type CFieldType S4 "s4_c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance HasField "s4_c" (Ptr S4) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
     where getField = fromPtr (Proxy @"s4_c")
 {-| __C declaration:__ @struct S5@
 
@@ -245,12 +245,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "s5_a"
     where type CFieldType S5 "s5_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s5_a" (Ptr S5) (Ptr CChar)
+instance TyEq ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
     where getField = fromPtr (Proxy @"s5_a")
 instance HasCField S5 "s5_b"
     where type CFieldType S5 "s5_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s5_b" (Ptr S5) (Ptr CInt)
+instance TyEq ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
     where getField = fromPtr (Proxy @"s5_b")
 {-| __C declaration:__ @struct S6@
 
@@ -293,12 +293,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "s6_a"
     where type CFieldType S6 "s6_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s6_a" (Ptr S6) (Ptr CChar)
+instance TyEq ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
     where getField = fromPtr (Proxy @"s6_a")
 instance HasCField S6 "s6_b"
     where type CFieldType S6 "s6_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s6_b" (Ptr S6) (Ptr CInt)
+instance TyEq ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
     where getField = fromPtr (Proxy @"s6_b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -341,12 +341,14 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "s7a_Aux_a"
     where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance HasCField S7a_Aux "s7a_Aux_b"
     where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"s7a_Aux_b")
 {-| __C declaration:__ @S7a@
 
@@ -368,7 +370,8 @@ newtype S7a
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapS7a" (Ptr S7a) (Ptr (Ptr S7a_Aux))
+instance TyEq ty (Ptr S7a_Aux) =>
+         HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
@@ -414,12 +417,14 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "s7b_Aux_a"
     where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance HasCField S7b_Aux "s7b_Aux_b"
     where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"s7b_Aux_b")
 {-| __C declaration:__ @S7b@
 
@@ -441,9 +446,8 @@ newtype S7b
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapS7b"
-                  (Ptr S7b)
-                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
+instance TyEq ty (Ptr (Ptr (Ptr S7b_Aux))) =>
+         HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -20,6 +22,7 @@ import qualified GHC.Ptr as Ptr
 import qualified GHC.Records
 import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct thing@
@@ -69,7 +72,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Thing "thing_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "thing_x" (Ptr.Ptr Thing) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "thing_x" (Ptr.Ptr Thing) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"thing_x")

--- a/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/fixtures/types/structs/struct_arg/th.txt
@@ -129,7 +129,7 @@ deriving via (EquivStorable Thing) instance Storable Thing
 instance HasCField Thing "thing_x"
     where type CFieldType Thing "thing_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "thing_x" (Ptr Thing) (Ptr CInt)
+instance TyEq ty CInt => HasField "thing_x" (Ptr Thing) (Ptr ty)
     where getField = fromPtr (Proxy @"thing_x")
 -- __unique:__ @test_typesstructsstruct_arg_Example_Safe_thing_fun_1@
 foreign import ccall safe "hs_bindgen_4ad25504590fdd2b" hs_bindgen_4ad25504590fdd2b_base ::

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
 {-| Auxiliary type used by 'F1'
@@ -78,7 +81,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
+instance ( TyEq ty (FC.CInt -> FC.CInt -> IO ())
+         ) => GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1_Aux")
@@ -108,7 +112,8 @@ newtype F1 = F1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr (Ptr.FunPtr F1_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr F1_Aux)
+         ) => GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1")
@@ -165,7 +170,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F2_Aux where
 
   fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 
-instance GHC.Records.HasField "unwrapF2_Aux" (Ptr.Ptr F2_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
+instance ( TyEq ty (FC.CInt -> FC.CInt -> IO ())
+         ) => GHC.Records.HasField "unwrapF2_Aux" (Ptr.Ptr F2_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF2_Aux")
@@ -195,7 +201,8 @@ newtype F2 = F2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF2" (Ptr.Ptr F2) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F2_Aux))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.FunPtr F2_Aux))
+         ) => GHC.Records.HasField "unwrapF2" (Ptr.Ptr F2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF2")
@@ -253,7 +260,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F3_Aux where
 
   fromFunPtr = hs_bindgen_66460422a7197535
 
-instance GHC.Records.HasField "unwrapF3_Aux" (Ptr.Ptr F3_Aux) (Ptr.Ptr (FC.CInt -> FC.CInt -> IO ())) where
+instance ( TyEq ty (FC.CInt -> FC.CInt -> IO ())
+         ) => GHC.Records.HasField "unwrapF3_Aux" (Ptr.Ptr F3_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF3_Aux")
@@ -283,7 +291,8 @@ newtype F3 = F3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF3" (Ptr.Ptr F3) (Ptr.Ptr (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux)))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F3_Aux)))
+         ) => GHC.Records.HasField "unwrapF3" (Ptr.Ptr F3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF3")
@@ -341,7 +350,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F4_Aux where
 
   fromFunPtr = hs_bindgen_40f9a8d432b9eb97
 
-instance GHC.Records.HasField "unwrapF4_Aux" (Ptr.Ptr F4_Aux) (Ptr.Ptr (IO FC.CInt)) where
+instance ( TyEq ty (IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapF4_Aux" (Ptr.Ptr F4_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF4_Aux")
@@ -370,7 +380,8 @@ newtype F4 = F4
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF4" (Ptr.Ptr F4) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F4_Aux))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.FunPtr F4_Aux))
+         ) => GHC.Records.HasField "unwrapF4" (Ptr.Ptr F4) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF4")
@@ -428,7 +439,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F5_Aux where
 
   fromFunPtr = hs_bindgen_586f6635c057975f
 
-instance GHC.Records.HasField "unwrapF5_Aux" (Ptr.Ptr F5_Aux) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapF5_Aux" (Ptr.Ptr F5_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF5_Aux")
@@ -457,7 +469,8 @@ newtype F5 = F5
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF5" (Ptr.Ptr F5) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F5_Aux))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.FunPtr F5_Aux))
+         ) => GHC.Records.HasField "unwrapF5" (Ptr.Ptr F5) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF5")
@@ -497,7 +510,8 @@ newtype MyInt = MyInt
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMyInt" (Ptr.Ptr MyInt) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyInt")
@@ -554,7 +568,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F6_Aux where
 
   fromFunPtr = hs_bindgen_a887947b26e58f0c
 
-instance GHC.Records.HasField "unwrapF6_Aux" (Ptr.Ptr F6_Aux) (Ptr.Ptr (MyInt -> IO ())) where
+instance ( TyEq ty (MyInt -> IO ())
+         ) => GHC.Records.HasField "unwrapF6_Aux" (Ptr.Ptr F6_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF6_Aux")
@@ -584,7 +599,8 @@ newtype F6 = F6
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF6" (Ptr.Ptr F6) (Ptr.Ptr (Ptr.Ptr (Ptr.FunPtr F6_Aux))) where
+instance ( TyEq ty (Ptr.Ptr (Ptr.FunPtr F6_Aux))
+         ) => GHC.Records.HasField "unwrapF6" (Ptr.Ptr F6) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF6")

--- a/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -39,9 +39,8 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance HasField "unwrapF1_Aux"
-                  (Ptr F1_Aux)
-                  (Ptr (CInt -> CInt -> IO Unit))
+instance TyEq ty (CInt -> CInt -> IO Unit) =>
+         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = CInt ->
@@ -67,7 +66,8 @@ newtype F1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
+instance TyEq ty (FunPtr F1_Aux) =>
+         HasField "unwrapF1" (Ptr F1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -112,9 +112,8 @@ instance ToFunPtr F2_Aux
     where toFunPtr = hs_bindgen_c39d7524b75b54e8
 instance FromFunPtr F2_Aux
     where fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
-instance HasField "unwrapF2_Aux"
-                  (Ptr F2_Aux)
-                  (Ptr (CInt -> CInt -> IO Unit))
+instance TyEq ty (CInt -> CInt -> IO Unit) =>
+         HasField "unwrapF2_Aux" (Ptr F2_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF2_Aux")
 instance HasCField F2_Aux "unwrapF2_Aux"
     where type CFieldType F2_Aux "unwrapF2_Aux" = CInt ->
@@ -140,7 +139,8 @@ newtype F2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF2" (Ptr F2) (Ptr (Ptr (FunPtr F2_Aux)))
+instance TyEq ty (Ptr (FunPtr F2_Aux)) =>
+         HasField "unwrapF2" (Ptr F2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF2")
 instance HasCField F2 "unwrapF2"
     where type CFieldType F2 "unwrapF2" = Ptr (FunPtr F2_Aux)
@@ -185,9 +185,8 @@ instance ToFunPtr F3_Aux
     where toFunPtr = hs_bindgen_4a960721e7d1dcef
 instance FromFunPtr F3_Aux
     where fromFunPtr = hs_bindgen_66460422a7197535
-instance HasField "unwrapF3_Aux"
-                  (Ptr F3_Aux)
-                  (Ptr (CInt -> CInt -> IO Unit))
+instance TyEq ty (CInt -> CInt -> IO Unit) =>
+         HasField "unwrapF3_Aux" (Ptr F3_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF3_Aux")
 instance HasCField F3_Aux "unwrapF3_Aux"
     where type CFieldType F3_Aux "unwrapF3_Aux" = CInt ->
@@ -213,9 +212,8 @@ newtype F3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF3"
-                  (Ptr F3)
-                  (Ptr (Ptr (Ptr (FunPtr F3_Aux))))
+instance TyEq ty (Ptr (Ptr (FunPtr F3_Aux))) =>
+         HasField "unwrapF3" (Ptr F3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF3")
 instance HasCField F3 "unwrapF3"
     where type CFieldType F3 "unwrapF3" = Ptr (Ptr (FunPtr F3_Aux))
@@ -258,7 +256,8 @@ instance ToFunPtr F4_Aux
     where toFunPtr = hs_bindgen_83bcff023b3bc648
 instance FromFunPtr F4_Aux
     where fromFunPtr = hs_bindgen_40f9a8d432b9eb97
-instance HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr (IO CInt))
+instance TyEq ty (IO CInt) =>
+         HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF4_Aux")
 instance HasCField F4_Aux "unwrapF4_Aux"
     where type CFieldType F4_Aux "unwrapF4_Aux" = IO CInt
@@ -283,7 +282,8 @@ newtype F4
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF4" (Ptr F4) (Ptr (Ptr (FunPtr F4_Aux)))
+instance TyEq ty (Ptr (FunPtr F4_Aux)) =>
+         HasField "unwrapF4" (Ptr F4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF4")
 instance HasCField F4 "unwrapF4"
     where type CFieldType F4 "unwrapF4" = Ptr (FunPtr F4_Aux)
@@ -326,7 +326,8 @@ instance ToFunPtr F5_Aux
     where toFunPtr = hs_bindgen_6891cbd81d6f42b9
 instance FromFunPtr F5_Aux
     where fromFunPtr = hs_bindgen_586f6635c057975f
-instance HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr (IO Unit))
+instance TyEq ty (IO Unit) =>
+         HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF5_Aux")
 instance HasCField F5_Aux "unwrapF5_Aux"
     where type CFieldType F5_Aux "unwrapF5_Aux" = IO Unit
@@ -351,7 +352,8 @@ newtype F5
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF5" (Ptr F5) (Ptr (Ptr (FunPtr F5_Aux)))
+instance TyEq ty (Ptr (FunPtr F5_Aux)) =>
+         HasField "unwrapF5" (Ptr F5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF5")
 instance HasCField F5 "unwrapF5"
     where type CFieldType F5 "unwrapF5" = Ptr (FunPtr F5_Aux)
@@ -386,7 +388,8 @@ newtype MyInt
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -430,9 +433,8 @@ instance ToFunPtr F6_Aux
     where toFunPtr = hs_bindgen_c1baf73f98614f45
 instance FromFunPtr F6_Aux
     where fromFunPtr = hs_bindgen_a887947b26e58f0c
-instance HasField "unwrapF6_Aux"
-                  (Ptr F6_Aux)
-                  (Ptr (MyInt -> IO Unit))
+instance TyEq ty (MyInt -> IO Unit) =>
+         HasField "unwrapF6_Aux" (Ptr F6_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF6_Aux")
 instance HasCField F6_Aux "unwrapF6_Aux"
     where type CFieldType F6_Aux "unwrapF6_Aux" = MyInt -> IO Unit
@@ -457,7 +459,8 @@ newtype F6
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF6" (Ptr F6) (Ptr (Ptr (FunPtr F6_Aux)))
+instance TyEq ty (Ptr (FunPtr F6_Aux)) =>
+         HasField "unwrapF6" (Ptr F6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF6")
 instance HasCField F6 "unwrapF6"
     where type CFieldType F6 "unwrapF6" = Ptr (FunPtr F6_Aux)

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +30,7 @@ import qualified HsBindgen.Runtime.Internal.Bitfield
 import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Bounded, Enum, Eq, Int, Integral, Num, Ord, Read, Real, Show, pure)
 
 {-| __C declaration:__ @T1@
@@ -58,7 +61,8 @@ newtype T1 = T1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapT1" (Ptr.Ptr T1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT1")
@@ -97,7 +101,8 @@ newtype T2 = T2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapT2" (Ptr.Ptr T2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapT2")
@@ -136,7 +141,8 @@ newtype M1 = M1
     , Real
     )
 
-instance GHC.Records.HasField "unwrapM1" (Ptr.Ptr M1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapM1" (Ptr.Ptr M1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM1")
@@ -175,7 +181,8 @@ newtype M2 = M2
     , Real
     )
 
-instance GHC.Records.HasField "unwrapM2" (Ptr.Ptr M2) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unwrapM2" (Ptr.Ptr M2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM2")
@@ -204,7 +211,8 @@ newtype M3 = M3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapM3" (Ptr.Ptr M3) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "unwrapM3" (Ptr.Ptr M3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapM3")
@@ -293,7 +301,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_t1" 
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exampleStruct_t1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr T1) where
+instance ( TyEq ty T1
+         ) => GHC.Records.HasField "exampleStruct_t1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_t1")
@@ -304,7 +313,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_t2" 
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "exampleStruct_t2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr T2) where
+instance ( TyEq ty T2
+         ) => GHC.Records.HasField "exampleStruct_t2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_t2")
@@ -315,7 +325,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_m1" 
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "exampleStruct_m1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr M1) where
+instance ( TyEq ty M1
+         ) => GHC.Records.HasField "exampleStruct_m1" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_m1")
@@ -326,7 +337,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExampleStruct "exampleStruct_m2" 
 
   offset# = \_ -> \_ -> 12
 
-instance GHC.Records.HasField "exampleStruct_m2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr M2) where
+instance ( TyEq ty M2
+         ) => GHC.Records.HasField "exampleStruct_m2" (Ptr.Ptr ExampleStruct) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exampleStruct_m2")
@@ -359,7 +371,8 @@ newtype Uint64_t = Uint64_t
     , Real
     )
 
-instance GHC.Records.HasField "unwrapUint64_t" (Ptr.Ptr Uint64_t) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapUint64_t" (Ptr.Ptr Uint64_t) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapUint64_t")
@@ -417,7 +430,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Foo "foo_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "foo_a" (Ptr.Ptr Foo) (Ptr.Ptr (Ptr.Ptr Uint64_t)) where
+instance ( TyEq ty (Ptr.Ptr Uint64_t)
+         ) => GHC.Records.HasField "foo_a" (Ptr.Ptr Foo) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"foo_a")

--- a/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -29,7 +29,7 @@ newtype T1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -64,7 +64,7 @@ newtype T2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapT2" (Ptr T2) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CChar
@@ -99,7 +99,7 @@ newtype M1
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapM1" (Ptr M1) (Ptr CInt)
+instance TyEq ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
@@ -134,7 +134,7 @@ newtype M2
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapM2" (Ptr M2) (Ptr CChar)
+instance TyEq ty CChar => HasField "unwrapM2" (Ptr M2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = CChar
@@ -159,7 +159,8 @@ newtype M3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapM3" (Ptr M3) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) =>
+         HasField "unwrapM3" (Ptr M3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = Ptr CInt
@@ -221,22 +222,26 @@ deriving via (EquivStorable ExampleStruct) instance Storable ExampleStruct
 instance HasCField ExampleStruct "exampleStruct_t1"
     where type CFieldType ExampleStruct "exampleStruct_t1" = T1
           offset# = \_ -> \_ -> 0
-instance HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr T1)
+instance TyEq ty T1 =>
+         HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"exampleStruct_t1")
 instance HasCField ExampleStruct "exampleStruct_t2"
     where type CFieldType ExampleStruct "exampleStruct_t2" = T2
           offset# = \_ -> \_ -> 4
-instance HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr T2)
+instance TyEq ty T2 =>
+         HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"exampleStruct_t2")
 instance HasCField ExampleStruct "exampleStruct_m1"
     where type CFieldType ExampleStruct "exampleStruct_m1" = M1
           offset# = \_ -> \_ -> 8
-instance HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr M1)
+instance TyEq ty M1 =>
+         HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"exampleStruct_m1")
 instance HasCField ExampleStruct "exampleStruct_m2"
     where type CFieldType ExampleStruct "exampleStruct_m2" = M2
           offset# = \_ -> \_ -> 12
-instance HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr M2)
+instance TyEq ty M2 =>
+         HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr ty)
     where getField = fromPtr (Proxy @"exampleStruct_m2")
 {-| __C declaration:__ @uint64_t@
 
@@ -268,7 +273,8 @@ newtype Uint64_t
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint64_t")
 instance HasCField Uint64_t "unwrapUint64_t"
     where type CFieldType Uint64_t "unwrapUint64_t" = CInt
@@ -306,5 +312,6 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_a"
     where type CFieldType Foo "foo_a" = Ptr Uint64_t
           offset# = \_ -> \_ -> 0
-instance HasField "foo_a" (Ptr Foo) (Ptr (Ptr Uint64_t))
+instance TyEq ty (Ptr Uint64_t) =>
+         HasField "foo_a" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_a")

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,6 +32,7 @@ import qualified HsBindgen.Runtime.Internal.HasFFIType
 import qualified HsBindgen.Runtime.Marshal
 import qualified Prelude as P
 import Data.Bits (FiniteBits)
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude (Bounded, Enum, Eq, IO, Integral, Num, Ord, Read, Real, Show)
 
 {-| __C declaration:__ @myint@
@@ -60,7 +63,8 @@ newtype Myint = Myint
     , Real
     )
 
-instance GHC.Records.HasField "unwrapMyint" (Ptr.Ptr Myint) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unwrapMyint" (Ptr.Ptr Myint) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapMyint")
@@ -89,7 +93,8 @@ newtype Intptr = Intptr
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapIntptr" (Ptr.Ptr Intptr) (Ptr.Ptr (Ptr.Ptr FC.CInt)) where
+instance ( TyEq ty (Ptr.Ptr FC.CInt)
+         ) => GHC.Records.HasField "unwrapIntptr" (Ptr.Ptr Intptr) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapIntptr")
@@ -145,7 +150,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr Int2int where
 
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
-instance GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapInt2int" (Ptr.Ptr Int2int) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapInt2int")
@@ -203,7 +209,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr FunctionPointer_Function_A
 
   fromFunPtr = hs_bindgen_4c3da8240a31e036
 
-instance GHC.Records.HasField "unwrapFunctionPointer_Function_Aux" (Ptr.Ptr FunctionPointer_Function_Aux) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapFunctionPointer_Function_Aux" (Ptr.Ptr FunctionPointer_Function_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunctionPointer_Function_Aux")
@@ -233,7 +240,8 @@ newtype FunctionPointer_Function = FunctionPointer_Function
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapFunctionPointer_Function" (Ptr.Ptr FunctionPointer_Function) (Ptr.Ptr (Ptr.FunPtr FunctionPointer_Function_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr FunctionPointer_Function_Aux)
+         ) => GHC.Records.HasField "unwrapFunctionPointer_Function" (Ptr.Ptr FunctionPointer_Function) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapFunctionPointer_Function")
@@ -289,7 +297,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr NonFunctionPointer_Functio
 
   fromFunPtr = hs_bindgen_36c7108d046bcbc3
 
-instance GHC.Records.HasField "unwrapNonFunctionPointer_Function" (Ptr.Ptr NonFunctionPointer_Function) (Ptr.Ptr (FC.CInt -> IO FC.CInt)) where
+instance ( TyEq ty (FC.CInt -> IO FC.CInt)
+         ) => GHC.Records.HasField "unwrapNonFunctionPointer_Function" (Ptr.Ptr NonFunctionPointer_Function) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapNonFunctionPointer_Function")
@@ -347,7 +356,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapF1_Aux" (Ptr.Ptr F1_Aux) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1_Aux")
@@ -376,7 +386,8 @@ newtype F1 = F1
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr (Ptr.FunPtr F1_Aux)) where
+instance ( TyEq ty (Ptr.FunPtr F1_Aux)
+         ) => GHC.Records.HasField "unwrapF1" (Ptr.Ptr F1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapF1")
@@ -431,7 +442,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr G1 where
 
   fromFunPtr = hs_bindgen_8405c8e75aa78be5
 
-instance GHC.Records.HasField "unwrapG1" (Ptr.Ptr G1) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapG1" (Ptr.Ptr G1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapG1")
@@ -460,7 +472,8 @@ newtype G2 = G2
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapG2" (Ptr.Ptr G2) (Ptr.Ptr (Ptr.FunPtr G1)) where
+instance ( TyEq ty (Ptr.FunPtr G1)
+         ) => GHC.Records.HasField "unwrapG2" (Ptr.Ptr G2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapG2")
@@ -515,7 +528,8 @@ instance HsBindgen.Runtime.Internal.FunPtr.FromFunPtr H1 where
 
   fromFunPtr = hs_bindgen_1a33688324e1924f
 
-instance GHC.Records.HasField "unwrapH1" (Ptr.Ptr H1) (Ptr.Ptr (IO ())) where
+instance ( TyEq ty (IO ())
+         ) => GHC.Records.HasField "unwrapH1" (Ptr.Ptr H1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH1")
@@ -538,7 +552,8 @@ newtype H2 = H2
   deriving stock (GHC.Generics.Generic)
   deriving newtype (HsBindgen.Runtime.Internal.HasFFIType.HasFFIType)
 
-instance GHC.Records.HasField "unwrapH2" (Ptr.Ptr H2) (Ptr.Ptr H1) where
+instance ( TyEq ty H1
+         ) => GHC.Records.HasField "unwrapH2" (Ptr.Ptr H2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH2")
@@ -567,7 +582,8 @@ newtype H3 = H3
     , HsBindgen.Runtime.Internal.HasFFIType.HasFFIType
     )
 
-instance GHC.Records.HasField "unwrapH3" (Ptr.Ptr H3) (Ptr.Ptr (Ptr.FunPtr H2)) where
+instance ( TyEq ty (Ptr.FunPtr H2)
+         ) => GHC.Records.HasField "unwrapH3" (Ptr.Ptr H3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unwrapH3")

--- a/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/typedefs/typedefs/th.txt
@@ -29,7 +29,8 @@ newtype Myint
                       Ix,
                       Num,
                       Real)
-instance HasField "unwrapMyint" (Ptr Myint) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "unwrapMyint" (Ptr Myint) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyint")
 instance HasCField Myint "unwrapMyint"
     where type CFieldType Myint "unwrapMyint" = CInt
@@ -54,7 +55,8 @@ newtype Intptr
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapIntptr" (Ptr Intptr) (Ptr (Ptr CInt))
+instance TyEq ty (Ptr CInt) =>
+         HasField "unwrapIntptr" (Ptr Intptr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapIntptr")
 instance HasCField Intptr "unwrapIntptr"
     where type CFieldType Intptr "unwrapIntptr" = Ptr CInt
@@ -94,9 +96,8 @@ instance ToFunPtr Int2int
     where toFunPtr = hs_bindgen_a6c7dd49f5b9d470
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
-instance HasField "unwrapInt2int"
-                  (Ptr Int2int)
-                  (Ptr (CInt -> IO CInt))
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
@@ -141,9 +142,10 @@ instance ToFunPtr FunctionPointer_Function_Aux
     where toFunPtr = hs_bindgen_b171c028cdc0781d
 instance FromFunPtr FunctionPointer_Function_Aux
     where fromFunPtr = hs_bindgen_4c3da8240a31e036
-instance HasField "unwrapFunctionPointer_Function_Aux"
+instance TyEq ty (IO Unit) =>
+         HasField "unwrapFunctionPointer_Function_Aux"
                   (Ptr FunctionPointer_Function_Aux)
-                  (Ptr (IO Unit))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function_Aux")
 instance HasCField FunctionPointer_Function_Aux
                    "unwrapFunctionPointer_Function_Aux"
@@ -170,9 +172,10 @@ newtype FunctionPointer_Function
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapFunctionPointer_Function"
+instance TyEq ty (FunPtr FunctionPointer_Function_Aux) =>
+         HasField "unwrapFunctionPointer_Function"
                   (Ptr FunctionPointer_Function)
-                  (Ptr (FunPtr FunctionPointer_Function_Aux))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function")
 instance HasCField FunctionPointer_Function
                    "unwrapFunctionPointer_Function"
@@ -217,9 +220,10 @@ instance ToFunPtr NonFunctionPointer_Function
     where toFunPtr = hs_bindgen_766ae751d60365e9
 instance FromFunPtr NonFunctionPointer_Function
     where fromFunPtr = hs_bindgen_36c7108d046bcbc3
-instance HasField "unwrapNonFunctionPointer_Function"
+instance TyEq ty (CInt -> IO CInt) =>
+         HasField "unwrapNonFunctionPointer_Function"
                   (Ptr NonFunctionPointer_Function)
-                  (Ptr (CInt -> IO CInt))
+                  (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapNonFunctionPointer_Function")
 instance HasCField NonFunctionPointer_Function
                    "unwrapNonFunctionPointer_Function"
@@ -264,7 +268,8 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr (IO Unit))
+instance TyEq ty (IO Unit) =>
+         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = IO Unit
@@ -289,7 +294,8 @@ newtype F1
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
+instance TyEq ty (FunPtr F1_Aux) =>
+         HasField "unwrapF1" (Ptr F1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -328,7 +334,7 @@ instance ToFunPtr G1
     where toFunPtr = hs_bindgen_fa5806570b682579
 instance FromFunPtr G1
     where fromFunPtr = hs_bindgen_8405c8e75aa78be5
-instance HasField "unwrapG1" (Ptr G1) (Ptr (IO Unit))
+instance TyEq ty (IO Unit) => HasField "unwrapG1" (Ptr G1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapG1")
 instance HasCField G1 "unwrapG1"
     where type CFieldType G1 "unwrapG1" = IO Unit
@@ -353,7 +359,8 @@ newtype G2
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapG2" (Ptr G2) (Ptr (FunPtr G1))
+instance TyEq ty (FunPtr G1) =>
+         HasField "unwrapG2" (Ptr G2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapG2")
 instance HasCField G2 "unwrapG2"
     where type CFieldType G2 "unwrapG2" = FunPtr G1
@@ -392,7 +399,7 @@ instance ToFunPtr H1
     where toFunPtr = hs_bindgen_ffae0d1234ed018f
 instance FromFunPtr H1
     where fromFunPtr = hs_bindgen_1a33688324e1924f
-instance HasField "unwrapH1" (Ptr H1) (Ptr (IO Unit))
+instance TyEq ty (IO Unit) => HasField "unwrapH1" (Ptr H1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH1")
 instance HasCField H1 "unwrapH1"
     where type CFieldType H1 "unwrapH1" = IO Unit
@@ -413,7 +420,7 @@ newtype H2
       -}
     deriving stock Generic
     deriving newtype HasFFIType
-instance HasField "unwrapH2" (Ptr H2) (Ptr H1)
+instance TyEq ty H1 => HasField "unwrapH2" (Ptr H2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH2")
 instance HasCField H2 "unwrapH2"
     where type CFieldType H2 "unwrapH2" = H1
@@ -438,7 +445,8 @@ newtype H3
                       WriteRaw,
                       Storable,
                       HasFFIType)
-instance HasField "unwrapH3" (Ptr H3) (Ptr (FunPtr H2))
+instance TyEq ty (FunPtr H2) =>
+         HasField "unwrapH3" (Ptr H3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH3")
 instance HasCField H3 "unwrapH3"
     where type CFieldType H3 "unwrapH3" = FunPtr H2

--- a/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), Int, pure)
 
 {-| __C declaration:__ @union unionA@
@@ -104,7 +107,8 @@ instance HsBindgen.Runtime.HasCField.HasCField UnionA "unionA_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "unionA_a" (Ptr.Ptr UnionA) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "unionA_a" (Ptr.Ptr UnionA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unionA_a")
@@ -115,7 +119,8 @@ instance HsBindgen.Runtime.HasCField.HasCField UnionA "unionA_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "unionA_b" (Ptr.Ptr UnionA) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "unionA_b" (Ptr.Ptr UnionA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"unionA_b")
@@ -167,7 +172,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr UnionA) where
+instance ( TyEq ty UnionA
+         ) => GHC.Records.HasField "exA_fieldA1" (Ptr.Ptr ExA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exA_fieldA1")
@@ -251,7 +257,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB_fieldB1 "exB_fieldB1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exB_fieldB1_a" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "exB_fieldB1_a" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1_a")
@@ -263,7 +270,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB_fieldB1 "exB_fieldB1_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exB_fieldB1_b" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr FC.CChar) where
+instance ( TyEq ty FC.CChar
+         ) => GHC.Records.HasField "exB_fieldB1_b" (Ptr.Ptr ExB_fieldB1) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1_b")
@@ -315,7 +323,8 @@ instance HsBindgen.Runtime.HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ExB_fieldB1) where
+instance ( TyEq ty ExB_fieldB1
+         ) => GHC.Records.HasField "exB_fieldB1" (Ptr.Ptr ExB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/nested_unions/th.txt
@@ -89,12 +89,12 @@ set_unionA_b = setUnionPayload
 instance HasCField UnionA "unionA_a"
     where type CFieldType UnionA "unionA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "unionA_a" (Ptr UnionA) (Ptr CInt)
+instance TyEq ty CInt => HasField "unionA_a" (Ptr UnionA) (Ptr ty)
     where getField = fromPtr (Proxy @"unionA_a")
 instance HasCField UnionA "unionA_b"
     where type CFieldType UnionA "unionA_b" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "unionA_b" (Ptr UnionA) (Ptr CChar)
+instance TyEq ty CChar => HasField "unionA_b" (Ptr UnionA) (Ptr ty)
     where getField = fromPtr (Proxy @"unionA_b")
 {-| __C declaration:__ @struct exA@
 
@@ -129,7 +129,8 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = UnionA
           offset# = \_ -> \_ -> 0
-instance HasField "exA_fieldA1" (Ptr ExA) (Ptr UnionA)
+instance TyEq ty UnionA =>
+         HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @union \@exB_fieldB1@
 
@@ -221,12 +222,14 @@ set_exB_fieldB1_b = setUnionPayload
 instance HasCField ExB_fieldB1 "exB_fieldB1_a"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr CInt)
+instance TyEq ty CInt =>
+         HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1_a")
 instance HasCField ExB_fieldB1 "exB_fieldB1_b"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_b" = CChar
           offset# = \_ -> \_ -> 0
-instance HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr CChar)
+instance TyEq ty CChar =>
+         HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1_b")
 {-| __C declaration:__ @struct exB@
 
@@ -261,5 +264,6 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
+instance TyEq ty ExB_fieldB1 =>
+         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/fixtures/types/unions/unions/Example.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example where
@@ -23,6 +25,7 @@ import qualified HsBindgen.Runtime.HasCField
 import qualified HsBindgen.Runtime.Internal.ByteArray
 import qualified HsBindgen.Runtime.Internal.SizedByteArray
 import qualified HsBindgen.Runtime.Marshal
+import HsBindgen.Runtime.Internal.TypeEquality (TyEq)
 import Prelude ((<*>), (>>), Eq, Int, Show, pure)
 
 {-| __C declaration:__ @struct Dim2@
@@ -81,7 +84,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim2 "dim2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dim2_x" (Ptr.Ptr Dim2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim2_x" (Ptr.Ptr Dim2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim2_x")
@@ -92,7 +96,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim2 "dim2_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "dim2_y" (Ptr.Ptr Dim2) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim2_y" (Ptr.Ptr Dim2) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim2_y")
@@ -162,7 +167,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dim3_x" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim3_x" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_x")
@@ -173,7 +179,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "dim3_y" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim3_y" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_y")
@@ -184,7 +191,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim3 "dim3_z" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "dim3_z" (Ptr.Ptr Dim3) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim3_z" (Ptr.Ptr Dim3) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim3_z")
@@ -268,7 +276,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayload "dimPayload_dim2" wher
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dimPayload_dim2" (Ptr.Ptr DimPayload) (Ptr.Ptr Dim2) where
+instance ( TyEq ty Dim2
+         ) => GHC.Records.HasField "dimPayload_dim2" (Ptr.Ptr DimPayload) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayload_dim2")
@@ -279,7 +288,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayload "dimPayload_dim3" wher
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dimPayload_dim3" (Ptr.Ptr DimPayload) (Ptr.Ptr Dim2) where
+instance ( TyEq ty Dim2
+         ) => GHC.Records.HasField "dimPayload_dim3" (Ptr.Ptr DimPayload) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayload_dim3")
@@ -340,7 +350,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim "dim_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dim_tag" (Ptr.Ptr Dim) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dim_tag" (Ptr.Ptr Dim) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim_tag")
@@ -351,7 +362,8 @@ instance HsBindgen.Runtime.HasCField.HasCField Dim "dim_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "dim_payload" (Ptr.Ptr Dim) (Ptr.Ptr DimPayload) where
+instance ( TyEq ty DimPayload
+         ) => GHC.Records.HasField "dim_payload" (Ptr.Ptr Dim) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dim_payload")
@@ -435,7 +447,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayloadB "dimPayloadB_dim2" wh
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dimPayloadB_dim2" (Ptr.Ptr DimPayloadB) (Ptr.Ptr Dim2) where
+instance ( TyEq ty Dim2
+         ) => GHC.Records.HasField "dimPayloadB_dim2" (Ptr.Ptr DimPayloadB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayloadB_dim2")
@@ -446,7 +459,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimPayloadB "dimPayloadB_dim3" wh
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dimPayloadB_dim3" (Ptr.Ptr DimPayloadB) (Ptr.Ptr Dim2) where
+instance ( TyEq ty Dim2
+         ) => GHC.Records.HasField "dimPayloadB_dim3" (Ptr.Ptr DimPayloadB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimPayloadB_dim3")
@@ -507,7 +521,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimB "dimB_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "dimB_tag" (Ptr.Ptr DimB) (Ptr.Ptr FC.CInt) where
+instance ( TyEq ty FC.CInt
+         ) => GHC.Records.HasField "dimB_tag" (Ptr.Ptr DimB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimB_tag")
@@ -518,7 +533,8 @@ instance HsBindgen.Runtime.HasCField.HasCField DimB "dimB_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance GHC.Records.HasField "dimB_payload" (Ptr.Ptr DimB) (Ptr.Ptr DimPayloadB) where
+instance ( TyEq ty DimPayloadB
+         ) => GHC.Records.HasField "dimB_payload" (Ptr.Ptr DimB) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"dimB_payload")
@@ -579,7 +595,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_xy "anonA_xy_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "anonA_xy_x" (Ptr.Ptr AnonA_xy) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "anonA_xy_x" (Ptr.Ptr AnonA_xy) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy_x")
@@ -590,7 +607,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_xy "anonA_xy_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "anonA_xy_y" (Ptr.Ptr AnonA_xy) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "anonA_xy_y" (Ptr.Ptr AnonA_xy) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy_y")
@@ -652,7 +670,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_polar "anonA_polar_r" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "anonA_polar_r" (Ptr.Ptr AnonA_polar) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "anonA_polar_r" (Ptr.Ptr AnonA_polar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar_r")
@@ -664,7 +683,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA_polar "anonA_polar_p" where
 
   offset# = \_ -> \_ -> 8
 
-instance GHC.Records.HasField "anonA_polar_p" (Ptr.Ptr AnonA_polar) (Ptr.Ptr FC.CDouble) where
+instance ( TyEq ty FC.CDouble
+         ) => GHC.Records.HasField "anonA_polar_p" (Ptr.Ptr AnonA_polar) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar_p")
@@ -748,7 +768,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA "anonA_xy" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "anonA_xy" (Ptr.Ptr AnonA) (Ptr.Ptr AnonA_xy) where
+instance ( TyEq ty AnonA_xy
+         ) => GHC.Records.HasField "anonA_xy" (Ptr.Ptr AnonA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_xy")
@@ -759,7 +780,8 @@ instance HsBindgen.Runtime.HasCField.HasCField AnonA "anonA_polar" where
 
   offset# = \_ -> \_ -> 0
 
-instance GHC.Records.HasField "anonA_polar" (Ptr.Ptr AnonA) (Ptr.Ptr AnonA_polar) where
+instance ( TyEq ty AnonA_polar
+         ) => GHC.Records.HasField "anonA_polar" (Ptr.Ptr AnonA) (Ptr.Ptr ty) where
 
   getField =
     HsBindgen.Runtime.HasCField.fromPtr (Data.Proxy.Proxy @"anonA_polar")

--- a/hs-bindgen/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/fixtures/types/unions/unions/th.txt
@@ -40,12 +40,12 @@ deriving via (EquivStorable Dim2) instance Storable Dim2
 instance HasCField Dim2 "dim2_x"
     where type CFieldType Dim2 "dim2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "dim2_x" (Ptr Dim2) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim2_x" (Ptr Dim2) (Ptr ty)
     where getField = fromPtr (Proxy @"dim2_x")
 instance HasCField Dim2 "dim2_y"
     where type CFieldType Dim2 "dim2_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "dim2_y" (Ptr Dim2) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim2_y" (Ptr Dim2) (Ptr ty)
     where getField = fromPtr (Proxy @"dim2_y")
 {-| __C declaration:__ @struct Dim3@
 
@@ -96,17 +96,17 @@ deriving via (EquivStorable Dim3) instance Storable Dim3
 instance HasCField Dim3 "dim3_x"
     where type CFieldType Dim3 "dim3_x" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "dim3_x" (Ptr Dim3) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim3_x" (Ptr Dim3) (Ptr ty)
     where getField = fromPtr (Proxy @"dim3_x")
 instance HasCField Dim3 "dim3_y"
     where type CFieldType Dim3 "dim3_y" = CInt
           offset# = \_ -> \_ -> 4
-instance HasField "dim3_y" (Ptr Dim3) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim3_y" (Ptr Dim3) (Ptr ty)
     where getField = fromPtr (Proxy @"dim3_y")
 instance HasCField Dim3 "dim3_z"
     where type CFieldType Dim3 "dim3_z" = CInt
           offset# = \_ -> \_ -> 8
-instance HasField "dim3_z" (Ptr Dim3) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim3_z" (Ptr Dim3) (Ptr ty)
     where getField = fromPtr (Proxy @"dim3_z")
 {-| __C declaration:__ @union DimPayload@
 
@@ -198,12 +198,14 @@ set_dimPayload_dim3 = setUnionPayload
 instance HasCField DimPayload "dimPayload_dim2"
     where type CFieldType DimPayload "dimPayload_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr Dim2)
+instance TyEq ty Dim2 =>
+         HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr ty)
     where getField = fromPtr (Proxy @"dimPayload_dim2")
 instance HasCField DimPayload "dimPayload_dim3"
     where type CFieldType DimPayload "dimPayload_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr Dim2)
+instance TyEq ty Dim2 =>
+         HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr ty)
     where getField = fromPtr (Proxy @"dimPayload_dim3")
 {-| __C declaration:__ @struct Dim@
 
@@ -246,12 +248,13 @@ deriving via (EquivStorable Dim) instance Storable Dim
 instance HasCField Dim "dim_tag"
     where type CFieldType Dim "dim_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "dim_tag" (Ptr Dim) (Ptr CInt)
+instance TyEq ty CInt => HasField "dim_tag" (Ptr Dim) (Ptr ty)
     where getField = fromPtr (Proxy @"dim_tag")
 instance HasCField Dim "dim_payload"
     where type CFieldType Dim "dim_payload" = DimPayload
           offset# = \_ -> \_ -> 4
-instance HasField "dim_payload" (Ptr Dim) (Ptr DimPayload)
+instance TyEq ty DimPayload =>
+         HasField "dim_payload" (Ptr Dim) (Ptr ty)
     where getField = fromPtr (Proxy @"dim_payload")
 {-| __C declaration:__ @union DimPayloadB@
 
@@ -343,12 +346,14 @@ set_dimPayloadB_dim3 = setUnionPayload
 instance HasCField DimPayloadB "dimPayloadB_dim2"
     where type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr Dim2)
+instance TyEq ty Dim2 =>
+         HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr ty)
     where getField = fromPtr (Proxy @"dimPayloadB_dim2")
 instance HasCField DimPayloadB "dimPayloadB_dim3"
     where type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr Dim2)
+instance TyEq ty Dim2 =>
+         HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr ty)
     where getField = fromPtr (Proxy @"dimPayloadB_dim3")
 {-| __C declaration:__ @struct DimB@
 
@@ -391,12 +396,13 @@ deriving via (EquivStorable DimB) instance Storable DimB
 instance HasCField DimB "dimB_tag"
     where type CFieldType DimB "dimB_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance HasField "dimB_tag" (Ptr DimB) (Ptr CInt)
+instance TyEq ty CInt => HasField "dimB_tag" (Ptr DimB) (Ptr ty)
     where getField = fromPtr (Proxy @"dimB_tag")
 instance HasCField DimB "dimB_payload"
     where type CFieldType DimB "dimB_payload" = DimPayloadB
           offset# = \_ -> \_ -> 4
-instance HasField "dimB_payload" (Ptr DimB) (Ptr DimPayloadB)
+instance TyEq ty DimPayloadB =>
+         HasField "dimB_payload" (Ptr DimB) (Ptr ty)
     where getField = fromPtr (Proxy @"dimB_payload")
 {-| __C declaration:__ @struct \@AnonA_xy@
 
@@ -439,12 +445,14 @@ deriving via (EquivStorable AnonA_xy) instance Storable AnonA_xy
 instance HasCField AnonA_xy "anonA_xy_x"
     where type CFieldType AnonA_xy "anonA_xy_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_xy_x")
 instance HasCField AnonA_xy "anonA_xy_y"
     where type CFieldType AnonA_xy "anonA_xy_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_xy_y")
 {-| __C declaration:__ @struct \@AnonA_polar@
 
@@ -487,12 +495,14 @@ deriving via (EquivStorable AnonA_polar) instance Storable AnonA_polar
 instance HasCField AnonA_polar "anonA_polar_r"
     where type CFieldType AnonA_polar "anonA_polar_r" = CDouble
           offset# = \_ -> \_ -> 0
-instance HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_polar_r")
 instance HasCField AnonA_polar "anonA_polar_p"
     where type CFieldType AnonA_polar "anonA_polar_p" = CDouble
           offset# = \_ -> \_ -> 8
-instance HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr CDouble)
+instance TyEq ty CDouble =>
+         HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_polar_p")
 {-| __C declaration:__ @union AnonA@
 
@@ -584,10 +594,12 @@ set_anonA_polar = setUnionPayload
 instance HasCField AnonA "anonA_xy"
     where type CFieldType AnonA "anonA_xy" = AnonA_xy
           offset# = \_ -> \_ -> 0
-instance HasField "anonA_xy" (Ptr AnonA) (Ptr AnonA_xy)
+instance TyEq ty AnonA_xy =>
+         HasField "anonA_xy" (Ptr AnonA) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_xy")
 instance HasCField AnonA "anonA_polar"
     where type CFieldType AnonA "anonA_polar" = AnonA_polar
           offset# = \_ -> \_ -> 0
-instance HasField "anonA_polar" (Ptr AnonA) (Ptr AnonA_polar)
+instance TyEq ty AnonA_polar =>
+         HasField "anonA_polar" (Ptr AnonA) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_polar")

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -563,7 +563,12 @@ translateHasFieldInstance inst mbComment = Instance{
     , args    = [fieldLit, parentPtr, tyPtr]
     , types   = []
     , comment = mbComment
-    , super   = []
+    , super   = [ ( NomEq_class
+                  , [ tyTypeVar
+                    , field
+                    ]
+                  )
+                ]
     , decs    = [ ( HasField_getField
                   , EGlobal ptrToFieldGlobal `EApp`
                       (EGlobal Proxy_constructor `ETypeApp` fieldLit)
@@ -575,17 +580,19 @@ translateHasFieldInstance inst mbComment = Instance{
       case inst.deriveVia of
         Hs.ViaHasCField -> (
             HasCField_fromPtr
-          , TGlobal Foreign_Ptr `TApp` field
+          , TGlobal Foreign_Ptr `TApp` tyTypeVar
           )
         Hs.ViaHasCBitfield -> (
             HasCBitfield_toPtr
-          , TGlobal HasCBitfield_BitfieldPtr `TApp` field
+          , TGlobal HasCBitfield_BitfieldPtr `TApp` tyTypeVar
           )
 
     parent    = translateType inst.parentType
     parentPtr = TGlobal Foreign_Ptr `TApp` parent
     field     = translateType inst.fieldType
     fieldLit  = translateType $ HsStrLit $ T.unpack $ Hs.getName inst.fieldName
+    -- TODO: this is not actually a free type variable. See issue #1287.
+    tyTypeVar = TFree $ Hs.ExportedName "ty"
 
 {-------------------------------------------------------------------------------
   Unions


### PR DESCRIPTION
Follow-up to #1676

Rather than 

```hs
instance HasField "unwrapTriplet" (Ptr Triplet) (Ptr (ConstantArray 3 CInt)) where
``` 

we now generate

```hs
instance TyEq ty (ConstantArray 3 CInt)
      => HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty) where
```

Functionally, nothing changes, but this style allows us to use type families in the superclass constraints (which I'm planning to do in a later PR)