### PR TITLE
CLI: log bugs as errors flag

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -108,6 +108,8 @@
   messages are created (in pure code), rather than at the IO emission site.
   This makes `--log-show-call-stack` output useful for debugging which pass and
   function produced a given message.
+* A new CLI option `--log-as-error-bugs` changes bug-level trace message to be
+  errors. This is useful when `hs-bindgen` is used in a CI pipeline.
 
 ### Bug fixes
 

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -112,11 +112,13 @@ parseCustomLogLevel = do
     makeTraceWarnings <- many $ parseMakeTrace Warning
     makeTraceErrors   <- many $ parseMakeTrace Error
     -- Generic modifiers
+    makeBugsErrors     <- optional parseMakeBugsErrors
     makeWarningsErrors <- optional parseMakeWarningsErrors
     -- Specific setters
     enableMacroWarnings <- optional parseEnableMacroWarnings
     pure $ getCustomLogLevel $ catMaybes [
         enableMacroWarnings
+      , makeBugsErrors
       , makeWarningsErrors
       ]
       ++ makeTraceInfos
@@ -132,10 +134,16 @@ parseCustomLogLevel = do
             , help $ "Set log level of traces with TRACE_ID to " <> levelStr
             ]
 
+    parseMakeBugsErrors :: Parser CustomLogLevelSetting
+    parseMakeBugsErrors = flag' MakeBugsErrors $ mconcat [
+        long "log-as-error-bugs"
+      , help "Set log level of bugs to error"
+      ]
+
     parseMakeWarningsErrors :: Parser CustomLogLevelSetting
     parseMakeWarningsErrors = flag' MakeWarningsErrors $ mconcat [
         long "log-as-error-warnings"
-      , help "Set log level of warnings to error"
+      , help "Set log level of warnings and bugs to error"
       ]
 
     parseEnableMacroWarnings :: Parser CustomLogLevelSetting

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -79,6 +79,9 @@ data CustomLogLevelSetting =
     -- | Modify traces with log level 'Warning' to be fatal 'Error's.
   | MakeWarningsErrors
 
+    -- | Modify traces with log level Bug' to be fatal 'Error's.
+  | MakeBugsErrors
+
     -- * Specific setters
     -- | Set the log level of macro-related parsing traces to 'Warning'.
     --
@@ -112,7 +115,9 @@ fromSetting = \case
     -- Generic setters.
     MakeTrace level traceId -> makeTrace level traceId
     -- Generic modifiers.
-    MakeWarningsErrors      -> makeWarningsErrors
+    MakeWarningsErrors      -> makeLevelErrors Warning
+    -- Generic modifiers.
+    MakeBugsErrors          -> makeLevelErrors Bug
     -- Specific setters.
     EnableMacroWarnings     -> enableMacroWarnings
   where
@@ -135,8 +140,8 @@ fromSetting = \case
         _otherTrace
           -> id
 
-    makeWarningsErrors :: CustomLogLevel Level TraceMsg
-    makeWarningsErrors = CustomLogLevel $ \_ lvl ->
-      if lvl == Warning
+    makeLevelErrors :: Level -> CustomLogLevel Level TraceMsg
+    makeLevelErrors lvlError = CustomLogLevel $ \_ lvl ->
+      if lvl >= lvlError
       then Error
       else lvl


### PR DESCRIPTION
Add a CLI option `--log-as-error-bugs`.
We need this option for our CI scripts. CI should fail when it encounters a `BUG`. 

See discussion in #1910.
