### PR TITLE
Add contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ bug reports, feature requests, blog posts, etc., including:
 * [Jonathan Lorimer](https://github.com/JonathanLorimer)
 * [Joris Dral](https://github.com/jorisdral)
 * [`Krantz98`](https://www.reddit.com/user/Krantz98)
+* [Lin Jian](https://github.com/jian-lin)
 * [`Merivuokko`](https://github.com/Merivuokko)
 * [Oleg Grenrus](https://github.com/phadej)
 * [Sam Derbyshire](https://github.com/sheaf)


### PR DESCRIPTION
This PR updates the README to add a new contributor.

Should we list contributors' names in natural name order, or should we mangle names to follow Western conventions (given name(s) before family name(s))?  In this case, I went with Western conventions only because the GitHub ID uses that order, but I am of course happy to change to natural name order if desired.