### PR TITLE
Audit usages of `TH.mkName`, inform users when splices use declarations not in scope

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### New features
 
+* When using the Template Haskell backend, external types referenced via
+  external binding specifications that are not in scope now produce a helpful
+  compile error suggesting the missing import.
 * Macro handling has been overhauled. Macros are now parsed during the `Parse`
   pass and typechecked in a dedicated `TypecheckMacros` pass (replacing the old
   `HandleMacros` pass). A new `ReparseMacroExpansions` pass handles declarations

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -6,6 +6,7 @@ module HsBindgen.Backend.TH.Translation (
 ) where
 
 import Control.Monad (liftM2)
+import Data.Set qualified as Set
 import Data.Text qualified as Text
 import DeBruijn (Add (..), EmptyCtx, Env (..), lookupEnv)
 import Foreign.C.Types qualified
@@ -47,7 +48,7 @@ mkGlobalExpr g = case g.cat of
   GVar -> TH.varE g.name
   GCon -> TH.conE g.name
 
-mkExpr :: Quote q => Env ctx TH.Name -> SExpr ctx -> q TH.Exp
+mkExpr :: Guasi q => Env ctx TH.Name -> SExpr ctx -> q TH.Exp
 mkExpr env expr = case asNaryEApp expr of
     (EBoxedTup n, args) ->
       prettyTupleExpr Boxed env n args
@@ -60,12 +61,12 @@ mkExpr env expr = case asNaryEApp expr of
     _otherwise -> mkRolledExpr env expr
 
 -- See 'mkExpr' but do not unroll/recognize function applications.
-mkRolledExpr :: Quote q => Env ctx TH.Name -> SExpr ctx -> q TH.Exp
+mkRolledExpr :: Guasi q => Env ctx TH.Name -> SExpr ctx -> q TH.Exp
 mkRolledExpr env expr = case expr of
     EGlobal n     -> mkGlobalExpr n
-    EFree n       -> hsVarE n
+    EFree n       -> TH.varE $ mkHsName n
     EBound x      -> TH.varE (lookupEnv x env)
-    ECon n        -> hsConE n
+    ECon n        -> TH.conE $ mkHsName n
     EUnboxedIntegral i -> TH.sigE (TH.litE (TH.IntPrimL i)) (TH.conT ''GHC.Base.Int#)
     EIntegral i Nothing -> TH.litE (TH.IntegerL i)
     EIntegral i (Just t) -> TH.sigE (TH.litE (TH.IntegerL i)) (mkType EmptyEnv t)
@@ -116,7 +117,7 @@ mkRolledExpr env expr = case expr of
                            SAlt c add hints b -> do
                              (xs, env') <- newNames env add hints
                              TH.match
-                                (hsConP c $ map TH.varP xs)
+                                (TH.conP (mkHsName c) (map TH.varP xs))
                                 (TH.normalB $ mkExpr env' b)
                                 []
                            SAltNoConstr hints b -> do
@@ -157,10 +158,10 @@ mkRolledExpr env expr = case expr of
 
 mkPat :: Quote q => PatExpr -> q TH.Pat
 mkPat = \case
-    PEApps n xs -> hsConP n (map mkPat xs)
+    PEApps n xs -> TH.conP (mkHsName n) (map mkPat xs)
     PELit i -> TH.litP (TH.IntegerL i)
 
-mkType :: Quote q => Env ctx TH.Name -> SType ctx -> q TH.Type
+mkType :: Guasi q => Env ctx TH.Name -> SType ctx -> q TH.Type
 mkType env ty = case asNaryTApp ty of
     (TBoxedTup n, args) ->
       prettyTupleType env n args
@@ -172,13 +173,13 @@ mkType env ty = case asNaryTApp ty of
       mkRolledType env ty
 
 -- See 'mkType' but do not unroll/recognize type applications.
-mkRolledType :: Quote q => Env ctx TH.Name -> SType ctx -> q TH.Type
+mkRolledType :: Guasi q => Env ctx TH.Name -> SType ctx -> q TH.Type
 mkRolledType env ty = case ty of
     TGlobal n  -> TH.conT n.name
     TClass cls -> TH.conT $ (.name) $ typeClassGlobal cls
     TBound x   -> TH.varT (lookupEnv x env)
-    TCon n     -> hsConT n
-    TFree n    -> hsVarT n
+    TCon n     -> TH.conT $ mkHsName n
+    TFree n    -> TH.varT $ mkHsName n
     TLit n     -> TH.litT (TH.numTyLit (toInteger n))
     TStrLit s  -> TH.litT (TH.strTyLit s)
     TFun a b   -> TH.arrowT `TH.appT` mkType env a `TH.appT` mkType env b
@@ -198,17 +199,13 @@ mkRolledType env ty = case ty of
             (traverse (mkType env') ctxt)
             (mkType env' body)
     TExt extRef _cTypeSpec _hsTypeSpec ->
-        TH.conT . TH.mkName $ concat [
-              Hs.moduleNameToString extRef.moduleName
-            , "."
-            , Text.unpack extRef.ident.text
-            ]
+        lookupExtType extRef
 
 mkDecl :: forall q. Guasi q => FieldNamingStrategy -> SDecl -> q [TH.Dec]
 mkDecl fns = \case
       DTypSyn typSyn -> do
         targetType <- mkType EmptyEnv typSyn.typ
-        pure [TH.TySynD (hsNameToTH typSyn.name) [] targetType]
+        pure [TH.TySynD (mkHsName typSyn.name) [] targetType]
       DInst inst -> do
         instanceDec <-
           TH.instanceD
@@ -235,7 +232,7 @@ mkDecl fns = \case
         let fields :: [q TH.VarBangType]
             docs   :: [(Hs.Name Hs.NsVar, Maybe HsDoc.Comment)]
             (fields, docs) = unzip
-              [ ( TH.varBangType (hsNameToTH field.name) $
+              [ ( TH.varBangType (mkHsName field.name) $
                     TH.bangType
                       (TH.bang TH.noSourceUnpackedness TH.noSourceStrictness)
                       (mkType EmptyEnv field.typ)
@@ -248,23 +245,23 @@ mkDecl fns = \case
         decl <-
           TH.dataD
             (TH.cxt [])
-            (hsNameToTH record.typ)
+            (mkHsName record.typ)
             []
             Nothing
-            [TH.recC (hsNameToTH record.con) fields]
+            [TH.recC (mkHsName record.con) fields]
             (nestedDeriving record.deriv)
         putLocalDocM record.typ record.comment
 
         pure [decl]
 
       DEmptyData empty -> do
-        decl <- TH.dataD (TH.cxt []) (hsNameToTH empty.name) [] Nothing [] []
+        decl <- TH.dataD (TH.cxt []) (mkHsName empty.name) [] Nothing [] []
         putLocalDocM empty.name empty.comment
         pure [decl]
 
       DNewtype newtyp -> do
         let field :: q TH.VarBangType
-            field = TH.varBangType (hsNameToTH newtyp.field.name) $
+            field = TH.varBangType (mkHsName newtyp.field.name) $
               TH.bangType
                 (TH.bang TH.noSourceUnpackedness TH.noSourceStrictness)
                 (mkType EmptyEnv newtyp.field.typ)
@@ -274,10 +271,10 @@ mkDecl fns = \case
         decl <-
           TH.newtypeD
             (TH.cxt [])
-            (hsNameToTH newtyp.name)
+            (mkHsName newtyp.name)
             []
             Nothing
-            (TH.recC (hsNameToTH newtyp.con) [field])
+            (TH.recC (mkHsName newtyp.con) [field])
             (nestedDeriving newtyp.deriv)
         putLocalDocM (newtyp.name) (newtyp.comment)
         pure [decl]
@@ -324,14 +321,14 @@ mkDecl fns = \case
               <$> pure callconv
               <*> pure safety
               <*> pure impent
-              <*> pure (hsNameToTH foreignImport.name)
+              <*> pure (mkHsName foreignImport.name)
               <*> mkType EmptyEnv importType
         putLocalDocM foreignImport.name foreignImport.comment
         pure [decl]
 
       DBinding binding -> do
         let bindingName :: TH.Name
-            bindingName = hsNameToTH binding.name
+            bindingName = mkHsName binding.name
             bindingType :: SType EmptyCtx
             bindingType = foldr (TFun . (.typ)) binding.result.typ binding.parameters
 
@@ -346,7 +343,7 @@ mkDecl fns = \case
         pure decls
 
       DPatternSynonym patSyn -> do
-        let thPatSynName = hsNameToTH patSyn.name
+        let thPatSynName = mkHsName patSyn.name
 
         decls <- sequence
           [ TH.patSynSigD
@@ -375,11 +372,11 @@ mkDecl fns = \case
       pragma :: Hs.Name Hs.NsVar -> Pragma -> q TH.Dec
       pragma n = \case
         NOINLINE ->
-            TH.pragInlD (hsNameToTH n) TH.NoInline TH.FunLike TH.AllPhases
+            TH.pragInlD (mkHsName n) TH.NoInline TH.FunLike TH.AllPhases
 
 -- | Nested deriving clauses (part of a datatype declaration)
 nestedDeriving :: forall q.
-     Quote q
+     Guasi q
   => [(Hs.Strategy ClosedType, [Inst.TypeClass])] -> [q TH.DerivClause]
 nestedDeriving = map aux
   where
@@ -388,7 +385,7 @@ nestedDeriving = map aux
         s' <- strategy s
         TH.derivClause (Just s') (map (TH.conT . (.name) . typeClassGlobal) clss)
 
-strategy :: Quote q => Hs.Strategy ClosedType -> q TH.DerivStrategy
+strategy :: Guasi q => Hs.Strategy ClosedType -> q TH.DerivStrategy
 strategy Hs.DeriveNewtype  = return TH.NewtypeStrategy
 strategy Hs.DeriveStock    = return TH.StockStrategy
 strategy (Hs.DeriveVia ty) = TH.ViaStrategy <$> mkType EmptyEnv ty
@@ -400,25 +397,21 @@ strategy (Hs.DeriveVia ty) = TH.ViaStrategy <$> mkType EmptyEnv ty
 appsT :: Quote q => q TH.Type -> [q TH.Type] -> q TH.Type
 appsT = foldl' TH.appT
 
-hsConE :: Quote m => Hs.Name Hs.NsConstr -> m TH.Exp
-hsConE = TH.conE . hsNameToTH
+-- | Create a 'TH.name' from an 'Hs.Name'
+--
+-- Be careful! This function uses 'TH.mkName'. Names created with 'TH.mkName'
+-- are resolved in the context of the use site of the splice. That is, used
+-- symbols /must be in scope/, and users must import the probably only
+-- indirectly-used modules.
+mkHsName :: Hs.Name ns -> TH.Name
+mkHsName = TH.mkName . Text.unpack . Hs.getName
 
-hsConP :: Quote m => Hs.Name Hs.NsConstr -> [m TH.Pat] -> m TH.Pat
-hsConP = TH.conP . hsNameToTH
-
-hsConT :: Quote m => Hs.Name Hs.NsTypeConstr -> m TH.Type
-hsConT = TH.conT . hsNameToTH
-
-hsVarT :: Quote m => Hs.Name Hs.NsVar -> m TH.Type
-hsVarT = TH.varT . hsNameToTH
-
-hsVarE :: Quote m => Hs.Name Hs.NsVar -> m TH.Exp
-hsVarE = TH.varE . hsNameToTH
-
-hsNameToTH :: Hs.Name ns -> TH.Name
-hsNameToTH = TH.mkName . Text.unpack  . Hs.getName
-
-newNames :: Quote q => Env ctx TH.Name -> Add n ctx ctx' -> Vec n NameHint -> q ([TH.Name], Env ctx' TH.Name)
+newNames ::
+     Quote q
+  => Env ctx TH.Name
+  -> Add n ctx ctx'
+  -> Vec n NameHint
+  -> q ([TH.Name], Env ctx' TH.Name)
 newNames env AZ _ = return ([], env)
 newNames env (AS n) (NameHint hint ::: hints) = do
     (xs, env') <- newNames env n hints
@@ -444,7 +437,13 @@ putLocalFieldDocM fns parent field = traverse_ (putLocalFieldDoc fns parent fiel
 
 data TupleType = Boxed | Unboxed
 
-prettyTupleExpr :: Quote q => TupleType -> Env ctx TH.Name -> Plus2 -> [SExpr ctx] -> q TH.Exp
+prettyTupleExpr ::
+     Guasi q
+  => TupleType
+  -> Env ctx TH.Name
+  -> Plus2
+  -> [SExpr ctx]
+  -> q TH.Exp
 prettyTupleExpr ty env n decls = case compare arity nDecls of
   LT ->
     panicPure $ mconcat [
@@ -471,7 +470,7 @@ prettyTupleExpr ty env n decls = case compare arity nDecls of
       Boxed   -> TH.TupE
       Unboxed -> TH.UnboxedTupE
 
-prettyTupleType :: Quote q => Env ctx TH.Name -> Plus2 -> [SType ctx] -> q TH.Type
+prettyTupleType :: Guasi q => Env ctx TH.Name -> Plus2 -> [SType ctx] -> q TH.Type
 prettyTupleType env n decls = case compare arity nDecls of
   LT ->
     panicPure $ mconcat [
@@ -492,3 +491,30 @@ prettyTupleType env n decls = case compare arity nDecls of
 
 panicWith :: Show a => String -> a -> b
 panicWith msg x = panicPure $ msg ++ ": " ++ show x
+
+-- | Look up a type name from an external binding spec.
+--
+-- If the name is not in scope, report a helpful error message telling the user
+-- which module they need to import, then falls back to 'TH.mkName' to avoid
+-- cascading type errors.
+--
+-- See https://github.com/well-typed/hs-bindgen/issues/1622.
+lookupExtType :: Guasi q => Hs.ExtRef -> q TH.Type
+lookupExtType extRef = do
+    mName <- lookupTypeName qualName
+    case mName of
+      Just n  -> TH.conT n
+      Nothing -> do
+          modifyGuasi (putMissingModule extRef.moduleName)
+          TH.conT (TH.mkName qualName)
+  where
+    qualName :: String
+    qualName = concat [
+          Hs.moduleNameToString extRef.moduleName
+        , "."
+        , Text.unpack extRef.ident.text
+        ]
+
+    putMissingModule :: Hs.ModuleName -> GuasiState -> GuasiState
+    putMissingModule m s = s & #missingModules %~ Set.insert m
+

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
@@ -303,7 +303,7 @@ getImplicitField encObj decl = do
         offset' = offset - target.fieldOffset
     makeImplicitFieldM
       decl.info.loc
-      (mkName target)
+      (mkScopedName target)
       (C.TypeRef decl.info.id)
       offset'
       (mkOrigin target)
@@ -329,8 +329,8 @@ getImplicitField encObj decl = do
       -> Origin.ImplicitFieldOrigin
     mkOrigin target = Origin.ImplicitFieldOrigin encObj.typ (CScopedName target.originName.text)
 
-    mkName :: Target -> ScopedName Parse
-    mkName target = CScopedName target.fieldName.text
+    mkScopedName :: Target -> ScopedName Parse
+    mkScopedName target = CScopedName target.fieldName.text
 
 -- | When the field is implicit and we want to ask for its offset using its
 -- name, then we should ask for the offset to an explicit field of the

--- a/hs-bindgen/src-internal/HsBindgen/Guasi.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Guasi.hs
@@ -2,8 +2,12 @@
 
 module HsBindgen.Guasi (
     Guasi (..)
+    -- * State
+  , GuasiState(..)
+  , emptyGuasiState
   ) where
 
+import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
@@ -13,16 +17,29 @@ import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Backend.HsModule.Pretty.Comment (CommentKind (..))
 import HsBindgen.Config (FieldNamingStrategy (..))
+import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
 
 -- | An intermediate class between 'TH.Quote' and 'TH.Quasi'
 -- which doesn't provide reification functionality of 'TH.Quasi',
 -- but has a bit more than 'TH.Quote'.
 class TH.Quote g => Guasi g where
-    addDependentFile :: FilePath -> g ()
-    extsEnabled :: g [TH.Extension]
-    reportError :: String -> g ()
+    getGuasi :: g GuasiState
+    putGuasi :: GuasiState -> g ()
+    modifyGuasi :: (GuasiState -> GuasiState) -> g ()
+    modifyGuasi f = getGuasi >>= putGuasi . f
+
     addCSource :: String -> g ()
+    addDependentFile :: FilePath -> g ()
+
+    extsEnabled :: g [TH.Extension]
+
+    -- | Look up a name in the type namespace of the environment.
+    --
+    -- Returns 'Nothing' if the name is not in scope.
+    lookupTypeName :: String -> g (Maybe TH.Name)
+
+    reportError :: String -> g ()
 
     -- | Attach a documentation to a declaration with provided name /in the
     --   current module/.
@@ -39,12 +56,26 @@ class TH.Quote g => Guasi g where
     putLocalFieldDoc ::
       FieldNamingStrategy -> Hs.Name Hs.NsConstr -> Hs.Name Hs.NsVar -> HsDoc.Comment -> g ()
 
+data GuasiState = GuasiState {
+      missingModules :: Set Hs.ModuleName
+    }
+    deriving (Eq, Show, Generic)
+
+emptyGuasiState :: GuasiState
+emptyGuasiState = GuasiState { missingModules = Set.empty }
+
 instance Guasi TH.Q where
-    addDependentFile = TH.addDependentFile
-    extsEnabled = TH.extsEnabled
-    reportError = TH.reportError
+    getGuasi = fromMaybe emptyGuasiState <$> TH.getQ
+    putGuasi = TH.putQ
 
     addCSource = TH.addForeignSource TH.LangC
+    addDependentFile = TH.addDependentFile
+
+    extsEnabled = TH.extsEnabled
+
+    lookupTypeName = TH.lookupTypeName
+
+    reportError = TH.reportError
 
     putLocalDoc :: forall ns. Hs.SingNamespace ns => Hs.Name ns -> HsDoc.Comment -> TH.Q ()
     putLocalDoc nm comment = do

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -30,6 +30,7 @@ import HsBindgen.Errors
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Guasi
 import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.TraceMsg
 import HsBindgen.Util.TH
 import HsBindgen.Util.Tracer
@@ -156,10 +157,27 @@ getThDecls fns deps wrappers decls = do
     addCSource wrapperSrc
 
     -- Generate TH declarations.
-    fmap concat $ traverse (mkDecl fns) decls
+    xs <- fmap concat $ traverse (mkDecl fns) decls
+
+    -- Report warnings/errors.
+    reportMissingModules
+
+    pure xs
   where
     wrapperSrc :: String
     wrapperSrc = getCWrappersSource wrappers
+
+    reportMissingModules :: Guasi q => q ()
+    reportMissingModules = do
+      missingModules <- (.missingModules) <$> getGuasi
+      unless (Set.null missingModules) $ do
+        reportError $ concat $
+          "External types not in scope. Add the following import(s):\n"
+          : map getImportStatement (Set.elems missingModules)
+
+    getImportStatement :: Hs.ModuleName -> String
+    getImportStatement m =
+      "    import " <> Hs.moduleNameToString m <> " qualified"
 
 {-------------------------------------------------------------------------------
   Helpers

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
@@ -4,6 +4,7 @@
 -- | Golden test: TH output
 module Test.HsBindgen.Golden.Infra.Check.TH (check) where
 
+import Control.Monad.State (MonadState)
 import Control.Monad.State.Strict (State, get, put, runState)
 import Data.Foldable qualified as Foldable
 import Data.Generics qualified as SYB
@@ -129,7 +130,7 @@ convertWindows = map f where
 
 -- | Deterministic monad with TH.Quote instance
 newtype Qu a = Qu (State QuState a)
-  deriving newtype (Functor, Applicative, Monad)
+  deriving newtype (Functor, Applicative, Monad, MonadState QuState)
 
 data QuDecLoc = QuDecLoc {
     ns :: Hs.Namespace
@@ -153,34 +154,46 @@ data QuState = QuState{
     , uniquenessNumber :: !Integer
     , cSources         :: [String]
     , docMap           :: QuDocMap
+    , guasiState       :: GuasiState
     }
+  deriving stock (Show, Generic)
 
 emptyQuState :: QuState
-emptyQuState = QuState [] 0 [] Map.empty
+emptyQuState = QuState [] 0 [] Map.empty emptyGuasiState
 
 instance TH.Quote Qu where
-    newName n = Qu $ do
+    newName n = do
         q@QuState{ uniquenessNumber = u } <- get
         put $! q { uniquenessNumber = u + 1 }
         return $ TH.Name (TH.OccName n) (TH.NameU u)
 
 instance Guasi Qu where
-    addDependentFile fp = Qu $ do
-        q@QuState{ dependencyFiles = depfiles } <- get
-        put $! q { dependencyFiles = depfiles ++ [fp] }
+    getGuasi = (.guasiState) <$> get
+    putGuasi x = do
+        st <- get
+        put $! st & #guasiState .~ x
 
-    addCSource src = Qu $ do
+    addCSource src = do
         q@QuState{ cSources = csources } <- get
         put $! q { cSources = csources ++ [src] }
+
+    addDependentFile fp = do
+        q@QuState{ dependencyFiles = depfiles } <- get
+        put $! q { dependencyFiles = depfiles ++ [fp] }
 
     -- Note: we could mock these better, if we want to test error reporting
     -- Currently (2025-04-15) we only report missing extensions,
     -- so there isn't much to test.
     extsEnabled = return []
+
+    -- In the test mock, we treat all external names as in scope (resolving to
+    -- an unqualified 'mkName') to avoid triggering error-reporting paths.
+    lookupTypeName str = return $ Just $ TH.mkName str
+
     reportError _ = return ()
 
     putLocalDoc :: forall ns. Hs.SingNamespace ns => Hs.Name ns -> HsDoc.Comment -> Qu ()
-    putLocalDoc nm s = Qu $ do
+    putLocalDoc nm s = do
         q@QuState{ docMap = docMap } <- get
         let ns = Hs.namespaceOf (Hs.singNamespace :: Hs.SNamespace ns)
             loc = QuDecLoc ns (Text.unpack $ Hs.getName nm)
@@ -189,14 +202,13 @@ instance Guasi Qu where
                 Map.insert (QuD loc) s docMap
             }
 
-    putLocalFieldDoc _fns parent field s =
-        Qu $ do
-          q@QuState{ docMap = docMap } <- get
-          let loc = QuFldLoc parentStr fieldStr
-          put $!
-            q { docMap =
-                  Map.insert (QuF loc) s docMap
-              }
+    putLocalFieldDoc _fns parent field s = do
+        q@QuState{ docMap = docMap } <- get
+        let loc = QuFldLoc parentStr fieldStr
+        put $!
+          q { docMap =
+                Map.insert (QuF loc) s docMap
+            }
       where
         parentStr, fieldStr :: String
         parentStr = Text.unpack $ Hs.getName parent


### PR DESCRIPTION
Audit all usages of `TH.mkName`, and make them more explicit.

Add note to `mkHsName`, which uses `TH.mkName` internally, and inform potential future developers of its pitfall.

Add `lookupTypeName` to `Guasi`, so we can use it, and inform the user about names missing in a splice. This works really well, for example, removing the `LibC` import in our `Test02.hs` leads to an informative compilation error:

```
External types not in scope. Add the following import(s):
    import HsBindgen.Runtime.LibC qualified
```

We ensure that we report each missing module import only once.

Closes #1622.

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
