### PR TITLE
Bump `s-r-p` for `libclang-bindings`

### DIFF
--- a/cabal.project.base
+++ b/cabal.project.base
@@ -5,7 +5,7 @@ index-state: 2026-02-05T03:27:53Z
 source-repository-package
     type: git
     location: https://github.com/well-typed/libclang
-    tag: f2be590f9b9b0f3351e0c5135279dad04d642c47
+    tag: d6e482df49b88375cf3075928a78ee86c2a068d4
 
 --
 -- Temporary package bounds overrides for ghc 9.14

--- a/flake.lock
+++ b/flake.lock
@@ -21,17 +21,17 @@
     "libclang-bindings-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1772714307,
-        "narHash": "sha256-RrAVhJ6IT6lC8gEnKeS3a946y8mNF3fjkzfc9m0gVfo=",
+        "lastModified": 1773221966,
+        "narHash": "sha256-VPG7jKdq2g/Hwf5cPiy4coAvLULxDeA4KHCVkNSSs5w=",
         "owner": "well-typed",
         "repo": "libclang",
-        "rev": "f2be590f9b9b0f3351e0c5135279dad04d642c47",
+        "rev": "d6e482df49b88375cf3075928a78ee86c2a068d4",
         "type": "github"
       },
       "original": {
         "owner": "well-typed",
         "repo": "libclang",
-        "rev": "f2be590f9b9b0f3351e0c5135279dad04d642c47",
+        "rev": "d6e482df49b88375cf3075928a78ee86c2a068d4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     libclang-bindings-src = {
-      url = "github:well-typed/libclang?rev=f2be590f9b9b0f3351e0c5135279dad04d642c47";
+      url = "github:well-typed/libclang?rev=d6e482df49b88375cf3075928a78ee86c2a068d4";
       flake = false;
     };
   };


### PR DESCRIPTION
This updates the dependency to include changes from https://github.com/well-typed/libclang/pull/39