### PR TITLE
Add `zeroUnionValue` and test unions in `test-th`

### DIFF
--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Internal/SizedByteArray.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Internal/SizedByteArray.hs
@@ -1,9 +1,11 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 module HsBindgen.Runtime.Internal.SizedByteArray (
-    SizedByteArray (..),
+    SizedByteArray(..)
+  , zeroUnionValue
 ) where
 
+import Data.Coerce (Coercible, coerce)
 import Data.Primitive.ByteArray (ByteArray (..))
 import Data.Primitive.ByteArray qualified as BA
 import Data.Proxy (Proxy (..))
@@ -68,3 +70,9 @@ instance GHC.KnownNat n => WriteRaw (SizedByteArray n m) where
     let ptr  = castPtr ptrSBA :: Ptr Word8
         size = fromIntegral $ GHC.natVal (Proxy @n)
     BA.copyByteArrayToAddr ptr arr 0 size
+
+-- | Create a value of a C union with all bytes initialized to zero.
+zeroUnionValue :: forall a. (Coercible a ByteArray, StaticSize a) => a
+zeroUnionValue = coerce $ BA.byteArrayFromListN n $ replicate n (0 :: Word8)
+  where
+    n = staticSizeOf (Proxy :: Proxy a)

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Prelude.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Prelude.hs
@@ -24,6 +24,9 @@ module HsBindgen.Runtime.Prelude (
   , ConstantArray   -- opaque
   , IncompleteArray -- opaque
 
+    -- * Unions
+  , zeroUnionValue
+
     -- * Marshaling and serialization
   , StaticSize(..)
   , ReadRaw(..)
@@ -46,5 +49,6 @@ import HsBindgen.Runtime.HasCField
 import HsBindgen.Runtime.IncompleteArray
 import HsBindgen.Runtime.Internal.FunPtr
 import HsBindgen.Runtime.Internal.Ptr
+import HsBindgen.Runtime.Internal.SizedByteArray
 import HsBindgen.Runtime.Marshal
 import HsBindgen.Runtime.PtrConst

--- a/hs-bindgen/examples/test_01.h
+++ b/hs-bindgen/examples/test_01.h
@@ -228,7 +228,7 @@ static inline void reverse(struct StructFLAM *s) {
  *
  * Size: @c sizeof(double) or @c sizeof(long long), whichever is larger
  */
-union longDouble {
+union longLongOrDouble {
     long long l; /**< Value interpreted as long long (typically 64 bits) */
     double d;    /**< Value interpreted as double (IEEE 754 double precision) */
 };

--- a/hs-bindgen/test/th/test-th.hs
+++ b/hs-bindgen/test/th/test-th.hs
@@ -162,6 +162,22 @@ test01 = testGroup "test_01"
         res' <- Test01.thing_fun_3 (Test01.Thing 6)
         Test01.Thing 12 @?= res'
 
+    , testCase "union" $ do
+        let x :: Test01.LongLongOrDouble
+            x = zeroUnionValue
+            l :: CLLong
+            l = Test01.get_longLongOrDouble_l x
+            d :: CDouble
+            d = Test01.get_longLongOrDouble_d x
+        l @?= 0
+        d @?= 0
+        let d' :: CDouble
+            d' = Test01.get_longLongOrDouble_d $ Test01.set_longLongOrDouble_d 3.5
+            l' :: CLLong
+            l' = Test01.get_longLongOrDouble_l $ Test01.set_longLongOrDouble_l 10
+        l' @?= 10
+        d' @?= 3.5
+
     , testCase "fixed-size-array" $ do
         let v = CA.repeat 4 :: ConstantArray 3 CInt
         res <- CA.withPtr v (\ptr -> Test01.sum3 5 (PtrConst.unsafeFromPtr ptr))


### PR DESCRIPTION
Closes #1743

- Add `zeroUnionValue` initializing union types to zero
- Briefly test C unions in `test-th` (including `zeroUnionValue`)