### PR TITLE
Compile TH fixtures with `-j1`

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Compile.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Compile.hs
@@ -52,7 +52,9 @@ setupBatchCompile repoRoot cases =
             [ "build"
             , "hs-bindgen-th-fixtures"
             , "--keep-going"
-            , "-j"
+            -- Attempt to avoid nondeterministic failures; see
+            -- <https://github.com/well-typed/hs-bindgen/issues/1813>
+            , "-j1"
             , "--builddir=" ++ repoRoot </> "dist-newstyle-th-fixtures"
             ]
           createProc = (proc "cabal" cabalArgs) { cwd = Just tmpDir }


### PR DESCRIPTION
This is an attempt to avoid nondeterministic failures where `ghc-pkg` is unable to find files in the package database during the configure step. I have not had any failures while using `-j1`, though I do not know if this makes failure impossible or just more unlikely.  This commit sets `-j1`, and we can see if the issue pops up again.

See #1813