### PR TITLE
Deduplicate trace callstacks

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -261,7 +261,7 @@ runFrontend tracer config boot = do
       afterParse <- parsePass
       let (afterSimplifyAST, msgsSimplifyAST) =
             simplifyAST afterParse.usageAnalysis afterParse.results
-      forM_ msgsSimplifyAST $ traceWith tracer . extendCallStackMsg FrontendSimplifyAST
+      forM_ msgsSimplifyAST $ traceWith (contramap FrontendSimplifyAST tracer)
       pure afterSimplifyAST
 
     assignAnonIdsPass <- cache "assignAnonIds" $ do
@@ -269,7 +269,7 @@ runFrontend tracer config boot = do
       afterSimplifyAST <- simplifyASTPass
       let (afterAssignAnonIds, msgsAssignAnonIds) =
             assignAnonIds afterParse.usageAnalysis afterSimplifyAST
-      forM_ msgsAssignAnonIds $ traceWith tracer . extendCallStackMsg FrontendAssignAnonIds
+      forM_ msgsAssignAnonIds $ traceWith (contramap FrontendAssignAnonIds tracer)
       pure afterAssignAnonIds
 
     enrichCommentsPass <- cache "enrichComments" $ do
@@ -305,14 +305,14 @@ runFrontend tracer config boot = do
               extSpecs
               pSpec
               afterReparseMacroExpansions
-      forM_ msgsResolveBindingSpecs $ traceWith tracer . extendCallStackMsg FrontendResolveBindingSpecs
+      forM_ msgsResolveBindingSpecs $ traceWith (contramap FrontendResolveBindingSpecs tracer)
       pure afterResolveBindingSpecs
 
     mangleNamesPass <- cache "mangleNames" $ do
       afterResolveBindingSpecs <- resolveBindingSpecsPass
       let (afterMangleNames, msgsMangleNames) =
             mangleNames config.fieldNamingStrategy afterResolveBindingSpecs
-      forM_ msgsMangleNames $ traceWith tracer . extendCallStackMsg FrontendMangleNames
+      forM_ msgsMangleNames $ traceWith (contramap FrontendMangleNames tracer)
       pure afterMangleNames
 
     adjustTypesPass <- cache "AdjustTypes" $ do
@@ -328,7 +328,7 @@ runFrontend tracer config boot = do
               afterParse.isInMainHeaderDir
               selectConfig
               afterAdjustTypesPass
-      forM_ msgsSelect $ traceWith tracer . extendCallStackMsg FrontendSelect
+      forM_ msgsSelect $  traceWith (contramap FrontendSelect tracer)
       pure afterSelect
 
     finalPass <- cache "Final" $ selectPass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -1,6 +1,7 @@
 module HsBindgen.Frontend.Pass (
     Pass
   , IsPass(..)
+  , AMsg
   , NoAnn(..)
   , NoMsg
   ) where
@@ -178,6 +179,10 @@ class (
   macroIdId :: Proxy p -> MacroId p -> Id p
   default macroIdId :: MacroId p ~ Void => Proxy p -> MacroId p -> Id p
   macroIdId _ = absurd
+
+-- | Trace messages with call-stack annotations
+type AMsg :: Pass -> Star
+type AMsg p = WithCallStack (Msg p)
 
 {-------------------------------------------------------------------------------
   Defaults

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -32,7 +32,7 @@ assignAnonIds ::
      HasCallStack
   => AnonUsageAnalysis
   -> [ParseResult SimplifyAST]
-  -> ([ParseResult AssignAnonIds], [Msg AssignAnonIds])
+  -> ([ParseResult AssignAnonIds], [AMsg AssignAnonIds])
 assignAnonIds usage parseResults =
     swap . partitionEithers $
       map (updateParseResult chosenNames) parseResults
@@ -48,7 +48,7 @@ updateParseResult ::
      HasCallStack
   => ChosenNames
   -> ParseResult SimplifyAST
-  -> Either (Msg AssignAnonIds) (ParseResult AssignAnonIds)
+  -> Either (AMsg AssignAnonIds) (ParseResult AssignAnonIds)
 updateParseResult chosenNames result =
     case result.classification of
       ParseResultSuccess success -> do
@@ -116,7 +116,7 @@ updateDefSite ::
      HasCallStack
   => ChosenNames
   -> Id SimplifyAST
-  -> Either (Msg AssignAnonIds) (Id AssignAnonIds)
+  -> Either (AMsg AssignAnonIds) (Id AssignAnonIds)
 updateDefSite chosenNames =
     first (withCallStack . AssignAnonIdsSkippedDecl) . fromPrelimDeclId chosenNames
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -31,7 +31,7 @@ instance IsPass AssignAnonIds where
   type MacroBody   AssignAnonIds = ParsedMacro
   type ExtBinding  AssignAnonIds = Void
   type Ann ix      AssignAnonIds = AnnAssignAnonIds ix
-  type Msg         AssignAnonIds = WithCallStack ImmediateAssignAnonIdsMsg
+  type Msg         AssignAnonIds = ImmediateAssignAnonIdsMsg
   type CommentDecl AssignAnonIds = ()
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -57,7 +57,7 @@ mangleNames ::
      HasCallStack
   => FieldNamingStrategy
   -> C.TranslationUnit ResolveBindingSpecs
-  -> (C.TranslationUnit MangleNames, [Msg MangleNames])
+  -> (C.TranslationUnit MangleNames, [AMsg MangleNames])
 mangleNames fieldNaming unit = (
          C.TranslationUnit{
            decls        = decls2
@@ -80,7 +80,7 @@ mangleNames fieldNaming unit = (
     -- Pass 1.
     nameMap   :: NameMap
     failures1 :: [MangleNamesFailure]
-    msgs1     :: [Msg MangleNames]
+    msgs1     :: [AMsg MangleNames]
     (decls1, nameMap, failures1, msgs1) =
       chooseNames typedefAnalysis mangleCandidateConfig unit.decls
 
@@ -94,7 +94,7 @@ mangleNames fieldNaming unit = (
         }
 
     mangleDeclResults   :: [MangleDeclResult]
-    msgs2 :: [Msg MangleNames]
+    msgs2 :: [AMsg MangleNames]
     (mangleDeclResults, msgs2) = runM env $ mapM mangleDecl decls1
 
     failures2 :: [MangleNamesFailure]
@@ -150,14 +150,14 @@ chooseNames ::
   => TypedefAnalysis
   -> MangleCandidate Maybe
   -> [C.Decl ResolveBindingSpecs]
-  -> ([C.Decl ResolveBindingSpecs], NameMap, [MangleNamesFailure], [Msg MangleNames])
+  -> ([C.Decl ResolveBindingSpecs], NameMap, [MangleNamesFailure], [AMsg MangleNames])
 chooseNames td mc decls =
     let specifiedNames :: Map DeclId (Hs.Name Hs.NsTypeConstr)
         specifiedNames = Map.fromList $ mapMaybe getSpecifiedName decls
 
         nameInfos :: [NameInfo]
         failures  :: [MangleNamesFailure]
-        messages  :: [Msg MangleNames]
+        messages  :: [AMsg MangleNames]
         ((failures, nameInfos), messages) =
           bimap partitionEithers mconcat $ unzip $
             map (nameForDecl td mc specifiedNames) decls
@@ -214,7 +214,7 @@ nameForDecl ::
   -> MangleCandidate Maybe
   -> Map DeclId (Hs.Name Hs.NsTypeConstr)
   -> C.Decl ResolveBindingSpecs
-  -> (Either MangleNamesFailure NameInfo, [Msg MangleNames])
+  -> (Either MangleNamesFailure NameInfo, [AMsg MangleNames])
 nameForDecl td mc specifiedNames decl =
     withDeclNamespace decl.kind $ \(nsProxy :: Proxy ns) ->
       let mangleCandidate' :: Text -> Either MangleNamesError (Hs.Name ns)
@@ -282,7 +282,7 @@ nameForDecl td mc specifiedNames decl =
     loc :: SingleLoc
     loc = decl.info.loc
 
-    failWith :: MangleNamesError -> (Either MangleNamesFailure a, [Msg MangleNames])
+    failWith :: MangleNamesError -> (Either MangleNamesFailure a, [AMsg MangleNames])
     failWith err = (Left $ toFailure info err, [])
 
     toMs :: HasCallStack => [a] -> [WithCallStack (WithLocationInfo a)]
@@ -310,7 +310,7 @@ mangleCandidate mc _ cName =
 type E m a = ExceptT MangleNamesError m a
 
 newtype M a = WrapM (
-      StateT [Msg MangleNames] (Reader Env) a
+      StateT [AMsg MangleNames] (Reader Env) a
     )
   deriving newtype (
       Functor
@@ -343,7 +343,7 @@ data Env = Env{
     }
   deriving stock (Generic)
 
-runM :: Env -> M a -> (a, [Msg MangleNames])
+runM :: Env -> M a -> (a, [AMsg MangleNames])
 runM env (WrapM ma) = second reverse . flip runReader env $ runStateT ma mempty
 
 checkTypedefAnalysis :: DeclId -> M (Maybe TypedefAnalysis.Conclusion)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -47,7 +47,7 @@ instance IsPass MangleNames where
   type MacroBody   MangleNames = CheckedMacro MangleNames
   type ExtBinding  MangleNames = ResolvedExtBinding
   type Ann ix      MangleNames = AnnMangleNames ix
-  type Msg         MangleNames = WithCallStack (WithLocationInfo MangleNamesMsg)
+  type Msg         MangleNames = WithLocationInfo MangleNamesMsg
   type MacroId     MangleNames = Id MangleNames
   type CommentDecl MangleNames = Maybe (C.Comment MangleNames)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -23,7 +23,6 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId (PrelimDeclId)
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId qualified as PrelimDeclId
 import HsBindgen.Imports
-import HsBindgen.Util.Tracer (WithCallStack)
 
 {-------------------------------------------------------------------------------
   Definition
@@ -47,7 +46,7 @@ instance IsPass Parse where
   type MacroBody   Parse = ParsedMacro
   type ExtBinding  Parse = Void
   type Ann ix      Parse = AnnParse ix
-  type Msg         Parse = WithCallStack (WithLocationInfo ImmediateParseMsg)
+  type Msg         Parse = WithLocationInfo ImmediateParseMsg
   type CommentDecl Parse = ()
 
   idNameKind     _ = PrelimDeclId.nameKind

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/Decl.hs
@@ -190,21 +190,22 @@ getMacroExpansions range
 
 -- | Immediately emit a parse trace message with location information
 traceImmediate ::
-     PrelimDeclId
+     HasCallStack
+  => PrelimDeclId
   -> SingleLoc
   -> ImmediateParseMsg
   -> ParseDecl ()
 traceImmediate declId declLoc msg = wrapEff $ \support ->
-    traceWith (contramap withCallStack support.env.tracer) $
+    traceWith support.env.tracer $
       withCallStack WithLocationInfo{
         loc = prelimDeclIdLocationInfo declId [declLoc]
       , msg = msg
       }
 
 -- | Immediately emit a global parse trace message without location information
-traceImmediateGlobal :: ImmediateParseMsg -> ParseDecl ()
+traceImmediateGlobal :: HasCallStack => ImmediateParseMsg -> ParseDecl ()
 traceImmediateGlobal msg = wrapEff $ \support ->
-    traceWith (contramap withCallStack support.env.tracer) $
+    traceWith support.env.tracer $
       withCallStack WithLocationInfo{
         loc = LocationUnavailable
       , msg = msg

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -50,7 +50,7 @@ resolveBindingSpecs ::
   -> MergedBindingSpecs
   -> PrescriptiveBindingSpec
   -> C.TranslationUnit PreviousPass
-  -> (C.TranslationUnit ResolveBindingSpecs, [Msg ResolveBindingSpecs])
+  -> (C.TranslationUnit ResolveBindingSpecs, [AMsg ResolveBindingSpecs])
 resolveBindingSpecs hsModuleName extSpecs pSpec unit =
     let pSpecModule = BindingSpec.moduleName pSpec
         (pSpecErrs, pSpec')
@@ -145,7 +145,7 @@ data MEnv = MEnv {
 -------------------------------------------------------------------------------}
 
 data MState = MState {
-      traces    :: [Msg ResolveBindingSpecs] -- ^ reverse order
+      traces    :: [AMsg ResolveBindingSpecs] -- ^ reverse order
     , extTypes  :: Map DeclId (ExtBinding ResolveBindingSpecs)
     , noPTypes  :: Map DeclId [Set SourcePath]
     , omitTypes :: Map DeclId SingleLoc
@@ -162,7 +162,7 @@ initMState pSpec = MState {
     , opqTypes  = Set.empty
     }
 
-insertTrace :: Msg ResolveBindingSpecs -> MState -> MState
+insertTrace :: AMsg ResolveBindingSpecs -> MState -> MState
 insertTrace msg = #traces %~ (msg :)
 
 insertExtType :: DeclId -> ExtBinding ResolveBindingSpecs -> MState -> MState
@@ -618,7 +618,7 @@ resolveExtBinding ::
   => DeclId
   -> Set SourcePath
      -- | Message to emit for omitted types.
-  -> Maybe (Msg ResolveBindingSpecs)
+  -> Maybe (AMsg ResolveBindingSpecs)
   -> M (Maybe ResolvedExtBinding)
 resolveExtBinding cDeclId declPaths mMsg = do
     env <- Reader.ask

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -46,7 +46,7 @@ instance IsPass ResolveBindingSpecs where
   type MacroBody   ResolveBindingSpecs = CheckedMacro ResolveBindingSpecs
   type ExtBinding  ResolveBindingSpecs = ResolvedExtBinding
   type Ann ix      ResolveBindingSpecs = AnnResolveBindingSpecs ix
-  type Msg         ResolveBindingSpecs = WithCallStack ResolveBindingSpecsMsg
+  type Msg         ResolveBindingSpecs = ResolveBindingSpecsMsg
   type MacroId     ResolveBindingSpecs = Id ResolveBindingSpecs
   type CommentDecl ResolveBindingSpecs = Maybe (C.Comment ResolveBindingSpecs)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -93,7 +93,7 @@ selectDecls ::
   -> IsInMainHeaderDir
   -> SelectConfig
   -> C.TranslationUnit AdjustTypes
-  -> (C.TranslationUnit Select, [Msg Select])
+  -> (C.TranslationUnit Select, [AMsg Select])
 selectDecls isMainHeader isInMainHeaderDir config unit =
     let -- Directly match the select predicate on the 'DeclIndex', obtaining
         -- information about succeeded _and failed_ selection roots.
@@ -185,7 +185,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
         selectedUnitDecls  :: [Decl]
         selectedUnitDecls = mapMaybe selectDecl unitDecls
 
-        selectMsgs :: [Msg Select]
+        selectMsgs :: [AMsg Select]
         selectMsgs =
           getSelectMsgs
             rootIds
@@ -201,7 +201,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
               }
 
         -- If there were no predicate matches we issue a warning to the user.
-        noDeclarationsMatchedMsg :: [Msg Select]
+        noDeclarationsMatchedMsg :: [AMsg Select]
         noDeclarationsMatchedMsg = [
             withCallStack WithLocationInfo{
                 loc = LocationUnavailable
@@ -210,7 +210,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
           | Set.null rootIds
           ]
 
-        msgs :: [Msg Select]
+        msgs :: [AMsg Select]
         msgs =
           concat [
               selectMsgs
@@ -280,7 +280,7 @@ getSelectMsgs ::
   -> Set DeclId
   ->(DeclId -> TransitiveSelectability)
   -> DeclIndex
-  -> [Msg Select]
+  -> [AMsg Select]
 getSelectMsgs
   rootIds
   additionalSelectedTransDepIds
@@ -288,7 +288,7 @@ getSelectMsgs
   declIndex
   = concatMap (uncurry aux) $ DeclIndex.toList declIndex
   where
-    aux :: HasCallStack => DeclId -> Entry -> [Msg Select]
+    aux :: HasCallStack => DeclId -> Entry -> [AMsg Select]
     aux =
       getSelectMsgsDeclId
         getTransitiveSelectability
@@ -307,7 +307,7 @@ getSelectMsgsDeclId ::
   -> Set DeclId
   -> DeclId
   -> Entry
-  -> [Msg Select]
+  -> [AMsg Select]
 getSelectMsgsDeclId
   getTransitiveSelectability
   declIndex
@@ -345,7 +345,7 @@ getSelectMsgsDeclId
       Set.member declId additionalSelectedTransDepIds
     transitiveSelectability = getTransitiveSelectability declId
 
-    getMsgsFor :: HasCallStack => SelectReason -> [Msg Select]
+    getMsgsFor :: HasCallStack => SelectReason -> [AMsg Select]
     getMsgsFor selectReason = concat [
           [ withLoc $ SelectStatusInfo (Selected selectReason) ]
         , [ withLoc $ SelectDeprecated selectReason | isDeprecated ]
@@ -360,7 +360,7 @@ getSelectMsgsDeclId
                 , msg = x
                 }
 
-    getUnavailMsg :: HasCallStack => SelectReason -> Map DeclId Unselectable -> Maybe (Msg Select)
+    getUnavailMsg :: HasCallStack => SelectReason -> Map DeclId Unselectable -> Maybe (AMsg Select)
     getUnavailMsg selectReason unavailReasons =
         if null msgs then
           Nothing
@@ -388,10 +388,10 @@ getSelectMsgsDeclId
   Delayed traces
 -------------------------------------------------------------------------------}
 
-getDelayedMsgsSelectionRoots :: HasCallStack => DeclIndex -> [Msg Select]
+getDelayedMsgsSelectionRoots :: HasCallStack => DeclIndex -> [AMsg Select]
 getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => DeclId -> Entry -> [Msg Select]
+    aux :: HasCallStack => DeclId -> Entry -> [AMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success ->
@@ -437,10 +437,10 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
         UnusableOmitted{} ->
           []
 
-getDelayedMsgsAdditionalSelectedTransDeps :: HasCallStack => DeclIndex -> [Msg Select]
+getDelayedMsgsAdditionalSelectedTransDeps :: HasCallStack => DeclIndex -> [AMsg Select]
 getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => DeclId -> Entry -> [Msg Select]
+    aux :: HasCallStack => DeclId -> Entry -> [AMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success ->
@@ -466,10 +466,10 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
 -- NOTE: We emit delayed BUG-level parse messages even for declarations that are
 -- not selected. We do not have a test for this; please ensure delayed BUG-level
 -- parse messages are emitted for all declarations also in the future.
-getDelayedMsgsNotSelected :: HasCallStack => DeclIndex -> [Msg Select]
+getDelayedMsgsNotSelected :: HasCallStack => DeclIndex -> [AMsg Select]
 getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => DeclId -> Entry -> [Msg Select]
+    aux :: HasCallStack => DeclId -> Entry -> [AMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success ->
@@ -526,7 +526,7 @@ compareSingleLocs xs x y =
     getLineCol :: SingleLoc -> (Int, Int)
     getLineCol z = (singleLocLine z, singleLocColumn z)
 
-compareMsgs :: Map SourcePath Int -> Msg Select -> Msg Select -> Ordering
+compareMsgs :: Map SourcePath Int -> AMsg Select -> AMsg Select -> Ordering
 compareMsgs orderMap x y =
   case (locationInfoLocs x.traceMsg.loc, locationInfoLocs y.traceMsg.loc) of
     (lx : __, ly : _) -> compareSingleLocs orderMap lx ly
@@ -534,7 +534,7 @@ compareMsgs orderMap x y =
     ([] , _ ) -> GT
     (_  , []) -> LT
 
-sortSelectMsgs :: IncludeGraph -> [Msg Select] -> [Msg Select]
+sortSelectMsgs :: IncludeGraph -> [AMsg Select] -> [AMsg Select]
 sortSelectMsgs includeGraph = sortBy (compareMsgs orderMap)
   where
     -- Compute the order map once.

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -59,7 +59,7 @@ instance IsPass Select where
   type MacroBody   Select = CheckedMacro Select
   type ExtBinding  Select = ResolvedExtBinding
   type Ann ix      Select = AnnSelect ix
-  type Msg         Select = WithCallStack (WithLocationInfo SelectMsg)
+  type Msg         Select = WithLocationInfo SelectMsg
   type MacroId     Select = Id Select
   type CommentDecl Select = Maybe (C.Comment Select)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST.hs
@@ -35,14 +35,14 @@ simplifyAST ::
      HasCallStack
   => AnonUsageAnalysis
   -> [ParseResult Parse]
-  -> ([ParseResult SimplifyAST], [Msg SimplifyAST])
+  -> ([ParseResult SimplifyAST], [AMsg SimplifyAST])
 simplifyAST usage parseResults = (results, msgs)
   where
     processedResults = map processResult parseResults
     results = concatMap fst processedResults
     msgs = concatMap snd processedResults
 
-    processResult :: HasCallStack => ParseResult Parse -> ([ParseResult SimplifyAST], [Msg SimplifyAST])
+    processResult :: HasCallStack => ParseResult Parse -> ([ParseResult SimplifyAST], [AMsg SimplifyAST])
     processResult result =
       case result.classification of
         ParseResultSuccess success ->

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -38,7 +38,7 @@ instance IsPass SimplifyAST where
   type MacroBody   SimplifyAST = ParsedMacro
   type ExtBinding  SimplifyAST = Void
   type Ann ix      SimplifyAST = AnnSimplifyAST ix
-  type Msg         SimplifyAST = WithCallStack SimplifyASTMsg
+  type Msg         SimplifyAST = SimplifyASTMsg
   type CommentDecl SimplifyAST = ()
 
   idNameKind     _ = PrelimDeclId.nameKind

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -135,7 +135,7 @@ fromSetting = \case
         t | "macro" `List.isInfixOf` (getTraceId t).id
           -> const Warning
         -- Macro parsing requires declarations required for scoping.
-        TraceFrontend (FrontendParse WithCallStack{traceMsg = WithLocationInfo{msg = ParseOfDeclarationRequiredForScopingFailed{}}})
+        TraceFrontend (FrontendParse WithLocationInfo{msg = ParseOfDeclarationRequiredForScopingFailed{}})
           -> const Warning
         _otherTrace
           -> id

--- a/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
@@ -9,7 +9,6 @@ module HsBindgen.Util.Tracer (
   , withCallStack
   , simpleTracer
   , nullTracer
-  , extendCallStackMsg
     -- * Data types and typeclasses useful for tracing
   , PrettyForTrace (..)
   , Level (..)
@@ -128,19 +127,6 @@ squelchUnless p =
       Wrap
     . ContraTracer.squelchUnless (p . (.traceMsg))
     . unwrap
-
--- | Apply a function that consumes a t'WithCallStack' value, preserving the
--- original callstack in the result.
---
--- This is the comonadic extend for t'WithCallStack': the function sees the
--- full wrapped value (including the callstack), but the output is re-wrapped
--- with the original callstack.
---
--- Useful when wrapping pass-specific messages in a sum type constructor
--- (e.g. 'HsBindgen.Frontend.FrontendSimplifyAST') that takes @t'WithCallStack' a@, while
--- preserving the creation-site callstack for tracing.
-extendCallStackMsg :: (WithCallStack a -> b) -> WithCallStack a -> WithCallStack b
-extendCallStackMsg f wcs@(WithCallStack cs _) = WithCallStack cs (f wcs)
 
 nullTracer :: Tracer e
 nullTracer = Wrap ContraTracer.nullTracer

--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
@@ -33,7 +33,6 @@ import HsBindgen.Frontend.Pass.Parse.Msg (ParseImplicitFieldsMsg)
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
 import HsBindgen.TraceMsg
-import HsBindgen.Util.Tracer (WithCallStack (..))
 
 {-------------------------------------------------------------------------------
   Clang
@@ -72,10 +71,10 @@ matchDiagnosticSpelling text = \case
 
 pattern MatchImmediate :: CDeclName -> ImmediateParseMsg -> TraceMsg
 pattern MatchImmediate name x <- TraceFrontend (
-      FrontendParse WithCallStack{traceMsg = WithLocationInfo{
+      FrontendParse WithLocationInfo{
           loc = locationInfoName -> Just name
         , msg = x
-        }}
+        }
     )
 
 pattern MatchDelayed :: CDeclName -> DelayedParseMsg -> TraceMsg
@@ -95,7 +94,7 @@ pattern MatchBindingSpec x <- TraceBoot (
 
 pattern MatchResolveBindingSpecs :: ResolveBindingSpecsMsg -> TraceMsg
 pattern MatchResolveBindingSpecs x <- TraceFrontend (
-      FrontendResolveBindingSpecs WithCallStack{traceMsg = x}
+      FrontendResolveBindingSpecs x
     )
 
 {-------------------------------------------------------------------------------
@@ -104,17 +103,17 @@ pattern MatchResolveBindingSpecs x <- TraceFrontend (
 
 pattern MatchNoDeclarations :: TraceMsg
 pattern MatchNoDeclarations <- TraceFrontend (
-      FrontendSelect WithCallStack{traceMsg = WithLocationInfo{
+      FrontendSelect WithLocationInfo{
           msg = SelectNoDeclarationsMatched
-        }}
+        }
     )
 
 pattern MatchSelect :: CDeclName -> SelectMsg -> TraceMsg
 pattern MatchSelect name x <- TraceFrontend (
-      FrontendSelect WithCallStack{traceMsg = WithLocationInfo{
+      FrontendSelect WithLocationInfo{
           loc = locationInfoName -> Just name
         , msg = x
-        }}
+        }
     )
 
 -- | Transitive dependencies of a declaration are missing
@@ -135,10 +134,10 @@ pattern MatchTransUnusable x <- TransitiveDependencyUnusable _ x _
 
 pattern MatchMangle :: CDeclName -> MangleNamesMsg -> TraceMsg
 pattern MatchMangle name x <- TraceFrontend (
-      FrontendMangleNames WithCallStack{traceMsg = WithLocationInfo{
+      FrontendMangleNames WithLocationInfo{
            loc = locationInfoName -> Just name
          , msg = x
-        }}
+        }
     )
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
What I found was that we were creating trace messages with multiple callstacks. For example, a message from the `Parse` pass lifted into the `FrontendMsg` type would look like this when traced:

```hs
WithCallStack {
    callStack = ...
  , traceMsg = FrontendParse WithCallStack {
        callStack = ...
      , traceMsg = ... -- a parse message
      }
  }
```

This is in part because `Msg p` is now set to `WithCallStack ...` for most passes, but our tracer type also separately requires `WithCallStack` on top of trace messages.

```hs
newtype Tracer e = Wrap (ContraTracer.Tracer IO (WithCallStack e))
```

I think it might be better if `Msg p` would be a plain, non-callstacked message type. And then we enforce that plain messages are always annotated with a callstack using a different type synonym, like:

```hs
-- | Trace messages with annotations (like a call stack)
type AMsg p :: Star
type AMsg p = WithCallStack (Msg p)
```

Moreover, I think we can replace `extendCallStackMsg` with `contramap`, but I may be wrong