### PR TITLE
Make `allow-newer`s for `ghc-9.14` dependent on the compiler version

### DIFF
--- a/cabal.project.base
+++ b/cabal.project.base
@@ -11,39 +11,40 @@ source-repository-package
 -- Temporary package bounds overrides for ghc 9.14
 --
 
-allow-newer: aeson-2.2.3.0:base
-allow-newer: aeson-2.2.3.0:containers
-allow-newer: aeson-2.2.3.0:template-haskell
-allow-newer: aeson-2.2.3.0:time
-allow-newer: boring-0.2.2:base
-allow-newer: debruijn-0.3.1:base
-allow-newer: dec-0.0.6:base
-allow-newer: fin-0.3.2:base
-allow-newer: indexed-traversable-0.1.4:base
-allow-newer: indexed-traversable-0.1.4:containers
-allow-newer: indexed-traversable-instances-0.1.2:base
-allow-newer: optics-0.4.2.1:containers
-allow-newer: optics-core-0.4.1.1:containers
-allow-newer: optics-extra-0.4.2.1:containers
-allow-newer: optics-th-0.4.1:containers
-allow-newer: semialign-1.3.1:base
-allow-newer: semialign-1.3.1:containers
-allow-newer: skew-list-0.1:base
-allow-newer: some-1.0.6:base
-allow-newer: text-iso8601-0.1.1:time
-allow-newer: these-1.2.1:base
-allow-newer: time-compat-1.9.8:base
-allow-newer: time-compat-1.9.8:time
-allow-newer: universe-base-1.1.4:base
-allow-newer: universe-base-1.1.4:containers
-allow-newer: uuid-types-1.0.6:template-haskell
-allow-newer: vec-0.5.1:base
+if impl(ghc >= 9.14)
+  allow-newer: aeson-2.2.3.0:base
+  allow-newer: aeson-2.2.3.0:containers
+  allow-newer: aeson-2.2.3.0:template-haskell
+  allow-newer: aeson-2.2.3.0:time
+  allow-newer: boring-0.2.2:base
+  allow-newer: debruijn-0.3.1:base
+  allow-newer: dec-0.0.6:base
+  allow-newer: fin-0.3.2:base
+  allow-newer: indexed-traversable-0.1.4:base
+  allow-newer: indexed-traversable-0.1.4:containers
+  allow-newer: indexed-traversable-instances-0.1.2:base
+  allow-newer: optics-0.4.2.1:containers
+  allow-newer: optics-core-0.4.1.1:containers
+  allow-newer: optics-extra-0.4.2.1:containers
+  allow-newer: optics-th-0.4.1:containers
+  allow-newer: semialign-1.3.1:base
+  allow-newer: semialign-1.3.1:containers
+  allow-newer: skew-list-0.1:base
+  allow-newer: some-1.0.6:base
+  allow-newer: text-iso8601-0.1.1:time
+  allow-newer: these-1.2.1:base
+  allow-newer: time-compat-1.9.8:base
+  allow-newer: time-compat-1.9.8:time
+  allow-newer: universe-base-1.1.4:base
+  allow-newer: universe-base-1.1.4:containers
+  allow-newer: uuid-types-1.0.6:template-haskell
+  allow-newer: vec-0.5.1:base
 
---
--- Temporary package bounds overrides for QuickCheck 2.17
---
+  --
+  -- Temporary package bounds overrides for QuickCheck 2.17
+  --
 
-allow-newer: aeson-2.2.3.0:QuickCheck
-allow-newer: fin-0.3.2:QuickCheck
-allow-newer: skew-list-0.1:QuickCheck
-allow-newer: vec-0.5.1:QuickCheck
+  allow-newer: aeson-2.2.3.0:QuickCheck
+  allow-newer: fin-0.3.2:QuickCheck
+  allow-newer: skew-list-0.1:QuickCheck
+  allow-newer: vec-0.5.1:QuickCheck


### PR DESCRIPTION
Resolves #1665