### PR TITLE
nix: use composeExtensions to compose overlays instead of manually

### DIFF
--- a/nix/overlay/hs-bindgen.nix
+++ b/nix/overlay/hs-bindgen.nix
@@ -19,13 +19,12 @@ let
 in
 {
   haskell = prev.haskell // {
-    packageOverrides =
+    packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
       hfinal: hprev:
       let
         hsBindgenPkgs = mkHsBindgenPkgs hfinal;
       in
-      prev.haskell.packageOverrides hfinal hprev
-      // {
+      {
         inherit (hsBindgenPkgs) hs-bindgen-runtime hs-bindgen-test-runtime;
         # TODO: The documentation fails to build.
         c-expr-dsl = hlib.dontHaddock hsBindgenPkgs.c-expr-dsl;
@@ -46,7 +45,8 @@ in
             final.hsBindgenHook
           ];
         }) hsBindgenPkgs.hs-bindgen;
-      };
+      }
+    );
     lib.compose = prev.haskell.lib.compose // final.callPackage ../hs-bindgen-lib.nix { };
   };
   hsBindgenHook = final.callPackage ../hs-bindgen-hook.nix { inherit llvmPackages; };

--- a/nix/overlay/libclang-bindings.nix
+++ b/nix/overlay/libclang-bindings.nix
@@ -13,11 +13,10 @@ let
 in
 {
   haskell = prev.haskell // {
-    packageOverrides =
-      hfinal: hprev:
-      prev.haskell.packageOverrides hfinal hprev
-      // {
+    packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
+      hfinal: hprev: {
         libclang-bindings = hfinal.callPackage libclang-bindings { inherit llvmPackages; };
-      };
+      }
+    );
   };
 }

--- a/nix/overlay/overrides.nix
+++ b/nix/overlay/overrides.nix
@@ -4,12 +4,11 @@ let
 in
 {
   haskell = prev.haskell // {
-    packageOverrides =
-      hfinal: hprev:
-      prev.haskell.packageOverrides hfinal hprev
-      // {
+    packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
+      hfinal: hprev: {
         # TODO: See https://gitlab.haskell.org/ghc/ghc/-/issues/25681.
         optics = hlib.dontCheck hprev.optics;
-      };
+      }
+    );
   };
 }


### PR DESCRIPTION
`lib.composeExtensions' is semantically correct.  The manual way is not totally correct in all cases (but is correct in these use cases).

In addition, `lib.composeExtensions` improves readability a bit.

cc @dschrempf for review

---

Some reminders, in case they are helpful:

- [ ] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
