### PR TITLE
Check links in documentation using `lychee`

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,61 @@
+name: Check links
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+  repository_dispatch:
+  workflow_dispatch:
+  # Run daily on the default branch to catch links that break unexpectedly, for
+  # example because they link to web pages that do not exist anymore.
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  # Checks links in Markdown, HTML and text files using lychee.
+  #
+  # We are mostly interested in checking links in our manual, which consists of
+  # Markdown files.
+  #
+  # <https://github.com/marketplace/actions/lychee-broken-link-checker>
+  check-links:
+    name: Check links with lychee
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Initialise git submodules so that links into submodules can be checked.
+      # Because we are only interested in checking links defined in our own
+      # documentation, we use the exclude_path key in the lychee.toml file to
+      # make sure that we do not check links defined *inside* the submodules,
+      - name: Initialise git submodules
+        run: |
+          git submodule init
+          git submodule update
+
+      # NOTE: if lychee-action runs too slowly in the future, then we can use
+      # caching to improve performance. A tutorial for configuring the cache can
+      # be found in the lychee-action README:
+      #
+      # <https://github.com/lycheeverse/lychee-action/blob/master/README.md>
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        env:
+          # Default arguments taken directly from:
+          # <github.com/lycheeverse/lychee-action/blob/master/action.yml>
+          default-args: "--verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'"
+          # With --include-fragments we also enable anchor link checking.
+          #
+          # Unfortunately, broken reference links are not checked because it is
+          # not (yet) implemented:
+          # <https://github.com/lycheeverse/lychee/issues/456>
+          custom-args: "--include-fragments"
+
+        with:
+          args: "${{ env.default-args }} ${{ env.custom-args }}"
+          fail: true
+          failIfEmpty: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+https://dl.acm.org/doi/10.1145/3759164.3759350
+https://www.reddit.com/user/Krantz98

--- a/examples/bundled-c/README.md
+++ b/examples/bundled-c/README.md
@@ -21,9 +21,8 @@ Cabal compiles `rect.c` and links it into the executable automatically.
 on Linux), while `hs-bindgen` uses `libclang` to parse headers and derive type
 layouts. For simple types this is unlikely to cause problems, but GCC and Clang
 can disagree on memory layout for more exotic constructs (bitfields, packed
-structs, platform-specific alignment). See the [Compiler choice (GCC
-vs. Clang)](../../../manual/LowLevel/Usage/01-Invocation.md#compiler-choice-gcc-vs-clang)
-section in the manual for details.
+structs, platform-specific alignment). See the [Compiler choice (GCC vs.
+Clang)](../../manual/LowLevel/Usage/01-Invocation.md#compiler-choice-gcc-vs-clang)
 
 ## Prerequisites
 
@@ -44,7 +43,7 @@ bindings, then builds and runs the executable.
 
 This example also demonstrates the non-portability problem described in
 [issue #893](https://github.com/well-typed/hs-bindgen/issues/893) and the
-[Non-portability](../../../manual/LowLevel/Usage/06-BindingSpecifications.md#non-portability)
+[Non-portability](../../manual/LowLevel/Usage/06-BindingSpecifications.md#non-portability)
 section of the manual.
 
 ### Setup

--- a/examples/cross-compilation/README.md
+++ b/examples/cross-compilation/README.md
@@ -17,7 +17,7 @@ nix develop
 
 ## Prerequisites
 
-- [Nix](https://nixos.org/download.html) with flakes enabled
+- [Nix](https://nixos.org/download/) with flakes enabled
 
 Enable flakes by adding to `~/.config/nix/nix.conf`:
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,14 @@
+exclude_path = [
+  # skip submodules, because we are only interested in checking links in our own
+  # documentation.
+  "alternatives/tools/c2hs",
+  "alternatives/tools/hsc2hs",
+  "examples/botan/botan",
+  "examples/c-minisat/minisat-c-bindings",
+  "examples/c-qrcode/QR-Code-generator",
+  "examples/c-rogueutil/rogueuti",
+  "examples/c-rpm/rpm",
+  # copied from .gitignore because lychee does not respect .gitignore when
+  # passed globs (see https://github.com/lycheeverse/lychee/discussions/1612).
+  "dist-newstyle*",
+]

--- a/manual/Installation.md
+++ b/manual/Installation.md
@@ -247,5 +247,5 @@ $env:Path = "C:\path\to\your\c\libs;" + $env:Path
 
 ## Nix
 
-We provide and maintain a [Nix Flake](../../../flake.nix), and a [Nix-focused
+We provide and maintain a [Nix Flake](../flake.nix), and a [Nix-focused
 tutorial](https://github.com/well-typed/hs-bindgen-tutorial-nix).

--- a/manual/LowLevel/Appendix/01-Visibility.md
+++ b/manual/LowLevel/Appendix/01-Visibility.md
@@ -67,7 +67,7 @@ TODO: we currently use `clang` for parsing in `hs-bindgen` without an
 linked using `-fvisibility=hidden`, but we use clang in `hs-bindgen` with
 `-fvisibility=default`? It sounds like that would be wrong.
 
-[visibility]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-visibility-function-attribute
+[visibility]: https://gcc.gnu.org/onlinedocs/gcc/Common-Attributes.html#index-visibility
 [gcc-options]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fvisibility
 [clang-options]: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fvisibility
 

--- a/manual/LowLevel/Terminology.md
+++ b/manual/LowLevel/Terminology.md
@@ -18,7 +18,7 @@ struct/union][t:nested] is called an *anonymous struct/union*.
 > consistently apply the *anonymous* terminology correctly. See [issue
 > #1893][issue-1893].
 
-[issue-1893]: https://github.com/well-typed/hs-bindgen/pull/1893
+[issue-1893]: https://github.com/well-typed/hs-bindgen/issues/1893
 
 </details>
 
@@ -90,7 +90,7 @@ A [field][t:field] with a name is called a *named field*. All fields should be
 named, with some exceptions: see [unnamed field][t:unnamed_field].
 
 ### Nested struct/union
-[t:nested]: #nested
+[t:nested]: #nested-structunion
 
 A [field][t:field] can declare a new struct or union type, in which case it is
 called a *nested struct/union*. The nested struct/union can be
@@ -120,7 +120,7 @@ to this name as a *tag*.
 
 ### Tagged struct/union/enum
 
-A struct or union or enum with a [tag][t:tag] is called *tagged*.
+A struct or union or enum with a [tag][t:stag] is called *tagged*.
 
 ### Unnamed field
 [t:unnamed_field]: #unnamed-field

--- a/manual/LowLevel/Translation/02-Structs.md
+++ b/manual/LowLevel/Translation/02-Structs.md
@@ -3,7 +3,7 @@
 In this section we will consider the details of translating [C
 structures](https://en.wikipedia.org/wiki/Struct_(C_programming_language))
 (`struct`s). The examples are available in the [C header file
-`structs.h`](/manual/c/structs.h).
+`structs.h`](../../c/structs.h).
 
 In the [Introduction](../Introduction.md), we have seen bindings
 created for a named C `struct` (structure) storing a triple of integers:
@@ -55,7 +55,7 @@ See the [Structs/Nesting](./02-Structs/Nesting.md) manual section.
 
 ## Bitfields
 
-[_Bitfields_](https://www.geeksforgeeks.org/bit-fields-c/) are structures or
+[_Bitfields_](https://www.geeksforgeeks.org/c/bit-fields-c/) are structures or
 unions with elements of individual size. For example,
 
 ```c

--- a/manual/LowLevel/Translation/02-Structs/Nesting.md
+++ b/manual/LowLevel/Translation/02-Structs/Nesting.md
@@ -209,4 +209,4 @@ warning-level trace message will be emitted in this case.
 
 [c-reference:struct]: https://en.cppreference.com/w/c/language/struct.html
 [manual:usage/binding-specs]: ../../Usage/06-BindingSpecifications.md
-[manual:unions/nesting]: ./04-Unions/Nesting.md
+[manual:unions/nesting]: ../04-Unions/Nesting.md

--- a/manual/LowLevel/Translation/04-Unions/Nesting.md
+++ b/manual/LowLevel/Translation/04-Unions/Nesting.md
@@ -238,4 +238,4 @@ warning-level trace message will be emitted in this case.
 
 [c-reference:union]: https://en.cppreference.com/w/c/language/union.html
 [manual:usage/binding-specs]: ../../Usage/06-BindingSpecifications.md
-[manual:structs/nesting]: ./02-Structs/Nesting.md
+[manual:structs/nesting]: ../02-Structs/Nesting.md

--- a/manual/Roadmap.md
+++ b/manual/Roadmap.md
@@ -6,7 +6,7 @@ their own right and can be released as version
 [0.2](https://github.com/well-typed/hs-bindgen/issues/30) and
 [0.3](https://github.com/well-typed/hs-bindgen/issues/31).
 
-## [Milestone 1: `Storable` instances](https://github.com/well-typed/hs-bindgen/milestone/2)
+## Milestone 1: `Storable` instances
 
 The object here is to be able to generate Haskell types with `Storable`
 instances for "all"
@@ -40,7 +40,7 @@ We should also [generate a
 test-suite](https://github.com/well-typed/hs-bindgen/issues/22) to check that
 the `Storable` instances we generate are correct.
 
-## [Milestone 2: Low-level API](https://github.com/well-typed/hs-bindgen/milestone/3)
+## Milestone 2: Low-level API
 
 The goal of this milestone is to [generate low-level `foreign import`
 declarations](https://github.com/well-typed/hs-bindgen/issues/25) for all
@@ -73,7 +73,7 @@ supported by tooling such as HLS.
 
 We might want to release this together with milestone 2.5, see below.
 
-## [Milestone 2.5: Library support for hand-written high-level bindings](https://github.com/well-typed/hs-bindgen/milestone/6)
+## Milestone 2.5: Library support for hand-written high-level bindings
 
 This milestone sits in between milestones 2 and 3 because it is useful for both.
 When hand-writing high-level bindings, there are undoubtedly a lot of patterns
@@ -117,7 +117,7 @@ decisions](https://github.com/well-typed/hs-bindgen/issues/23). In other words,
 the generated code should provide sufficient information to the user to allow
 them to change the way that the code is generated.
 
-## [Milestone 4: Additional features](https://github.com/well-typed/hs-bindgen/milestone/5)
+## Milestone 4: Additional features
 
 This milestone is currently just a collection of additional features that we
 might consider, such as

--- a/scripts/ci/run-lychee.sh
+++ b/scripts/ci/run-lychee.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+lychee --verbose --no-progress \
+  --format markdown \
+  --include-fragments \
+  './**/*.md' './**/*.html' './**/*.rst'


### PR DESCRIPTION
This PR adds a job in CI that checks whether there are no dead links in our documentation. This should make it easier to maintain our documentation.