### PR TITLE
Introduce LibclangException and handle it in tests

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -24,6 +24,7 @@ module HsBindgen (
   , hsBindgenE
   ) where
 
+import Control.Exception (Exception (..), catch)
 import Control.Monad.Except (MonadError (..), withExceptT)
 import Control.Monad.Trans.Except (runExceptT)
 import System.Exit (ExitCode (..), exitWith)
@@ -37,6 +38,7 @@ import HsBindgen.Backend.HsModule.Translation
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.BindingSpec.Gen
 import HsBindgen.Boot
+import HsBindgen.Clang
 import HsBindgen.Config.Internal
 import HsBindgen.DelayedIO
 import HsBindgen.Errors (throwPure_TODO)
@@ -61,7 +63,13 @@ hsBindgen ::
   -> Artefact a
   -> IO a
 hsBindgen tu ts b i a = do
-    eRes <- hsBindgenE tu ts b i a
+    eRes <- hsBindgenE tu ts b i a `catch` \e -> case fromException e of
+      Just (LibclangException msg) -> do
+        putStrLn $ PP.renderCtxDoc PP.defaultContext (PP.string msg)
+        -- We specifically use exit code 2 here; it means that the call to
+        -- `libclang` has failed.
+        exitWith (ExitFailure 2)
+      _ -> throwIO e
     case eRes of
       Left err -> do
         putStrLn $ PP.renderCtxDoc PP.defaultContext $ prettyForTrace err

--- a/hs-bindgen/src-internal/HsBindgen/Clang.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang.hs
@@ -5,6 +5,7 @@ module HsBindgen.Clang (
   , ClangInput(..)
   , defaultClangSetup
   , withClang
+  , LibclangException(..)
   , withClang'
     -- * Trace messages
   , ClangMsg(..)
@@ -12,7 +13,6 @@ module HsBindgen.Clang (
   ) where
 
 import Data.Text qualified as Text
-import System.Exit (ExitCode (..), exitWith)
 import Text.SimplePrettyPrint ((><))
 import Text.SimplePrettyPrint qualified as PP
 
@@ -73,10 +73,10 @@ withClang tracer setup k = do
     mRes <- withClang' tracer setup $ \unit -> do
       anyIsError <- traceDiagnostics unit
       if anyIsError
-        then exit
+        then throwIO $ LibclangException "Call to 'libclang' returned an error"
         else Just <$> k unit
     case mRes of
-      Nothing  -> exit
+      Nothing  -> throwIO $ LibclangException "Call to 'libclang' failed"
       Just res -> pure res
   where
     traceDiagnostics :: CXTranslationUnit -> IO Bool
@@ -89,10 +89,10 @@ withClang tracer setup k = do
             traceWith (contramap ClangDiagnostic tracer) d
             go (anyIsError || diagnosticIsError d) ds
 
-    -- We specifically use exit code 2 here; it means that the invocation of
-    -- `libclang` has failed.
-    exit :: IO b
-    exit = exitWith (ExitFailure 2)
+data LibclangException = LibclangException String
+  deriving stock (Show, Eq, Ord)
+
+instance Exception LibclangException
 
 -- | Call clang to parse with the specified 'ClangSetup'
 --

--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Predicate.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Predicate.hs
@@ -19,7 +19,7 @@ module Test.Common.HsBindgen.Trace.Predicate (
   , withTraceConfigPredicate
   ) where
 
-import Control.Exception (Exception, throwIO)
+import Control.Exception (Exception (..), catch, throwIO)
 import Control.Monad.Except (Except, runExcept, throwError)
 import Data.Foldable qualified as Foldable
 import Data.IORef (modifyIORef', newIORef, readIORef)
@@ -33,6 +33,7 @@ import Data.Typeable (Typeable)
 import Text.SimplePrettyPrint (CtxDoc)
 import Text.SimplePrettyPrint qualified as PP
 
+import HsBindgen.Clang
 import HsBindgen.Errors
 import HsBindgen.Frontend.Naming
 import HsBindgen.Imports (Default (def))
@@ -186,15 +187,23 @@ withTraceConfigPredicate report (TracePredicate predicate) action = do
               }
           }
 
+        reportTraces :: IO ()
+        reportTraces = do
+          traces <- readIORef tracesRef
+          mapM_ (report . show . prettyForTrace) traces
+
+
         checkTraces :: IO ()
         checkTraces = do
           traces <- readIORef tracesRef
-          mapM_ (report . show . prettyForTrace) traces
           case runExcept (predicate traces) of
             Left  e -> throwIO e
             Right _ -> pure ()
 
-    action tracerConfig <* checkTraces
+    (action tracerConfig <* reportTraces <* checkTraces) `catch` \e ->
+      case fromException e of
+        Just (_ :: LibclangException) -> reportTraces >> throwIO e
+        _                             -> throwIO e
 
 {-------------------------------------------------------------------------------
   Trace exception

--- a/hs-bindgen/test/common/Test/Common/Util/Tasty/Golden.hs
+++ b/hs-bindgen/test/common/Test/Common/Util/Tasty/Golden.hs
@@ -10,6 +10,9 @@ module Test.Common.Util.Tasty.Golden (
     ActualValue(..)
   , goldenTestSteps
   , RunMode(..)
+
+    -- * Options
+  , Debug(..)
   ) where
 
 import Control.DeepSeq (rnf)

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/FailureBindgen.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/FailureBindgen.hs
@@ -3,11 +3,12 @@
 -- For failing test cases, we verify the trace messages.
 module Test.HsBindgen.Golden.Check.FailureBindgen (check) where
 
-import Test.Tasty (TestTree)
+import Test.Tasty (TestTree, askOption)
 import Test.Tasty.HUnit
 
 import HsBindgen
 
+import Test.Common.Util.Tasty.Golden
 import Test.HsBindgen.Golden.TestCase
 import Test.HsBindgen.Resources
 
@@ -16,15 +17,18 @@ import Test.HsBindgen.Resources
 -------------------------------------------------------------------------------}
 
 check :: IO TestResources -> TestCase -> TestTree
-check getTestResources test = testCase test.name $ do
-    eRes <- runTestHsBindgen noReport getTestResources test FinalDecls
-    case eRes of
-      Left  _ -> pure ()
-      Right r -> assertFailure (msgWith r)
+check getTestResources test =
+    askOption $ \(Debug debug) -> do
+      let report :: String -> IO ()
+          report = case debug of
+            False -> const $ pure ()
+            True  -> putStrLn
+      testCase test.name $ do
+        eRes <- runTestHsBindgen report getTestResources test FinalDecls
+        case eRes of
+          Left  _ -> pure ()
+          Right r -> assertFailure (msgWith r)
   where
-    noReport :: a -> IO ()
-    noReport = const $ pure ()
-
     msgWith :: Show b => b -> String
     msgWith r = mconcat [
         "Expected 'hs-bindgen' to fail, "

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/FailureLibclang.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Check/FailureLibclang.hs
@@ -3,13 +3,14 @@
 -- Test for non-zero exit code
 module Test.HsBindgen.Golden.Check.FailureLibclang (check) where
 
-import Control.Exception (handle, throw)
-import System.Exit (ExitCode (..))
-import Test.Tasty (TestTree)
+import Control.Exception (Exception (..), SomeException, handle, throw)
+import Test.Tasty (TestTree, askOption)
 import Test.Tasty.HUnit
 
 import HsBindgen
+import HsBindgen.Clang
 
+import Test.Common.Util.Tasty.Golden
 import Test.HsBindgen.Golden.TestCase
 import Test.HsBindgen.Resources
 
@@ -18,22 +19,23 @@ import Test.HsBindgen.Resources
 -------------------------------------------------------------------------------}
 
 check :: IO TestResources -> TestCase -> TestTree
-check getTestResources test = testCase test.name $
-    handle expectExitFailure $ do
-      eRes <- runTestHsBindgen noReport getTestResources test FinalDecls
-      assertFailure $ mconcat [
-          "expected hs-bindgen to fail early, "
-        , "but it finished with the following result:\n"
-        , show eRes
-        ]
+check getTestResources test =
+    askOption $ \(Debug debug) -> do
+      let report :: String -> IO ()
+          report = case debug of
+            False -> const $ pure ()
+            True  -> putStrLn
+      testCase test.name $
+        handle expectLibclangFailure $ do
+          eRes <- runTestHsBindgen report getTestResources test FinalDecls
+          assertFailure $ mconcat [
+              "expected 'hs-bindgen' to fail early, "
+            , "but it finished with the following result:\n"
+            , show eRes
+            ]
 
   where
-    noReport :: a -> IO ()
-    noReport = const $ pure ()
-
-    expectExitFailure :: ExitCode -> IO ()
-    expectExitFailure = \case
-      -- We specifically test for exit code 2 here; it means that the
-      -- `hs-bindgen` invocation of `libclang` has failed.
-      ExitFailure 2  -> pure ()
-      otherException -> throw otherException
+    expectLibclangFailure :: SomeException -> IO ()
+    expectLibclangFailure e = case fromException e of
+      Just (_ :: LibclangException)  -> pure ()
+      _                              -> throw e

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/ExitCode.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/ExitCode.hs
@@ -1,6 +1,6 @@
 module Test.HsBindgen.Integration.ExitCode (tests) where
 
-import Control.Exception (handle, throw)
+import Control.Exception (Exception (..), SomeException, handle)
 import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -9,6 +9,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import HsBindgen.Artefact (Artefact (..))
+import HsBindgen.Clang (LibclangException)
 import HsBindgen.Imports
 
 import Test.Common.HsBindgen.Trace.Predicate
@@ -54,14 +55,12 @@ testUnresolvedInclude getTestResources = testCase "unresolved include throws exc
         noReport :: a -> IO ()
         noReport = const $ pure ()
 
-        expectExitFailure :: ExitCode -> IO ()
-        expectExitFailure = \case
-          -- We specifically test for exit code 2 here; it means that the
-          -- `hs-bindgen` invocation of `libclang` has failed.
-          ExitFailure 2  -> pure ()
-          otherException -> throw otherException
+        expectLibclangException :: SomeException -> IO ()
+        expectLibclangException e = case fromException e of
+          Just (_ :: LibclangException) -> pure ()
+          _                             -> throwIO e
 
-    handle expectExitFailure $ do
+    handle expectLibclangException $ do
       eRes <- runTestHsBindgen noReport getTestResources test FinalDecls
       assertFailure $ mconcat [
           "expected hs-bindgen to fail early, "


### PR DESCRIPTION
Now we throw a `LibclangException` that we handle in our tests.

Looks like so:

<img width="1341" height="344" alt="image" src="https://github.com/user-attachments/assets/c2fa699b-0d01-44d1-9e83-1b03cdcb87d5" />

The client behavior does not change (we catch `LibclangException` and rethrow using `ExitFailure 2`, as before).

Closes #1789 