### PR TITLE
Set target in `argsAfter`

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Resources.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Resources.hs
@@ -68,15 +68,11 @@ getTestPackageRoot = fmap (.packageRoot)
 
 mkTestClangArgsConfig :: FilePath -> ClangArgsConfig FilePath
 mkTestClangArgsConfig packageRoot = def {
-      extraIncludeDirs = [
-          packageRoot </> "musl-include/x86_64"
-        ]
-    , argsBefore = cStandardArg : targetArgs
+      extraIncludeDirs = [packageRoot </> "musl-include/x86_64"]
+    , argsBefore       = [cStandardArg]
+    , argsAfter        = targetArgs
     }
   where
-    targetArgs :: [String]
-    targetArgs = ["-target", "x86_64-pc-linux-musl"]
-
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1516>
     -- We should use the minimum standard required for each test.
     cStandardArg :: String
@@ -86,6 +82,9 @@ mkTestClangArgsConfig packageRoot = def {
         | version < (18, 0, 0) -> "c2x"
         | otherwise            -> "c23"
       ClangVersionUnknown v -> panicPure $ "Unknown clang version: " ++ show v
+
+    targetArgs :: [String]
+    targetArgs = ["-target", "x86_64-pc-linux-musl"]
 
 getTestDefaultClangArgsConfig ::
      IO TestResources


### PR DESCRIPTION
By setting the standard in `argsBefore` and the target *separately* in `argsAfter`, tests can simply set a different standard by replacing `argsBefore`.
