### PR TITLE
Improve botan caching

### DIFF
--- a/.github/actions/examples/botan/action.yml
+++ b/.github/actions/examples/botan/action.yml
@@ -14,7 +14,7 @@ runs:
         create-symlink: true
         variant: 'ccache'
         key: setup-botan
-        append-timestamp: false
+        append-timestamp: true
         evict-old-files: 'job'
         max-size: 50M
 


### PR DESCRIPTION
Caching of the botan example has recently regressed to a point where no caching effects occur at all. We now create caches more often to restore the cache effects.