### PR TITLE
nix: keep haskell.lib.* when extending haskell.lib.compose

### DIFF
--- a/nix/overlay/hs-bindgen.nix
+++ b/nix/overlay/hs-bindgen.nix
@@ -47,7 +47,9 @@ in
           ];
         }) hsBindgenPkgs.hs-bindgen;
       };
-    lib.compose = prev.haskell.lib.compose // final.callPackage ../hs-bindgen-lib.nix { };
+    lib = prev.haskell.lib // {
+      compose = prev.haskell.lib.compose // final.callPackage ../hs-bindgen-lib.nix { };
+    };
   };
   hsBindgenHook = final.callPackage ../hs-bindgen-hook.nix { inherit llvmPackages; };
   hs-bindgen-cli = final.callPackage ../hs-bindgen-cli.nix { inherit llvmPackages; };


### PR DESCRIPTION
Previously, after the `default` or `hsBindgen` overlay was applied, other lib functions under haskell.lib.* were dropped:

```
nix-repl> builtins.attrNames haskell.lib == [ "compose" ]
true
```

This patch fixes that.

cc @dschrempf for review

---

Some reminders, in case they are helpful:

- [ ] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

