### PR TITLE
Set test C standard by replacing `argsBefore`

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -398,7 +398,7 @@ test_attributes_asm :: TestCase
 test_attributes_asm =
     defaultTest "attributes/asm"
       & #clangVersion .~ Just (>= (18, 0, 0))
-      & #onBoot       .~ ( #clangArgs % #argsBefore %~ (<> ["-std=gnu2x"]) )
+      & #onBoot       .~ ( #clangArgs % #argsBefore .~ ["-std=gnu2x"] )
 
 test_attributes_attributes :: TestCase
 test_attributes_attributes =
@@ -1368,7 +1368,7 @@ test_macros_reparse :: TestCase
 test_macros_reparse =
     defaultTest "macros/reparse"
       & #clangVersion   .~ Just (>= (15, 0, 0)) -- parse 'bool'
-      & #onBoot         .~ ( #clangArgs % #argsBefore %~ (<> ["-std=c2x"]) )
+      & #onBoot         .~ ( #clangArgs % #argsBefore .~ ["-std=c2x"] )
       & #tracePredicate .~ tolerateAll
 
 {-------------------------------------------------------------------------------
@@ -1843,7 +1843,7 @@ test_types_primitives_bool_c23 :: TestCase
 test_types_primitives_bool_c23 =
     defaultTest "types/primitives/bool_c23"
       & #clangVersion .~ Just (>= (15, 0, 0))
-      & #onBoot       .~ ( #clangArgs % #argsBefore %~ (<> ["-std=c2x"]) )
+      & #onBoot       .~ ( #clangArgs % #argsBefore .~ ["-std=c2x"] )
 
 test_types_primitives_least_fast :: TestCase
 test_types_primitives_least_fast =


### PR DESCRIPTION
While looking into the TH complication package issue, I noticed that Armando ran into the same issue with setting the C version in tests that I addressed in #1774, and he dealt with it as follows:

```diff
-      & #onBoot       .~ ( #clangArgs % #argsBefore .~ ["-std=gnu2x"] )
+      & #onBoot       .~ ( #clangArgs % #argsBefore %~ (<> ["-std=c2x"]) )
```

This does indeed work; the last option is used when multiple are specified:

```
$ cabal run hs-bindgen-cli -- info builtin-macros \
    --clang-option-before=-std=c11 \
    --clang-option-before=-std=c23 \
  | grep __STDC_VERSION__
#define __STDC_VERSION__ 202311L
```

Now that `argBefore` sets just the standard in the golden tests, I am changing it to replace the setting instead of appending, to avoid confusion.  The API will be improved when #1516 is resolved.