### PR TITLE
Audit unnamed bit-field terminology

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -48,7 +48,7 @@
   after the global variable. Extern anonymous declarations
   (e.g., `extern struct { .. } config;`) are rejected as unusable.
 * Generate an `IsArray` instance for each newtype of a type with an `IsArray`
-* Support unnamed bit-field declarations, used for padding.
+* Support unnamed bit-fields, used for padding.
 * Generate bindings for nested struct and union declarations even if we failed
   to generate bindings for the enclosing struct or union. See [PR
   #1849][pr-1849].

--- a/hs-bindgen/examples/golden/types/anonymous/edge-cases/bitfield.h
+++ b/hs-bindgen/examples/golden/types/anonymous/edge-cases/bitfield.h
@@ -1,8 +1,7 @@
 #pragma once
 
 // Implicit field detection works the same if any of the indirect fields are
-// bit-fields.  Note that unnamed bit-field declarations, which specify padding,
-// are not fields.
+// bit-fields.
 //
 // Note: implicit field detection works the same for both unions and structs in
 // any order of nesting, so testing the struct-only case should be sufficient to

--- a/hs-bindgen/examples/golden/types/anonymous/edge-cases/empty_anon.h
+++ b/hs-bindgen/examples/golden/types/anonymous/edge-cases/empty_anon.h
@@ -8,14 +8,14 @@
 // <https://en.cppreference.com/w/c/language/struct.html>
 // <https://en.cppreference.com/w/c/language/union.html>
 //
-// We need at least one (bit-)field in an anonymous struct or union to determine
-// the offset of that anonymous object within an enclosing object. In other
-// words, anonymous structs and unions should be "non-empty". A struct or
-// union with only unnamed bit-field declarations, used to specify padding, is
-// also considered "empty". The parser should not generate any bindings for
-// empty structs or unions, and emit a message instead. Moreover, if a nested
-// struct or union fails to parse, for example because it is empty, then the
-// enclosing struct or union should also fail to parse.
+// We need at least one named (bit-)field in an anonymous struct or union to
+// determine the offset of that anonymous object within an enclosing object. In
+// other words, anonymous structs and unions should be "non-empty". A struct or
+// union with only unnamed bit-fields, used to specify padding, is also
+// considered "empty". The parser should not generate any bindings for empty
+// structs or unions, and emit a message instead. Moreover, if a nested struct
+// or union fails to parse, for example because it is empty, then the enclosing
+// struct or union should also fail to parse.
 //
 // This edge case was not properly handled by implicit field detection in the
 // past, so we include this as an edge case regression test.
@@ -34,7 +34,7 @@ struct S1 {
 struct S2 {
   struct {
     struct {
-      char : 3; // unnamed bit-field declaration specifies padding
+      char : 3; // unnamed bit-field specifies padding
     };
     int x;
   };

--- a/hs-bindgen/examples/golden/types/anonymous/edge-cases/padding.h
+++ b/hs-bindgen/examples/golden/types/anonymous/edge-cases/padding.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // We can compute offsets for implicit fields even if the anonymous struct or
-// union starts with padding (specified by an unnamed bit-field declaration).
+// union starts with padding (specified by an unnamed bit-field).
 //
 // This edge case was not properly handled by implicit field detection in the
 // past, so we include this as an edge case regression test.

--- a/hs-bindgen/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
+++ b/hs-bindgen/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
@@ -28,7 +28,7 @@ import qualified HsBindgen.Runtime.Marshal as Marshal
 
 {-| __C declaration:__ @struct \@S1_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:3@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:3@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -36,7 +36,7 @@ data S1_y = S1_y
   { s1_y_y :: RIP.CChar
     {- ^ __C declaration:__ @y@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 15:10@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:10@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
@@ -82,7 +82,7 @@ instance ( ((~) ty) RIP.CChar
 
 {-| __C declaration:__ @struct S1@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:8@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 12:8@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -90,14 +90,14 @@ data S1 = S1
   { s1_y :: S1_y
     {- ^ __C declaration:__ @y@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:3@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:3@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
   , s1_x :: RIP.CInt
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 17:7@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 16:7@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
@@ -153,7 +153,7 @@ instance ( ((~) ty) RIP.CInt
 
 {-| __C declaration:__ @struct \@S2_y_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:5@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:5@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -161,7 +161,7 @@ data S2_y_y = S2_y_y
   { s2_y_y_y :: RIP.CChar
     {- ^ __C declaration:__ @y@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 23:12@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:12@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
@@ -207,7 +207,7 @@ instance ( ((~) ty) RIP.CChar
 
 {-| __C declaration:__ @struct \@S2_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:3@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:3@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -215,14 +215,14 @@ data S2_y = S2_y
   { s2_y_y :: S2_y_y
     {- ^ __C declaration:__ @y@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:5@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:5@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
   , s2_y_x :: RIP.CInt
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 25:9@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 24:9@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}
@@ -279,7 +279,7 @@ instance ( ((~) ty) RIP.CInt
 
 {-| __C declaration:__ @struct S2@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:8@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 19:8@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -287,7 +287,7 @@ data S2 = S2
   { s2_y :: S2_y
     {- ^ __C declaration:__ @y@
 
-         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:3@
+         __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:3@
 
          __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
     -}

--- a/hs-bindgen/fixtures/types/anonymous/edge-cases/bitfield/th.txt
+++ b/hs-bindgen/fixtures/types/anonymous/edge-cases/bitfield/th.txt
@@ -1,7 +1,7 @@
 -- addDependentFile examples/golden/types/anonymous/edge-cases/bitfield.h
 {-| __C declaration:__ @struct \@S1_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:3@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:3@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -9,7 +9,7 @@ data S1_y
     = S1_y {s1_y_y :: CChar
             {- ^ __C declaration:__ @y@
 
-                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 15:10@
+                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:10@
 
                  __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
             -}}
@@ -32,7 +32,7 @@ instance (~) ty CChar =>
     where getField = toPtr (Proxy @"s1_y_y")
 {-| __C declaration:__ @struct S1@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:8@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 12:8@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -40,14 +40,14 @@ data S1
     = S1 {s1_y :: S1_y
           {- ^ __C declaration:__ @y@
 
-               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 14:3@
+               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 13:3@
 
                __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
           -},
           s1_x :: CInt
           {- ^ __C declaration:__ @x@
 
-               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 17:7@
+               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 16:7@
 
                __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
           -}}
@@ -74,7 +74,7 @@ instance (~) ty CInt => HasField "s1_x" (Ptr S1) (Ptr ty)
     where getField = fromPtr (Proxy @"s1_x")
 {-| __C declaration:__ @struct \@S2_y_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:5@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:5@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -82,7 +82,7 @@ data S2_y_y
     = S2_y_y {s2_y_y_y :: CChar
               {- ^ __C declaration:__ @y@
 
-                   __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 23:12@
+                   __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:12@
 
                    __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
               -}}
@@ -105,7 +105,7 @@ instance (~) ty CChar =>
     where getField = toPtr (Proxy @"s2_y_y_y")
 {-| __C declaration:__ @struct \@S2_y@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:3@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:3@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -113,14 +113,14 @@ data S2_y
     = S2_y {s2_y_y :: S2_y_y
             {- ^ __C declaration:__ @y@
 
-                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 22:5@
+                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:5@
 
                  __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
             -},
             s2_y_x :: CInt
             {- ^ __C declaration:__ @x@
 
-                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 25:9@
+                 __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 24:9@
 
                  __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
             -}}
@@ -147,7 +147,7 @@ instance (~) ty CInt => HasField "s2_y_x" (Ptr S2_y) (Ptr ty)
     where getField = fromPtr (Proxy @"s2_y_x")
 {-| __C declaration:__ @struct S2@
 
-    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:8@
+    __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 19:8@
 
     __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
 -}
@@ -155,7 +155,7 @@ data S2
     = S2 {s2_y :: S2_y
           {- ^ __C declaration:__ @y@
 
-               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:3@
+               __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:3@
 
                __exported by:__ @types\/anonymous\/edge-cases\/bitfield.h@
           -}}

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -264,11 +264,10 @@ structDecl ctx info = \curr -> do
                           _otherwise->
                             go (f:acc) fs
 
-    -- An unnamed bit-field declaration is used to specify padding, using a
-    -- specified padding width or zero to instruct the compiler to not pack
-    -- any more fields into the current storage unit.  This is used to conform
-    -- to externally imposed layouts.  This predicate is used to filter out such
-    -- declarations, which do not create fields.
+    -- An unnamed bit-field is used to specify padding, using a specified
+    -- padding width or zero to instruct the compiler to not pack any more
+    -- fields into the current storage unit.  This predicate is used to filter
+    -- out such bit-fields.
     isField :: C.StructField Parse -> Bool
     isField field = not $ Text.null field.info.name.text && isJust field.width
 
@@ -322,11 +321,10 @@ unionDecl ctx info = \curr -> do
       DefinitionElsewhere _ ->
         foldContinue
   where
-    -- An unnamed bit-field declaration is used to specify padding, using a
-    -- specified padding width or zero to instruct the compiler to not pack
-    -- any more fields into the current storage unit.  This is used to conform
-    -- to externally imposed layouts.  This predicate is used to filter out such
-    -- declarations, which do not create fields.
+    -- An unnamed bit-field is used to specify padding, using a specified
+    -- padding width or zero to instruct the compiler to not pack any more
+    -- fields into the current storage unit.  This predicate is used to filter
+    -- out such bit-fields.
     isField :: C.UnionField Parse -> Bool
     isField field = not $ Text.null field.info.name.text
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
@@ -85,8 +85,7 @@ data Outputs field =
 -- declarations that are present in the C source. If any failed to parse and are
 -- not included, then it is unsafe to use 'withImplicitFields'.
 --
--- Unnamed bit-field declarations, used to specify padding, are already filtered
--- out.
+-- Unnamed bit-fields, used to specify padding, are already filtered out.
 --
 -- === Algorithm description
 --
@@ -99,7 +98,7 @@ data Outputs field =
 -- that implicit field is equal to the offset to any of $A$'s fields (let's say
 -- $F$), subtracted by the offset to $F$ with respect to $A$.
 --
--- Let's walk through an example to make this more concrete. We asssume that
+-- Let's walk through an example to make this more concrete. We assume that
 -- @int@s are 4 bytes.
 --
 -- > struct E {
@@ -142,9 +141,9 @@ data Outputs field =
 -- The implicit field detection algorithm does rely on one condition: the
 -- anonymous nested struct or union should have at least one named field. In
 -- other words, the anonymous nested struct\/union should be "non-empty". A
--- struct\/union with only unnamed bit-field declarations, used to specify
--- padding, is also considered empty. A warning-level trace message will be
--- emitted if these conditions are not met.
+-- struct\/union with only unnamed bit-fields, used to specify padding, is also
+-- considered empty. A warning-level trace message will be emitted if these
+-- conditions are not met.
 --
 -- Anonymous nested structs/unions have no name, but they need one for our Haskell
 -- bindings, so they are named after their first field. Informally, the former will

--- a/manual/LowLevel/Translation/02-Structs/Nesting.md
+++ b/manual/LowLevel/Translation/02-Structs/Nesting.md
@@ -199,8 +199,8 @@ If these generated names are too unwieldy, they can always be customised using
 ### Limitations
 
 For technical reasons we can only generate bindings for anonymous structs that
-have at least one field. Empty anonymous structs and anonymous structs with only
-padding (specified using unnamed bit-field declarations) are not supported.  A
+have at least one named field. Empty anonymous structs and anonymous structs
+with only padding (specified using unnamed bit-fields) are not supported. A
 warning-level trace message will be emitted in this case.
 
 

--- a/manual/LowLevel/Translation/04-Unions/Nesting.md
+++ b/manual/LowLevel/Translation/04-Unions/Nesting.md
@@ -228,8 +228,8 @@ If these generated names are too unwieldy, they can always be customised using
 ### Limitations
 
 For technical reasons we can only generate bindings for anonymous unions that
-have at least one field. Empty anonymous unions and anonymous unions with only
-padding (specified using unnamed bit-field declarations) are not supported. A
+have at least one named field. Empty anonymous unions and anonymous unions with
+only padding (specified using unnamed bit-fields) are not supported. A
 warning-level trace message will be emitted in this case.
 
 


### PR DESCRIPTION
The C spec indeed uses "unnamed bit-field" to refer to the syntax used to specify padding.  This commit changes all comments and documentation so that we use "unnamed bit-field" for consistency.
