### PR TITLE
`Golden`: some object-like macros treated as function-like macros

### DIFF
--- a/hs-bindgen/examples/golden/macros/object_like_as_function_like.h
+++ b/hs-bindgen/examples/golden/macros/object_like_as_function_like.h
@@ -1,0 +1,14 @@
+// F is a function-like macro definition while G is an object-like macro
+// definition. The difference is in the whitespace between the identifier and
+// the opening parenthesis. hs-bindgen treats F and G both as function-like
+// macro definitions, which is wrong.
+//
+// TODO <https://github.com/well-typed/hs-bindgen/issues/1903>
+//
+// <https://en.cppreference.com/w/cpp/preprocessor/replace.html>
+
+#define F(x, y) x + y
+#define G (x, y) x + y
+
+int a = F(3, 5);
+// int b = G(4, 2); // does not work!

--- a/hs-bindgen/fixtures/macros/object_like_as_function_like/Example.hs
+++ b/hs-bindgen/fixtures/macros/object_like_as_function_like/Example.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Example
+    ( Example.f
+    , Example.g
+    )
+  where
+
+import qualified C.Expr.HostPlatform
+
+{-| __C declaration:__ @macro F@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 10:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+f :: forall a0 b1. (C.Expr.HostPlatform.Add a0) b1 => a0 -> b1 -> (C.Expr.HostPlatform.AddRes a0) b1
+f = \x0 -> \y1 -> (C.Expr.HostPlatform.+) x0 y1
+
+{-| __C declaration:__ @macro G@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+g :: forall a0 b1. (C.Expr.HostPlatform.Add a0) b1 => a0 -> b1 -> (C.Expr.HostPlatform.AddRes a0) b1
+g = \x0 -> \y1 -> (C.Expr.HostPlatform.+) x0 y1

--- a/hs-bindgen/fixtures/macros/object_like_as_function_like/Example/Global.hs
+++ b/hs-bindgen/fixtures/macros/object_like_as_function_like/Example/Global.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.a
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/object_like_as_function_like.h>"
+  , "/* test_macrosobject_like_as_function_Example_get_a */"
+  , "__attribute__ ((const))"
+  , "signed int *hs_bindgen_06ace787c069879f (void)"
+  , "{"
+  , "  return &a;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
+foreign import ccall unsafe "hs_bindgen_06ace787c069879f" hs_bindgen_06ace787c069879f_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
+hs_bindgen_06ace787c069879f :: IO (RIP.Ptr RIP.CInt)
+hs_bindgen_06ace787c069879f =
+  RIP.fromFFIType hs_bindgen_06ace787c069879f_base
+
+{-# NOINLINE a #-}
+{-| __C declaration:__ @a@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 13:5@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+a :: RIP.Ptr RIP.CInt
+a = RIP.unsafePerformIO hs_bindgen_06ace787c069879f

--- a/hs-bindgen/fixtures/macros/object_like_as_function_like/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/object_like_as_function_like/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/fixtures/macros/object_like_as_function_like/th.txt
+++ b/hs-bindgen/fixtures/macros/object_like_as_function_like/th.txt
@@ -1,0 +1,58 @@
+-- addDependentFile examples/golden/macros/object_like_as_function_like.h
+-- #include <macros/object_like_as_function_like.h>
+-- /* test_macrosobject_like_as_function_Example_get_a */
+-- __attribute__ ((const))
+-- signed int *hs_bindgen_06ace787c069879f (void)
+-- {
+--   return &a;
+-- }
+{-| __C declaration:__ @macro F@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 10:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+f :: forall a_0 b_1 . Add a_0 b_1 => a_0 -> b_1 -> AddRes a_0 b_1
+{-| __C declaration:__ @macro F@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 10:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+f = \x_0 -> \y_1 -> (+) x_0 y_1
+{-| __C declaration:__ @macro G@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+g :: forall a_0 b_1 . Add a_0 b_1 => a_0 -> b_1 -> AddRes a_0 b_1
+{-| __C declaration:__ @macro G@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+g = \x_0 -> \y_1 -> (+) x_0 y_1
+-- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
+foreign import ccall unsafe "hs_bindgen_06ace787c069879f" hs_bindgen_06ace787c069879f_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
+hs_bindgen_06ace787c069879f :: IO (Ptr CInt)
+-- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
+hs_bindgen_06ace787c069879f = fromFFIType hs_bindgen_06ace787c069879f_base
+{-# NOINLINE a #-}
+{-| __C declaration:__ @a@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 13:5@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+a :: Ptr CInt
+{-| __C declaration:__ @a@
+
+    __defined at:__ @macros\/object_like_as_function_like.h 13:5@
+
+    __exported by:__ @macros\/object_like_as_function_like.h@
+-}
+a = unsafePerformIO hs_bindgen_06ace787c069879f

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -25,6 +25,7 @@ testCases = [
     , defaultTest "macros/macro_typedef_scope"
     , defaultTest "macros/macro_typedef_struct"
     , defaultTest "macros/macro_types"
+    , defaultTest "macros/object_like_as_function_like"
       -- Bespoke tests
     , test_macros_macro_in_fundecl
     , test_macros_macro_in_fundecl_vs_typedef

--- a/scripts/ci/compile-and-generate-haddocks-fixtures.sh
+++ b/scripts/ci/compile-and-generate-haddocks-fixtures.sh
@@ -102,7 +102,7 @@ KNOWN_WERROR_UNCLEAN=(
 #
 # This number is used for sanity checks. Make sure to update this number when
 # new fixtures are added or old ones are removed.
-KNOWN_FIXTURES_COUNT=185
+KNOWN_FIXTURES_COUNT=186
 
 # Default options
 JOBS=4


### PR DESCRIPTION
In the example below, F is a function-like macro definition while G is an object-like macro definition. The difference is in the whitespace between the identifier and the opening parenthesis. hs-bindgen treats F and G both as function-like macro definitions, which is wrong.

```c
#define F(x, y) x + y
#define G (x, y) x + y
```

This PR adds a new golden test "macros/object_like_as_function_like" that shows that we generate the same bindings for F as G.
