### PR TITLE
Fix Nix derivation (skip impure `hs-bindgen` tests)

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Artefact.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Artefact.hs
@@ -164,7 +164,7 @@ instance PrettyForTrace ArtefactMsg where
     NoBindingsSingleModule md ->
       "No output generated (module " <+> PP.show md <+> " is empty)"
     NoBindingsMultipleModules md ->
-      "No output generated (all binding categories with base module name " <+> PP.show md <+> " are empty)"
+      "No output generated (all binding categories with base module name" <+> PP.show md <+> "are empty)"
     SkipWriteToFileNoBindings fp ->
       "Skipping 'write file' operation (" >< PP.show fp >< "): file is empty"
 

--- a/nix/overlay/hs-bindgen.nix
+++ b/nix/overlay/hs-bindgen.nix
@@ -32,14 +32,16 @@ in
         # TODO: The test of `c-expr-runtime` requires `musl` headers, but
         # providing `musl` as test system dependency causes other build errors.
         c-expr-runtime = hlib.dontCheck hsBindgenPkgs.c-expr-runtime;
-        # TODO: Test of `hs-bindgen` fails because it run `hs-bindgen-cli` which
-        # is a build output of `hs-bindgen` (chicken-egg problem).
         hs-bindgen = hlib.overrideCabal (drv: {
-          # Tests depend on executable.
+          # TODO: Test of `hs-bindgen` fails because it runs `hs-bindgen-cli`
+          # which is a build output of `hs-bindgen` (chicken-egg problem).
           preCheck = ''
             export PATH="$PWD/dist/build/hs-bindgen-cli:$PATH"
           ''
           + (drv.preCheck or "");
+          # TODO: Test of `hs-bindgen` fails because compilation of TH fixtures
+          # is impure.
+          doCheck = false;
           buildDepends = drv.buildDepends or [ ] ++ [
             final.hsBindgenHook
           ];


### PR DESCRIPTION
This is a quick fix for our `hs-bindgen` Nix derivation.

The TH tests are now highly impure (external `cabal` calls), making it difficult to run them in a Nix derviation. I deactivated the tests for now, so we can at least build `hs-bindgen`.

(The development shell was always working).

I noticed this problem while pulling along the Nix tutorials.