### PR TITLE
Make bindings compile even when `NoFieldSelectors` is enabled globally

### DIFF
--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -73,7 +73,7 @@ instance CEnum.CEnum MyEnum where
 
   toCEnum = MyEnum
 
-  fromCEnum = unwrapMyEnum
+  fromCEnum = RIP.getField @"unwrapMyEnum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -143,7 +143,7 @@ deriving via CUInt instance Prim MyEnum
 instance CEnum MyEnum
     where type CEnumZ MyEnum = CUInt
           toCEnum = MyEnum
-          fromCEnum = unwrapMyEnum
+          fromCEnum = getField @"unwrapMyEnum"
           declaredValues = \_ -> declaredValuesFromList [(0, singleton "X")]
           showsUndeclared = showsWrappedUndeclared "MyEnum"
           readPrecUndeclared = readPrecWrappedUndeclared "MyEnum"

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -73,7 +73,7 @@ instance CEnum.CEnum MyEnum where
 
   toCEnum = MyEnum
 
-  fromCEnum = unwrapMyEnum
+  fromCEnum = RIP.getField @"unwrapMyEnum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -143,7 +143,7 @@ deriving via CUInt instance Prim MyEnum
 instance CEnum MyEnum
     where type CEnumZ MyEnum = CUInt
           toCEnum = MyEnum
-          fromCEnum = unwrapMyEnum
+          fromCEnum = getField @"unwrapMyEnum"
           declaredValues = \_ -> declaredValuesFromList [(0, singleton "X")]
           showsUndeclared = showsWrappedUndeclared "MyEnum"
           readPrecUndeclared = readPrecWrappedUndeclared "MyEnum"

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -195,7 +195,7 @@ instance CEnum.CEnum Color_enum where
 
   toCEnum = Color_enum
 
-  fromCEnum = unwrapColor_enum
+  fromCEnum = RIP.getField @"unwrapColor_enum"
 
   declaredValues =
     \_ ->
@@ -603,7 +603,7 @@ instance CEnum.CEnum Status_code_t where
 
   toCEnum = Status_code_t
 
-  fromCEnum = unwrapStatus_code_t
+  fromCEnum = RIP.getField @"unwrapStatus_code_t"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -446,7 +446,7 @@ deriving via CUInt instance Prim Color_enum
 instance CEnum Color_enum
     where type CEnumZ Color_enum = CUInt
           toCEnum = Color_enum
-          fromCEnum = unwrapColor_enum
+          fromCEnum = getField @"unwrapColor_enum"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "COLOR_RED"),
                                                          (1, singleton "COLOR_GREEN"),
@@ -723,7 +723,7 @@ deriving via CInt instance Prim Status_code_t
 instance CEnum Status_code_t
     where type CEnumZ Status_code_t = CInt
           toCEnum = Status_code_t
-          fromCEnum = unwrapStatus_code_t
+          fromCEnum = getField @"unwrapStatus_code_t"
           declaredValues = \_ -> declaredValuesFromList [(-99,
                                                           singleton "STATUS_ERROR"),
                                                          (-3, singleton "STATUS_TIMEOUT"),

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -170,7 +170,8 @@ instance CEnum.CEnum Another_typedef_enum_e where
 
   toCEnum = Another_typedef_enum_e
 
-  fromCEnum = unwrapAnother_typedef_enum_e
+  fromCEnum =
+    RIP.getField @"unwrapAnother_typedef_enum_e"
 
   declaredValues =
     \_ ->
@@ -707,7 +708,7 @@ instance CEnum.CEnum A_typedef_enum_e where
 
   toCEnum = A_typedef_enum_e
 
-  fromCEnum = unwrapA_typedef_enum_e
+  fromCEnum = RIP.getField @"unwrapA_typedef_enum_e"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -111,7 +111,7 @@ deriving via CUInt instance Prim Another_typedef_enum_e
 instance CEnum Another_typedef_enum_e
     where type CEnumZ Another_typedef_enum_e = CUInt
           toCEnum = Another_typedef_enum_e
-          fromCEnum = unwrapAnother_typedef_enum_e
+          fromCEnum = getField @"unwrapAnother_typedef_enum_e"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "FOO"),
                                                          (1, singleton "BAR")]
@@ -546,7 +546,7 @@ deriving via CUChar instance Prim A_typedef_enum_e
 instance CEnum A_typedef_enum_e
     where type CEnumZ A_typedef_enum_e = CUChar
           toCEnum = A_typedef_enum_e
-          fromCEnum = unwrapA_typedef_enum_e
+          fromCEnum = getField @"unwrapA_typedef_enum_e"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "ENUM_CASE_0"),
                                                          (1, singleton "ENUM_CASE_1"),

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -70,7 +70,7 @@ instance CEnum.CEnum Test where
 
   toCEnum = Test
 
-  fromCEnum = unwrapTest
+  fromCEnum = RIP.getField @"unwrapTest"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -29,7 +29,7 @@ deriving via CUInt instance Prim Test
 instance CEnum Test
     where type CEnumZ Test = CUInt
           toCEnum = Test
-          fromCEnum = unwrapTest
+          fromCEnum = getField @"unwrapTest"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "Test_a"),
                                                          (1, singleton "Test_count")]

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/Example.hs
@@ -70,7 +70,7 @@ instance CEnum.CEnum MyEnum where
 
   toCEnum = MyEnum
 
-  fromCEnum = unwrapMyEnum
+  fromCEnum = RIP.getField @"unwrapMyEnum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/uses_utf8/th.txt
@@ -22,7 +22,7 @@ deriving via CUInt instance Prim MyEnum
 instance CEnum MyEnum
     where type CEnumZ MyEnum = CUInt
           toCEnum = MyEnum
-          fromCEnum = unwrapMyEnum
+          fromCEnum = getField @"unwrapMyEnum"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "Say\20320\22909"),
                                                          (1, singleton "Say\25308\25308")]

--- a/hs-bindgen/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/fixtures/functions/callbacks/Example.hs
@@ -1021,7 +1021,7 @@ instance CEnum.CEnum Processor_mode where
 
   toCEnum = Processor_mode
 
-  fromCEnum = unwrapProcessor_mode
+  fromCEnum = RIP.getField @"unwrapProcessor_mode"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/fixtures/functions/callbacks/th.txt
@@ -1157,7 +1157,7 @@ deriving via CUInt instance Prim Processor_mode
 instance CEnum Processor_mode
     where type CEnumZ Processor_mode = CUInt
           toCEnum = Processor_mode
-          fromCEnum = unwrapProcessor_mode
+          fromCEnum = getField @"unwrapProcessor_mode"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "MODE_SIMPLE"),
                                                          (1, singleton "MODE_VALIDATED"),

--- a/hs-bindgen/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/fixtures/globals/globals/Example.hs
@@ -627,7 +627,7 @@ instance CEnum.CEnum AnonEnum where
 
   toCEnum = AnonEnum
 
-  fromCEnum = unwrapAnonEnum
+  fromCEnum = RIP.getField @"unwrapAnonEnum"
 
   declaredValues =
     \_ ->
@@ -735,7 +735,7 @@ instance CEnum.CEnum AnonEnumCoords where
 
   toCEnum = AnonEnumCoords
 
-  fromCEnum = unwrapAnonEnumCoords
+  fromCEnum = RIP.getField @"unwrapAnonEnumCoords"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/fixtures/globals/globals/th.txt
@@ -496,7 +496,7 @@ deriving via CUInt instance Prim AnonEnum
 instance CEnum AnonEnum
     where type CEnumZ AnonEnum = CUInt
           toCEnum = AnonEnum
-          fromCEnum = unwrapAnonEnum
+          fromCEnum = getField @"unwrapAnonEnum"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "VAL_A"),
                                                          (1, singleton "VAL_B")]
@@ -558,7 +558,7 @@ deriving via CUInt instance Prim AnonEnumCoords
 instance CEnum AnonEnumCoords
     where type CEnumZ AnonEnumCoords = CUInt
           toCEnum = AnonEnumCoords
-          fromCEnum = unwrapAnonEnumCoords
+          fromCEnum = getField @"unwrapAnonEnumCoords"
           declaredValues = \_ -> declaredValuesFromList [(10, singleton "X"),
                                                          (20, singleton "Y"),
                                                          (30, singleton "Z")]

--- a/hs-bindgen/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/fixtures/macros/reparse/Example.hs
@@ -210,7 +210,7 @@ instance CEnum.CEnum Some_enum where
 
   toCEnum = Some_enum
 
-  fromCEnum = unwrapSome_enum
+  fromCEnum = RIP.getField @"unwrapSome_enum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/th.txt
@@ -2592,7 +2592,7 @@ deriving via CUInt instance Prim Some_enum
 instance CEnum Some_enum
     where type CEnumZ Some_enum = CUInt
           toCEnum = Some_enum
-          fromCEnum = unwrapSome_enum
+          fromCEnum = getField @"unwrapSome_enum"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "ENUM_A")]
           showsUndeclared = showsWrappedUndeclared "Some_enum"

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -76,7 +76,7 @@ instance CEnum.CEnum FileOperationStatus where
 
   toCEnum = FileOperationStatus
 
-  fromCEnum = unwrapFileOperationStatus
+  fromCEnum = RIP.getField @"unwrapFileOperationStatus"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -58,7 +58,7 @@ deriving via CInt instance Prim FileOperationStatus
 instance CEnum FileOperationStatus
     where type CEnumZ FileOperationStatus = CInt
           toCEnum = FileOperationStatus
-          fromCEnum = unwrapFileOperationStatus
+          fromCEnum = getField @"unwrapFileOperationStatus"
           declaredValues = \_ -> declaredValuesFromList [(-1,
                                                           singleton "CUSTOM_ERROR_OTHER"),
                                                          (0, singleton "SUCCESS"),

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -72,7 +72,7 @@ instance CEnum.CEnum Foo_enum where
 
   toCEnum = Foo_enum
 
-  fromCEnum = unwrapFoo_enum
+  fromCEnum = RIP.getField @"unwrapFoo_enum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -25,7 +25,7 @@ deriving via HsBindgen.Runtime.LibC.Word32 instance Prim Foo_enum
 instance CEnum Foo_enum
     where type CEnumZ Foo_enum = HsBindgen.Runtime.LibC.Word32
           toCEnum = Foo_enum
-          fromCEnum = unwrapFoo_enum
+          fromCEnum = getField @"unwrapFoo_enum"
           declaredValues = \_ -> declaredValuesFromList [(0, singleton "A"),
                                                          (1, singleton "B"),
                                                          (2, singleton "C")]

--- a/hs-bindgen/fixtures/types/enums/enum_unsigned_values/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enum_unsigned_values/Example.hs
@@ -73,7 +73,7 @@ instance CEnum.CEnum Uint8_enum where
 
   toCEnum = Uint8_enum
 
-  fromCEnum = unwrapUint8_enum
+  fromCEnum = RIP.getField @"unwrapUint8_enum"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/types/enums/enum_unsigned_values/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enum_unsigned_values/th.txt
@@ -25,7 +25,7 @@ deriving via HsBindgen.Runtime.LibC.Word8 instance Prim Uint8_enum
 instance CEnum Uint8_enum
     where type CEnumZ Uint8_enum = HsBindgen.Runtime.LibC.Word8
           toCEnum = Uint8_enum
-          fromCEnum = unwrapUint8_enum
+          fromCEnum = getField @"unwrapUint8_enum"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "U8_ZERO"),
                                                          (127, singleton "U8_127"),

--- a/hs-bindgen/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/enums/Example.hs
@@ -97,7 +97,7 @@ instance CEnum.CEnum First where
 
   toCEnum = First
 
-  fromCEnum = unwrapFirst
+  fromCEnum = RIP.getField @"unwrapFirst"
 
   declaredValues =
     \_ ->
@@ -205,7 +205,7 @@ instance CEnum.CEnum Second where
 
   toCEnum = Second
 
-  fromCEnum = unwrapSecond
+  fromCEnum = RIP.getField @"unwrapSecond"
 
   declaredValues =
     \_ ->
@@ -325,7 +325,7 @@ instance CEnum.CEnum Same where
 
   toCEnum = Same
 
-  fromCEnum = unwrapSame
+  fromCEnum = RIP.getField @"unwrapSame"
 
   declaredValues =
     \_ ->
@@ -432,7 +432,7 @@ instance CEnum.CEnum Nonseq where
 
   toCEnum = Nonseq
 
-  fromCEnum = unwrapNonseq
+  fromCEnum = RIP.getField @"unwrapNonseq"
 
   declaredValues =
     \_ ->
@@ -542,7 +542,7 @@ instance CEnum.CEnum Packed where
 
   toCEnum = Packed
 
-  fromCEnum = unwrapPacked
+  fromCEnum = RIP.getField @"unwrapPacked"
 
   declaredValues =
     \_ ->
@@ -662,7 +662,7 @@ instance CEnum.CEnum EnumA where
 
   toCEnum = EnumA
 
-  fromCEnum = unwrapEnumA
+  fromCEnum = RIP.getField @"unwrapEnumA"
 
   declaredValues =
     \_ ->
@@ -770,7 +770,7 @@ instance CEnum.CEnum EnumB where
 
   toCEnum = EnumB
 
-  fromCEnum = unwrapEnumB
+  fromCEnum = RIP.getField @"unwrapEnumB"
 
   declaredValues =
     \_ ->
@@ -878,7 +878,7 @@ instance CEnum.CEnum EnumC where
 
   toCEnum = EnumC
 
-  fromCEnum = unwrapEnumC
+  fromCEnum = RIP.getField @"unwrapEnumC"
 
   declaredValues =
     \_ ->
@@ -986,7 +986,7 @@ instance CEnum.CEnum EnumD_t where
 
   toCEnum = EnumD_t
 
-  fromCEnum = unwrapEnumD_t
+  fromCEnum = RIP.getField @"unwrapEnumD_t"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/enums/th.txt
@@ -22,7 +22,7 @@ deriving via CUInt instance Prim First
 instance CEnum First
     where type CEnumZ First = CUInt
           toCEnum = First
-          fromCEnum = unwrapFirst
+          fromCEnum = getField @"unwrapFirst"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "FIRST1"),
                                                          (1, singleton "FIRST2")]
@@ -84,7 +84,7 @@ deriving via CInt instance Prim Second
 instance CEnum Second
     where type CEnumZ Second = CInt
           toCEnum = Second
-          fromCEnum = unwrapSecond
+          fromCEnum = getField @"unwrapSecond"
           declaredValues = \_ -> declaredValuesFromList [(-1,
                                                           singleton "SECOND_A"),
                                                          (0, singleton "SECOND_B"),
@@ -155,7 +155,7 @@ deriving via CUInt instance Prim Same
 instance CEnum Same
     where type CEnumZ Same = CUInt
           toCEnum = Same
-          fromCEnum = unwrapSame
+          fromCEnum = getField @"unwrapSame"
           declaredValues = \_ -> declaredValuesFromList [(1,
                                                           "SAME_A" :| ["SAME_B"])]
           showsUndeclared = showsWrappedUndeclared "Same"
@@ -215,7 +215,7 @@ deriving via CUInt instance Prim Nonseq
 instance CEnum Nonseq
     where type CEnumZ Nonseq = CUInt
           toCEnum = Nonseq
-          fromCEnum = unwrapNonseq
+          fromCEnum = getField @"unwrapNonseq"
           declaredValues = \_ -> declaredValuesFromList [(200,
                                                           singleton "NONSEQ_A"),
                                                          (301, singleton "NONSEQ_B"),
@@ -281,7 +281,7 @@ deriving via CUChar instance Prim Packed
 instance CEnum Packed
     where type CEnumZ Packed = CUChar
           toCEnum = Packed
-          fromCEnum = unwrapPacked
+          fromCEnum = getField @"unwrapPacked"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "PACKED_A"),
                                                          (1, singleton "PACKED_B"),
@@ -352,7 +352,7 @@ deriving via CUInt instance Prim EnumA
 instance CEnum EnumA
     where type CEnumZ EnumA = CUInt
           toCEnum = EnumA
-          fromCEnum = unwrapEnumA
+          fromCEnum = getField @"unwrapEnumA"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "A_FOO"),
                                                          (1, singleton "A_BAR")]
@@ -414,7 +414,7 @@ deriving via CUInt instance Prim EnumB
 instance CEnum EnumB
     where type CEnumZ EnumB = CUInt
           toCEnum = EnumB
-          fromCEnum = unwrapEnumB
+          fromCEnum = getField @"unwrapEnumB"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "B_FOO"),
                                                          (1, singleton "B_BAR")]
@@ -476,7 +476,7 @@ deriving via CUInt instance Prim EnumC
 instance CEnum EnumC
     where type CEnumZ EnumC = CUInt
           toCEnum = EnumC
-          fromCEnum = unwrapEnumC
+          fromCEnum = getField @"unwrapEnumC"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "C_FOO"),
                                                          (1, singleton "C_BAR")]
@@ -538,7 +538,7 @@ deriving via CUInt instance Prim EnumD_t
 instance CEnum EnumD_t
     where type CEnumZ EnumD_t = CUInt
           toCEnum = EnumD_t
-          fromCEnum = unwrapEnumD_t
+          fromCEnum = getField @"unwrapEnumD_t"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "D_FOO"),
                                                          (1, singleton "D_BAR")]

--- a/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/Example.hs
@@ -75,7 +75,7 @@ instance CEnum.CEnum EnumA where
 
   toCEnum = EnumA
 
-  fromCEnum = unwrapEnumA
+  fromCEnum = RIP.getField @"unwrapEnumA"
 
   declaredValues =
     \_ ->
@@ -236,7 +236,7 @@ instance CEnum.CEnum ExB_fieldB1 where
 
   toCEnum = ExB_fieldB1
 
-  fromCEnum = unwrapExB_fieldB1
+  fromCEnum = RIP.getField @"unwrapExB_fieldB1"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/fixtures/types/enums/nested_enums/th.txt
@@ -22,7 +22,7 @@ deriving via CUInt instance Prim EnumA
 instance CEnum EnumA
     where type CEnumZ EnumA = CUInt
           toCEnum = EnumA
-          fromCEnum = unwrapEnumA
+          fromCEnum = getField @"unwrapEnumA"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "VALA_1"),
                                                          (1, singleton "VALA_2")]
@@ -113,7 +113,7 @@ deriving via CUInt instance Prim ExB_fieldB1
 instance CEnum ExB_fieldB1
     where type CEnumZ ExB_fieldB1 = CUInt
           toCEnum = ExB_fieldB1
-          fromCEnum = unwrapExB_fieldB1
+          fromCEnum = getField @"unwrapExB_fieldB1"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "VALB_1"),
                                                          (1, singleton "VALB_2")]

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -168,7 +168,7 @@ instance CEnum.CEnum E where
 
   toCEnum = E
 
-  fromCEnum = unwrapE
+  fromCEnum = RIP.getField @"unwrapE"
 
   declaredValues =
     \_ ->

--- a/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -151,7 +151,7 @@ deriving via CUInt instance Prim E
 instance CEnum E
     where type CEnumZ E = CUInt
           toCEnum = E
-          fromCEnum = unwrapE
+          fromCEnum = getField @"unwrapE"
           declaredValues = \_ -> declaredValuesFromList [(0,
                                                           singleton "Foo")]
           showsUndeclared = showsWrappedUndeclared "E"

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -101,7 +101,6 @@ import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Backend.Hs.Origin qualified as Origin
 import HsBindgen.Backend.SHs.AST qualified as SHs
 import HsBindgen.Backend.UniqueSymbol (UniqueSymbol)
-import HsBindgen.Config.Prelims (FieldNamingStrategy (..))
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
@@ -287,7 +286,6 @@ data InstanceDecl where
       -> HsType
       -> Map Integer (NonEmpty String)
       -> Bool  -- is sequential?
-      -> FieldNamingStrategy  -- field naming strategy
       -> InstanceDecl
     InstanceSequentialCEnum ::
          Struct (S Z)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -180,7 +180,7 @@ generateDecs uniqueId fns haddockConfig moduleName sizeofs (C.Decl info kind spe
       C.DeclUnion union -> withCategoryM CType $
         State.immediateM $ unionDecs haddockConfig info union spec
       C.DeclEnum enum -> withCategoryM CType $
-        State.immediateM $ enumDecs supInsts.enum fns haddockConfig info enum spec
+        State.immediateM $ enumDecs supInsts.enum haddockConfig info enum spec
       C.DeclAnonEnumConstant anonEnumConst -> withCategoryM CType $
         pure $ State.immediate $ anonEnumConstantDecs haddockConfig info anonEnumConst
       C.DeclTypedef typedef -> withCategoryM CType $
@@ -260,13 +260,12 @@ opaqueDecs haddockConfig info spec = do
 
 enumDecs ::
      Map Inst.TypeClass Inst.SupportedStrategies
-  -> FieldNamingStrategy
   -> HaddockConfig
   -> C.DeclInfo Final
   -> C.Enum Final
   -> PrescriptiveDeclSpec
   -> HsM [Hs.Decl]
-enumDecs supInsts fns haddockConfig info enum spec = aux <$> newtypeDec
+enumDecs supInsts haddockConfig info enum spec = aux <$> newtypeDec
   where
     valueMap :: Map Integer (NonEmpty (C.FieldInfo Final, Hs.Name Hs.NsConstr))
     valueMap = Map.fromListWith (flip (<>)) [ -- preserve source order
@@ -420,7 +419,6 @@ enumDecs supInsts fns haddockConfig info enum spec = aux <$> newtypeDec
                       nt.field.typ
                       valueNames
                       (isJust mSeqBounds)
-                      fns
                 }
               cEnumShowDecl = Hs.DeclDefineInstance Hs.DefineInstance{
                   comment      = Nothing

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -23,7 +23,6 @@ import HsBindgen.Backend.Level
 import HsBindgen.Backend.SHs.AST
 import HsBindgen.Backend.SHs.Macro
 import HsBindgen.Backend.SHs.Translation.Common
-import HsBindgen.Config.Prelims (FieldNamingStrategy (..))
 import HsBindgen.Errors
 import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
@@ -108,8 +107,8 @@ translateDefineInstanceDecl defInst =
                         , ELam "_ty" $ EIntegral (toInteger i) Nothing)
                       ]
           }
-      Hs.InstanceCEnum struct fTyp vMap isSequential fieldNamingStrategy ->
-        DInst $ translateCEnumInstance struct fTyp vMap isSequential fieldNamingStrategy defInst.comment
+      Hs.InstanceCEnum struct fTyp vMap isSequential ->
+        DInst $ translateCEnumInstance struct fTyp vMap isSequential defInst.comment
       Hs.InstanceSequentialCEnum struct nameMin nameMax ->
         DInst $ translateSequentialCEnum struct nameMin nameMax defInst.comment
       Hs.InstanceCEnumShow struct ->
@@ -620,10 +619,9 @@ translateCEnumInstance ::
   -> HsType
   -> Map Integer (NonEmpty String)
   -> Bool
-  -> FieldNamingStrategy
   -> Maybe HsDoc.Comment
   -> Instance
-translateCEnumInstance struct fTyp vMap isSequential fieldNamingStrategy mbComment = Instance {
+translateCEnumInstance struct fTyp vMap isSequential mbComment = Instance {
       clss    = Inst.CEnum
     , args    = [tcon]
     , super   = []
@@ -647,17 +645,11 @@ translateCEnumInstance struct fTyp vMap isSequential fieldNamingStrategy mbComme
     fname :: Hs.Name Hs.NsVar
     fname = (NonEmpty.head $ Vec.toNonEmpty struct.fields).name
 
-    -- When using OmitFieldPrefixes, many newtypes will have fields named "unwrap",
-    -- which makes the bare identifier "unwrap" ambiguous. We use getField with
-    -- type application only in that case. Otherwise, we use the bare field name
-    -- directly since it's unique (e.g., unwrapE, unwrapValue).
+    fnameStr :: String
+    fnameStr = T.unpack $ Hs.getName fname
+
     fromCEnumE :: ClosedExpr
-    fromCEnumE =
-      case fieldNamingStrategy of
-        OmitFieldPrefixes ->
-          eBindgenGlobal HasField_getField `ETypeApp` translateType (Hs.HsStrLit "unwrap")
-        AddFieldPrefixes ->
-          EFree fname
+    fromCEnumE = eBindgenGlobal HasField_getField `ETypeApp` translateType (Hs.HsStrLit fnameStr)
 
     declaredValuesE :: SExpr ctx
     declaredValuesE = EApp (eBindgenGlobal CEnum_declaredValuesFromList) $ EList [


### PR DESCRIPTION
Resolves #1657

Rather than using field selectors, we use `getField` calls unconditionally. Generated bindings should then compile regardless of whether `NoFieldSelectors` is enabled.