### PR TITLE
c-expr-dsl: distinguish macro parameters from free variables

### DIFF
--- a/c-expr-dsl/CHANGELOG.md
+++ b/c-expr-dsl/CHANGELOG.md
@@ -9,6 +9,12 @@
 * Re-export typecheck-related symbols from `C.Expr.Typecheck`; demote
   `C.Expr.Typecheck.Expr` to `other-modules`; `C.Expr.Typecheck.Type` is still
   an exposed module.
+* `Expr` and `Term` gain a `ctx :: Ctx` type index (from `debruijn`) for
+  the local macro parameter scope. `Macro.macroArgs :: [Name]` is replaced
+  by an existential `macroParams :: Vec ctx Name`; `macroExpr` becomes
+  `Expr ctx Ps`. `sameMacro` compares macros structurally, ignoring location.
+* `TypeTagged !TagKind !Name` is now a separate `Literal` constructor
+  instead of a `TypeLit` variant.
 
 ### New features
 
@@ -16,6 +22,9 @@
   distinction to the typechecking phase. See [PR #1862][pr-1862].
 * Add test suite covering the parser (token-based and real-world libclang
   tests) and the typechecker. See [PR #1862][pr-1862].
+* Local macro parameters in function-like macros are resolved to de Bruijn
+  indices (`LocalParam (Idx ctx)`) at parse time, distinguishing them from
+  free variables (`Var`).
 
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 

--- a/c-expr-dsl/c-expr-dsl.cabal
+++ b/c-expr-dsl/c-expr-dsl.cabal
@@ -29,6 +29,7 @@ common lang
     DerivingStrategies
     LambdaCase
     MultiWayIf
+    OverloadedStrings
     PatternSynonyms
     QuantifiedConstraints
     TypeFamilies
@@ -66,6 +67,7 @@ library
     C.Expr.Syntax.TTG.Typecheck
     C.Expr.Syntax.Type
     C.Expr.Typecheck.Expr
+    C.Expr.Util.Panic
     C.Expr.Util.Parsec
     C.Expr.Util.TestEquality
 
@@ -76,14 +78,16 @@ library
 
   -- external dependencies
   build-depends:
-    , containers  >=0.6.5.1 && <0.9
-    , fin         >=0.3.2   && <0.4
-    , mtl         >=2.2     && <2.4
-    , parsec      >=3.1     && <3.2
-    , scientific  >=0.3.7   && <0.4
-    , some        >=1.0.6   && <1.1
-    , text        >=1.2     && <2.2
-    , vec         >=0.5     && <0.6
+    , containers           >=0.6.5.1 && <0.9
+    , debruijn             >=0.3.1   && <0.4
+    , fin                  >=0.3.2   && <0.4
+    , indexed-traversable  >=0.1.4   && <0.2
+    , mtl                  >=2.2     && <2.4
+    , parsec               >=3.1     && <3.2
+    , scientific           >=0.3.7   && <0.4
+    , some                 >=1.0.6   && <1.1
+    , text                 >=1.2     && <2.2
+    , vec                  >=0.5     && <0.6
 
 test-suite test-c-expr-dsl
   import:         lang
@@ -108,12 +112,14 @@ test-suite test-c-expr-dsl
 
   -- external dependencies
   build-depends:
-    , bytestring   >=0.10 && <0.13
-    , containers   >=0.6  && <0.9
-    , directory    >=1.3  && <1.4
-    , filepath     >=1.4  && <1.6
-    , parsec       >=3.1  && <3.2
-    , tasty        >=1.4  && <1.6
-    , tasty-hunit  >=0.10 && <0.11
-    , text         >=1.2  && <2.2
-    , vec          >=0.5  && <0.6
+    , bytestring   >=0.10  && <0.13
+    , containers   >=0.6   && <0.9
+    , debruijn     >=0.3.1 && <0.4
+    , directory    >=1.3   && <1.4
+    , filepath     >=1.4   && <1.6
+    , fin          >=0.3.2 && <0.4
+    , parsec       >=3.1   && <3.2
+    , tasty        >=1.4   && <1.6
+    , tasty-hunit  >=0.10  && <0.11
+    , text         >=1.2   && <2.2
+    , vec          >=0.5   && <0.6

--- a/c-expr-dsl/src/C/Expr/Parse/Expr.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Expr.hs
@@ -1,24 +1,25 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module C.Expr.Parse.Expr (parseMacro, parseMacroType) where
 
 import Control.Monad
+import Data.Foldable qualified as Foldable
 import Data.Functor.Identity
 import Data.Text (Text)
 import Data.Type.Nat
-import Data.Vec.Lazy hiding ((++), length)
-import Text.Parsec hiding (token, parseTest)
+import Data.Vec.Lazy (Vec (..))
+import Data.Vec.Lazy qualified as Vec
+import DeBruijn (Idx (..))
+import Text.Parsec hiding (parseTest, token)
 import Text.Parsec.Expr
-
-import Clang.CStandard
-import Clang.Enum.Simple
-import Clang.HighLevel.Types
-import Clang.LowLevel.Core
 
 import C.Expr.Parse.Infra
 import C.Expr.Parse.Literal
 import C.Expr.Parse.Name
 import C.Expr.Syntax
+
+import Clang.CStandard
+import Clang.Enum.Simple
+import Clang.HighLevel.Types
+import Clang.LowLevel.Core
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -42,28 +43,36 @@ import C.Expr.Syntax
 parseMacro :: ClangCStandard -> Parser Macro
 parseMacro cStd = do
     (macroLoc, macroName) <- parseLocName
-    (macroArgs, macroExpr) <- choice [try functionLike, objectLike]
+    let functionLike :: Parser Macro
+        functionLike = do
+          paramNames <- formalParams
+          Vec.reifyList (reverse paramNames) $ \macroParams -> do
+            macroExpr <- bodyExpr macroParams
+            pure $ Macro macroLoc macroName (Vec.reverse macroParams) macroExpr
+
+        objectLike :: Parser Macro
+        objectLike = do
+          macroExpr <- bodyExpr VNil
+          pure $ Macro macroLoc macroName VNil macroExpr
+    m <- choice [try functionLike, objectLike]
     eof
-    return $ Macro macroLoc macroName macroArgs macroExpr
+    return m
   where
-    functionLike :: Parser ([Name], Expr Ps)
-    functionLike = (,) <$> formalArgs <*> exprTuple cStd
-
-    objectLike :: Parser ([Name], Expr Ps)
-    objectLike = ([], ) <$> bodyExpr
-
     -- Try the body as a type expression first. The @'eof'@ inside the @'try'@
     -- is essential: if @'parseMacroType'@ succeeds on a prefix (e.g. the bare
     -- identifier in @size_t + 1@) but leaves tokens unconsumed, the whole
     -- attempt is abandoned and we fall back to the expression parser.
-    bodyExpr :: Parser (Expr Ps)
-    bodyExpr = try (parseMacroType cStd <* eof) <|> exprTuple cStd
+    bodyExpr :: Vec ctx Name -> Parser (Expr ctx Ps)
+    bodyExpr macroParams = try (parseMacroType cStd macroParams <* eof) <|> exprTuple cStd macroParams
 
-formalArgs :: Parser [Name]
-formalArgs = parens $ formalArg `sepBy` comma
+formalParams :: Parser [Name]
+formalParams = parens $ parseName `sepBy` comma
 
-formalArg :: Parser Name
-formalArg = parseName
+lookupParam :: Name -> Vec ctx Name -> Maybe (Idx ctx)
+lookupParam _ VNil    = Nothing
+lookupParam n (m ::: vec)
+  | n == m    = Just IZ
+  | otherwise = IS <$> lookupParam n vec
 
 {-------------------------------------------------------------------------------
   Types
@@ -91,14 +100,15 @@ formalArg = parseName
 -- Returns an 'Expr Ps' where:
 --
 -- * A keyword or tagged base type becomes @'Term' ('Type' literal)@.
--- * A bare identifier becomes @'Term' ('Var' …)@; the typechecker decides
---   whether it names a type or a value.
+-- * A bare identifier that is a local macro parameter becomes @'Term' ('LocalParam' …)@.
+-- * A bare identifier that is a free variable becomes @'Term' ('Var' …)@;
+--   the typechecker decides whether it names a type or a value.
 -- * Each @const@ qualifier wraps the expression in @'TyApp' 'Const'@.
 -- * Each @*@ pointer layer wraps the expression in @'TyApp' 'Pointer'@.
-parseMacroType :: ClangCStandard -> Parser (Expr Ps)
-parseMacroType cStd = do
+parseMacroType :: ClangCStandard -> Vec ctx Name -> Parser (Expr ctx Ps)
+parseMacroType cStd macroParams = do
     constBefore <- option False (True <$ keyword "const")
-    base        <- typeBase cStd
+    base        <- typeBase cStd macroParams
     constAfter  <- option False (True <$ keyword "const")
     ptrs        <- pointerLayers
     -- In C, @const@ is idempotent: @const int const@ is valid but equivalent
@@ -107,7 +117,7 @@ parseMacroType cStd = do
     let withConst
           | constBefore || constAfter = TyApp Const (base ::: VNil)
           | otherwise                 = base
-    return (foldl apPtr withConst ptrs)
+    return (Foldable.foldl' apPtr withConst ptrs)
   where
     apPtr acc ptrConst =
       let withPtr = TyApp Pointer (acc ::: VNil)
@@ -117,14 +127,17 @@ parseMacroType cStd = do
 --
 -- Returns:
 --
--- * @'Term' ('Type' literal)@ for keyword or elaborated base types.
--- * @'Term' ('Var' …)@ for a bare identifier; the caller / typechecker
---   decides whether it names a type or a value.
-typeBase :: ClangCStandard -> Parser (Expr Ps)
-typeBase cStd =
+-- * @'Term' ('Literal' …)@ for keyword or elaborated base types.
+-- * @'Term' ('LocalParam' …)@ for a bare identifier that is a local macro parameter.
+-- * @'Term' ('Var' …)@ for any other bare identifier; the typechecker decides
+--   whether it names a type or a value.
+typeBase :: forall ctx. ClangCStandard -> Vec ctx Name -> Parser (Expr ctx Ps)
+typeBase cStd macroParams =
     choice [
         -- Type literal.
-        Term . Literal . TypeLit <$> tyLit cStd
+        Term . Literal . TypeLit <$> typeLiteral cStd
+        -- Tagged type (e.g., @struct Foo@)
+      , Term . Literal . uncurry TypeTagged <$> taggedTypeLit
         -- The bare identifier (typedef name, type macro, or expression
         -- variable) is needed to parse pointer-qualified typedef references
         -- such as @size_t *@: without it, @parseMacroType@ would reject the
@@ -133,17 +146,13 @@ typeBase cStd =
         -- the two by restricting @parseMacroType@ to keyword\/tagged bases only
         -- does not help (both paths produce the same @'Var'@ node) while
         -- adding backtracking overhead.
-      , (\n -> Term (Var NoXVar n [])) <$> parseName
+      , (Term . mkVar) <$> parseName
       ]
-
-tyLit :: ClangCStandard -> Parser TypeLit
-tyLit cStd =
-    choice [
-        -- Keyword type (e.g. @int@, @unsigned long@)
-        pritypeLiteral cStd
-        -- Elaborated type literal: @struct/union/enum Name@
-      , taggedTypeLit
-      ]
+  where
+    mkVar :: Name -> Term ctx Ps
+    mkVar n = case lookupParam n macroParams of
+      Just i  -> LocalParam i
+      Nothing -> Var NoXVar n []
 
 -- | Parse a sequence of type-literal keywords and combine them
 --
@@ -156,8 +165,8 @@ tyLit cStd =
 -- @
 --
 -- are all the same type.
-pritypeLiteral :: ClangCStandard -> Parser TypeLit
-pritypeLiteral cStd = do
+typeLiteral :: ClangCStandard -> Parser TypeLit
+typeLiteral cStd = do
     kws <- many1 (typeKeyword cStd)
     case interpretKeywords kws of
       Just lit -> return lit
@@ -170,15 +179,15 @@ pritypeLiteral cStd = do
 --   union  tag
 --   enum   tag
 -- @
-taggedTypeLit :: Parser TypeLit
+taggedTypeLit :: Parser (TagKind, Name)
 taggedTypeLit = do
     tag <- choice [
         TagStruct <$ keyword "struct"
       , TagUnion  <$ keyword "union"
       , TagEnum   <$ keyword "enum"
       ]
-    name <- identifier
-    return $ TypeTagged tag name
+    name <- parseName
+    return $ (tag, name)
 
 data TypeKeyword =
     KwSigned | KwUnsigned
@@ -280,26 +289,26 @@ keyword expected = token $ \t ->
       then Just ()
       else Nothing
 
--- | Match an identifier token, returning its spelling
-identifier :: Parser Text
-identifier = token $ \t ->
-    if fromSimpleEnum (tokenKind t) == Right CXToken_Identifier
-      then Just $ getTokenSpelling (tokenSpelling t)
-      else Nothing
-
 {-------------------------------------------------------------------------------
   Simple expressions
 -------------------------------------------------------------------------------}
 
-term :: ClangCStandard -> Parser (Term Ps)
-term cStd =
+term :: forall ctx. ClangCStandard -> Vec ctx Name -> Parser (Term ctx Ps)
+term cStd macroParams =
     buildExpressionParser ops trm <?> "simple expression"
   where
-    trm :: Parser (Term Ps)
+    trm :: Parser (Term ctx Ps)
     trm = choice [
         Literal <$> lit
-      , Var NoXVar <$> var <*> option [] (actualArgs cStd)
+      , localParamOrVar
       ]
+
+    localParamOrVar :: Parser (Term ctx Ps)
+    localParamOrVar = do
+      varName <- parseName
+      case lookupParam varName macroParams of
+        Just i  -> pure $ LocalParam i
+        Nothing -> Var NoXVar varName <$> option [] (actualArgs cStd macroParams)
 
     lit :: Parser Literal
     lit = ValueLit <$> choice [
@@ -309,11 +318,9 @@ term cStd =
       , ValueString <$> literalString
       ]
 
-    ops :: OperatorTable [Token TokenSpelling] () Identity (Term Ps)
+    ops :: OperatorTable [Token TokenSpelling] () Identity (Term ctx Ps)
     ops = []
 
-var :: Parser Name
-var = parseName
 
 -- | Parse integer literal
 literalInteger :: Parser IntegerLiteral
@@ -362,8 +369,8 @@ literalString = do
       , stringLiteralValue = val
       }
 
-actualArgs :: ClangCStandard -> Parser [Expr Ps]
-actualArgs cStd = parens $ expr cStd `sepBy` comma
+actualArgs :: ClangCStandard -> Vec ctx Name -> Parser [Expr ctx Ps]
+actualArgs cStd macroParams = parens $ expr cStd macroParams `sepBy` comma
 
 {-------------------------------------------------------------------------------
   Expressions
@@ -373,27 +380,27 @@ actualArgs cStd = parens $ expr cStd `sepBy` comma
   follow the same structure.
 -------------------------------------------------------------------------------}
 
-exprTuple :: ClangCStandard -> Parser (Expr Ps)
-exprTuple cStd = try tuple <|> expr cStd
+exprTuple :: ClangCStandard -> Vec ctx Name -> Parser (Expr ctx Ps)
+exprTuple cStd macroParams = try tuple <|> expr cStd macroParams
   where
     tuple = do
       openParen <- optionMaybe $ punctuation "("
-      (e1, e2, es) <- expr cStd `sepBy2` comma
+      (e1, e2, es) <- expr cStd macroParams `sepBy2` comma
       case openParen of
         Nothing -> return ()
         Just {} -> punctuation ")"
       return $
-        reifyList es $ \es' ->
+        Vec.reifyList es $ \es' ->
            VaApp NoXApp MTuple ( e1 ::: e2 ::: es' )
 
-expr :: ClangCStandard -> Parser (Expr Ps)
-expr cStd = buildExpressionParser ops trm <?> "expression"
+expr :: forall ctx. ClangCStandard -> Vec ctx Name -> Parser (Expr ctx Ps)
+expr cStd macroParams = buildExpressionParser ops trm <?> "expression"
   where
 
-    trm :: Parser (Expr Ps)
+    trm :: Parser (Expr ctx Ps)
     trm = choice [
-          parens (expr cStd)
-        , Term <$> term cStd
+          parens (expr cStd macroParams)
+        , Term <$> term cStd macroParams
         ]
 
     -- 'OperatorTable' expects the list in descending precedence
@@ -444,10 +451,10 @@ expr cStd = buildExpressionParser ops trm <?> "expression"
       , [ Infix (ap2 MLogicalOr  <$ punctuation "||") AssocLeft ]
       ]
 
-    ap1 :: VaFun (S Z) -> Expr Ps -> Expr Ps
+    ap1 :: VaFun (S Z) -> Expr ctx Ps -> Expr ctx Ps
     ap1 op arg = VaApp NoXApp op ( arg ::: VNil )
 
-    ap2 :: VaFun (S (S Z)) -> Expr Ps -> Expr Ps -> Expr Ps
+    ap2 :: VaFun (S (S Z)) -> Expr ctx Ps -> Expr ctx Ps -> Expr ctx Ps
     ap2 op arg1 arg2 = VaApp NoXApp op ( arg1 ::: arg2 ::: VNil )
 
 sepBy2 :: ParsecT s u m a -> ParsecT s u m sep -> ParsecT s u m (a, a, [a])

--- a/c-expr-dsl/src/C/Expr/Parse/Infra.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Infra.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | Infrastructure for reparsing
 module C.Expr.Parse.Infra (
     -- * Parser type

--- a/c-expr-dsl/src/C/Expr/Parse/Literal.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Literal.hs
@@ -18,9 +18,10 @@ import Text.Parsec
 import Text.Parsec.Pos (updatePosChar)
 
 import C.Char qualified as Runtime
+import C.Type qualified as Runtime
+
 import C.Expr.Parse.Infra
 import C.Expr.Util.Parsec
-import C.Type qualified as Runtime
 
 {-------------------------------------------------------------------------------
   Parser for integer literals

--- a/c-expr-dsl/src/C/Expr/Syntax.hs
+++ b/c-expr-dsl/src/C/Expr/Syntax.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ >=908
+{-# LANGUAGE TypeAbstractions #-}
+#endif
+
 -- | The syntax for macros recognized by hs-bindgen
 --
 -- Intended for unqualified import.
 module C.Expr.Syntax (
     -- * Definition
     Macro(..)
+  , sameMacro
     -- ** Type syntax
   , TypeLit(..)
   , TagKind(..)
@@ -32,7 +39,10 @@ module C.Expr.Syntax (
   ) where
 
 import Data.Kind qualified as Hs
-import GHC.Generics (Generic)
+import Data.Type.Equality ((:~:) (..))
+import Data.Type.Nat qualified as Nat
+import Data.Vec.Lazy (Vec, withDict)
+import DeBruijn (Ctx)
 
 import C.Expr.Syntax.Expr
 import C.Expr.Syntax.Literals
@@ -44,10 +54,33 @@ import C.Expr.Syntax.Type
 import Clang.HighLevel.Types
 
 type Macro :: Hs.Type
-data Macro = Macro {
-      macroLoc  :: MultiLoc
-    , macroName :: Name
-    , macroArgs :: [Name]
-    , macroExpr :: Expr Ps
+data Macro = forall (ctx :: Ctx). Macro {
+      macroLoc    :: MultiLoc
+    , macroName   :: Name
+    , macroParams :: Vec ctx Name
+    , macroExpr   :: Expr ctx Ps
     }
-  deriving stock (Eq, Show, Generic)
+
+instance Eq Macro where
+  (Macro @c1 loc1 n1 p1 e1) == (Macro @c2 loc2 n2 p2 e2) =
+      loc1 == loc2 && n1   == n2 && eqBody
+    where
+      eqBody = withDict p1 $ withDict p2 $
+        case Nat.eqNat @c1 @c2 of
+          Just Refl -> p1 == p2 && e1 == e2
+          Nothing   -> False
+
+deriving stock instance Show Macro
+
+-- | Are two macros referring to the same macro.
+--
+-- The location and parameter names do not need to match. Everything else must
+-- be equal.
+sameMacro :: Macro -> Macro -> Bool
+sameMacro (Macro @c1 _ n1 p1 e1) (Macro @c2 _ n2 p2 e2) =
+    n1 == n2 && sameBody
+  where
+    sameBody = withDict p1 $ withDict p2 $
+      case Nat.eqNat @c1 @c2 of
+        Just Refl -> e1 == e2
+        Nothing   -> False

--- a/c-expr-dsl/src/C/Expr/Syntax/Expr.hs
+++ b/c-expr-dsl/src/C/Expr/Syntax/Expr.hs
@@ -23,6 +23,7 @@ import Data.Type.Nat (SNatI)
 import Data.Type.Nat qualified as Nat
 import Data.Vec.Lazy (Vec (..))
 import Data.Vec.Lazy qualified as Vec
+import DeBruijn (Idx, Ctx)
 import GHC.Generics (Generic)
 
 import C.Expr.Syntax.Literals
@@ -38,21 +39,21 @@ import C.Expr.Util.TestEquality
 -- | Macro expression
 --
 -- For examples, see the extensive test suite "Test.CExpr.Parse".
-type Expr :: Pass -> Type
-data Expr p
+type Expr :: Ctx -> Pass -> Type
+data Expr ctx p
   -- | A term that is not a function application.
-  = Term ( Term p )
+  = Term ( Term ctx p )
   -- | Exactly saturated non-nullary type-level function application.
   --
   -- We don't need an extension point here, because we do not need to evaluate
   -- type functions in Haskell. 'XApp' may be unnecessary if we can remove
   -- 'FunValue'.
-  | forall n. TyApp             ( TyFun ( S n ) ) ( Vec ( S n ) ( Expr p ) )
+  | forall n. TyApp             ( TyFun ( S n ) ) ( Vec ( S n ) ( Expr ctx p ) )
   -- | Exactly saturated non-nullary function application.
-  | forall n. VaApp !( XApp p ) ( VaFun ( S n ) ) ( Vec ( S n ) ( Expr p ) )
-deriving stock instance ( Show ( XVar p ), Show ( XApp p ) ) => Show ( Expr p )
+  | forall n. VaApp !( XApp p ) ( VaFun ( S n ) ) ( Vec ( S n ) ( Expr ctx p ) )
+deriving stock instance ( Show ( XVar p ), Show ( XApp p ) ) => Show ( Expr ctx p )
 
-instance ( Eq ( XApp p ), Eq ( XVar p ) ) => Eq ( Expr p ) where
+instance ( Eq ( XApp p ), Eq ( XVar p ) ) => Eq ( Expr ctx p ) where
   Term m1 == Term m2 = m1 == m2
   TyApp f1 args1 == TyApp f2 args2
     | Just Refl <- f1 `equals1` f2
@@ -66,15 +67,15 @@ instance ( Eq ( XApp p ), Eq ( XVar p ) ) => Eq ( Expr p ) where
     = False
   _ == _ = False
 
-instance ( Ord ( XApp p ), Ord ( XVar p ) ) => Ord ( Expr p ) where
+instance ( Ord ( XApp p ), Ord ( XVar p ) ) => Ord ( Expr ctx p ) where
   compare ( Term m1 ) ( Term m2 ) = compare m1 m2
-  compare ( TyApp @_ @n1 f1 args1 ) ( TyApp @_ @n2 f2 args2 ) =
+  compare ( TyApp @_ @_ @n1 f1 args1 ) ( TyApp @_ @_ @n2 f2 args2 ) =
     Vec.withDict args1 $ Vec.withDict args2 $
     case Nat.eqNat @( S n1 ) @( S n2 ) of
       Just Refl -> compare f1 f2 <> compare args1 args2
       Nothing ->
         compare ( Nat.reflect @( S n1 ) Proxy ) ( Nat.reflect @( S n2 ) Proxy )
-  compare ( VaApp @_ @n1 x1 f1 args1 ) ( VaApp @_ @n2 x2 f2 args2 ) =
+  compare ( VaApp @_ @_ @n1 x1 f1 args1 ) ( VaApp @_ @_ @n2 x2 f2 args2 ) =
     Vec.withDict args1 $ Vec.withDict args2 $
     case Nat.eqNat @( S n1 ) @( S n2 ) of
       Just Refl -> compare f1 f2 <> compare x1 x2 <> compare args1 args2
@@ -198,32 +199,43 @@ instance GEq VaFun where
 
 -- | Value literal
 data ValueLit =
-    -- | Integer literal
-    ValueInt IntegerLiteral
-    -- | Floating-point literal
-  | ValueFloat FloatingLiteral
-    -- | Character literal
-  | ValueChar CharLiteral
-    -- | String literal
+    ValueInt    IntegerLiteral
+  | ValueFloat  FloatingLiteral
+  | ValueChar   CharLiteral
   | ValueString StringLiteral
   deriving stock (Eq, Ord, Show)
 
 type Literal :: Type
 data Literal =
-    TypeLit TypeLit
+    TypeLit  TypeLit
+
   | ValueLit ValueLit
+
+    -- NB: We do not accept untagged identifiers here, since they may correspond
+    -- to a value expression, not a type expression.
+
+    -- | An elaborated type literal: @struct tag@, @union tag@, @enum tag@
+  | TypeTagged !TagKind !Name
   deriving stock (Eq, Ord, Show)
 
-type Term :: Pass -> Type
-data Term p =
+type Term :: Ctx -> Pass -> Type
+data Term ctx p =
     -- | Literal (i.e., constant) type or value
     Literal Literal
 
-    -- | Variable or function/macro call
+    -- | Reference to a function parameter
     --
-    -- This might be a macro argument, or another macro.
-  | Var ( XVar p ) Name [Expr p]
+    -- A parameter De Bruijn index and name of the enclosing function-like
+    -- macro. For example, the second @X@ in @#define F(X) X + 1@, with index 0.
+    --
+    -- The language defined in @c-expr-dsl@ is a first-order language, so there
+    -- is no need for arguments. For example, we do not support
+    -- @#define MACRO(F,X) F(X)@.
+  | LocalParam (Idx ctx)
+
+    -- | Free variable: another macro or typedef
+  | Var ( XVar p ) Name [Expr ctx p]
   deriving stock Generic
-deriving stock instance ( Eq   ( XApp p ), Eq   ( XVar p ) ) => Eq   ( Term p )
-deriving stock instance ( Ord  ( XApp p ), Ord  ( XVar p ) ) => Ord  ( Term p )
-deriving stock instance ( Show ( XApp p ), Show ( XVar p ) ) => Show ( Term p )
+deriving stock instance ( Eq   ( XApp p ), Eq   ( XVar p ) ) => Eq   ( Term ctx p )
+deriving stock instance ( Ord  ( XApp p ), Ord  ( XVar p ) ) => Ord  ( Term ctx p )
+deriving stock instance ( Show ( XApp p ), Show ( XVar p ) ) => Show ( Term ctx p )

--- a/c-expr-dsl/src/C/Expr/Syntax/Type.hs
+++ b/c-expr-dsl/src/C/Expr/Syntax/Type.hs
@@ -13,7 +13,6 @@ module C.Expr.Syntax.Type (
   , FloatSize(..)
   ) where
 
-import Data.Text (Text)
 import GHC.Generics (Generic)
 
 {-------------------------------------------------------------------------------
@@ -57,12 +56,6 @@ data TypeLit =
 
     -- | @_Bool@ or @bool@ (C23)
   | TypeBool
-
-    -- NB: We do not accept untagged identifiers here, since they may correspond
-    -- to a value expression, not a type expression.
-
-    -- | An elaborated type literal: @struct tag@, @union tag@, @enum tag@
-  | TypeTagged !TagKind !Text
   deriving stock (Eq, Ord, Show, Generic)
 
 -- | Tag kind for elaborated types

--- a/c-expr-dsl/src/C/Expr/Typecheck.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck.hs
@@ -1,66 +1,98 @@
+{-# LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ >=908
+{-# LANGUAGE TypeAbstractions #-}
+#endif
+
 module C.Expr.Typecheck (
     tcMacro
+  , CheckedMacroTypeExpr(..)
+  , CheckedMacroValueExpr(..)
   , MacroTcResult(..)
   , TypeEnv
+  , buildTypedefEnv
 
     -- * Errors
   , MacroTcError(..)
   , pprMacroTcError
   ) where
 
+import Data.Type.Equality ((:~:) (..))
+import Data.Type.Nat qualified as Nat
+import Data.Vec.Lazy (Vec)
 import Data.Vec.Lazy qualified as Vec
 
 import C.Expr.Syntax
+import C.Expr.Syntax qualified as M
 import C.Expr.Typecheck.Expr
-import C.Expr.Typecheck.Type
 import C.Expr.Typecheck.Interface.Type qualified as T
 import C.Expr.Typecheck.Interface.Value qualified as V
-import Control.Exception (Exception (displayException))
+import C.Expr.Typecheck.Type
 
 {-------------------------------------------------------------------------------
   Typechecking macros: public entry point
 -------------------------------------------------------------------------------}
 
+-- | The macro is C type expression (e.g., @#define FOO int@).
+data CheckedMacroTypeExpr var = CheckedMacroTypeExpr{
+      macroTypeBody :: T.Expr var
+    , macroTypeType :: Quant (FunValue, Type Ty)
+    }
+  deriving stock (Eq, Show)
+
+-- | The macro is a value expression (e.g., @#define BAR 1@).
+data CheckedMacroValueExpr var = forall ctx. CheckedMacroValueExpr{
+      macroValueParams :: Vec ctx Name
+    , macroValueBody   :: V.Expr ctx var
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1950>
+      --
+      -- We should not require 'FunValue's for value-like expressions.
+    , macroValueType   :: Quant (FunValue, Type Ty)
+    }
+instance Eq var => Eq (CheckedMacroValueExpr var) where
+  (CheckedMacroValueExpr @_ @c1 p1 b1 t1) == (CheckedMacroValueExpr @_ @c2 p2 b2 t2) =
+    t1 == t2 && (
+      Vec.withDict p1 $ Vec.withDict p2 $
+        case Nat.eqNat @c1 @c2 of
+          Just Refl -> p1 == p2 && b1 == b2
+          Nothing   -> False
+    )
+deriving stock instance Show var => Show (CheckedMacroValueExpr var)
+
 -- | The result of typechecking a macro is either a type or value expression
-data MacroTcResult =
-    MacroTcTypeExpr  (T.Expr Name) (Quant (FunValue, Type Ty))
-    -- ^ The macro is C type expression (e.g., @#define FOO int@).
-  | MacroTcValueExpr (V.Expr Name) (Quant (FunValue, Type Ty))
-    -- ^ The macro is a value expression (e.g., @#define BAR 1@).
-  deriving stock Show
+data MacroTcResult var =
+    MacroTcTypeExpr  (CheckedMacroTypeExpr  var)
+  | MacroTcValueExpr (CheckedMacroValueExpr var)
+
+deriving stock instance (Show var) => Show (MacroTcResult var)
 
 -- | Typecheck a macro
-tcMacro
-  :: TypeEnv
-  -> Name    -- ^ macro name
-  -> [Name]  -- ^ macro args
-  -> Expr Ps -- ^ macro body
-  -> Either MacroTcError MacroTcResult
-tcMacro tyEnv name args expr =
-    Vec.reifyList args $ \args' -> do
-      checkedExpr <- tcExpr tyEnv name args' expr
-      pure $ classify checkedExpr
+tcMacro ::
+     forall m ctx var.
+     Applicative m
+  => TypeEnv
+  -> (Name -> m var)              -- ^ Inject type
+  -> (M.TagKind -> Name -> m var) -- ^ Inject tagged type
+  -> (Name -> m var)              -- ^ Inject value
+  -> Name                         -- ^ macro name
+  -> Vec ctx Name                 -- ^ macro local params
+  -> Expr ctx Ps                  -- ^ macro body
+  -> m (Either MacroTcError (MacroTcResult var))
+tcMacro tyEnv injectType injectTaggedType injectValue name params expr =
+    case tcExpr tyEnv name params expr of
+      Left  err -> pure $ Left err
+      Right res -> classify res
   where
-    classify :: (Type Ty, Quant (FunValue, Type Ty)) -> MacroTcResult
+    classify ::
+         (Type Ty, Quant (FunValue, Type Ty))
+      -> m (Either MacroTcError (MacroTcResult var))
     classify = \case
       (MacroTypeTy, quant) ->
-        let typeExpr  = panicOnFailure $ T.fromExpr expr
-        in  MacroTcTypeExpr typeExpr  quant
+        if Vec.null params then
+          let toRes texpr = MacroTcTypeExpr $ CheckedMacroTypeExpr texpr quant
+          in  Right . toRes <$> T.fromExpr injectType injectTaggedType expr
+        else
+          pure $ Left $ TcUnsupportedTypeWithLocalParameters name (Vec.toList params)
       (_, quant)           ->
-        let valueExpr = panicOnFailure $ V.fromExpr expr
-        in  MacroTcValueExpr valueExpr quant
-
-    panicOnFailure :: Exception e => Either e a -> a
-    panicOnFailure = \case
-      Left  e ->
-        let msg = unlines [
-                "Classification and conversion of typechecked macro failed:"
-              , displayException e
-              , ""
-              -- TODO <https://github.com/well-typed/hs-bindgen/issues/943>
-              --
-              -- Amend when `c-expr-dsl` is separated from `hs-bindgen`.
-              , "Please report this as a bug at https://github.com/well-typed/hs-bindgen/issues/"
-              ]
-        in  error msg
-      Right x -> x
+        let toRes vexpr = MacroTcValueExpr $ CheckedMacroValueExpr params vexpr quant
+        in  Right . toRes <$> V.fromExpr injectValue expr

--- a/c-expr-dsl/src/C/Expr/Typecheck/Expr.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck/Expr.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ParallelListComp #-}
 
 #if __GLASGOW_HASKELL__ >=908
@@ -30,7 +29,6 @@ module C.Expr.Typecheck.Expr
 
     -- * Evaluating macros
   , naturalMaybe
-
   )
   where
 
@@ -66,11 +64,13 @@ import Data.STRef (newSTRef, readSTRef)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Traversable (for)
+import Data.Traversable.WithIndex (ifor)
 import Data.Type.Equality (type (:~:) (..))
 import Data.Type.Nat qualified as Nat
 import Data.Typeable (Typeable, eqT)
 import Data.Vec.Lazy (Vec (..))
 import Data.Vec.Lazy qualified as Vec
+import DeBruijn (Idx, idxToInt)
 import Debug.Trace (traceM)
 import Foreign.C.Types
 import GHC.Exts (Int (I#), dataToTag#)
@@ -79,11 +79,13 @@ import GHC.Stack
 import Numeric.Natural
 
 import C.Expr.HostPlatform qualified as Runtime
+import C.Type qualified as Runtime
+
 import C.Expr.Syntax
 import C.Expr.Typecheck.Type
 import C.Expr.Util.TestEquality (equals2)
+
 import C.Operators qualified as Runtime
-import C.Type qualified as Runtime
 
 {-------------------------------------------------------------------------------
   Free type variables and substitution
@@ -158,9 +160,6 @@ isEmptySubst ( Subst s ) = IntMap.null s
 
 domain :: Subst tv -> IntSet
 domain ( Subst s ) = IntMap.keysSet s
-
---range :: IntSet -> Subst tv -> [ Type Ty ]
---range tvs ( Subst s ) = IntMap.elems $ fmap snd $ IntMap.restrictKeys s tvs
 
 addOneToSubst :: HasCallStack => TyVar -> Type Ty -> Subst TyVar -> Subst TyVar
 addOneToSubst tv ty s = mkSubst [ ( tv, ty ) ] <> s
@@ -252,13 +251,16 @@ isAtomicType = \case
   Constraints & errors
 -------------------------------------------------------------------------------}
 
-data Fun = forall arity. Fun ( Either Name ( VaFun arity ) )
+data Fun ctx =
+    FunLocal ( Idx ctx )
+  | FunVar   Name
+  | forall arity. FunVaFun ( VaFun arity )
 
-funName :: Fun -> FunName
-funName ( Fun f ) =
-  case f of
-    Left  n  -> getName n
-    Right mf -> Text.pack ( show mf )
+funName :: Fun ctx -> FunName
+funName = \case
+    FunLocal i  -> Text.pack ( "local_param_" ++ show i )
+    FunVar   n  -> getName n
+    FunVaFun mf -> Text.pack ( show mf )
 
 typFunName :: TyFun n -> FunName
 typFunName = \case
@@ -342,8 +344,8 @@ instance Show SrcSpan where
 
 data TcLclEnv
   = TcLclEnv
-      { tcSrcSpan :: !SrcSpan
-      , tcVarEnv  :: !VarEnv
+      { tcSrcSpan   :: !SrcSpan
+      , tcLclParams :: !ParamEnv
       }
 
 newtype TcPureM a = TcPureM ( forall s. TcEnv s -> ST s a )
@@ -363,7 +365,7 @@ runTcM plat initTyEnv ( TcPureM f ) = runST do
   tcErrs    <- newSTRef []
   let
     tcGblEnv = TcGblEnv { tcTypeEnv = initTyEnv, tcPlatform = plat }
-    tcLclEnv = TcLclEnv { tcSrcSpan = SrcSpan, tcVarEnv = Map.empty }
+    tcLclEnv = TcLclEnv { tcSrcSpan = SrcSpan, tcLclParams = IntMap.empty }
   res <- f ( TcEnv { tcGblEnv, tcLclEnv } )
   errs <- readSTRef tcErrs
   return ( res, errs )
@@ -382,13 +384,18 @@ lookupTyEnv :: Name -> TcPureM ( Maybe ( Quant ( FunValue, Type Ty ) ) )
 lookupTyEnv varNm = TcPureM \ ( TcEnv ( TcGblEnv { tcTypeEnv } ) _ ) ->
   return $ Map.lookup varNm tcTypeEnv
 
-lookupVar :: Name -> TcPureM ( Maybe ( Type Ty ) )
-lookupVar varNm = TcPureM \ ( TcEnv _ lcl ) ->
-  return $ Map.lookup varNm ( tcVarEnv lcl )
+declareLocalParams :: Vec ctx (Type Ty ) -> TcPureM a -> TcPureM a
+declareLocalParams tys ( TcPureM f ) = TcPureM \ ( TcEnv gbl lcl ) ->
+    f $
+      TcEnv
+        gbl
+        lcl { tcLclParams = IntMap.fromList $ zip [0..] $ reverse (Vec.toList tys) }
 
-declareLocalVars :: Map Name ( Type Ty ) -> TcPureM a -> TcPureM a
-declareLocalVars vs ( TcPureM f ) = TcPureM \ ( TcEnv gbl lcl ) ->
-  f ( TcEnv gbl ( lcl { tcVarEnv = tcVarEnv lcl <> vs } ) )
+lookupLocalParam :: forall ctx. Idx ctx -> TcPureM ( Type Ty )
+lookupLocalParam i = TcPureM \ ( TcEnv _ lcl ) ->
+    case IntMap.lookup (idxToInt i) ( tcLclParams lcl ) of
+      Nothing -> error "impossible: lookupLocalParam: index out of bounds"
+      Just ty -> pure ty
 
 {-------------------------------------------------------------------------------
   Typechecking macros: constraint generation monad
@@ -747,44 +754,49 @@ instantiate ctOrig instOrig body = do
 -------------------------------------------------------------------------------}
 
 -- | Infer the type of a macro declaration (before constraint solving and generalisation).
-inferTop :: Name -> Vec nbArgs Name -> Expr Ps
-         -> TcUniqueM ( ( ( Expr Tc, ( Vec nbArgs ( Type Ty ), Type Ty ) ), Cts ), [ ( TcError, SrcSpan ) ] )
-inferTop funNm args body = do
+inferTop :: Name -> Vec ctx Name -> Expr ctx Ps
+         -> TcUniqueM ( ( ( Expr ctx Tc, ( Vec ctx ( Type Ty ), Type Ty ) ), Cts )
+                      , [ ( TcError, SrcSpan ) ] )
+inferTop funNm params body = do
   plat <- lift getPlatform
-  ( ( ( tcBody, ( argTys, bodyTy ) ), ( cts, mbErrs ) ), subst ) <- runTcGenMTcM ( inferLam funNm args body )
-  let argTys' = fmap ( applySubstNormalise plat subst ) argTys
+  ( ( ( tcBody, ( paramTys, bodyTy ) ), ( cts, mbErrs ) ), subst ) <- runTcGenMTcM ( inferLam funNm params body )
+  let paramTys' = fmap ( applySubstNormalise plat subst ) paramTys
       bodyTy' = applySubstNormalise plat subst bodyTy
       cts' = map ( first ( applySubstNormalise plat subst ) ) cts
   debugTraceM $ unlines
     [ "inferTop " ++ show funNm
-    , "argTys: " ++ show argTys'
+    , "paramTys: " ++ show paramTys'
     , "bodyTy: " ++ show bodyTy'
     , "cts: " ++ show cts'
     , "final subst: " ++ show subst
     ]
-  return ( ( ( tcBody, ( argTys', bodyTy' ) ), cts' ), mbErrs )
+  return ( ( ( tcBody, ( paramTys', bodyTy' ) ), cts' ), mbErrs )
 
-inferExpr :: Expr Ps -> TcGenM ( Type Ty, Expr Tc )
+inferExpr :: Expr ctx Ps -> TcGenM ( Type Ty, Expr ctx Tc )
 inferExpr = \case
   Term tm -> second Term <$> inferTerm tm
   TyApp fun args -> do
     ( args', resTy ) <- inferTyApp fun args
     pure ( resTy, TyApp fun args' )
   VaApp NoXApp fun args -> do
-    ( funVal, ( args', resTy ) ) <- inferVaApp ( Fun $ Right fun ) args
+    ( funVal, ( args', resTy ) ) <- inferVaApp ( FunVaFun fun ) args
     return ( resTy, VaApp ( XAppTc funVal ) fun args' )
 
-inferTerm :: Term Ps -> TcGenM ( Type Ty, Term Tc )
+inferTerm :: Term ctx Ps -> TcGenM ( Type Ty, Term ctx Tc )
 inferTerm = \case
   Literal x ->
     pure (inferLit x, Literal x)
+  LocalParam i ->
+    do resTy <- liftTcPureM $ lookupLocalParam i
+       return ( resTy, LocalParam i )
   Var NoXVar fun argsList -> Vec.reifyList argsList $ \ args ->
-    do ( funVal, ( args', resTy ) ) <- inferVaApp ( Fun $ Left fun ) args
+    do ( funVal, ( args', resTy ) ) <- inferVaApp ( FunVar fun ) args
        return ( resTy, Var ( XVarTc funVal ) fun ( Vec.toList args' ) )
 
 inferLit :: Literal -> Type Ty
 inferLit = \case
   TypeLit{}        -> MacroTypeTy
+  TypeTagged{}     -> MacroTypeTy
   ValueLit vaLit -> case vaLit of
     ValueInt ( IntegerLiteral { integerLiteralType = intyTy } ) ->
       IntLike $ PrimIntInfoTy $ CIntegralType $ Runtime.IntLike intyTy
@@ -797,8 +809,8 @@ inferLit = \case
 
 inferTyApp ::
      TyFun n
-  -> Vec nbArgs ( Expr Ps )
-  -> TcGenM ( Vec nbArgs ( Expr Tc ), Type Ty )
+  -> Vec nbArgs ( Expr ctx Ps )
+  -> TcGenM ( Vec nbArgs ( Expr ctx Tc ), Type Ty )
 inferTyApp fun args = do
   let funTy = inferTyFun fun
   -- The handling of arguments is duplicated in 'inferVaApp'.
@@ -819,9 +831,9 @@ inferTyApp fun args = do
 --
 -- Also returns a 'FunValue', which allows evaluating the instantiated function.
 inferVaApp ::
-     Fun
-  -> Vec nbArgs ( Expr Ps )
-  -> TcGenM ( FunValue, ( Vec nbArgs ( Expr Tc ), Type Ty ) )
+     Fun ctx
+  -> Vec nbArgs ( Expr ctx Ps )
+  -> TcGenM ( FunValue, ( Vec nbArgs ( Expr ctx Tc ), Type Ty ) )
 inferVaApp fun args = do
   ( funVal, funTy ) <- inferFun fun
   -- The handling of arguments is duplicated in 'inferTyApp'.
@@ -838,53 +850,51 @@ inferVaApp fun args = do
 
 -- | Infer the type of an occurrence of a variable or function,
 -- instantiating if necessary.
-inferFun :: Fun -> TcGenM ( FunValue, Type Ty )
-inferFun f@( Fun fun ) =
-  case fun of
-    Left varNm@( Name varStr ) -> do
-      -- Variable: should either be a local variable (a macro argument)
-      -- or a top-level macro (calling another macro).
-      mbTy <- liftTcPureM $ lookupVar varNm
-      case mbTy of
-        Just varTy ->
-          return
-            ( FunValue @Z varStr $ const NoValue -- this is not consulted, see 'evaluateTerm'
-            , varTy )
+inferFun :: Fun ctx -> TcGenM ( FunValue, Type Ty )
+inferFun f = case f of
+    FunLocal idx -> do
+      paramTy <- liftTcPureM $ lookupLocalParam idx
+      pure
+        -- The value is not consulted, see 'evaluateTerm'.
+        ( FunValue @Z funNm $ const NoValue
+        , paramTy )
+    FunVar   varNm -> do
+      mbQTy <- liftTcPureM $ lookupTyEnv varNm
+      case mbQTy of
+        Just ( Quant funQTy ) ->
+          snd <$>
+            instantiate ( FunInstOrigin funNm ) ( FunInstMetaOrigin funNm ) funQTy
         Nothing -> do
-          mbQTy <- liftTcPureM $ lookupTyEnv varNm
-          case mbQTy of
-            Just ( Quant funQTy ) ->
-              snd <$>
-                instantiate ( FunInstOrigin funNm ) ( FunInstMetaOrigin funNm ) funQTy
-            Nothing -> do
-              addErrTcGenM $ UnboundVariable varNm
-              alpha <- newMetaTyVarTy ( ExpectedVarTy varNm ) ( varStr <> "_ty" )
-              return ( FunValue @Z varStr $ const NoValue, alpha )
-    Right mFun  ->
+          addErrTcGenM $ UnboundVariable varNm
+          alpha <- newMetaTyVarTy ( ExpectedVarTy varNm ) ( funNm <> "_ty" )
+          return ( FunValue @Z funNm $ const NoValue, alpha )
+    FunVaFun mFun  ->
       case inferVaFun mFun of
         Quant funQTy -> do
           snd <$>
             instantiate ( FunInstOrigin funNm ) ( FunInstMetaOrigin funNm ) funQTy
   where
+    funNm :: FunName
     funNm = funName f
 
 -- | Infer the type of a lambda expression.
-inferLam :: forall nbArgs
-         .  Name            -- ^ name of the function (for error messages)
-         -> Vec nbArgs Name -- ^ argument names
-         -> Expr Ps        -- ^ function body
-         -> TcGenM ( Expr Tc, ( Vec nbArgs ( Type Ty ), Type Ty ) )
+inferLam :: forall ctx
+         .  Name         -- ^ name of the function (for error messages)
+         -> Vec ctx Name -- ^ local parameters
+         -> Expr ctx Ps  -- ^ function body
+         -> TcGenM ( Expr ctx Tc, ( Vec ctx ( Type Ty ), Type Ty ) )
 inferLam _ VNil body = do
   ( bodyTy, body' ) <- inferExpr body
   return ( body', ( VNil, bodyTy) )
-inferLam funNm argNms@( _ ::: _ ) body = do
-  let is = Vec.imap ( \ i _ -> fromIntegral ( Fin.toNatural i ) + 1 ) argNms
-  argTys <-
-    for ( Vec.zipWith (,) is argNms ) \ ( i, argNm@( Name argStr ) ) ->
-      newMetaTyVarTy ( FunArg funNm ( argNm, i ) ) ( "ty_" <> argStr )
-  liftBaseTcM ( declareLocalVars ( Map.fromList $ Foldable.toList $ Vec.zipWith (,) argNms argTys ) ) $ do
+inferLam funNm params body = do
+  paramTys <-
+    ifor params \ i param  ->
+      newMetaTyVarTy
+        ( FunParam funNm ( param, Fin.toNatural i ) )
+        ( "ty_" <> getName param )
+  liftBaseTcM ( declareLocalParams paramTys ) $ do
     ( bodyTy, body' ) <- inferExpr body
-    return ( body', ( argTys, bodyTy ) )
+    return ( body', ( paramTys, bodyTy ) )
 
 -- Unlike value functions, functions on the type level are always monomorphic,
 -- so we don't need a 'Quant'.
@@ -1133,7 +1143,7 @@ instanceKey ( Instance { instanceQuantTy = qty } ) =
   map typeHead $ Vec.toList $ quantTyBody ( mkQuantTyBody ( Quant qty ) )
 
 argsTypeHeads :: Vec n ( Type Ty ) -> [ Maybe TypeHead ]
-argsTypeHeads = Foldable.toList . fmap typeHead
+argsTypeHeads = Vec.toList . fmap typeHead
 
 typeHead :: Type Ty -> Maybe TypeHead
 typeHead = \case
@@ -1805,11 +1815,11 @@ This is easier than erasing the types and dealing with typeclass specialisation,
 which is what GHC does.
 -}
 
-evaluateExpr :: Map Name Value -> TypeEnv -> Expr Tc -> Value
+evaluateExpr :: IntMap Value -> TypeEnv -> Expr ctx Tc -> Value
 evaluateExpr argVals tyEnv = \case
   Term tm  -> evaluateTerm argVals tyEnv tm
   TyApp{}  -> NoValue
-  VaApp @_ @m ( XAppTc ( FunValue @n _ fn ) ) _funName args ->
+  VaApp @_ @_ @m ( XAppTc ( FunValue @n _ fn ) ) _funName args ->
     -- We have stored the function that performs evaluation in the XAppTc
     -- field of the AST. For example, for addition, we have wrapped
     --
@@ -1823,16 +1833,13 @@ evaluateExpr argVals tyEnv = \case
         Nothing ->
           NoValue
 
-evaluateTerm :: Map Name Value -> TypeEnv -> Term Tc -> Value
+evaluateTerm :: IntMap Value -> TypeEnv -> Term ctx Tc -> Value
 evaluateTerm argVals tyEnv = \case
   Literal x -> evaluateLit x
+  -- Local macro parameter, e.g. @X@ in @#define AddOne(X) X+1@.
+  LocalParam i -> fromMaybe NoValue $ IntMap.lookup (idxToInt i) argVals
   Var ( XVarTc ( FunValue @n _ fn ) ) nm args
-    -- Is this an argument to the macro, e.g. @X@ in @#define AddOne(X) X+1@?
-    | [] <- args
-    , Just mbVal <- Map.lookup nm argVals
-    -> mbVal
-    | otherwise
-    -> Vec.reifyList args $ \ ( argsVec :: Vec m ( Expr Tc ) ) ->
+    -> Vec.reifyList args $ \ ( argsVec :: Vec m ( Expr ctx Tc ) ) ->
         case Nat.eqNat @n @m of
           Nothing ->
             error $ unlines
@@ -1842,7 +1849,7 @@ evaluateTerm argVals tyEnv = \case
               , "arguments: " ++ show args
               ]
           Just Refl ->
-            -- This is a macro call; evaluate the arguments and apply the
+            -- This is a macro call; evaluate the argument and apply the
             -- evaluator function. See also the 'MApp' case in 'evaluateExpr'.
             fn $ fmap ( evaluateExpr argVals tyEnv ) argsVec
 
@@ -1876,6 +1883,7 @@ evaluateLit = \case
     ValueString {} -> NoValue
   -- We do not evaluate type functions.
   TypeLit    {} -> NoValue
+  TypeTagged {} -> NoValue
 
 naturalMaybe :: ValSType ty -> ty -> Maybe Natural
 naturalMaybe ( ValSType ty ) i =
@@ -1897,10 +1905,11 @@ naturalMaybe ( ValSType ty ) i =
 -- Also returns the body type (post-inference, pre-quantification) so the
 -- caller can tell whether the macro denotes a type or a value.
 tcExpr ::
-     TypeEnv
-  -> Name            -- ^ name of the macro
-  -> Vec nbArgs Name -- ^ macro arguments
-  -> Expr Ps        -- ^ macro body
+     forall ctx
+  .  TypeEnv
+  -> Name         -- ^ name of the macro
+  -> Vec ctx Name -- ^ macro arguments
+  -> Expr ctx Ps  -- ^ macro body
   -> Either MacroTcError ( Type Ty, Quant ( FunValue, Type Ty ) )
 tcExpr tyEnv macroNm args body =
   let plat = Runtime.hostPlatform in
@@ -1912,7 +1921,9 @@ tcExpr tyEnv macroNm args body =
 
     -- Step 2: compute the set of metavariables that are candidates for quantification.
     let
-      freeTvs = seenTvs $ getFVs noBoundVars $ freeTyVarsOfTypes ( bodyTy : Vec.toList argTys )
+      freeTvs =
+        seenTvs $ getFVs noBoundVars $
+          freeTyVarsOfTypes ( bodyTy : Vec.toList argTys )
 
     -- Step 3: simplify and default constraints.
     ( ctSubst, simpleCts ) <- simplifyAndDefault freeTvs ctsOrigs
@@ -1921,7 +1932,9 @@ tcExpr tyEnv macroNm args body =
     let
       qtvsFVs =
         getFVs noBoundVars $
-          freeTyVarsOfTypes ( fmap ( applySubstNormalise plat ctSubst ) $ bodyTy : Vec.toList argTys )
+          freeTyVarsOfTypes $
+            fmap ( applySubstNormalise plat ctSubst ) $
+              Vec.toList ( argTys ) ++ [ bodyTy ]
       qtvsList = reverse $ seenTvsRevList qtvsFVs
       ctTvs =
         seenTvs $ getFVs noBoundVars $
@@ -1975,20 +1988,20 @@ tcExpr tyEnv macroNm args body =
       ( bodyTy
       , Vec.reifyList qtvsList \ qtvs ->
           Quant \ tys ->
-            let quantSubst = mkSubst $ Foldable.toList $ Vec.zipWith (,) qtvs tys
+            let quantSubst = mkSubst $ Vec.toList $ Vec.zipWith (,) qtvs tys
                 finalSubst = quantSubst <> ctSubst
                 norm :: Type ki -> Type ki
                 norm = applySubstNormalise plat finalSubst
                 evalFun =
                   Vec.withDict args $
-                    FunValue ( getName macroNm )$ \ argVals ->
-                    evaluateExpr
-                      ( Map.fromList $ Vec.toList $ Vec.zipWith (,) args argVals )
-                      tyEnv
-                      body'
+                    FunValue ( getName macroNm ) $ \ (argVals :: Vec ctx Value) ->
+                      evaluateExpr
+                        ( IntMap.fromList $ zip [0..] $ Vec.toList argVals )
+                        tyEnv
+                        body'
             in QuantTyBody
                 { quantTyQuant = map norm ( fmap fst simpleCts )
-                , quantTyBody  = ( evalFun, mkFunTy ( fmap norm argTys ) ( norm bodyTy ) )
+                , quantTyBody  = ( evalFun, mkFunTy ( fmap norm ( argTys ) ) ( norm bodyTy ) )
                 }
       )
   where
@@ -2001,6 +2014,7 @@ data MacroTcError
   = TcErrors !( NE.NonEmpty ( TcError, SrcSpan ) )
   -- | A collection of class constraints was inconsistent.
   | TcInconsistentConstraints !( NE.NonEmpty Cts )
+  | TcUnsupportedTypeWithLocalParameters Name [Name]
   deriving stock ( Show, Generic )
 
 instance Eq MacroTcError where
@@ -2020,6 +2034,10 @@ pprMacroTcError tcMacroErr =
           | cts <- NE.toList ctss
           | i <- [ ( 1 :: Int ) .. ]
           ]
+      TcUnsupportedTypeWithLocalParameters nm ps -> [
+          "Unsupported type-like macro expression with local parameters:"
+        , getName nm <> " with parameters " <> Text.pack (show ps)
+        ]
 
 mapMaybeA :: Applicative m => ( a -> m ( Maybe b ) ) -> [ a ] -> m [ b ]
 mapMaybeA f =

--- a/c-expr-dsl/src/C/Expr/Typecheck/Interface/Type.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck/Interface/Type.hs
@@ -8,18 +8,18 @@
 module C.Expr.Typecheck.Interface.Type (
     Expr(..)
   , Fun(..)
-  , ConversionError(..)
   , fromExpr
   )
   where
 
 import Control.Exception (Exception)
-import Control.Monad.Except ( Except, MonadError (..), runExcept)
-import Data.Vec.Lazy (Vec(..))
 import Data.Nat (Nat (..))
+import Data.Vec.Lazy (Vec (..))
+import DeBruijn (idxToInt)
 
 import C.Expr.Syntax qualified as M
 import C.Expr.Syntax.Name
+import C.Expr.Util.Panic
 
 data Expr var =
     TypeLit M.TypeLit
@@ -28,18 +28,25 @@ data Expr var =
   --
   -- Change how we represent @const@.
   | App Fun (Expr var)
-  deriving stock (Show)
+
+deriving stock instance Eq var   => Eq         (Expr var)
+deriving stock instance Show var => Show       (Expr var)
+deriving stock instance             Functor     Expr
+deriving stock instance             Foldable    Expr
+deriving stock instance             Traversable Expr
 
 data Fun =
     Pointer
   | Const
-  deriving stock (Show)
+  deriving stock (Eq, Show)
 
 data ConversionError =
     -- | Unexpected value literal (e.g., the integer @42@)
     UnexpectedValueLiteralInType String
     -- | Unexpected named function call in type
   | UnexpectedFunctionCallInType Name
+    -- | Unexpected local parameter in type
+  | UnexpectedLocalParameterInType Int
     -- | A unary type function received multiple arguments
   | UnexpectedMultipleArgumentsToUnaryTypeFunction
     -- | Unexpected function application on a value (not a type)
@@ -48,31 +55,41 @@ data ConversionError =
 
 instance Exception ConversionError
 
-fromExpr :: M.Expr p -> Either ConversionError (Expr Name)
-fromExpr =  runExcept . go
+fromExpr ::
+     forall ctx m var p. Applicative m
+  => (Name -> m var)
+  -> (M.TagKind -> Name -> m var)
+  -> M.Expr ctx p
+  -> m (Expr var)
+fromExpr injectType injectTaggedType = go
   where
-    go :: M.Expr p -> Except ConversionError (Expr Name)
+    go :: M.Expr ctx p -> m (Expr var)
     go = \case
       M.Term (M.Literal x) ->
         fromLit x
+      M.Term (M.LocalParam i) ->
+        panicPure $ show $ UnexpectedLocalParameterInType (idxToInt i)
       M.Term (M.Var _ nm []) ->
-        pure $ Var nm
+        Var <$> (injectType nm)
       M.Term (M.Var _ nm _ ) ->
-        throwError $ UnexpectedFunctionCallInType nm
+        panicPure $ show $ UnexpectedFunctionCallInType nm
       M.TyApp fun args -> do
-        arg <- myHead args
+        let arg = myHead args
         case fun of
           M.Pointer -> App Pointer <$> (go arg)
           M.Const   -> App Const   <$> (go arg)
       M.VaApp _ fun _ ->
-        throwError $ UnexpectedValueFunctionApplicationInType (show fun)
+        panicPure $ show $ UnexpectedValueFunctionApplicationInType (show fun)
 
-    fromLit :: M.Literal -> Except ConversionError (Expr Name)
+    fromLit :: M.Literal -> m (Expr var)
     fromLit = \case
-      M.TypeLit x -> pure $ TypeLit x
-      M.ValueLit x -> throwError $ UnexpectedValueLiteralInType (show x)
+      M.TypeLit x         -> pure $ TypeLit x
+      M.TypeTagged tag nm -> Var <$> injectTaggedType tag nm
+      M.ValueLit x        -> panicPure $ show $ UnexpectedValueLiteralInType (show x)
 
-    myHead :: Vec ('S n) a -> Except ConversionError a
+    myHead :: Vec ('S n) a -> a
     myHead = \case
-      (x ::: VNil)    -> pure x
-      (_ ::: _ ::: _) -> throwError $ UnexpectedMultipleArgumentsToUnaryTypeFunction
+      (x ::: VNil) ->
+        x
+      (_ ::: _ ::: _) ->
+        panicPure $ show $ UnexpectedMultipleArgumentsToUnaryTypeFunction

--- a/c-expr-dsl/src/C/Expr/Typecheck/Interface/Value.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck/Interface/Value.hs
@@ -7,37 +7,40 @@
 -- @
 module C.Expr.Typecheck.Interface.Value (
     Expr(..)
-  , ConversionError
   , fromExpr
   )
   where
 
 import Control.Exception (Exception)
-import Control.Monad.Except ( Except, MonadError (..), runExcept)
 import Data.GADT.Compare (GEq (..))
+import Data.Nat (Nat (..))
 import Data.Type.Equality ((:~:) (..))
 import Data.Vec.Lazy (Vec)
-import Data.Nat (Nat (..))
+import DeBruijn (Idx)
 
 import C.Expr.Syntax qualified as M
 import C.Expr.Syntax.Name
+import C.Expr.Util.Panic
 
-data Expr var =
+data Expr ctx var =
     Literal M.ValueLit
-  | Var var [Expr var]
-  | forall n . App (M.VaFun (S n)) (Vec (S n) (Expr var))
+  | LocalParam (Idx ctx)
+  | Var var [Expr ctx var]
+  | forall n . App (M.VaFun (S n)) (Vec (S n) (Expr ctx var))
 
-deriving stock instance (Show var) => (Show (Expr var))
-deriving stock instance Functor Expr
-deriving stock instance Foldable Expr
-deriving stock instance Traversable Expr
+deriving stock instance (Show var) => Show        (Expr ctx var)
+deriving stock instance               Functor     (Expr ctx)
+deriving stock instance               Foldable    (Expr ctx)
+deriving stock instance               Traversable (Expr ctx)
 
-instance Eq var => Eq (Expr var) where
-  Literal l1 == Literal l2 = l1 == l2
-  Var v1 as1 == Var v2 as2 = v1 == v2 && as1 == as2
-  App f1 xs1 == App f2 xs2 = case f1 `geq` f2 of
-                               Just Refl -> xs1 == xs2
-                               Nothing   -> False
+instance Eq var => Eq (Expr ctx var) where
+  Literal l1    == Literal l2    = l1 == l2
+  LocalParam n1 == LocalParam n2 = n1 == n2
+  Var v1 as1    == Var v2 as2    = v1 == v2 && as1 == as2
+  App f1 xs1    == App f2 xs2    =
+    case f1 `geq` f2 of
+      Just Refl -> xs1 == xs2
+      Nothing   -> False
   _ == _ = False
 
 data ConversionError =
@@ -49,24 +52,32 @@ data ConversionError =
 
 instance Exception ConversionError
 
-fromExpr :: M.Expr p -> Either ConversionError (Expr Name)
-fromExpr = runExcept . go
+fromExpr ::
+     forall ctx m var p. Applicative m
+  => (Name -> m var)
+  -> M.Expr ctx p
+  -> m (Expr ctx var)
+fromExpr injectValue = go
   where
-    go :: M.Expr p -> Except ConversionError (Expr Name)
+    go :: M.Expr ctx p -> m (Expr ctx var)
     go = \case
       M.Term (M.Literal x) ->
         fromLit x
+      M.Term (M.LocalParam i) ->
+        pure $ LocalParam i
       M.Term (M.Var _ nm args) ->
-        Var nm <$> mapM go args
+        Var <$> injectValue nm <*> traverse go args
       M.TyApp fun _ ->
-        throwError $ UnexpectedTypeFunctionApplicationInValue (show fun)
+        panicPure $ show $ UnexpectedTypeFunctionApplicationInValue (show fun)
       M.VaApp _ fun args ->
-        App fun <$> mapM go args
+        App fun <$> traverse go args
 
-    fromLit :: M.Literal -> Except ConversionError (Expr Name)
+    fromLit :: M.Literal -> m (Expr ctx var)
     fromLit = \case
       M.TypeLit x ->
-        throwError $ UnexpectedTypeInValue (show x)
+        panicPure $ show $ UnexpectedTypeInValue (show x)
+      M.TypeTagged tag nm ->
+        panicPure $ show $ UnexpectedTypeInValue (show (tag, nm))
       M.ValueLit x -> pure . Literal $ case x of
         M.ValueInt y    -> M.ValueInt y
         M.ValueFloat y  -> M.ValueFloat y

--- a/c-expr-dsl/src/C/Expr/Typecheck/Type.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck/Type.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash         #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 #if __GLASGOW_HASKELL__ >=908
 {-# LANGUAGE TypeAbstractions #-}
@@ -18,7 +17,8 @@ module C.Expr.Typecheck.Type (
   , Tc
     -- * Type inference
   , TypeEnv
-  , VarEnv
+  , buildTypedefEnv
+  , ParamEnv
     -- ** Type system
   , Type(..)
   , IntegralType(..)
@@ -98,9 +98,11 @@ module C.Expr.Typecheck.Type (
 
 import Data.Foldable qualified as Foldable
 import Data.GADT.Compare
+import Data.IntMap (IntMap)
 import Data.Kind qualified as Hs
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Data.Nat (Nat (..))
 import Data.Proxy
@@ -115,9 +117,11 @@ import Foreign.C.Types
 import Foreign.Ptr qualified as Foreign
 import GHC.Generics (Generic)
 import GHC.Show (showSpace)
+import Numeric.Natural
 
 import C.Expr.Syntax
 import C.Expr.Util.TestEquality (equals2)
+
 import C.Type qualified as Runtime
 
 {-------------------------------------------------------------------------------
@@ -162,19 +166,11 @@ data Quant res where
     -> Quant res
 deriving stock instance Functor Quant
 
-instance Eq ( Quant ( Type ki ) ) where
+instance Eq (QuantTyBody body) => Eq ( Quant body ) where
   qty1@( Quant @n1 _ ) == qty2@( Quant @n2 _ ) =
     case Nat.eqNat @n1 @n2 of
-      Nothing -> False
-      Just Refl ->
-        mkQuantTyBody qty1 == mkQuantTyBody qty2
-
-instance Eq ( Quant ( Vec n ( Type ki ) ) ) where
-  qty1@( Quant @n1 _ ) == qty2@( Quant @n2 _ ) =
-    case Nat.eqNat @n1 @n2 of
-      Nothing -> False
-      Just Refl ->
-        mkQuantTyBody qty1 == mkQuantTyBody qty2
+      Nothing   -> False
+      Just Refl -> mkQuantTyBody qty1 == mkQuantTyBody qty2
 
 -- | The body of a quantified type (what's under the forall).
 type QuantTyBody :: Hs.Type -> Hs.Type
@@ -191,6 +187,14 @@ instance Eq ( QuantTyBody ( Type ki ) ) where
         , all ( uncurry eqType ) ( zip cts1 cts2 )
         , eqType body1 body2
         ]
+instance Eq ( QuantTyBody ( FunValue, Type ki ) ) where
+  QuantTyBody cts1 (funVal1, body1) == QuantTyBody cts2 (funVal2, body2) =
+    and [ length cts1 == length cts2
+        , all ( uncurry eqType ) ( zip cts1 cts2 )
+        , eqType body1 body2
+        , funVal1 == funVal2
+        ]
+
 instance Eq ( QuantTyBody ( Vec n ( Type ki ) ) ) where
   QuantTyBody cts1 body1 == QuantTyBody cts2 body2 =
     and [ length cts1 == length cts2
@@ -458,8 +462,30 @@ instance Show ( ClassTyCon n ) where
 --
 -- Use @'Maybe' 'FunValue'@ and emit typecheck error when value required but
 -- unavailable.
-type TypeEnv = Map Name ( Quant ( FunValue, Type Ty ) )
-type VarEnv  = Map Name ( Type Ty )
+type TypeEnv  = Map Name ( Quant ( FunValue, Type Ty ) )
+type ParamEnv = IntMap   ( Type Ty )
+
+-- | Build a 'TypeEnv' from a list of typedef names.
+--
+-- Each name is registered as a type alias (with kind 'MacroTypeTy') and a
+-- dummy 'FunValue' that is never invoked.
+--
+-- Note: @struct@, @union@, and @enum@ types should /not/ be added here.
+-- Tagged types always parse as 'TypeTagged' literals, never as bare 'Var'
+-- nodes, so they are resolved through the @injectTagged@ callback of
+-- 'C.Expr.Typecheck.tcMacro' instead.
+buildTypedefEnv :: [Name] -> TypeEnv
+buildTypedefEnv names =
+    Map.fromList
+      [ ( nm
+        , Quant @Z $ \VNil ->
+            QuantTyBody []
+              ( FunValue @Z (getName nm) (\VNil -> NoValue)
+              , MacroTypeTy
+              )
+        )
+      | nm <- names
+      ]
 
 {-------------------------------------------------------------------------------
   Pass definition
@@ -563,10 +589,11 @@ data MetaOrigin
   = ExpectedFunTyResTy !FunName
   | ExpectedVarTy !Name
   | Inst { instOrigin :: !InstOrigin, instPos :: !Int }
-  | FunArg !Name !( Name, Int )
+  | FunParam !Name !( Name, Natural )
   | IntLitMeta !IntegerLiteral
   | FloatLitMeta !FloatingLiteral
-  deriving stock ( Generic, Show )
+
+deriving stock instance Show MetaOrigin
 
 data InstOrigin
   = FunInstMetaOrigin !FunName
@@ -581,8 +608,8 @@ pprMetaOrigin = \case
     "the type of the identifier '" <> varNm <> "'"
   Inst funNm i ->
     "the " <> speakNth i <> " type argument in the instantiation of '" <> Text.pack ( show funNm ) <> "'"
-  FunArg ( Name funNm ) ( _argNm, i ) ->
-    "the type of the " <> speakNth i <> " argument of '" <> funNm <> "'"
+  FunParam ( Name funNm ) ( param, i ) ->
+    "the type of the " <> speakNth (fromIntegral i) <> " parameter of '" <> funNm <> "' with name '" <> getName param <> "'"
   IntLitMeta i ->
     "the type of the integer literal '" <> Text.pack ( show i ) <> "'"
   FloatLitMeta f ->

--- a/c-expr-dsl/src/C/Expr/Util/Panic.hs
+++ b/c-expr-dsl/src/C/Expr/Util/Panic.hs
@@ -1,0 +1,34 @@
+module C.Expr.Util.Panic (
+    panicPure
+  , panicIO
+  ) where
+
+import Control.Exception
+import Control.Monad.IO.Class
+import GHC.Stack
+
+-- | Unexpected (e.g. invariant violation) conditions.
+data PanicException = PanicException !CallStack !String
+  deriving Show
+
+instance Exception PanicException where
+    displayException (PanicException cs  msg) = unlines
+        [ "PANIC!: the impossible happened"
+        , pleaseReport
+        , msg
+        , prettyCallStack cs
+        ]
+
+-- TODO <https://github.com/well-typed/hs-bindgen/issues/943>
+--
+-- Amend when `c-expr-dsl` is separated from `hs-bindgen`.
+pleaseReport :: String
+pleaseReport = "Please report this as a bug at https://github.com/well-typed/hs-bindgen/issues/"
+
+-- | Panic in pure context
+panicPure :: HasCallStack => String -> a
+panicPure msg = throw (PanicException callStack msg)
+
+-- | Panic in IO
+panicIO :: (HasCallStack, MonadIO m) => String -> m a
+panicIO msg = liftIO (throwIO (PanicException callStack msg))

--- a/c-expr-dsl/test/Main.hs
+++ b/c-expr-dsl/test/Main.hs
@@ -2,8 +2,8 @@ module Main (main) where
 
 import Test.Tasty
 
-import Test.CExpr.Parse       qualified as Parse
-import Test.CExpr.Typecheck   qualified as Typecheck
+import Test.CExpr.Parse qualified as Parse
+import Test.CExpr.Typecheck qualified as Typecheck
 
 main :: IO ()
 main = defaultMain $ testGroup "c-expr-dsl" [

--- a/c-expr-dsl/test/Test/CExpr/Parse.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse.hs
@@ -4,9 +4,9 @@ module Test.CExpr.Parse (
 
 import Test.Tasty
 
-import Test.CExpr.Parse.Golden    qualified as Golden
-import Test.CExpr.Parse.Macro     qualified as Macro
-import Test.CExpr.Parse.Type      qualified as Type
+import Test.CExpr.Parse.Golden qualified as Golden
+import Test.CExpr.Parse.Macro qualified as Macro
+import Test.CExpr.Parse.Type qualified as Type
 
 tests :: TestTree
 tests = testGroup "parse" [

--- a/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | Golden integration tests for 'C.Expr.Parse.Expr.parseMacro'
 --
 -- These tests use @libclang@ to tokenise the macros defined in
@@ -9,14 +7,18 @@
 -- To regenerate the golden file, delete it and re-run the test suite.
 module Test.CExpr.Parse.Golden (tests) where
 
-import Control.Monad (unless, filterM)
+import Control.Monad (filterM, unless)
+import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.FilePath ((</>))
-import Test.Tasty (TestTree, TestName, testGroup)
-import Test.Tasty.HUnit (testCase, assertFailure)
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase)
+
+import C.Expr.Parse
+import C.Expr.Syntax
 
 import Clang.Args
 import Clang.CStandard
@@ -27,10 +29,6 @@ import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 import Clang.Paths
 import Clang.Version
-
-import C.Expr.Parse
-import C.Expr.Syntax
-import Data.Bifunctor (Bifunctor(..))
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -130,8 +128,8 @@ parseMacrosFixture testCStd fixturePath = do
         Text.unpack name ++ ": " ++ formatResult result
 
     formatResult :: Either MacroParseError Macro -> String
-    formatResult (Right mac) = "Right " ++ show (macroExpr mac)
-    formatResult (Left _)    = "Left <parse error>"
+    formatResult (Right (Macro{macroExpr})) = "Right " ++ show macroExpr
+    formatResult (Left _)                   = "Left <parse error>"
 
 {-------------------------------------------------------------------------------
   Collect macro definitions from a C header file via libclang

--- a/c-expr-dsl/test/Test/CExpr/Parse/Infra.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Infra.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | Test infrastructure for the c-expr-dsl parser tests
 module Test.CExpr.Parse.Infra (
     -- * Token constructors
@@ -15,16 +13,18 @@ module Test.CExpr.Parse.Infra (
   , tyLit
   ) where
 
+import Data.Nat (Nat (..))
 import Data.Text (Text)
+import Data.Vec.Lazy (Vec (..))
 import Text.Parsec (eof)
+
+import C.Expr.Parse
+import C.Expr.Syntax
 
 import Clang.CStandard
 import Clang.Enum.Simple
 import Clang.HighLevel.Types
 import Clang.LowLevel.Core
-
-import C.Expr.Parse
-import C.Expr.Syntax
 
 {-------------------------------------------------------------------------------
   Token constructors
@@ -75,8 +75,8 @@ mkToken kind spelling = Token{
 --
 -- Adds 'eof' so that trailing tokens are rejected as parse failures.
 checkType ::
-  ClangCStandard -> [Token TokenSpelling] -> Either MacroParseError (Expr Ps)
-checkType cStd = runParser (parseMacroType cStd <* eof)
+  ClangCStandard -> [Token TokenSpelling] -> Either MacroParseError (Expr Z Ps)
+checkType cStd = runParser (parseMacroType cStd VNil <* eof)
 
 -- | Run the macro parser on a complete token sequence
 --
@@ -102,5 +102,5 @@ parseTestWith p pairs = print $ runParser p (map (uncurry mkToken) pairs)
   Results
 -------------------------------------------------------------------------------}
 
-tyLit :: TypeLit -> Expr Ps
+tyLit :: TypeLit -> Expr ctx Ps
 tyLit = Term . Literal . TypeLit

--- a/c-expr-dsl/test/Test/CExpr/Parse/Macro.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Macro.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ >=908
+{-# LANGUAGE TypeAbstractions #-}
+#endif
 
 -- | Unit tests for 'C.Expr.Parse.Expr.parseMacro'
 --
@@ -9,7 +13,12 @@
 module Test.CExpr.Parse.Macro (tests) where
 
 import Data.Either (isLeft, isRight)
+import Data.Nat (Nat (..))
+import Data.Type.Equality ((:~:)(..))
+import Data.Type.Nat qualified as Nat
 import Data.Vec.Lazy (Vec (..))
+import Data.Vec.Lazy qualified as Vec
+import DeBruijn (Idx(..))
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -31,9 +40,10 @@ tests = testGroup "Parse.Macro" [
 
 testsWithCStd :: CStandard -> TestTree
 testsWithCStd cStd = testGroup (show cStd) [
-      testGroup "type bodies"       $ tests_typeBody       std
-    , testGroup "expression bodies" $ tests_exprBody       std
-    , testGroup "disambiguation"    $ tests_disambiguation std
+      testGroup "type bodies"               $ tests_typeBody         std
+    , testGroup "function-like type bodies" $ tests_funcLikeTypeBody std
+    , testGroup "expression bodies"         $ tests_exprBody         std
+    , testGroup "disambiguation"            $ tests_disambiguation   std
     ]
   where
     std = ClangCStandard cStd DisableGnu
@@ -69,9 +79,22 @@ isExprBody (Right Macro{macroExpr}) = case macroExpr of
     _                 -> False
 isExprBody _ = False
 
-getMacroExpr :: Either e Macro -> Maybe (Expr Ps)
-getMacroExpr (Right Macro{macroExpr}) = Just macroExpr
-getMacroExpr _                        = Nothing
+getMacroExpr :: forall e ctx. Nat.SNatI ctx => Either e Macro -> Maybe (Expr ctx Ps)
+getMacroExpr (Right (Macro @ctx1 _ _ macroParams macroExpr)) =
+    Vec.withDict macroParams $
+      case Nat.eqNat @ctx @ctx1 of
+        Just Refl -> Just macroExpr
+        Nothing   -> Nothing
+getMacroExpr _ =
+    Nothing
+
+-- | Extract the expression body from an object-like (0-arg) macro.
+getObjExpr :: forall e. Either e Macro -> Maybe (Expr Z Ps)
+getObjExpr = getMacroExpr
+
+-- | Extract the expression body from a function-like macro with one parameter.
+getFn1Expr :: forall e. Either e Macro -> Maybe (Expr (S Z) Ps)
+getFn1Expr = getMacroExpr
 
 {-------------------------------------------------------------------------------
   Type bodies
@@ -81,36 +104,67 @@ tests_typeBody :: ClangCStandard -> [TestTree]
 tests_typeBody cStd = [
       testCase "int" $
         -- #define FOO int
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "int"])
+        getObjExpr (checkMacro cStd [macroNameTok, kw "int"])
           @?= Just (tyLit (TypeInt Nothing (Just SizeInt)))
     , testCase "unsigned long" $
         -- #define FOO unsigned long
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "unsigned", kw "long"])
+        getObjExpr (checkMacro cStd [macroNameTok, kw "unsigned", kw "long"])
           @?= Just (tyLit (TypeInt (Just Unsigned) (Just SizeLong)))
     , testCase "const int*" $
         -- #define FOO const int *
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "const", kw "int", punc "*"])
+        getObjExpr (checkMacro cStd [macroNameTok, kw "const", kw "int", punc "*"])
           @?= Just (TyApp Pointer (TyApp Const (tyLit (TypeInt Nothing (Just SizeInt)) ::: VNil) ::: VNil))
     , testCase "void*" $
         -- #define FOO void *
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "void", punc "*"])
+        getObjExpr (checkMacro cStd [macroNameTok, kw "void", punc "*"])
           @?= Just (TyApp Pointer (tyLit TypeVoid ::: VNil))
     , testCase "struct Foo" $
         -- #define FOO struct Foo
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "struct", ident "Foo"])
-          @?= Just (tyLit (TypeTagged TagStruct "Foo"))
+        getObjExpr (checkMacro cStd [macroNameTok, kw "struct", ident "Foo"])
+          @?= Just (Term $ Literal (TypeTagged TagStruct "Foo"))
     , testCase "size_t" $
         -- #define FOO size_t (bare identifier; typechecker decides it's a type)
-        getMacroExpr (checkMacro cStd [macroNameTok, ident "size_t"])
+        getObjExpr (checkMacro cStd [macroNameTok, ident "size_t"])
           @?= Just (Term (Var NoXVar "size_t" []))
     , testCase "_Bool" $
         -- #define FOO _Bool
-        getMacroExpr (checkMacro cStd [macroNameTok, kw "_Bool"])
+        getObjExpr (checkMacro cStd [macroNameTok, kw "_Bool"])
           @?= Just (tyLit TypeBool)
     , testCase "_Bool" $
         -- #define FOO size_t const * const
-        getMacroExpr (checkMacro cStd [macroNameTok, ident "size_t", kw "const", punc "*", kw "const" ])
+        getObjExpr (checkMacro cStd [macroNameTok, ident "size_t", kw "const", punc "*", kw "const" ])
           @?= Just (TyApp Const (TyApp Pointer (TyApp Const (Term (Var NoXVar "size_t" []) ::: VNil) ::: VNil) ::: VNil))
+    ]
+
+{-------------------------------------------------------------------------------
+  Function-like type bodies (local args)
+-------------------------------------------------------------------------------}
+
+tests_funcLikeTypeBody :: ClangCStandard -> [TestTree]
+tests_funcLikeTypeBody cStd = [
+      testCase "PTR(T) = T*" $
+        -- #define PTR(T) T*
+        -- T is a local arg; the body is a pointer type parameterised by T.
+        getFn1Expr (checkMacro cStd
+            [ macroNameTok, punc "(", ident "T", punc ")"
+            , ident "T", punc "*"
+            ])
+          @?= Just (TyApp Pointer (Term (LocalParam IZ) ::: VNil))
+    , testCase "CONST_PTR(T) = const T*" $
+        -- #define CONST_PTR(T) const T*
+        getFn1Expr (checkMacro cStd
+            [ macroNameTok, punc "(", ident "T", punc ")"
+            , kw "const", ident "T", punc "*"
+            ])
+          @?= Just (TyApp Pointer (TyApp Const (Term (LocalParam IZ) ::: VNil) ::: VNil))
+    , testCase "free var is not a local arg" $
+        -- #define PTR(T) size_t*
+        -- size_t is not a formal parameter, so it stays as Var, not LocalParam.
+        getFn1Expr (checkMacro cStd
+            [ macroNameTok, punc "(", ident "T", punc ")"
+            , ident "size_t", punc "*"
+            ])
+          @?= Just (TyApp Pointer (Term (Var NoXVar "size_t" []) ::: VNil))
     ]
 
 {-------------------------------------------------------------------------------

--- a/c-expr-dsl/test/Test/CExpr/Parse/Type.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Type.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | Unit tests for 'C.Expr.Parse.Type.parseMacroType'
 module Test.CExpr.Parse.Type (tests) where
 
@@ -8,9 +6,9 @@ import Data.Vec.Lazy (Vec (..))
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Clang.CStandard
-
 import C.Expr.Syntax
+
+import Clang.CStandard
 
 import Test.CExpr.Parse.Infra
 
@@ -25,17 +23,17 @@ tests = testGroup "Parse.Type" [
 
 testWithCStd :: CStandard -> TestTree
 testWithCStd cStd = testGroup (show cStd) [
-      testGroup "void and bool"        $ tests_voidBool     std
-    , testGroup "integer types"        $ tests_int          std
-    , testGroup "char"                 $ tests_char         std
-    , testGroup "float and double"     $ tests_float        std
-    , testGroup "named types"          $ tests_named        std
-    , testGroup "tagged types"         $ tests_tagged       std
-    , testGroup "const qualifier"      $ tests_const        std
-    , testGroup "pointer indirection"  $ tests_pointer      std
-    , testGroup "combined"             $ tests_combined     std
-    , testGroup "keyword order"        $ tests_keywordOrder std
-    , testGroup "failures"             $ tests_failures     std
+      testGroup "void and bool"       $ tests_voidBool     std
+    , testGroup "integer types"       $ tests_int          std
+    , testGroup "char"                $ tests_char         std
+    , testGroup "float and double"    $ tests_float        std
+    , testGroup "named types"         $ tests_named        std
+    , testGroup "tagged types"        $ tests_tagged       std
+    , testGroup "const qualifier"     $ tests_const        std
+    , testGroup "pointer indirection" $ tests_pointer      std
+    , testGroup "combined"            $ tests_combined     std
+    , testGroup "keyword order"       $ tests_keywordOrder std
+    , testGroup "failures"            $ tests_failures     std
     ]
   where
     std = ClangCStandard cStd DisableGnu
@@ -197,15 +195,15 @@ tests_tagged cStd = [
       testCase "struct Foo" $
         -- struct Foo
         checkType cStd [kw "struct", ident "Foo"]
-          @?= Right (tyLit (TypeTagged TagStruct "Foo"))
+          @?= Right (Term $ Literal (TypeTagged TagStruct "Foo"))
     , testCase "union Bar" $
         -- union Bar
         checkType cStd [kw "union", ident "Bar"]
-          @?= Right (tyLit (TypeTagged TagUnion "Bar"))
+          @?= Right (Term $ Literal (TypeTagged TagUnion "Bar"))
     , testCase "enum Baz" $
         -- enum Baz
         checkType cStd [kw "enum", ident "Baz"]
-          @?= Right (tyLit (TypeTagged TagEnum "Baz"))
+          @?= Right (Term $ Literal (TypeTagged TagEnum "Baz"))
     ]
 
 {-------------------------------------------------------------------------------
@@ -233,7 +231,7 @@ tests_const cStd = [
     , testCase "const struct Foo" $
         -- const struct Foo
         checkType cStd [kw "const", kw "struct", ident "Foo"]
-          @?= Right (TyApp Const (tyLit (TypeTagged TagStruct "Foo") ::: VNil))
+          @?= Right (TyApp Const (Term (Literal (TypeTagged TagStruct "Foo")) ::: VNil))
     ]
 
 {-------------------------------------------------------------------------------
@@ -261,7 +259,7 @@ tests_pointer cStd = [
     , testCase "struct Foo*" $
         -- struct Foo *
         checkType cStd [kw "struct", ident "Foo", punc "*"]
-          @?= Right (TyApp Pointer (tyLit (TypeTagged TagStruct "Foo") ::: VNil))
+          @?= Right (TyApp Pointer (Term (Literal (TypeTagged TagStruct "Foo")) ::: VNil))
     ]
 
 {-------------------------------------------------------------------------------
@@ -292,7 +290,7 @@ tests_combined cStd = [
     , testCase "const struct Foo**" $
         -- const struct Foo **
         checkType cStd [kw "const", kw "struct", ident "Foo", punc "*", punc "*"]
-          @?= Right (TyApp Pointer (TyApp Pointer (TyApp Const (tyLit (TypeTagged TagStruct "Foo") ::: VNil) ::: VNil) ::: VNil))
+          @?= Right (TyApp Pointer (TyApp Pointer (TyApp Const (Term (Literal (TypeTagged TagStruct "Foo")) ::: VNil) ::: VNil) ::: VNil))
     , testCase "unsigned long long int" $
         -- unsigned long long int
         checkType cStd [kw "unsigned", kw "long", kw "long", kw "int"]

--- a/c-expr-dsl/test/Test/CExpr/Typecheck/Classify.hs
+++ b/c-expr-dsl/test/Test/CExpr/Typecheck/Classify.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Test.CExpr.Typecheck.Classify (
     tests
   ) where
 
+import Data.Vec.Lazy (Vec (..))
+import DeBruijn (Idx (..), pattern I1)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -28,16 +28,16 @@ tests = testGroup "classify" [
 
 tests_keywordTypes :: TestTree
 tests_keywordTypes = testGroup "keyword type bodies" [
-      testCase "void"       $ assertTypeMacro $ classifyOne "M" [] (tyLit TypeVoid)
-    , testCase "int"        $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeInt Nothing (Just SizeInt)))
-    , testCase "unsigned"   $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeInt (Just Unsigned) Nothing))
-    , testCase "float"      $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeFloat SizeFloat))
-    , testCase "double"     $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeFloat SizeDouble))
-    , testCase "_Bool"      $ assertTypeMacro $ classifyOne "M" [] (tyLit TypeBool)
-    , testCase "char"       $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeChar Nothing))
-    , testCase "struct Foo" $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeTagged TagStruct "Foo"))
-    , testCase "union Bar"  $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeTagged TagUnion  "Bar"))
-    , testCase "enum Baz"   $ assertTypeMacro $ classifyOne "M" [] (tyLit (TypeTagged TagEnum   "Baz"))
+      testCase "void"       $ assertTypeMacro $ classifyOne "M" VNil (tyLit TypeVoid)
+    , testCase "int"        $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeInt Nothing (Just SizeInt)))
+    , testCase "unsigned"   $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeInt (Just Unsigned) Nothing))
+    , testCase "float"      $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeFloat SizeFloat))
+    , testCase "double"     $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeFloat SizeDouble))
+    , testCase "_Bool"      $ assertTypeMacro $ classifyOne "M" VNil (tyLit TypeBool)
+    , testCase "char"       $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeChar Nothing))
+    , testCase "struct Foo" $ assertTypeMacro $ classifyOne "M" VNil (Term (Literal (TypeTagged TagStruct "Foo")))
+    , testCase "union Bar"  $ assertTypeMacro $ classifyOne "M" VNil (Term (Literal (TypeTagged TagUnion  "Bar")))
+    , testCase "enum Baz"   $ assertTypeMacro $ classifyOne "M" VNil (Term (Literal (TypeTagged TagEnum   "Baz")))
     ]
 
 {-------------------------------------------------------------------------------
@@ -46,12 +46,12 @@ tests_keywordTypes = testGroup "keyword type bodies" [
 
 tests_typeApp :: TestTree
 tests_typeApp = testGroup "type application bodies" [
-      testCase "int *"        $ assertTypeMacro $ classifyOne "M" [] (ptrOf (tyLit intTy))
-    , testCase "const int"    $ assertTypeMacro $ classifyOne "M" [] (constOf (tyLit intTy))
-    , testCase "const int *"  $ assertTypeMacro $ classifyOne "M" [] (ptrOf (constOf (tyLit intTy)))
-    , testCase "int * const"  $ assertTypeMacro $ classifyOne "M" [] (constOf (ptrOf (tyLit intTy)))
-    , testCase "void *"       $ assertTypeMacro $ classifyOne "M" [] (ptrOf (tyLit TypeVoid))
-    , testCase "struct Foo *" $ assertTypeMacro $ classifyOne "M" [] (ptrOf (tyLit (TypeTagged TagStruct "Foo")))
+      testCase "int *"        $ assertTypeMacro $ classifyOne "M" VNil (ptrOf (tyLit intTy))
+    , testCase "const int"    $ assertTypeMacro $ classifyOne "M" VNil (constOf (tyLit intTy))
+    , testCase "const int *"  $ assertTypeMacro $ classifyOne "M" VNil (ptrOf (constOf (tyLit intTy)))
+    , testCase "int * const"  $ assertTypeMacro $ classifyOne "M" VNil (constOf (ptrOf (tyLit intTy)))
+    , testCase "void *"       $ assertTypeMacro $ classifyOne "M" VNil (ptrOf (tyLit TypeVoid))
+    , testCase "struct Foo *" $ assertTypeMacro $ classifyOne "M" VNil (ptrOf (Term (Literal (TypeTagged TagStruct "Foo"))))
     ]
 
 {-------------------------------------------------------------------------------
@@ -60,10 +60,10 @@ tests_typeApp = testGroup "type application bodies" [
 
 tests_intLiterals :: TestTree
 tests_intLiterals = testGroup "integer literal bodies" [
-      testCase "0"   $ assertValueMacro $ classifyOne "M" [] (intLit 0)
-    , testCase "1"   $ assertValueMacro $ classifyOne "M" [] (intLit 1)
-    , testCase "42"  $ assertValueMacro $ classifyOne "M" [] (intLit 42)
-    , testCase "-1"  $ assertValueMacro $ classifyOne "M" [] (intLit (-1))
+      testCase "0"   $ assertValueMacro $ classifyOne "M" VNil (intLit 0)
+    , testCase "1"   $ assertValueMacro $ classifyOne "M" VNil (intLit 1)
+    , testCase "42"  $ assertValueMacro $ classifyOne "M" VNil (intLit 42)
+    , testCase "-1"  $ assertValueMacro $ classifyOne "M" VNil (intLit (-1))
     ]
 
 {-------------------------------------------------------------------------------
@@ -72,8 +72,8 @@ tests_intLiterals = testGroup "integer literal bodies" [
 
 tests_arithmetic :: TestTree
 tests_arithmetic = testGroup "arithmetic expression bodies" [
-      testCase "1 + 2"   $ assertValueMacro $ classifyOne "M" [] (add (intLit 1) (intLit 2))
-    , testCase "1 << 4"  $ assertValueMacro $ classifyOne "M" [] (shiftLeft (intLit 1) (intLit 4))
+      testCase "1 + 2"   $ assertValueMacro $ classifyOne "M" VNil (add (intLit 1) (intLit 2))
+    , testCase "1 << 4"  $ assertValueMacro $ classifyOne "M" VNil (shiftLeft (intLit 1) (intLit 4))
     ]
 
 {-------------------------------------------------------------------------------
@@ -84,10 +84,10 @@ tests_functionLike :: TestTree
 tests_functionLike = testGroup "function-like macro bodies" [
       testCase "identity: \\x -> x" $
         assertValueMacro $
-          classifyOne "IDENTITY" ["x"] (mvar "x")
+          classifyOne "IDENTITY" ("x" ::: VNil) (mlocal IZ)
     , testCase "add: \\a b -> a + b" $
         assertValueMacro $
-          classifyOne "ADD" ["a", "b"] (add (mvar "a") (mvar "b"))
+          classifyOne "ADD" ("a" ::: "b" ::: VNil) (add (mlocal I1) (mlocal IZ))
     ]
 
 {-------------------------------------------------------------------------------
@@ -98,16 +98,16 @@ tests_typeEnvChain :: TestTree
 tests_typeEnvChain = testGroup "TypeEnv chain (value macro references)" [
       testCase "B references A (both value macros)" $ do
         let results = runTcSeq
-              [ ("A", [], intLit 1)
-              , ("B", [], mvar "A")
+              [ ("A", intLit 1)
+              , ("B", mvar "A")
               ]
         mapM_ assertValueMacro results
 
     , testCase "C references B which references A" $ do
         let results = runTcSeq
-              [ ("A", [], intLit 42)
-              , ("B", [], mvar "A")
-              , ("C", [], add (mvar "B") (intLit 1))
+              [ ("A", intLit 42)
+              , ("B", mvar "A")
+              , ("C", add (mvar "B") (intLit 1))
               ]
         assertValueMacro $ last results
     ]
@@ -121,15 +121,24 @@ tests_errors = testGroup "error cases" [
       testCase "unbound variable" $
         -- A bare identifier not in TypeEnv and not a macro argument is an
         -- unbound variable.  'tcMacro' returns Left (TcErrors [UnboundVariable ...]).
-        case classifyOne "M" [] (mvar "unknown") of
+        case classifyOne "M" VNil (mvar "unknown") of
           Left  _ -> pure ()
           Right _ -> assertFailure "expected Left for unbound variable"
 
     , testCase "value macro referencing unknown name" $
         -- Even inside arithmetic, an unbound reference fails.
-        case classifyOne "M" [] (add (intLit 1) (mvar "UNDEFINED")) of
+        case classifyOne "M" VNil (add (intLit 1) (mvar "UNDEFINED")) of
           Left  _ -> pure ()
           Right _ -> assertFailure "expected Left for unbound reference in arithmetic"
+
+    , testCase "type macro with unused parameter" $
+        case classifyOne "M" ("X" ::: VNil) ((tyLit (TypeInt Nothing Nothing))) of
+          Left  _ -> pure ()
+          Right r ->
+            assertFailure $ unlines [
+                "expected Left for type macro with unused parameter; but got"
+              , show r
+              ]
     ]
 
 {-------------------------------------------------------------------------------

--- a/c-expr-dsl/test/Test/CExpr/Typecheck/Infra.hs
+++ b/c-expr-dsl/test/Test/CExpr/Typecheck/Infra.hs
@@ -16,78 +16,111 @@ module Test.CExpr.Typecheck.Infra (
   , intLit
   , add
   , shiftLeft
+  , mlocal
   , mvar
   ) where
 
+import Data.Functor.Identity (Identity (..))
 import Data.Map.Strict qualified as Map
+import Data.Nat (Nat (..))
 import Data.Text qualified as Text
 import Data.Vec.Lazy (Vec (..))
+import DeBruijn (Idx (..))
 import Test.Tasty.HUnit
 
-import C.Expr.Syntax
-import C.Expr.Typecheck (MacroTcError, MacroTcResult (..), TypeEnv, tcMacro)
 import C.Type qualified as Runtime
 
-type MacDef = (Name, [Name], Expr Ps)
+import C.Expr.Syntax
+import C.Expr.Typecheck
 
-runTcSeq :: [MacDef] -> [Either MacroTcError MacroTcResult]
+type MacDef = (Name, Expr Z Ps)
+
+tcMacroSimple ::
+     forall ctx.
+     TypeEnv
+  -> Name
+  -> Vec ctx Name
+  -> Expr ctx Ps
+  -> Either MacroTcError (MacroTcResult Name)
+tcMacroSimple tyEnv name params expr =
+    runIdentity $
+      tcMacro tyEnv pure injectTaggedName pure name params expr
+  where
+    tagToName :: TagKind -> Name
+    tagToName = \case
+      TagStruct -> "struct"
+      TagUnion  -> "union"
+      TagEnum   -> "enum"
+
+    injectTaggedName :: TagKind -> Name -> Identity Name
+    injectTaggedName tag nm = pure $ tagToName tag <> " " <> nm
+
+runTcSeq :: [MacDef] -> [Either MacroTcError (MacroTcResult Name)]
 runTcSeq = go Map.empty
   where
-    go :: TypeEnv -> [MacDef] -> [Either MacroTcError MacroTcResult]
-    go _   []                              = []
-    go env ((name, args, body) : rest) =
-      let result = tcMacro env name args body
+    go :: TypeEnv -> [MacDef] -> [Either MacroTcError (MacroTcResult Name)]
+    go _   []                    = []
+    go env ((name, body) : rest) =
+      let result = tcMacroSimple env name VNil body
           env'   = case result of
-                     Right (MacroTcValueExpr _ quant) ->
-                       Map.insert name quant env
+                     Right (MacroTcValueExpr vexpr) ->
+                       Map.insert name (macroValueType vexpr) env
                      _ -> env
       in  result : go env' rest
 
-classifyOne :: Name -> [Name] -> Expr Ps -> Either MacroTcError MacroTcResult
-classifyOne n args body = tcMacro Map.empty n args body
+classifyOne ::
+     forall ctx.
+     Name
+  -> Vec ctx Name
+  -> Expr ctx Ps
+  -> Either MacroTcError (MacroTcResult Name)
+classifyOne n params body = tcMacroSimple Map.empty n params body
 
-isTypeMacro :: MacroTcResult -> Bool
-isTypeMacro (MacroTcTypeExpr _ _) = True
-isTypeMacro _                     = False
+isTypeMacro :: MacroTcResult a -> Bool
+isTypeMacro (MacroTcTypeExpr _) = True
+isTypeMacro _                   = False
 
-isValueMacro :: MacroTcResult -> Bool
-isValueMacro (MacroTcValueExpr _ _) = True
-isValueMacro _                      = False
+isValueMacro :: MacroTcResult a -> Bool
+isValueMacro (MacroTcValueExpr _) = True
+isValueMacro _                    = False
 
-assertTypeMacro :: Show e => Either e MacroTcResult -> Assertion
+assertTypeMacro :: Show e => Either e (MacroTcResult a) -> Assertion
 assertTypeMacro = \case
     Left e  -> assertFailure $ "expected MacroTcTypeExpr, got Left: " ++ show e
     Right r -> assertBool "expected MacroTcTypeExpr" (isTypeMacro r)
 
-assertValueMacro :: Show e => Either e MacroTcResult -> Assertion
+assertValueMacro :: Show e => Either e (MacroTcResult a) -> Assertion
 assertValueMacro = \case
     Left e  -> assertFailure $ "expected MacroTcValueExpr, got Left: " ++ show e
     Right r -> assertBool "expected MacroTcValueExpr" (isValueMacro r)
 
-tyLit :: TypeLit -> Expr Ps
+tyLit :: TypeLit -> Expr ctx Ps
 tyLit = Term . Literal . TypeLit
 
-constOf :: Expr Ps -> Expr Ps
+constOf :: Expr ctx Ps -> Expr ctx Ps
 constOf e = TyApp Const (e ::: VNil)
 
-ptrOf :: Expr Ps -> Expr Ps
+ptrOf :: Expr ctx Ps -> Expr ctx Ps
 ptrOf e = TyApp Pointer (e ::: VNil)
 
 -- | Construct an integer literal expression with a 'signed int' type hint.
 -- Suitable for tests where the exact inferred integer type is not the subject
 -- under test.
-intLit :: Integer -> Expr Ps
+intLit :: Integer -> Expr ctx Ps
 intLit n = Term $ Literal $ ValueLit $ ValueInt $
     IntegerLiteral
       (Text.pack (show n))
       (Runtime.Int Runtime.Signed)
       n
 
-add :: Expr Ps -> Expr Ps -> Expr Ps
+add :: Expr ctx Ps -> Expr ctx Ps -> Expr ctx Ps
 add a b = VaApp NoXApp MAdd (a ::: b ::: VNil)
 
-shiftLeft :: Expr Ps -> Expr Ps -> Expr Ps
+shiftLeft :: Expr ctx Ps -> Expr ctx Ps -> Expr ctx Ps
 shiftLeft a b = VaApp NoXApp MShiftLeft (a ::: b ::: VNil)
 
-mvar :: Name -> Expr Ps
+mlocal :: Idx ctx -> Expr ctx Ps
+mlocal i = Term $ LocalParam i
+
+mvar :: Name -> Expr ctx Ps
 mvar n = Term $ Var NoXVar n []

--- a/c-expr-dsl/test/fixtures/macros.C17.golden
+++ b/c-expr-dsl/test/fixtures/macros.C17.golden
@@ -40,10 +40,10 @@ CONST_PTR_CHAIN_6: Right TyApp Const (TyApp Pointer (TyApp Const (TyApp Pointer 
 CONST_PTR_CHAIN_7: Right TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Const (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
 CONST_PTR_CHAIN_8: Right TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Const (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
 CONST_PTR_CHAIN_9: Right TyApp Pointer (TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
-TY_STRUCT_FOO: Right Term (Literal (TypeLit (TypeTagged TagStruct "Foo")))
-TY_UNION_BAR: Right Term (Literal (TypeLit (TypeTagged TagUnion "Bar")))
-TY_ENUM_BAZ: Right Term (Literal (TypeLit (TypeTagged TagEnum "Baz")))
-TY_STRUCT_FOO_PTR: Right TyApp Pointer (Term (Literal (TypeLit (TypeTagged TagStruct "Foo"))) ::: VNil)
+TY_STRUCT_FOO: Right Term (Literal (TypeTagged TagStruct "Foo"))
+TY_UNION_BAR: Right Term (Literal (TypeTagged TagUnion "Bar"))
+TY_ENUM_BAZ: Right Term (Literal (TypeTagged TagEnum "Baz"))
+TY_STRUCT_FOO_PTR: Right TyApp Pointer (Term (Literal (TypeTagged TagStruct "Foo")) ::: VNil)
 TY_SIZE_T: Right Term (Var NoXVar "size_t" [])
 TY_UINT32_T: Right Term (Var NoXVar "uint32_t" [])
 TY_CONST_SIZE_T: Right TyApp Const (Term (Var NoXVar "size_t" []) ::: VNil)
@@ -62,9 +62,10 @@ EXPR_SHIFT_LEFT: Right VaApp NoXApp MShiftLeft (Term (Literal (ValueLit (ValueIn
 EXPR_BITWISE_OR: Right VaApp NoXApp MBitwiseOr (Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "0x0F", integerLiteralType = Int Signed, integerLiteralValue = 15})))) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "0xF0", integerLiteralType = Int Signed, integerLiteralValue = 240})))) ::: VNil)
 EXPR_PARENS: Right Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "42", integerLiteralType = Int Signed, integerLiteralValue = 42}))))
 EXPR_COMPOUND: Right VaApp NoXApp MMult (VaApp NoXApp MAdd (Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2})))) ::: VNil) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "3", integerLiteralType = Int Signed, integerLiteralValue = 3})))) ::: VNil)
-FUNC_IDENTITY: Right Term (Var NoXVar "x" [])
-FUNC_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "a" []) ::: Term (Var NoXVar "b" []) ::: VNil)
-FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (Var NoXVar "x" []) ::: VNil)
+FUNC_IDENTITY: Right Term (LocalParam 0)
+FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
+FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
+FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)
@@ -72,5 +73,6 @@ CAST_SINGLE_NOKW: Right Term (Var NoXVar "x" [])
 CAST_SINGLE_KW: Left <parse error>
 BAD_CAST: Left <parse error>
 BAD_KEYWORD_AS_PARAM: Left <parse error>
+TYPE_FUN_WITH_PARAM: Right Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt))))
 BAD_TERNARY: Left <parse error>
 BAD_LONG_DOUBLE: Left <parse error>

--- a/c-expr-dsl/test/fixtures/macros.C23.golden
+++ b/c-expr-dsl/test/fixtures/macros.C23.golden
@@ -40,10 +40,10 @@ CONST_PTR_CHAIN_6: Right TyApp Const (TyApp Pointer (TyApp Const (TyApp Pointer 
 CONST_PTR_CHAIN_7: Right TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Const (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
 CONST_PTR_CHAIN_8: Right TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Const (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
 CONST_PTR_CHAIN_9: Right TyApp Pointer (TyApp Const (TyApp Pointer (TyApp Pointer (TyApp Pointer (TyApp Pointer (Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt)))) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil) ::: VNil)
-TY_STRUCT_FOO: Right Term (Literal (TypeLit (TypeTagged TagStruct "Foo")))
-TY_UNION_BAR: Right Term (Literal (TypeLit (TypeTagged TagUnion "Bar")))
-TY_ENUM_BAZ: Right Term (Literal (TypeLit (TypeTagged TagEnum "Baz")))
-TY_STRUCT_FOO_PTR: Right TyApp Pointer (Term (Literal (TypeLit (TypeTagged TagStruct "Foo"))) ::: VNil)
+TY_STRUCT_FOO: Right Term (Literal (TypeTagged TagStruct "Foo"))
+TY_UNION_BAR: Right Term (Literal (TypeTagged TagUnion "Bar"))
+TY_ENUM_BAZ: Right Term (Literal (TypeTagged TagEnum "Baz"))
+TY_STRUCT_FOO_PTR: Right TyApp Pointer (Term (Literal (TypeTagged TagStruct "Foo")) ::: VNil)
 TY_SIZE_T: Right Term (Var NoXVar "size_t" [])
 TY_UINT32_T: Right Term (Var NoXVar "uint32_t" [])
 TY_CONST_SIZE_T: Right TyApp Const (Term (Var NoXVar "size_t" []) ::: VNil)
@@ -62,9 +62,10 @@ EXPR_SHIFT_LEFT: Right VaApp NoXApp MShiftLeft (Term (Literal (ValueLit (ValueIn
 EXPR_BITWISE_OR: Right VaApp NoXApp MBitwiseOr (Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "0x0F", integerLiteralType = Int Signed, integerLiteralValue = 15})))) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "0xF0", integerLiteralType = Int Signed, integerLiteralValue = 240})))) ::: VNil)
 EXPR_PARENS: Right Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "42", integerLiteralType = Int Signed, integerLiteralValue = 42}))))
 EXPR_COMPOUND: Right VaApp NoXApp MMult (VaApp NoXApp MAdd (Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2})))) ::: VNil) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "3", integerLiteralType = Int Signed, integerLiteralValue = 3})))) ::: VNil)
-FUNC_IDENTITY: Right Term (Var NoXVar "x" [])
-FUNC_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "a" []) ::: Term (Var NoXVar "b" []) ::: VNil)
-FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (Var NoXVar "x" []) ::: VNil)
+FUNC_IDENTITY: Right Term (LocalParam 0)
+FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
+FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
+FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)
@@ -72,5 +73,6 @@ CAST_SINGLE_NOKW: Right Term (Var NoXVar "x" [])
 CAST_SINGLE_KW: Left <parse error>
 BAD_CAST: Left <parse error>
 BAD_KEYWORD_AS_PARAM: Left <parse error>
+TYPE_FUN_WITH_PARAM: Right Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt))))
 BAD_TERNARY: Left <parse error>
 BAD_LONG_DOUBLE: Left <parse error>

--- a/c-expr-dsl/test/fixtures/macros.h
+++ b/c-expr-dsl/test/fixtures/macros.h
@@ -145,6 +145,7 @@
 #define FUNC_IDENTITY(x) x
 #define FUNC_ADD(a, b) a + b
 #define FUNC_NEG(x) (-x)
+#define FUNC_MULTIPLE_LOCAL_PARAMS(a, b, c, d) a + (b - (c + d))
 // TODO <https://github.com/well-typed/hs-bindgen/issues/1904>
 //
 // Ternary operator is not yet in the expression grammar (see below).
@@ -192,6 +193,9 @@
 
 // This is genuine erroneous function; keywords must not be parameter names.
 #define BAD_KEYWORD_AS_PARAM(int) x
+
+// We can parse this macro, but typecheck will fail.
+#define TYPE_FUN_WITH_PARAM(X) int
 
 // TODO <https://github.com/well-typed/hs-bindgen/issues/1904>
 //

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -63,9 +63,15 @@
   #1790][is-1790] and [PR #1917][pr-1917].
 * Print type operators with infix notation in generated bindings. See [issue
   #1715][is-1715] and [PR #1917][pr-1917].
+* Function-like macro parameters are now resolved to de Bruijn indices at
+  parse time and correctly propagated through the backend.
 
 ### Bug fixes
 
+* Unresolved tagged types in macro expressions produce a `Warning`-level
+  diagnostic (`MacroTypecheckErrorUnresolvedTaggedType`) instead of panicking.
+* Forward-declared (opaque) tagged types are included in `knownTaggedTypes`
+  during macro typechecking.
 * Fixture tests now invoke the same GHC that cabal used to build the test
   suite, so they no longer fail when `with-compiler` is set to a non-default
   version and the system's `ghc` on `PATH` is something else. See [issue

--- a/hs-bindgen/examples/golden/edge-cases/mangle_fun_param_names.h
+++ b/hs-bindgen/examples/golden/edge-cases/mangle_fun_param_names.h
@@ -1,4 +1,4 @@
-// See issue #1490
+/* We must mangle function parameter names */
 
 struct S {
   int x;
@@ -6,9 +6,6 @@ struct S {
 
 typedef struct S T;
 
-T fun(T x);
-
-/* We must mangle function parameter names */
 void param_underscore(T _);
 void param_uppercase(T Type);
 void param_undersore_capital(T _T);

--- a/hs-bindgen/examples/golden/macros/macro_functions.h
+++ b/hs-bindgen/examples/golden/macros/macro_functions.h
@@ -3,12 +3,14 @@
 
 #define ID(X) X
 #define CONST(X,Y) X
+#define CONST_3(X,Y,Z) X
 
 #define CMP(X,Y) X < Y
 #define FUN1(X,Y) X + 12ull * Y
 #define FUN2(X,Y) X << ( 3ull * Y )
 
 #define G(X,Y) CONST(INCR(Y),ID(X))
+#define G_3(X,Y,Z) CONST_3(INCR(Y),ID(X),ID(Z))
 
 #define DIV1(X,Y) X / ( Y + 12u )
 #define DIV2(X,Y) 10.0f * X / Y

--- a/hs-bindgen/examples/golden/macros/macro_type_unresolved_tagged.h
+++ b/hs-bindgen/examples/golden/macros/macro_type_unresolved_tagged.h
@@ -1,0 +1,12 @@
+// Struct whose parse fails because of an unsupported field type (long double).
+// As a result it is absent from the declaration environment, so the macro
+// below triggers 'MacroTypecheckErrorUnresolvedTaggedType'.
+struct Unparsable {
+  long double x;
+};
+
+#define PTR_UNPARSABLE struct Unparsable *
+
+#define PTR_DOES_NOT_EXIST struct DoesNotExist *
+
+#define DOES_NOT_EXIST struct DoesNotExist

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/Example.hs
@@ -1285,7 +1285,7 @@ instance ( ty ~ HsBindgen.Runtime.LibC.CSize
 
 instance FLAM.Offset RIP.CInt Flexible_array_Aux where
 
-  offset = \_ty0 -> 8
+  offset = \_proxy0 -> 8
 
 {-| Structure with flexible array member.
 

--- a/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/fixtures/documentation/doxygen_docs/th.txt
@@ -1434,7 +1434,7 @@ instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"flexible_array_count")
 instance Offset CInt Flexible_array_Aux
-    where offset = \_ty_0 -> 8
+    where offset = \_proxy_0 -> 8
 type Flexible_array = WithFlam CInt Flexible_array_Aux
 {-| Struct with invariant.
 

--- a/hs-bindgen/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam/Example.hs
@@ -86,7 +86,7 @@ instance ( ty ~ RIP.CInt
 
 instance FLAM.Offset RIP.CChar Pascal_Aux where
 
-  offset = \_ty0 -> 4
+  offset = \_proxy0 -> 4
 
 {-| __C declaration:__ @struct pascal@
 
@@ -222,7 +222,7 @@ instance ( ty ~ RIP.CInt
 
 instance FLAM.Offset Foo_bar Foo_Aux where
 
-  offset = \_ty0 -> 4
+  offset = \_proxy0 -> 4
 
 {-| __C declaration:__ @struct foo@
 
@@ -308,7 +308,7 @@ instance ( ty ~ RIP.CChar
 
 instance FLAM.Offset RIP.CChar Diff_Aux where
 
-  offset = \_ty0 -> 9
+  offset = \_proxy0 -> 9
 
 {-| __C declaration:__ @struct diff@
 
@@ -376,7 +376,7 @@ instance ( ty ~ RIP.CInt
 
 instance FLAM.Offset (CA.ConstantArray 3 RIP.CInt) Triplets_Aux where
 
-  offset = \_ty0 -> 4
+  offset = \_proxy0 -> 4
 
 {-| The flexible array member is a multi-dimensional array of unknown size. In particular, it is a is an array of unknown size, where each element is of type length-3-array-of-int.
 

--- a/hs-bindgen/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam/th.txt
@@ -30,7 +30,7 @@ instance (~) ty CInt =>
          HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"pascal_len")
 instance Offset CChar Pascal_Aux
-    where offset = \_ty_0 -> 4
+    where offset = \_proxy_0 -> 4
 type Pascal = WithFlam CChar Pascal_Aux
 {-| __C declaration:__ @struct \@foo_bar@
 
@@ -104,7 +104,7 @@ instance HasCField Foo_Aux "foo_len"
 instance (~) ty CInt => HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"foo_len")
 instance Offset Foo_bar Foo_Aux
-    where offset = \_ty_0 -> 4
+    where offset = \_proxy_0 -> 4
 type Foo = WithFlam Foo_bar Foo_Aux
 {-| __C declaration:__ @struct diff@
 
@@ -151,7 +151,7 @@ instance (~) ty CChar =>
          HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"diff_second")
 instance Offset CChar Diff_Aux
-    where offset = \_ty_0 -> 9
+    where offset = \_proxy_0 -> 9
 type Diff = WithFlam CChar Diff_Aux
 {-| The flexible array member is a multi-dimensional array of unknown size. In particular, it is a is an array of unknown size, where each element is of type length-3-array-of-int.
 
@@ -186,5 +186,5 @@ instance (~) ty CInt =>
          HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"triplets_len")
 instance Offset (ConstantArray 3 CInt) Triplets_Aux
-    where offset = \_ty_0 -> 4
+    where offset = \_proxy_0 -> 4
 type Triplets = WithFlam (ConstantArray 3 CInt) Triplets_Aux

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/Example.hs
@@ -78,7 +78,7 @@ instance ( ty ~ RIP.CInt
 
 instance FLAM.Offset RIP.CLong Vector_Aux where
 
-  offset = \_ty0 -> 8
+  offset = \_proxy0 -> 8
 
 {-| __C declaration:__ @struct Vector@
 

--- a/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/flam_functions/th.txt
@@ -91,7 +91,7 @@ instance (~) ty CInt =>
          HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"vector_length")
 instance Offset CLong Vector_Aux
-    where offset = \_ty_0 -> 8
+    where offset = \_proxy_0 -> 8
 type Vector = WithFlam CLong Vector_Aux
 -- __unique:__ @test_edgecasesflam_functions_Example_Safe_vector_alloc@
 foreign import ccall safe "hs_bindgen_231473be98482b20" hs_bindgen_231473be98482b20_base ::

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example.hs
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.T(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 3:8@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+data T = T
+  { t_x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @edge-cases\/mangle_fun_param_names.h 4:7@
+
+         __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T where
+
+  readRaw =
+    \ptr0 ->
+          pure T
+      <*> HasCField.readRaw (RIP.Proxy @"t_x") ptr0
+
+instance Marshal.WriteRaw T where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T t_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t_x") ptr0 t_x2
+
+deriving via Marshal.EquivStorable T instance RIP.Storable T
+
+instance HasCField.HasCField T "t_x" where
+
+  type CFieldType T "t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/FunPtr.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.FunPtr
+    ( Example.FunPtr.param_underscore
+    , Example.FunPtr.param_uppercase
+    , Example.FunPtr.param_undersore_capital
+    , Example.FunPtr.param_haskell_reserved_name
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <edge-cases/mangle_fun_param_names.h>"
+  , "/* test_edgecasesmangle_fun_param_na_Example_get_param_underscore */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_2e4a9e3fbd884275 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_underscore;"
+  , "}"
+  , "/* test_edgecasesmangle_fun_param_na_Example_get_param_uppercase */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_3364ddfa127443d9 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_uppercase;"
+  , "}"
+  , "/* test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_33f2dcd4eac093b3 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_undersore_capital;"
+  , "}"
+  , "/* test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_89c62efefee0f3b3 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_haskell_reserved_name;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_underscore@
+foreign import ccall unsafe "hs_bindgen_2e4a9e3fbd884275" hs_bindgen_2e4a9e3fbd884275_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_underscore@
+hs_bindgen_2e4a9e3fbd884275 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_2e4a9e3fbd884275 =
+  RIP.fromFFIType hs_bindgen_2e4a9e3fbd884275_base
+
+{-# NOINLINE param_underscore #-}
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore :: RIP.FunPtr (T -> IO ())
+param_underscore =
+  RIP.unsafePerformIO hs_bindgen_2e4a9e3fbd884275
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_3364ddfa127443d9" hs_bindgen_3364ddfa127443d9_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_uppercase@
+hs_bindgen_3364ddfa127443d9 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_3364ddfa127443d9 =
+  RIP.fromFFIType hs_bindgen_3364ddfa127443d9_base
+
+{-# NOINLINE param_uppercase #-}
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase :: RIP.FunPtr (T -> IO ())
+param_uppercase =
+  RIP.unsafePerformIO hs_bindgen_3364ddfa127443d9
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_33f2dcd4eac093b3" hs_bindgen_33f2dcd4eac093b3_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital@
+hs_bindgen_33f2dcd4eac093b3 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_33f2dcd4eac093b3 =
+  RIP.fromFFIType hs_bindgen_33f2dcd4eac093b3_base
+
+{-# NOINLINE param_undersore_capital #-}
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital :: RIP.FunPtr (T -> IO ())
+param_undersore_capital =
+  RIP.unsafePerformIO hs_bindgen_33f2dcd4eac093b3
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_89c62efefee0f3b3" hs_bindgen_89c62efefee0f3b3_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name@
+hs_bindgen_89c62efefee0f3b3 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_89c62efefee0f3b3 =
+  RIP.fromFFIType hs_bindgen_89c62efefee0f3b3_base
+
+{-# NOINLINE param_haskell_reserved_name #-}
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name :: RIP.FunPtr (T -> IO ())
+param_haskell_reserved_name =
+  RIP.unsafePerformIO hs_bindgen_89c62efefee0f3b3

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/Safe.hs
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/Safe.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Safe
+    ( Example.Safe.param_underscore
+    , Example.Safe.param_uppercase
+    , Example.Safe.param_undersore_capital
+    , Example.Safe.param_haskell_reserved_name
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <edge-cases/mangle_fun_param_names.h>"
+  , "void hs_bindgen_32fb10fccaa5c64b ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_underscore)(*arg1);"
+  , "}"
+  , "void hs_bindgen_5888c48ab8bc55c6 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_uppercase)(*arg1);"
+  , "}"
+  , "void hs_bindgen_330a5861a2d663d1 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_undersore_capital)(*arg1);"
+  , "}"
+  , "void hs_bindgen_8db88cfd2f21fdb1 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_haskell_reserved_name)(*arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
+foreign import ccall safe "hs_bindgen_32fb10fccaa5c64b" hs_bindgen_32fb10fccaa5c64b_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
+hs_bindgen_32fb10fccaa5c64b ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_32fb10fccaa5c64b =
+  RIP.fromFFIType hs_bindgen_32fb10fccaa5c64b_base
+
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore ::
+     T
+     -- ^ __C declaration:__ @_@
+  -> IO ()
+param_underscore =
+  \_0 ->
+    RIP.with _0 (\_1 -> hs_bindgen_32fb10fccaa5c64b _1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_uppercase@
+foreign import ccall safe "hs_bindgen_5888c48ab8bc55c6" hs_bindgen_5888c48ab8bc55c6_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_uppercase@
+hs_bindgen_5888c48ab8bc55c6 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_5888c48ab8bc55c6 =
+  RIP.fromFFIType hs_bindgen_5888c48ab8bc55c6_base
+
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase ::
+     T
+     -- ^ __C declaration:__ @Type@
+  -> IO ()
+param_uppercase =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_5888c48ab8bc55c6 type'1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_undersore_capital@
+foreign import ccall safe "hs_bindgen_330a5861a2d663d1" hs_bindgen_330a5861a2d663d1_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_undersore_capital@
+hs_bindgen_330a5861a2d663d1 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_330a5861a2d663d1 =
+  RIP.fromFFIType hs_bindgen_330a5861a2d663d1_base
+
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital ::
+     T
+     -- ^ __C declaration:__ @_T@
+  -> IO ()
+param_undersore_capital =
+  \_T0 ->
+    RIP.with _T0 (\_T1 ->
+                    hs_bindgen_330a5861a2d663d1 _T1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_haskell_reserved_name@
+foreign import ccall safe "hs_bindgen_8db88cfd2f21fdb1" hs_bindgen_8db88cfd2f21fdb1_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_8db88cfd2f21fdb1 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_8db88cfd2f21fdb1 =
+  RIP.fromFFIType hs_bindgen_8db88cfd2f21fdb1_base
+
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name ::
+     T
+     -- ^ __C declaration:__ @type@
+  -> IO ()
+param_haskell_reserved_name =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_8db88cfd2f21fdb1 type'1)

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/Example/Unsafe.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Unsafe
+    ( Example.Unsafe.param_underscore
+    , Example.Unsafe.param_uppercase
+    , Example.Unsafe.param_undersore_capital
+    , Example.Unsafe.param_haskell_reserved_name
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <edge-cases/mangle_fun_param_names.h>"
+  , "void hs_bindgen_0ff5c586f093fdab ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_underscore)(*arg1);"
+  , "}"
+  , "void hs_bindgen_83f7b80a01e50f06 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_uppercase)(*arg1);"
+  , "}"
+  , "void hs_bindgen_a015d9b3e63c0a07 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_undersore_capital)(*arg1);"
+  , "}"
+  , "void hs_bindgen_6ac28bcdfd5bcd07 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_haskell_reserved_name)(*arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_underscore@
+foreign import ccall unsafe "hs_bindgen_0ff5c586f093fdab" hs_bindgen_0ff5c586f093fdab_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_underscore@
+hs_bindgen_0ff5c586f093fdab ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_0ff5c586f093fdab =
+  RIP.fromFFIType hs_bindgen_0ff5c586f093fdab_base
+
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore ::
+     T
+     -- ^ __C declaration:__ @_@
+  -> IO ()
+param_underscore =
+  \_0 ->
+    RIP.with _0 (\_1 -> hs_bindgen_0ff5c586f093fdab _1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_83f7b80a01e50f06" hs_bindgen_83f7b80a01e50f06_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_uppercase@
+hs_bindgen_83f7b80a01e50f06 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_83f7b80a01e50f06 =
+  RIP.fromFFIType hs_bindgen_83f7b80a01e50f06_base
+
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase ::
+     T
+     -- ^ __C declaration:__ @Type@
+  -> IO ()
+param_uppercase =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_83f7b80a01e50f06 type'1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_a015d9b3e63c0a07" hs_bindgen_a015d9b3e63c0a07_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_undersore_capital@
+hs_bindgen_a015d9b3e63c0a07 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_a015d9b3e63c0a07 =
+  RIP.fromFFIType hs_bindgen_a015d9b3e63c0a07_base
+
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital ::
+     T
+     -- ^ __C declaration:__ @_T@
+  -> IO ()
+param_undersore_capital =
+  \_T0 ->
+    RIP.with _T0 (\_T1 ->
+                    hs_bindgen_a015d9b3e63c0a07 _T1)
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_6ac28bcdfd5bcd07" hs_bindgen_6ac28bcdfd5bcd07_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_6ac28bcdfd5bcd07 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_6ac28bcdfd5bcd07 =
+  RIP.fromFFIType hs_bindgen_6ac28bcdfd5bcd07_base
+
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name ::
+     T
+     -- ^ __C declaration:__ @type@
+  -> IO ()
+param_haskell_reserved_name =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_6ac28bcdfd5bcd07 type'1)

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/bindingspec.yaml
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/bindingspec.yaml
@@ -1,0 +1,28 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: edge-cases/mangle_fun_param_names.h
+  cname: struct S
+  hsname: T
+- headers: edge-cases/mangle_fun_param_names.h
+  cname: T
+  hsname: T
+hstypes:
+- hsname: T
+  representation:
+    record:
+      constructor: T
+      fields:
+      - t_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/th.txt
+++ b/hs-bindgen/fixtures/edge-cases/mangle_fun_param_names/th.txt
@@ -1,0 +1,375 @@
+-- addDependentFile examples/golden/edge-cases/mangle_fun_param_names.h
+-- #include <edge-cases/mangle_fun_param_names.h>
+-- void hs_bindgen_32fb10fccaa5c64b (
+--   T *arg1
+-- )
+-- {
+--   (param_underscore)(*arg1);
+-- }
+-- void hs_bindgen_5888c48ab8bc55c6 (
+--   T *arg1
+-- )
+-- {
+--   (param_uppercase)(*arg1);
+-- }
+-- void hs_bindgen_330a5861a2d663d1 (
+--   T *arg1
+-- )
+-- {
+--   (param_undersore_capital)(*arg1);
+-- }
+-- void hs_bindgen_8db88cfd2f21fdb1 (
+--   T *arg1
+-- )
+-- {
+--   (param_haskell_reserved_name)(*arg1);
+-- }
+-- void hs_bindgen_0ff5c586f093fdab (
+--   T *arg1
+-- )
+-- {
+--   (param_underscore)(*arg1);
+-- }
+-- void hs_bindgen_83f7b80a01e50f06 (
+--   T *arg1
+-- )
+-- {
+--   (param_uppercase)(*arg1);
+-- }
+-- void hs_bindgen_a015d9b3e63c0a07 (
+--   T *arg1
+-- )
+-- {
+--   (param_undersore_capital)(*arg1);
+-- }
+-- void hs_bindgen_6ac28bcdfd5bcd07 (
+--   T *arg1
+-- )
+-- {
+--   (param_haskell_reserved_name)(*arg1);
+-- }
+-- /* test_edgecasesmangle_fun_param_na_Example_get_param_underscore */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_2e4a9e3fbd884275 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_underscore;
+-- }
+-- /* test_edgecasesmangle_fun_param_na_Example_get_param_uppercase */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_3364ddfa127443d9 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_uppercase;
+-- }
+-- /* test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_33f2dcd4eac093b3 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_undersore_capital;
+-- }
+-- /* test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_89c62efefee0f3b3 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_haskell_reserved_name;
+-- }
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 3:8@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+data T
+    = T {t_x :: CInt
+         {- ^ __C declaration:__ @x@
+
+              __defined at:__ @edge-cases\/mangle_fun_param_names.h 4:7@
+
+              __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+         -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T
+    where readRaw = \ptr_0 -> pure T <*> readRaw (Proxy @"t_x") ptr_0
+instance WriteRaw T
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
+deriving via (EquivStorable T) instance Storable T
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
+foreign import ccall safe "hs_bindgen_32fb10fccaa5c64b" hs_bindgen_32fb10fccaa5c64b_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
+hs_bindgen_32fb10fccaa5c64b :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
+hs_bindgen_32fb10fccaa5c64b = fromFFIType hs_bindgen_32fb10fccaa5c64b_base
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_safe :: T -> IO ()
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_safe = \__0 -> with __0 (\__1 -> hs_bindgen_32fb10fccaa5c64b __1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_uppercase@
+foreign import ccall safe "hs_bindgen_5888c48ab8bc55c6" hs_bindgen_5888c48ab8bc55c6_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_uppercase@
+hs_bindgen_5888c48ab8bc55c6 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_uppercase@
+hs_bindgen_5888c48ab8bc55c6 = fromFFIType hs_bindgen_5888c48ab8bc55c6_base
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_safe :: T -> IO ()
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_safe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_5888c48ab8bc55c6 type'_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_undersore_capital@
+foreign import ccall safe "hs_bindgen_330a5861a2d663d1" hs_bindgen_330a5861a2d663d1_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_undersore_capital@
+hs_bindgen_330a5861a2d663d1 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_undersore_capital@
+hs_bindgen_330a5861a2d663d1 = fromFFIType hs_bindgen_330a5861a2d663d1_base
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_safe :: T -> IO ()
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_safe = \_T_0 -> with _T_0 (\_T_1 -> hs_bindgen_330a5861a2d663d1 _T_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_haskell_reserved_name@
+foreign import ccall safe "hs_bindgen_8db88cfd2f21fdb1" hs_bindgen_8db88cfd2f21fdb1_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_8db88cfd2f21fdb1 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_8db88cfd2f21fdb1 = fromFFIType hs_bindgen_8db88cfd2f21fdb1_base
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_safe :: T -> IO ()
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_safe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_8db88cfd2f21fdb1 type'_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_underscore@
+foreign import ccall unsafe "hs_bindgen_0ff5c586f093fdab" hs_bindgen_0ff5c586f093fdab_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_underscore@
+hs_bindgen_0ff5c586f093fdab :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_underscore@
+hs_bindgen_0ff5c586f093fdab = fromFFIType hs_bindgen_0ff5c586f093fdab_base
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_unsafe = \__0 -> with __0 (\__1 -> hs_bindgen_0ff5c586f093fdab __1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_83f7b80a01e50f06" hs_bindgen_83f7b80a01e50f06_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_uppercase@
+hs_bindgen_83f7b80a01e50f06 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_uppercase@
+hs_bindgen_83f7b80a01e50f06 = fromFFIType hs_bindgen_83f7b80a01e50f06_base
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_unsafe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_83f7b80a01e50f06 type'_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_a015d9b3e63c0a07" hs_bindgen_a015d9b3e63c0a07_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_undersore_capital@
+hs_bindgen_a015d9b3e63c0a07 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_undersore_capital@
+hs_bindgen_a015d9b3e63c0a07 = fromFFIType hs_bindgen_a015d9b3e63c0a07_base
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_unsafe = \_T_0 -> with _T_0 (\_T_1 -> hs_bindgen_a015d9b3e63c0a07 _T_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_6ac28bcdfd5bcd07" hs_bindgen_6ac28bcdfd5bcd07_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_6ac28bcdfd5bcd07 :: Ptr T -> IO ()
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_6ac28bcdfd5bcd07 = fromFFIType hs_bindgen_6ac28bcdfd5bcd07_base
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_unsafe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_6ac28bcdfd5bcd07 type'_1)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_underscore@
+foreign import ccall unsafe "hs_bindgen_2e4a9e3fbd884275" hs_bindgen_2e4a9e3fbd884275_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_underscore@
+hs_bindgen_2e4a9e3fbd884275 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_underscore@
+hs_bindgen_2e4a9e3fbd884275 = fromFFIType hs_bindgen_2e4a9e3fbd884275_base
+{-# NOINLINE param_underscore_funptr #-}
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 9:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_underscore_funptr = unsafePerformIO hs_bindgen_2e4a9e3fbd884275
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_3364ddfa127443d9" hs_bindgen_3364ddfa127443d9_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_uppercase@
+hs_bindgen_3364ddfa127443d9 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_uppercase@
+hs_bindgen_3364ddfa127443d9 = fromFFIType hs_bindgen_3364ddfa127443d9_base
+{-# NOINLINE param_uppercase_funptr #-}
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 10:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_uppercase_funptr = unsafePerformIO hs_bindgen_3364ddfa127443d9
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_33f2dcd4eac093b3" hs_bindgen_33f2dcd4eac093b3_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital@
+hs_bindgen_33f2dcd4eac093b3 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_undersore_capital@
+hs_bindgen_33f2dcd4eac093b3 = fromFFIType hs_bindgen_33f2dcd4eac093b3_base
+{-# NOINLINE param_undersore_capital_funptr #-}
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 11:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_undersore_capital_funptr = unsafePerformIO hs_bindgen_33f2dcd4eac093b3
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_89c62efefee0f3b3" hs_bindgen_89c62efefee0f3b3_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name@
+hs_bindgen_89c62efefee0f3b3 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_edgecasesmangle_fun_param_na_Example_get_param_haskell_reserved_name@
+hs_bindgen_89c62efefee0f3b3 = fromFFIType hs_bindgen_89c62efefee0f3b3_base
+{-# NOINLINE param_haskell_reserved_name_funptr #-}
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @edge-cases\/mangle_fun_param_names.h 12:6@
+
+    __exported by:__ @edge-cases\/mangle_fun_param_names.h@
+-}
+param_haskell_reserved_name_funptr = unsafePerformIO hs_bindgen_89c62efefee0f3b3

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/FunPtr.hs
@@ -3,6 +3,10 @@
 
 module Example.FunPtr
     ( Example.FunPtr.fun
+    , Example.FunPtr.param_underscore
+    , Example.FunPtr.param_uppercase
+    , Example.FunPtr.param_undersore_capital
+    , Example.FunPtr.param_haskell_reserved_name
     )
   where
 
@@ -19,6 +23,38 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , ")"
   , "{"
   , "  return &fun;"
+  , "}"
+  , "/* test_functionsheap_typesstruct_Example_get_param_underscore */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_ee52ac50697405f8 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_underscore;"
+  , "}"
+  , "/* test_functionsheap_typesstruct_Example_get_param_uppercase */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_b51cac34e6c4eca3 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_uppercase;"
+  , "}"
+  , "/* test_functionsheap_typesstruct_Example_get_param_undersore_capital */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_2302284a38d84764 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_undersore_capital;"
+  , "}"
+  , "/* test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_af57be8569d5f651 (void)) ("
+  , "  T arg1"
+  , ")"
+  , "{"
+  , "  return &param_haskell_reserved_name;"
   , "}"
   ]))
 
@@ -40,3 +76,83 @@ hs_bindgen_071e2eda58051e4a =
 -}
 fun :: RIP.FunPtr (T -> IO T)
 fun = RIP.unsafePerformIO hs_bindgen_071e2eda58051e4a
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_underscore@
+foreign import ccall unsafe "hs_bindgen_ee52ac50697405f8" hs_bindgen_ee52ac50697405f8_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_underscore@
+hs_bindgen_ee52ac50697405f8 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_ee52ac50697405f8 =
+  RIP.fromFFIType hs_bindgen_ee52ac50697405f8_base
+
+{-# NOINLINE param_underscore #-}
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore :: RIP.FunPtr (T -> IO ())
+param_underscore =
+  RIP.unsafePerformIO hs_bindgen_ee52ac50697405f8
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_b51cac34e6c4eca3" hs_bindgen_b51cac34e6c4eca3_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_uppercase@
+hs_bindgen_b51cac34e6c4eca3 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_b51cac34e6c4eca3 =
+  RIP.fromFFIType hs_bindgen_b51cac34e6c4eca3_base
+
+{-# NOINLINE param_uppercase #-}
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase :: RIP.FunPtr (T -> IO ())
+param_uppercase =
+  RIP.unsafePerformIO hs_bindgen_b51cac34e6c4eca3
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_2302284a38d84764" hs_bindgen_2302284a38d84764_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_undersore_capital@
+hs_bindgen_2302284a38d84764 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_2302284a38d84764 =
+  RIP.fromFFIType hs_bindgen_2302284a38d84764_base
+
+{-# NOINLINE param_undersore_capital #-}
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital :: RIP.FunPtr (T -> IO ())
+param_undersore_capital =
+  RIP.unsafePerformIO hs_bindgen_2302284a38d84764
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_af57be8569d5f651" hs_bindgen_af57be8569d5f651_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name@
+hs_bindgen_af57be8569d5f651 :: IO (RIP.FunPtr (T -> IO ()))
+hs_bindgen_af57be8569d5f651 =
+  RIP.fromFFIType hs_bindgen_af57be8569d5f651_base
+
+{-# NOINLINE param_haskell_reserved_name #-}
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name :: RIP.FunPtr (T -> IO ())
+param_haskell_reserved_name =
+  RIP.unsafePerformIO hs_bindgen_af57be8569d5f651

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/Safe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/Safe.hs
@@ -3,6 +3,10 @@
 
 module Example.Safe
     ( Example.Safe.fun
+    , Example.Safe.param_underscore
+    , Example.Safe.param_uppercase
+    , Example.Safe.param_undersore_capital
+    , Example.Safe.param_haskell_reserved_name
     )
   where
 
@@ -18,6 +22,30 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , ")"
   , "{"
   , "  *arg2 = (fun)(*arg1);"
+  , "}"
+  , "void hs_bindgen_8b003c42270f977d ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_underscore)(*arg1);"
+  , "}"
+  , "void hs_bindgen_820d4de13c1d8dff ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_uppercase)(*arg1);"
+  , "}"
+  , "void hs_bindgen_aa622269ffe58e15 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_undersore_capital)(*arg1);"
+  , "}"
+  , "void hs_bindgen_40fff9d72335931a ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_haskell_reserved_name)(*arg1);"
   , "}"
   ]))
 
@@ -50,3 +78,110 @@ fun =
     RIP.with x0 (\x1 ->
                    RIP.allocaAndPeek (\res2 ->
                                         hs_bindgen_a5d53f538e59b1fc x1 res2))
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_underscore@
+foreign import ccall safe "hs_bindgen_8b003c42270f977d" hs_bindgen_8b003c42270f977d_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_underscore@
+hs_bindgen_8b003c42270f977d ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_8b003c42270f977d =
+  RIP.fromFFIType hs_bindgen_8b003c42270f977d_base
+
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore ::
+     T
+     -- ^ __C declaration:__ @_@
+  -> IO ()
+param_underscore =
+  \_0 ->
+    RIP.with _0 (\_1 -> hs_bindgen_8b003c42270f977d _1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_uppercase@
+foreign import ccall safe "hs_bindgen_820d4de13c1d8dff" hs_bindgen_820d4de13c1d8dff_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_uppercase@
+hs_bindgen_820d4de13c1d8dff ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_820d4de13c1d8dff =
+  RIP.fromFFIType hs_bindgen_820d4de13c1d8dff_base
+
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase ::
+     T
+     -- ^ __C declaration:__ @Type@
+  -> IO ()
+param_uppercase =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_820d4de13c1d8dff type'1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_undersore_capital@
+foreign import ccall safe "hs_bindgen_aa622269ffe58e15" hs_bindgen_aa622269ffe58e15_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_undersore_capital@
+hs_bindgen_aa622269ffe58e15 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_aa622269ffe58e15 =
+  RIP.fromFFIType hs_bindgen_aa622269ffe58e15_base
+
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital ::
+     T
+     -- ^ __C declaration:__ @_T@
+  -> IO ()
+param_undersore_capital =
+  \_T0 ->
+    RIP.with _T0 (\_T1 ->
+                    hs_bindgen_aa622269ffe58e15 _T1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_haskell_reserved_name@
+foreign import ccall safe "hs_bindgen_40fff9d72335931a" hs_bindgen_40fff9d72335931a_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_40fff9d72335931a ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_40fff9d72335931a =
+  RIP.fromFFIType hs_bindgen_40fff9d72335931a_base
+
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name ::
+     T
+     -- ^ __C declaration:__ @type@
+  -> IO ()
+param_haskell_reserved_name =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_40fff9d72335931a type'1)

--- a/hs-bindgen/fixtures/functions/heap_types/struct/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/Example/Unsafe.hs
@@ -3,6 +3,10 @@
 
 module Example.Unsafe
     ( Example.Unsafe.fun
+    , Example.Unsafe.param_underscore
+    , Example.Unsafe.param_uppercase
+    , Example.Unsafe.param_undersore_capital
+    , Example.Unsafe.param_haskell_reserved_name
     )
   where
 
@@ -18,6 +22,30 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , ")"
   , "{"
   , "  *arg2 = (fun)(*arg1);"
+  , "}"
+  , "void hs_bindgen_80a83be02e40bf03 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_underscore)(*arg1);"
+  , "}"
+  , "void hs_bindgen_bda30535ff7fd9f4 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_uppercase)(*arg1);"
+  , "}"
+  , "void hs_bindgen_7b5f5cbdd8a5ff0e ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_undersore_capital)(*arg1);"
+  , "}"
+  , "void hs_bindgen_5b71629b3ccc3fa8 ("
+  , "  T *arg1"
+  , ")"
+  , "{"
+  , "  (param_haskell_reserved_name)(*arg1);"
   , "}"
   ]))
 
@@ -50,3 +78,110 @@ fun =
     RIP.with x0 (\x1 ->
                    RIP.allocaAndPeek (\res2 ->
                                         hs_bindgen_c4af6bb824712c6a x1 res2))
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_underscore@
+foreign import ccall unsafe "hs_bindgen_80a83be02e40bf03" hs_bindgen_80a83be02e40bf03_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_underscore@
+hs_bindgen_80a83be02e40bf03 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_80a83be02e40bf03 =
+  RIP.fromFFIType hs_bindgen_80a83be02e40bf03_base
+
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore ::
+     T
+     -- ^ __C declaration:__ @_@
+  -> IO ()
+param_underscore =
+  \_0 ->
+    RIP.with _0 (\_1 -> hs_bindgen_80a83be02e40bf03 _1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_bda30535ff7fd9f4" hs_bindgen_bda30535ff7fd9f4_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_uppercase@
+hs_bindgen_bda30535ff7fd9f4 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_bda30535ff7fd9f4 =
+  RIP.fromFFIType hs_bindgen_bda30535ff7fd9f4_base
+
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase ::
+     T
+     -- ^ __C declaration:__ @Type@
+  -> IO ()
+param_uppercase =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_bda30535ff7fd9f4 type'1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_7b5f5cbdd8a5ff0e" hs_bindgen_7b5f5cbdd8a5ff0e_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_undersore_capital@
+hs_bindgen_7b5f5cbdd8a5ff0e ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_7b5f5cbdd8a5ff0e =
+  RIP.fromFFIType hs_bindgen_7b5f5cbdd8a5ff0e_base
+
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital ::
+     T
+     -- ^ __C declaration:__ @_T@
+  -> IO ()
+param_undersore_capital =
+  \_T0 ->
+    RIP.with _T0 (\_T1 ->
+                    hs_bindgen_7b5f5cbdd8a5ff0e _T1)
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_5b71629b3ccc3fa8" hs_bindgen_5b71629b3ccc3fa8_base ::
+     RIP.Ptr RIP.Void
+  -> IO ()
+
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_5b71629b3ccc3fa8 ::
+     RIP.Ptr T
+  -> IO ()
+hs_bindgen_5b71629b3ccc3fa8 =
+  RIP.fromFFIType hs_bindgen_5b71629b3ccc3fa8_base
+
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name ::
+     T
+     -- ^ __C declaration:__ @type@
+  -> IO ()
+param_haskell_reserved_name =
+  \type'0 ->
+    RIP.with type'0 (\type'1 ->
+                       hs_bindgen_5b71629b3ccc3fa8 type'1)

--- a/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/fixtures/functions/heap_types/struct/th.txt
@@ -7,12 +7,60 @@
 -- {
 --   *arg2 = (fun)(*arg1);
 -- }
+-- void hs_bindgen_8b003c42270f977d (
+--   T *arg1
+-- )
+-- {
+--   (param_underscore)(*arg1);
+-- }
+-- void hs_bindgen_820d4de13c1d8dff (
+--   T *arg1
+-- )
+-- {
+--   (param_uppercase)(*arg1);
+-- }
+-- void hs_bindgen_aa622269ffe58e15 (
+--   T *arg1
+-- )
+-- {
+--   (param_undersore_capital)(*arg1);
+-- }
+-- void hs_bindgen_40fff9d72335931a (
+--   T *arg1
+-- )
+-- {
+--   (param_haskell_reserved_name)(*arg1);
+-- }
 -- void hs_bindgen_c4af6bb824712c6a (
 --   T *arg1,
 --   T *arg2
 -- )
 -- {
 --   *arg2 = (fun)(*arg1);
+-- }
+-- void hs_bindgen_80a83be02e40bf03 (
+--   T *arg1
+-- )
+-- {
+--   (param_underscore)(*arg1);
+-- }
+-- void hs_bindgen_bda30535ff7fd9f4 (
+--   T *arg1
+-- )
+-- {
+--   (param_uppercase)(*arg1);
+-- }
+-- void hs_bindgen_7b5f5cbdd8a5ff0e (
+--   T *arg1
+-- )
+-- {
+--   (param_undersore_capital)(*arg1);
+-- }
+-- void hs_bindgen_5b71629b3ccc3fa8 (
+--   T *arg1
+-- )
+-- {
+--   (param_haskell_reserved_name)(*arg1);
 -- }
 -- /* test_functionsheap_typesstruct_Example_get_fun */
 -- __attribute__ ((const))
@@ -21,6 +69,38 @@
 -- )
 -- {
 --   return &fun;
+-- }
+-- /* test_functionsheap_typesstruct_Example_get_param_underscore */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_ee52ac50697405f8 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_underscore;
+-- }
+-- /* test_functionsheap_typesstruct_Example_get_param_uppercase */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_b51cac34e6c4eca3 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_uppercase;
+-- }
+-- /* test_functionsheap_typesstruct_Example_get_param_undersore_capital */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_2302284a38d84764 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_undersore_capital;
+-- }
+-- /* test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_af57be8569d5f651 (void)) (
+--   T arg1
+-- )
+-- {
+--   return &param_haskell_reserved_name;
 -- }
 {-| __C declaration:__ @struct S@
 
@@ -74,6 +154,94 @@ fun_safe :: T -> IO T
     __exported by:__ @functions\/heap_types\/struct.h@
 -}
 fun_safe = \x_0 -> with x_0 (\x_1 -> allocaAndPeek (\res_2 -> hs_bindgen_a5d53f538e59b1fc x_1 res_2))
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_underscore@
+foreign import ccall safe "hs_bindgen_8b003c42270f977d" hs_bindgen_8b003c42270f977d_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_underscore@
+hs_bindgen_8b003c42270f977d :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_underscore@
+hs_bindgen_8b003c42270f977d = fromFFIType hs_bindgen_8b003c42270f977d_base
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_safe :: T -> IO ()
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_safe = \__0 -> with __0 (\__1 -> hs_bindgen_8b003c42270f977d __1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_uppercase@
+foreign import ccall safe "hs_bindgen_820d4de13c1d8dff" hs_bindgen_820d4de13c1d8dff_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_uppercase@
+hs_bindgen_820d4de13c1d8dff :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_uppercase@
+hs_bindgen_820d4de13c1d8dff = fromFFIType hs_bindgen_820d4de13c1d8dff_base
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_safe :: T -> IO ()
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_safe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_820d4de13c1d8dff type'_1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_undersore_capital@
+foreign import ccall safe "hs_bindgen_aa622269ffe58e15" hs_bindgen_aa622269ffe58e15_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_undersore_capital@
+hs_bindgen_aa622269ffe58e15 :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_undersore_capital@
+hs_bindgen_aa622269ffe58e15 = fromFFIType hs_bindgen_aa622269ffe58e15_base
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_safe :: T -> IO ()
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_safe = \_T_0 -> with _T_0 (\_T_1 -> hs_bindgen_aa622269ffe58e15 _T_1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_haskell_reserved_name@
+foreign import ccall safe "hs_bindgen_40fff9d72335931a" hs_bindgen_40fff9d72335931a_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_40fff9d72335931a :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Safe_param_haskell_reserved_name@
+hs_bindgen_40fff9d72335931a = fromFFIType hs_bindgen_40fff9d72335931a_base
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_safe :: T -> IO ()
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_safe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_40fff9d72335931a type'_1)
 -- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_fun@
 foreign import ccall unsafe "hs_bindgen_c4af6bb824712c6a" hs_bindgen_c4af6bb824712c6a_base ::
     Ptr Void
@@ -97,6 +265,94 @@ fun_unsafe :: T -> IO T
     __exported by:__ @functions\/heap_types\/struct.h@
 -}
 fun_unsafe = \x_0 -> with x_0 (\x_1 -> allocaAndPeek (\res_2 -> hs_bindgen_c4af6bb824712c6a x_1 res_2))
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_underscore@
+foreign import ccall unsafe "hs_bindgen_80a83be02e40bf03" hs_bindgen_80a83be02e40bf03_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_underscore@
+hs_bindgen_80a83be02e40bf03 :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_underscore@
+hs_bindgen_80a83be02e40bf03 = fromFFIType hs_bindgen_80a83be02e40bf03_base
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_unsafe = \__0 -> with __0 (\__1 -> hs_bindgen_80a83be02e40bf03 __1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_bda30535ff7fd9f4" hs_bindgen_bda30535ff7fd9f4_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_uppercase@
+hs_bindgen_bda30535ff7fd9f4 :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_uppercase@
+hs_bindgen_bda30535ff7fd9f4 = fromFFIType hs_bindgen_bda30535ff7fd9f4_base
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_unsafe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_bda30535ff7fd9f4 type'_1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_7b5f5cbdd8a5ff0e" hs_bindgen_7b5f5cbdd8a5ff0e_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_undersore_capital@
+hs_bindgen_7b5f5cbdd8a5ff0e :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_undersore_capital@
+hs_bindgen_7b5f5cbdd8a5ff0e = fromFFIType hs_bindgen_7b5f5cbdd8a5ff0e_base
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_unsafe = \_T_0 -> with _T_0 (\_T_1 -> hs_bindgen_7b5f5cbdd8a5ff0e _T_1)
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_5b71629b3ccc3fa8" hs_bindgen_5b71629b3ccc3fa8_base ::
+    Ptr Void
+ -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_5b71629b3ccc3fa8 :: Ptr T -> IO ()
+-- __unique:__ @test_functionsheap_typesstruct_Example_Unsafe_param_haskell_reserved_name@
+hs_bindgen_5b71629b3ccc3fa8 = fromFFIType hs_bindgen_5b71629b3ccc3fa8_base
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_unsafe :: T -> IO ()
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_unsafe = \type'_0 -> with type'_0 (\type'_1 -> hs_bindgen_5b71629b3ccc3fa8 type'_1)
 -- __unique:__ @test_functionsheap_typesstruct_Example_get_fun@
 foreign import ccall unsafe "hs_bindgen_071e2eda58051e4a" hs_bindgen_071e2eda58051e4a_base ::
     IO (FunPtr Void)
@@ -119,3 +375,91 @@ fun_funptr :: FunPtr (T -> IO T)
     __exported by:__ @functions\/heap_types\/struct.h@
 -}
 fun_funptr = unsafePerformIO hs_bindgen_071e2eda58051e4a
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_underscore@
+foreign import ccall unsafe "hs_bindgen_ee52ac50697405f8" hs_bindgen_ee52ac50697405f8_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_underscore@
+hs_bindgen_ee52ac50697405f8 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_underscore@
+hs_bindgen_ee52ac50697405f8 = fromFFIType hs_bindgen_ee52ac50697405f8_base
+{-# NOINLINE param_underscore_funptr #-}
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_underscore@
+
+    __defined at:__ @functions\/heap_types\/struct.h 12:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_underscore_funptr = unsafePerformIO hs_bindgen_ee52ac50697405f8
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_uppercase@
+foreign import ccall unsafe "hs_bindgen_b51cac34e6c4eca3" hs_bindgen_b51cac34e6c4eca3_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_uppercase@
+hs_bindgen_b51cac34e6c4eca3 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_uppercase@
+hs_bindgen_b51cac34e6c4eca3 = fromFFIType hs_bindgen_b51cac34e6c4eca3_base
+{-# NOINLINE param_uppercase_funptr #-}
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_uppercase@
+
+    __defined at:__ @functions\/heap_types\/struct.h 13:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_uppercase_funptr = unsafePerformIO hs_bindgen_b51cac34e6c4eca3
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_undersore_capital@
+foreign import ccall unsafe "hs_bindgen_2302284a38d84764" hs_bindgen_2302284a38d84764_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_undersore_capital@
+hs_bindgen_2302284a38d84764 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_undersore_capital@
+hs_bindgen_2302284a38d84764 = fromFFIType hs_bindgen_2302284a38d84764_base
+{-# NOINLINE param_undersore_capital_funptr #-}
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_undersore_capital@
+
+    __defined at:__ @functions\/heap_types\/struct.h 14:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_undersore_capital_funptr = unsafePerformIO hs_bindgen_2302284a38d84764
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name@
+foreign import ccall unsafe "hs_bindgen_af57be8569d5f651" hs_bindgen_af57be8569d5f651_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name@
+hs_bindgen_af57be8569d5f651 :: IO (FunPtr (T -> IO ()))
+-- __unique:__ @test_functionsheap_typesstruct_Example_get_param_haskell_reserved_name@
+hs_bindgen_af57be8569d5f651 = fromFFIType hs_bindgen_af57be8569d5f651_base
+{-# NOINLINE param_haskell_reserved_name_funptr #-}
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_funptr :: FunPtr (T -> IO ())
+{-| __C declaration:__ @param_haskell_reserved_name@
+
+    __defined at:__ @functions\/heap_types\/struct.h 15:6@
+
+    __exported by:__ @functions\/heap_types\/struct.h@
+-}
+param_haskell_reserved_name_funptr = unsafePerformIO hs_bindgen_af57be8569d5f651

--- a/hs-bindgen/fixtures/macros/macro_functions/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_functions/Example.hs
@@ -6,10 +6,12 @@ module Example
     , Example.aDD
     , Example.iD
     , Example.cONST
+    , Example.cONST_3
     , Example.cMP
     , Example.fUN1
     , Example.fUN2
     , Example.g
+    , Example.g_3
     , Example.dIV1
     , Example.dIV2
     , Example.sWAP32
@@ -57,9 +59,18 @@ iD = \x0 -> x0
 cONST :: forall a0 b1. a0 -> b1 -> a0
 cONST = \x0 -> \y1 -> x0
 
+{-| __C declaration:__ @macro CONST_3@
+
+    __defined at:__ @macros\/macro_functions.h 6:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+cONST_3 :: forall a0 b1 c2. a0 -> b1 -> c2 -> a0
+cONST_3 = \x0 -> \y1 -> \z2 -> x0
+
 {-| __C declaration:__ @macro CMP@
 
-    __defined at:__ @macros\/macro_functions.h 7:9@
+    __defined at:__ @macros\/macro_functions.h 8:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -68,7 +79,7 @@ cMP = \x0 -> \y1 -> (C.Expr.HostPlatform.<) x0 y1
 
 {-| __C declaration:__ @macro FUN1@
 
-    __defined at:__ @macros\/macro_functions.h 8:9@
+    __defined at:__ @macros\/macro_functions.h 9:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -80,7 +91,7 @@ fUN1 =
 
 {-| __C declaration:__ @macro FUN2@
 
-    __defined at:__ @macros\/macro_functions.h 9:9@
+    __defined at:__ @macros\/macro_functions.h 10:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -92,16 +103,27 @@ fUN2 =
 
 {-| __C declaration:__ @macro G@
 
-    __defined at:__ @macros\/macro_functions.h 11:9@
+    __defined at:__ @macros\/macro_functions.h 12:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
-g :: forall a0 b1. C.Expr.HostPlatform.Add a0 RIP.CInt => b1 -> a0 -> C.Expr.HostPlatform.AddRes a0 RIP.CInt
+g :: forall a0 b1. C.Expr.HostPlatform.Add b1 RIP.CInt => a0 -> b1 -> C.Expr.HostPlatform.AddRes b1 RIP.CInt
 g = \x0 -> \y1 -> cONST (iNCR y1) (iD x0)
+
+{-| __C declaration:__ @macro G_3@
+
+    __defined at:__ @macros\/macro_functions.h 13:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+g_3 :: forall a0 b1 c2. C.Expr.HostPlatform.Add b1 RIP.CInt => a0 -> b1 -> c2 -> C.Expr.HostPlatform.AddRes b1 RIP.CInt
+g_3 =
+  \x0 ->
+    \y1 -> \z2 -> cONST_3 (iNCR y1) (iD x0) (iD z2)
 
 {-| __C declaration:__ @macro DIV1@
 
-    __defined at:__ @macros\/macro_functions.h 13:9@
+    __defined at:__ @macros\/macro_functions.h 15:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -113,7 +135,7 @@ dIV1 =
 
 {-| __C declaration:__ @macro DIV2@
 
-    __defined at:__ @macros\/macro_functions.h 14:9@
+    __defined at:__ @macros\/macro_functions.h 16:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -125,7 +147,7 @@ dIV2 =
 
 {-| __C declaration:__ @macro SWAP32@
 
-    __defined at:__ @macros\/macro_functions.h 18:9@
+    __defined at:__ @macros\/macro_functions.h 20:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -136,7 +158,7 @@ sWAP32 =
 
 {-| __C declaration:__ @macro AV_VERSION_INT@
 
-    __defined at:__ @macros\/macro_functions.h 19:9@
+    __defined at:__ @macros\/macro_functions.h 21:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}

--- a/hs-bindgen/fixtures/macros/macro_functions/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_functions/th.txt
@@ -55,23 +55,37 @@ cONST :: forall a_0 b_1 . a_0 -> b_1 -> a_0
     __exported by:__ @macros\/macro_functions.h@
 -}
 cONST = \x_0 -> \y_1 -> x_0
+{-| __C declaration:__ @macro CONST_3@
+
+    __defined at:__ @macros\/macro_functions.h 6:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+cONST_3 :: forall a_0 b_1 c_2 . a_0 -> b_1 -> c_2 -> a_0
+{-| __C declaration:__ @macro CONST_3@
+
+    __defined at:__ @macros\/macro_functions.h 6:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+cONST_3 = \x_0 -> \y_1 -> \z_2 -> x_0
 {-| __C declaration:__ @macro CMP@
 
-    __defined at:__ @macros\/macro_functions.h 7:9@
+    __defined at:__ @macros\/macro_functions.h 8:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 cMP :: forall a_0 b_1 . RelOrd a_0 b_1 => a_0 -> b_1 -> CInt
 {-| __C declaration:__ @macro CMP@
 
-    __defined at:__ @macros\/macro_functions.h 7:9@
+    __defined at:__ @macros\/macro_functions.h 8:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 cMP = \x_0 -> \y_1 -> (<) x_0 y_1
 {-| __C declaration:__ @macro FUN1@
 
-    __defined at:__ @macros\/macro_functions.h 8:9@
+    __defined at:__ @macros\/macro_functions.h 9:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -80,14 +94,14 @@ fUN1 :: forall a_0 b_1 . (Add a_0 (MultRes CULLong b_1),
         a_0 -> b_1 -> AddRes a_0 (MultRes CULLong b_1)
 {-| __C declaration:__ @macro FUN1@
 
-    __defined at:__ @macros\/macro_functions.h 8:9@
+    __defined at:__ @macros\/macro_functions.h 9:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 fUN1 = \x_0 -> \y_1 -> (+) x_0 ((*) (12 :: CULLong) y_1)
 {-| __C declaration:__ @macro FUN2@
 
-    __defined at:__ @macros\/macro_functions.h 9:9@
+    __defined at:__ @macros\/macro_functions.h 10:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -96,28 +110,43 @@ fUN2 :: forall a_0 b_1 . (Mult CULLong b_1,
         a_0 -> b_1 -> ShiftRes a_0
 {-| __C declaration:__ @macro FUN2@
 
-    __defined at:__ @macros\/macro_functions.h 9:9@
+    __defined at:__ @macros\/macro_functions.h 10:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 fUN2 = \x_0 -> \y_1 -> (<<) x_0 ((*) (3 :: CULLong) y_1)
 {-| __C declaration:__ @macro G@
 
-    __defined at:__ @macros\/macro_functions.h 11:9@
+    __defined at:__ @macros\/macro_functions.h 12:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
-g :: forall a_0 b_1 . Add a_0 CInt => b_1 -> a_0 -> AddRes a_0 CInt
+g :: forall a_0 b_1 . Add b_1 CInt => a_0 -> b_1 -> AddRes b_1 CInt
 {-| __C declaration:__ @macro G@
 
-    __defined at:__ @macros\/macro_functions.h 11:9@
+    __defined at:__ @macros\/macro_functions.h 12:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 g = \x_0 -> \y_1 -> cONST (iNCR y_1) (iD x_0)
-{-| __C declaration:__ @macro DIV1@
+{-| __C declaration:__ @macro G_3@
 
     __defined at:__ @macros\/macro_functions.h 13:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+g_3 :: forall a_0 b_1 c_2 . Add b_1 CInt =>
+       a_0 -> b_1 -> c_2 -> AddRes b_1 CInt
+{-| __C declaration:__ @macro G_3@
+
+    __defined at:__ @macros\/macro_functions.h 13:9@
+
+    __exported by:__ @macros\/macro_functions.h@
+-}
+g_3 = \x_0 -> \y_1 -> \z_2 -> cONST_3 (iNCR y_1) (iD x_0) (iD z_2)
+{-| __C declaration:__ @macro DIV1@
+
+    __defined at:__ @macros\/macro_functions.h 15:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -126,14 +155,14 @@ dIV1 :: forall a_0 b_1 . (Add b_1 CUInt,
         a_0 -> b_1 -> DivRes a_0 (AddRes b_1 CUInt)
 {-| __C declaration:__ @macro DIV1@
 
-    __defined at:__ @macros\/macro_functions.h 13:9@
+    __defined at:__ @macros\/macro_functions.h 15:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 dIV1 = \x_0 -> \y_1 -> (/) x_0 ((+) y_1 (12 :: CUInt))
 {-| __C declaration:__ @macro DIV2@
 
-    __defined at:__ @macros\/macro_functions.h 14:9@
+    __defined at:__ @macros\/macro_functions.h 16:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -142,14 +171,14 @@ dIV2 :: forall a_0 b_1 . (Mult CFloat a_0,
         a_0 -> b_1 -> DivRes (MultRes CFloat a_0) b_1
 {-| __C declaration:__ @macro DIV2@
 
-    __defined at:__ @macros\/macro_functions.h 14:9@
+    __defined at:__ @macros\/macro_functions.h 16:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 dIV2 = \x_0 -> \y_1 -> (/) ((*) (10.0 :: CFloat) x_0) y_1
 {-| __C declaration:__ @macro SWAP32@
 
-    __defined at:__ @macros\/macro_functions.h 18:9@
+    __defined at:__ @macros\/macro_functions.h 20:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -161,14 +190,14 @@ sWAP32 :: forall a_0 . (Bitwise (BitsRes (ShiftRes a_0) CInt)
           BitsRes (BitsRes (ShiftRes a_0) CInt) (BitsRes (ShiftRes a_0) CInt)
 {-| __C declaration:__ @macro SWAP32@
 
-    __defined at:__ @macros\/macro_functions.h 18:9@
+    __defined at:__ @macros\/macro_functions.h 20:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
 sWAP32 = \w_0 -> (.|.) ((.&.) ((>>) w_0 (24 :: CInt)) (255 :: CInt)) ((.&.) ((<<) w_0 (8 :: CInt)) (16711680 :: CInt))
 {-| __C declaration:__ @macro AV_VERSION_INT@
 
-    __defined at:__ @macros\/macro_functions.h 19:9@
+    __defined at:__ @macros\/macro_functions.h 21:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}
@@ -181,7 +210,7 @@ aV_VERSION_INT :: forall a_0 b_1 c_2 . (Bitwise (ShiftRes a_0)
                   b_1 -> c_2 -> BitsRes (BitsRes (ShiftRes a_0) (ShiftRes b_1)) c_2
 {-| __C declaration:__ @macro AV_VERSION_INT@
 
-    __defined at:__ @macros\/macro_functions.h 19:9@
+    __defined at:__ @macros\/macro_functions.h 21:9@
 
     __exported by:__ @macros\/macro_functions.h@
 -}

--- a/hs-bindgen/fixtures/macros/macro_type_unresolved_tagged/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_type_unresolved_tagged/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/fixtures/macros/macro_type_unresolved_tagged/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_type_unresolved_tagged/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile examples/golden/macros/macro_type_unresolved_tagged.h

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Category/ApplyChoice.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Category/ApplyChoice.hs
@@ -38,7 +38,7 @@ applyTerms = \case
         fiw@Hs.DeclForeignImportWrapper{} -> fiw
         fid@Hs.DeclForeignImportDynamic{} -> fid
         Hs.DeclFunction fn                -> Hs.DeclFunction $ over #name renameTerm $ fn
-        Hs.DeclMacroExpr{}                -> p
+        Hs.DeclMacroValue{}               -> p
         Hs.DeclUnionGetter{}              -> p
         Hs.DeclUnionSetter{}              -> p
         Hs.DeclVar x                      -> Hs.DeclVar $ over #name renameTerm $ x

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -29,7 +29,7 @@ module HsBindgen.Backend.Hs.AST (
   , DeriveInstance(..)
   , Var(..)
     -- ** Variable declarations
-  , MacroExpr(..)
+  , MacroValue(..)
   , VarDeclRHS(..)
   , VarDeclRHSAppHead(..)
     -- ** Deriving instances
@@ -96,7 +96,7 @@ import DeBruijn (Add (..), Ctx, EmptyCtx, Idx (..), Wk (..))
 
 import C.Char qualified as CExpr.Runtime
 
-import C.Expr.Syntax qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
 
 import HsBindgen.Backend.Hs.AST.Strategy
 import HsBindgen.Backend.Hs.AST.Type
@@ -263,7 +263,7 @@ data Decl where
     DeclForeignImportDynamic :: ForeignImportDynamic -> Decl
     DeclForeignImportWrapper :: ForeignImportWrapper -> Decl
     DeclFunction             :: FunctionDecl         -> Decl
-    DeclMacroExpr            :: MacroExpr            -> Decl
+    DeclMacroValue           :: MacroValue           -> Decl
     DeclUnionGetter          :: UnionGetter          -> Decl
     DeclUnionSetter          :: UnionSetter          -> Decl
     DeclVar                  :: Var                  -> Decl
@@ -296,12 +296,12 @@ data InstanceDecl where
 deriving instance Show InstanceDecl
 
 -- | Macro expression
-type MacroExpr :: Star
-data MacroExpr = MacroExpr {
+type MacroValue :: Star
+data MacroValue = MacroValue {
     -- | Name of variable/function.
       name    :: Hs.Name Hs.NsVar
     -- | Type of variable/function.
-    , expr    :: CheckedMacroExpr Final
+    , expr    :: CheckedMacroValue Final
     -- | RHS of variable/function.
     , comment :: Maybe HsDoc.Comment
     }
@@ -327,7 +327,7 @@ data VarDeclRHS ctx
 -- of a C macro.
 data VarDeclRHSAppHead
   -- | The translation of a built-in C infix function such as @*@ or @&&@.
-  = forall arity. InfixAppHead (CExpr.DSL.VaFun arity)
+  = forall arity. InfixAppHead (CExpr.VaFun arity)
   -- | A function name, or the name of a function-like macro.
   | VarAppHead (Hs.Name Hs.NsVar)
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -51,6 +51,7 @@ import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
+import HsBindgen.NameHint
 import HsBindgen.PrettyC qualified as PC
 
 import Doxygen.Parser.Types qualified as Doxy
@@ -369,7 +370,7 @@ enumDecs supInsts haddockConfig info enum spec = aux <$> newtypeDec
                 comment      = Nothing
               , instanceDecl =
                   Hs.InstanceReadRaw hsStruct Hs.ReadRawInstance{
-                      readRaw = Hs.Lambda "ptr" $
+                      readRaw = Hs.Lambda (NameHint "ptr") $
                         Hs.Ap (Hs.StructCon hsStruct) [ Hs.ReadRawByteOff IZ 0 ]
                     }
               }
@@ -377,7 +378,7 @@ enumDecs supInsts haddockConfig info enum spec = aux <$> newtypeDec
                 comment      = Nothing
               , instanceDecl =
                   Hs.InstanceWriteRaw hsStruct Hs.WriteRawInstance{
-                      writeRaw = Hs.Lambda "ptr" $ Hs.Lambda "s" $
+                      writeRaw = Hs.Lambda (NameHint "ptr") $ Hs.Lambda (NameHint "s") $
                         Hs.ElimStruct IZ hsStruct (AS AZ) $
                           Hs.Seq [ Hs.WriteRawByteOff I2 0 IZ ]
                     }
@@ -730,8 +731,8 @@ macroDecs ::
   -> HsM [Hs.Decl]
 macroDecs supInsts haddockConfig info checkedMacro spec =
     case checkedMacro of
-      MacroType ty   -> macroDecsTypedef supInsts haddockConfig info ty spec
-      MacroExpr expr -> pure $ macroVarDecs haddockConfig info expr
+      MacroType  ty  -> macroDecsTypedef supInsts haddockConfig info ty spec
+      MacroValue val -> pure $ macroVarDecs haddockConfig info val
 
 macroDecsTypedef ::
      HasCallStack
@@ -759,7 +760,7 @@ macroDecsTypedef supInsts haddockConfig info macroType spec = do
         newtypeField :: Hs.Field
         newtypeField = Hs.Field {
               name    = macroType.names.field
-            , typ     = Type.topLevel macroType.typ
+            , typ     = Type.topLevel macroType.cType
             , origin  = Origin.GeneratedField
             , comment = Nothing
             }
@@ -1075,13 +1076,13 @@ addressStubDecs uniqueId haddockConfig moduleName sizeofs info ty runnerNameSpec
 macroVarDecs ::
      HaddockConfig
   -> C.DeclInfo Final
-  -> CheckedMacroExpr Final
+  -> CheckedMacroValue Final
   -> [Hs.Decl]
-macroVarDecs haddockConfig info macroExpr = [
-      Hs.DeclMacroExpr $
-        Hs.MacroExpr
+macroVarDecs haddockConfig info macroValue = [
+      Hs.DeclMacroValue $
+        Hs.MacroValue
           { name    = hsVarName
-          , expr    = macroExpr
+          , expr    = macroValue
           , comment = mkHaddocks haddockConfig info
           }
     ]

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
@@ -27,6 +27,7 @@ import HsBindgen.Backend.UniqueSymbol (UniqueSymbol (..))
 import HsBindgen.Errors (panicPure)
 import HsBindgen.Frontend.Naming
 import HsBindgen.Language.C qualified as C
+import HsBindgen.NameHint
 
 -- | Info about a function name
 data FunName = FunName {
@@ -161,7 +162,7 @@ foreignImportWrapperDec sizeofs name hsType origin =
         ]
     fResult = Hs.HsIO $ Hs.HsFunPtr hsType
     fBody =
-        ELam "fun" $
+        ELam (NameHint "fun") $
         eBindgenGlobal Functor_fmap `EApp`
         eBindgenGlobal HasFFIType_castFunPtrFromFFIType `EApp`
         (EFree (Hs.InternalName fiName) `EApp`
@@ -230,7 +231,7 @@ foreignImportDynamicDec sizeofs name hsType origin =
         ]
     fResult = hsType
     fBody =
-        ELam "funPtr" $
+        ELam (NameHint "funPtr") $
         eBindgenGlobal HasFFIType_fromFFIType `EApp`
         (EFree (Hs.InternalName fiName) `EApp`
         (eBindgenGlobal HasFFIType_castFunPtrToFFIType `EApp`

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -7,9 +7,8 @@ import Data.Kind (Type)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as T
 import Data.Type.Equality ((:~:) (Refl))
-import DeBruijn (Ctx, Env (..), Idx (..), sizeEnv, tabulateEnv, zipWithEnv)
-import DeBruijn.Add (Add, lzeroAdd, swapAdd, unrzeroAdd)
-import GHC.Records
+import DeBruijn (Add, Ctx, Env (..), Idx (..), lzeroAdd, sizeEnv, swapAdd,
+                 tabulateEnv, unrzeroAdd, zipWithEnv)
 
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.Hs.AST qualified as Hs
@@ -26,6 +25,7 @@ import HsBindgen.Backend.Hs.Translation.Type qualified as Type
 import HsBindgen.Backend.SHs.AST qualified as SHs
 import HsBindgen.Backend.SHs.Translation.Common qualified as SHs
 import HsBindgen.Backend.UniqueSymbol
+import HsBindgen.Config.MangleCandidate (mangleCandidateDefaultFallback)
 import HsBindgen.Config.Prelims
 import HsBindgen.Errors (panicPure)
 import HsBindgen.Frontend.AST.Decl qualified as C
@@ -425,7 +425,7 @@ instance ToOrigType PassResBy where
 --
 requiresRestore :: PassBy byValue byAddress -> Bool
 requiresRestore = \case
-    PassByValue{} -> False
+    PassByValue{}   -> False
     PassByAddress{} -> True
 
 {-------------------------------------------------------------------------------
@@ -610,7 +610,7 @@ getRestoreOrigSignatureDecl hiName loName primResult primParams hsResult hsParam
             PassByAddress ty -> SHs.eAppMany (SHs.eBindgenGlobal Capi_with) $
               let wrapPtrConst = C.isErasedTypeConstQualified ty in
               [ SHs.EBound y
-              , SHs.ELam x.ptrNameHint $
+              , SHs.ELam x.nameHint $
                   go xs (IS <$> ys) (Var IZ wrapPtrConst : fmap succVar zs)
               ]
 
@@ -637,7 +637,7 @@ getRestoreOrigSignatureDecl hiName loName primResult primParams hsResult hsParam
       = let zs' = fmap succVar zs ++ [Var IZ False] in
         SHs.EApp
           (SHs.eBindgenGlobal Capi_allocaAndPeek)
-          (SHs.ELam "res" $ kont zs')
+          (SHs.ELam (NameHint "res") $ kont zs')
       | otherwise
       = kont zs
 
@@ -667,8 +667,18 @@ data FunArg = FunArg {
 funArgToVarInfo :: FunArg -> VarInfo
 funArgToVarInfo arg = VarInfo {
       typ = arg.typ
-    , optNameHint = fmap (fromString . T.unpack) arg.cParamName
+    , nameHint = toHint $ case arg.cParamName of
+        Nothing -> fallback
+        Just x  -> mangleCandidateDefaultFallback fallback x
     }
+  where
+    fallback :: Hs.Name Hs.NsVar
+    fallback = Hs.UnsafeName $ case arg.typ of
+      PassByValue{}   -> "x"
+      PassByAddress{} -> "ptr"
+
+    toHint :: Hs.Name Hs.NsVar -> NameHint
+    toHint n = NameHint $ T.unpack n.text
 
 {-------------------------------------------------------------------------------
   Variables
@@ -712,15 +722,9 @@ exprVar var
 
 -- | Information for variables corresponding to function arguments
 data VarInfo = VarInfo {
-    typ         :: PassArgBy
-  , optNameHint :: Maybe NameHint
+    typ      :: PassArgBy
+  , nameHint :: NameHint
   }
-
-instance HasField "nameHint" VarInfo NameHint where
-  getField vinfo = fromMaybe "x" vinfo.optNameHint
-
-instance HasField "ptrNameHint" VarInfo NameHint where
-  getField vinfo = fromMaybe "ptr" vinfo.optNameHint
 
 {-------------------------------------------------------------------------------
   Environment

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -30,6 +30,7 @@ import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
 import HsBindgen.Language.Haskell qualified as Hs
+import HsBindgen.NameHint
 
 -- | Generate declarations for given C struct
 structDecs ::
@@ -206,7 +207,7 @@ getDecls supInsts hCfg spec structName info struct fieldsVec insts =
                     comment      = Nothing
                   , instanceDecl =
                       Hs.InstanceReadRaw hsStruct Hs.ReadRawInstance{
-                          readRaw = Hs.Lambda "ptr" $
+                          readRaw = Hs.Lambda (NameHint "ptr") $
                             Hs.Ap (Hs.StructCon hsStruct) $
                               map (readRawField IZ) struct.fields
                         }
@@ -216,7 +217,7 @@ getDecls supInsts hCfg spec structName info struct fieldsVec insts =
                     comment      = Nothing
                   , instanceDecl =
                       Hs.InstanceWriteRaw hsStruct Hs.WriteRawInstance{
-                          writeRaw = Hs.Lambda "ptr" $ Hs.Lambda "s" $
+                          writeRaw = Hs.Lambda (NameHint "ptr") $ Hs.Lambda (NameHint "s") $
                             Hs.makeElimStruct IZ hsStruct $ \wk xs -> Hs.Seq $ Vec.toList $
                               Vec.zipWith (writeRawField (weaken wk I1))
                                 fieldsVec xs
@@ -235,10 +236,10 @@ getDecls supInsts hCfg spec structName info struct fieldsVec insts =
                     , instanceDecl = Hs.InstanceStorable hsStruct Hs.StorableInstance{
                           sizeOf    = struct.sizeof
                         , alignment = struct.alignment
-                        , peek      = Hs.Lambda "ptr" $
+                        , peek      = Hs.Lambda (NameHint "ptr") $
                             Hs.Ap (Hs.StructCon hsStruct) $
                               map (peekField IZ) struct.fields
-                        , poke      = Hs.Lambda "ptr" $ Hs.Lambda "s" $
+                        , poke      = Hs.Lambda (NameHint "ptr") $ Hs.Lambda (NameHint "s") $
                             Hs.makeElimStruct IZ hsStruct $ \wk xs -> Hs.Seq $ Vec.toList $
                               Vec.zipWith (pokeField (weaken wk I1))
                                 fieldsVec xs

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Expr.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Expr.hs
@@ -18,7 +18,7 @@ import Text.SimplePrettyPrint qualified as PP
 
 import C.Char qualified as CExpr.Runtime
 
-import C.Expr.Syntax qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
 
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.HsModule.Names
@@ -89,7 +89,7 @@ prettyRolledExpr env prec expr = case expr of
         ]
 
     EFloat f t -> PP.parens $ PP.hcat [
-        if CExpr.DSL.canBeRepresentedAsRational f then
+        if CExpr.canBeRepresentedAsRational f then
           PP.show f
         else
           prettyExpr env prec $
@@ -100,7 +100,7 @@ prettyRolledExpr env prec expr = case expr of
       , prettyType EmptyEnv 0 t
       ]
     EDouble f t -> PP.parens $ PP.hcat [
-        if CExpr.DSL.canBeRepresentedAsRational f then
+        if CExpr.canBeRepresentedAsRational f then
           PP.show f
         else
           prettyExpr env  prec $

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Macro.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Macro.hs
@@ -1,26 +1,29 @@
 module HsBindgen.Backend.SHs.Macro (
-    translateMacroExpr
+    translateMacroValue
   ) where
 
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Type.Nat (pattern SS')
 import Data.Type.Nat qualified as Fin
+import Data.Vec.Lazy qualified as Vec
 import DeBruijn (EmptyCtx, Idx (..), Size (..), rzeroAdd)
 
 import C.Char qualified as Runtime
 import C.Type (Sign (Signed, Unsigned))
 import C.Type qualified as Runtime
 
-import C.Expr.Syntax qualified as DSL
+import C.Expr.Syntax qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
 import C.Expr.Typecheck.Interface.Value qualified as V
 import C.Expr.Typecheck.Type (Kind (Ct, Ty))
-import C.Expr.Typecheck.Type qualified as DSL
+import C.Expr.Typecheck.Type qualified as CExpr
 
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Backend.SHs.AST
+import HsBindgen.Config.MangleCandidate (mangleCandidateDefaultFallback)
 import HsBindgen.Errors
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
@@ -34,54 +37,58 @@ import HsBindgen.NameHint
   External API
 -------------------------------------------------------------------------------}
 
-translateMacroExpr :: Hs.MacroExpr -> SDecl
-translateMacroExpr macro = DBinding Binding{
+translateMacroValue :: Hs.MacroValue -> SDecl
+translateMacroValue macro = DBinding Binding{
       name       = Hs.ExportedName macro.name
     , parameters = []
-    , result     = Result (translateType macro.expr.typ) Nothing
-    , body       = translateBody macro.expr.args macro.expr.body
+    , result     = Result (translateType typ) Nothing
+    , body       = translateBody macro.expr
     , pragmas    = []
     , comment    = macro.comment
     }
+  where
+    typ = fmap snd $ macro.expr.value.macroValueType
 
 {-------------------------------------------------------------------------------
   Translate type
 -------------------------------------------------------------------------------}
 
-translateType :: DSL.Quant (DSL.Type Ty) -> ClosedType
-translateType qty@(DSL.Quant @n _) =
-    case DSL.mkQuantTyBody qty of
-      DSL.QuantTyBody{quantTyQuant = cts, quantTyBody = ty} ->
-        quantTyBody (snd <$> DSL.tyVarNames @n) cts ty
+translateType :: CExpr.Quant (CExpr.Type Ty) -> ClosedType
+translateType qty@(CExpr.Quant @n _) =
+    case CExpr.mkQuantTyBody qty of
+      CExpr.QuantTyBody{quantTyQuant = cts, quantTyBody = ty} ->
+        quantTyBody (snd <$> CExpr.tyVarNames @n) cts ty
 
-quantTyBody :: Vec n Text -> [DSL.Type Ct] -> DSL.Type Ty -> ClosedType
+quantTyBody :: Vec n Text -> [CExpr.Type Ct] -> CExpr.Type Ty -> ClosedType
 quantTyBody args cts body =
     topLevelForall nameHint args $ \env -> (
         map (typeCt env) cts
       , typeTy env body
       )
   where
+    -- Use of 'NameHint' is justified because 'CExpr.tyVarNames' generates valid
+    -- names.
     nameHint :: Text -> NameHint
-    nameHint = fromString . T.unpack
+    nameHint = NameHint . T.unpack
 
-typeCt :: Map Text (Idx ctx) -> DSL.Type Ct -> SType ctx
+typeCt :: Map Text (Idx ctx) -> CExpr.Type Ct -> SType ctx
 typeCt env = \case
-    DSL.TyConAppTy cls as ->
+    CExpr.TyConAppTy cls as ->
       tAppN (tyCon cls) (typeTy env <$> as)
-    DSL.NomEqPred a b ->
+    CExpr.NomEqPred a b ->
       tAppN TEq [typeTy env a, typeTy env b]
 
-typeTy :: forall ctx. Map Text (Idx ctx) -> DSL.Type Ty -> SType ctx
+typeTy :: forall ctx. Map Text (Idx ctx) -> CExpr.Type Ty -> SType ctx
 typeTy env = go
   where
-    go :: DSL.Type Ty -> SType ctx
-    go (DSL.TyVarTy tv) =
-        case Map.lookup (DSL.tyVarName tv) env of
+    go :: CExpr.Type Ty -> SType ctx
+    go (CExpr.TyVarTy tv) =
+        case Map.lookup (CExpr.tyVarName tv) env of
           Just n  -> TBound n
           Nothing -> panicPure $ "Unbound type variable " ++ show tv
-    go (DSL.FunTy as r) =
+    go (CExpr.FunTy as r) =
         foldr (TFun . go) (go r) as
-    go (DSL.TyConAppTy tc as) =
+    go (CExpr.TyConAppTy tc as) =
         case simpleTyConApp tc as of
           Just ty -> tBindgenGlobal ty
           Nothing -> tAppN (tyCon tc) (go <$> as)
@@ -93,21 +100,21 @@ typeTy env = go
 --
 -- See 'C.Expr.Typecheck.Expr.isAtomicType'.
 simpleTyConApp ::
-     DSL.TyCon n Ty
-  -> Vec n (DSL.Type Ty)
+     CExpr.TyCon n Ty
+  -> Vec n (CExpr.Type Ty)
   -> Maybe BindgenGlobalType
-simpleTyConApp (DSL.GenerativeTyCon (DSL.DataTyCon tc)) (arg ::: VNil) =
+simpleTyConApp (CExpr.GenerativeTyCon (CExpr.DataTyCon tc)) (arg ::: VNil) =
     case (tc, arg) of
 
-      (   DSL.IntLikeTyCon
-        , DSL.TyConAppTy
-            (DSL.GenerativeTyCon (DSL.DataTyCon (DSL.PrimIntInfoTyCon t)))
+      (   CExpr.IntLikeTyCon
+        , CExpr.TyConAppTy
+            (CExpr.GenerativeTyCon (CExpr.DataTyCon (CExpr.PrimIntInfoTyCon t)))
             VNil
         ) -> Just $ dslIntegral t
 
-      (     DSL.FloatLikeTyCon
-          , DSL.TyConAppTy
-              (DSL.GenerativeTyCon (DSL.DataTyCon (DSL.PrimFloatInfoTyCon t)))
+      (     CExpr.FloatLikeTyCon
+          , CExpr.TyConAppTy
+              (CExpr.GenerativeTyCon (CExpr.DataTyCon (CExpr.PrimFloatInfoTyCon t)))
               VNil
         ) -> Just $ runtimeFloating t
 
@@ -121,45 +128,43 @@ simpleTyConApp _ _ =
   Translate body
 -------------------------------------------------------------------------------}
 
-translateBody ::
-     [Id Final]
-  -> V.Expr (Id Final)
-  -> SExpr EmptyCtx
-translateBody macroArgs expr =
-    topLevelLambdaN idNameHint macroArgs (flip mexpr expr)
+translateBody :: CheckedMacroValue Final -> SExpr EmptyCtx
+translateBody expr = case expr.value of
+  (CExpr.CheckedMacroValueExpr p b _) ->
+    lambdaN (Vec.reverse $ idNameHint <$> p) $ mexpr b
 
 mexpr :: forall ctx.
-     Map (Id Final) (Idx ctx)
-  -> V.Expr (Id Final)
+     V.Expr ctx (Id Final)
   -> SExpr ctx
-mexpr env =
-    goExpr
+mexpr = goExpr
   where
-    goExpr :: V.Expr (Id Final) -> SExpr ctx
+    goExpr :: V.Expr ctx (Id Final) -> SExpr ctx
     goExpr = \case
-      V.Literal lit ->
-        goLiteral lit
-      V.Var xId args ->
-        case Map.lookup xId env of
-          Just i  -> EBound i
-          Nothing -> eAppN (EFree (macroIdToHsName xId)) (goExpr <$> args)
-      V.App fun xs ->
-        eAppN (mfun fun) (goExpr <$> xs)
+      V.Literal lit  -> goLiteral lit
+      V.LocalParam i -> EBound i
+      V.Var xId args -> eAppN (EFree (macroIdToHsName xId)) (goExpr <$> args)
+      V.App fun xs   -> eAppN (mfun fun) (goExpr <$> xs)
 
-    goLiteral :: DSL.ValueLit -> SExpr ctx
+    goLiteral :: CExpr.ValueLit -> SExpr ctx
     goLiteral = \case
       -- Literals
-      DSL.ValueInt    x -> integerLiteral  x
-      DSL.ValueFloat  x -> floatingLiteral x
-      DSL.ValueChar   x -> charLiteral     x
-      DSL.ValueString x -> stringLiteral   x
+      CExpr.ValueInt    x -> integerLiteral  x
+      CExpr.ValueFloat  x -> floatingLiteral x
+      CExpr.ValueChar   x -> charLiteral     x
+      CExpr.ValueString x -> stringLiteral   x
 
 {-------------------------------------------------------------------------------
   Names
 -------------------------------------------------------------------------------}
 
-idNameHint :: Id Final -> NameHint
-idNameHint xId = fromString (T.unpack xId.cName.name.text)
+idNameHint :: CExpr.Name -> NameHint
+idNameHint xId = toHint $ mangleCandidateDefaultFallback fallback xId.getName
+  where
+    fallback :: Hs.Name Hs.NsVar
+    fallback = Hs.UnsafeName "x"
+
+    toHint :: Hs.Name Hs.NsVar -> NameHint
+    toHint x = NameHint $ T.unpack x.text
 
 macroIdToHsName :: Id Final -> Hs.TermName
 macroIdToHsName namePair =
@@ -169,36 +174,36 @@ macroIdToHsName namePair =
   Literals
 -------------------------------------------------------------------------------}
 
-integerLiteral :: DSL.IntegerLiteral -> SExpr ctx
+integerLiteral :: CExpr.IntegerLiteral -> SExpr ctx
 integerLiteral lit =
-    EIntegral (DSL.integerLiteralValue lit) $
+    EIntegral (CExpr.integerLiteralValue lit) $
       Just $ tBindgenGlobal $
-        runtimeIntegral $ Runtime.IntLike (DSL.integerLiteralType lit)
+        runtimeIntegral $ Runtime.IntLike (CExpr.integerLiteralType lit)
 
-charLiteral :: DSL.CharLiteral -> SExpr ctx
+charLiteral :: CExpr.CharLiteral -> SExpr ctx
 charLiteral lit =
-    EChar $ DSL.charLiteralValue lit
+    EChar $ CExpr.charLiteralValue lit
 
-stringLiteral :: DSL.StringLiteral -> SExpr ctx
+stringLiteral :: CExpr.StringLiteral -> SExpr ctx
 stringLiteral lit =
-    ECString $ foldMap Runtime.charValue (DSL.stringLiteralValue lit)
+    ECString $ foldMap Runtime.charValue (CExpr.stringLiteralValue lit)
 
-floatingLiteral :: DSL.FloatingLiteral -> SExpr ctx
+floatingLiteral :: CExpr.FloatingLiteral -> SExpr ctx
 floatingLiteral lit =
-    case DSL.floatingLiteralType lit of
+    case CExpr.floatingLiteralType lit of
       Runtime.FloatType ->
-        EFloat  (DSL.floatingLiteralFloatValue  lit) (tBindgenGlobal CFloat_type)
+        EFloat  (CExpr.floatingLiteralFloatValue  lit) (tBindgenGlobal CFloat_type)
       Runtime.DoubleType ->
-        EDouble (DSL.floatingLiteralDoubleValue lit) (tBindgenGlobal CDouble_type)
+        EDouble (CExpr.floatingLiteralDoubleValue lit) (tBindgenGlobal CDouble_type)
 
 {-------------------------------------------------------------------------------
   Primitive types
 -------------------------------------------------------------------------------}
 
-dslIntegral :: DSL.IntegralType -> BindgenGlobalType
+dslIntegral :: CExpr.IntegralType -> BindgenGlobalType
 dslIntegral = \case
-    DSL.CIntegralType primIntTy -> runtimeIntegral primIntTy
-    DSL.HsIntType               -> Int_type
+    CExpr.CIntegralType primIntTy -> runtimeIntegral primIntTy
+    CExpr.HsIntType               -> Int_type
 
 runtimeIntegral :: Runtime.IntegralType -> BindgenGlobalType
 runtimeIntegral = \case
@@ -233,84 +238,84 @@ runtimeFloating = \case
   Globals
 -------------------------------------------------------------------------------}
 
-tyCon :: DSL.TyCon args res -> SType ctx
-tyCon (DSL.GenerativeTyCon (DSL.DataTyCon tc))  = dataTyCon   tc
-tyCon (DSL.GenerativeTyCon (DSL.ClassTyCon tc)) = TGlobal $ cExprGlobalType $ classTyCon  tc
-tyCon (DSL.FamilyTyCon tc)                      = TGlobal $ cExprGlobalType $ familyTyCon tc
+tyCon :: CExpr.TyCon args res -> SType ctx
+tyCon (CExpr.GenerativeTyCon (CExpr.DataTyCon tc))  = dataTyCon   tc
+tyCon (CExpr.GenerativeTyCon (CExpr.ClassTyCon tc)) = TGlobal $ cExprGlobalType $ classTyCon  tc
+tyCon (CExpr.FamilyTyCon tc)                      = TGlobal $ cExprGlobalType $ familyTyCon tc
 
-dataTyCon :: DSL.DataTyCon n -> SType ctx
+dataTyCon :: CExpr.DataTyCon n -> SType ctx
 dataTyCon = \case
-    DSL.TupleTyCon (SS' (SS' n)) -> TBoxedTup $ Plus2 $ Fin.snatToNatural n
-    DSL.VoidTyCon                -> tBindgenGlobal Void_type
-    DSL.PrimIntInfoTyCon tc      -> tBindgenGlobal $ dslIntegral tc
-    DSL.PrimFloatInfoTyCon tc    -> tBindgenGlobal $ runtimeFloating tc
-    DSL.PtrTyCon                 -> tBindgenGlobal Foreign_Ptr_type
-    DSL.CharLitTyCon             -> TGlobal $ cExprGlobalType CharValue_type
+    CExpr.TupleTyCon (SS' (SS' n)) -> TBoxedTup $ Plus2 $ Fin.snatToNatural n
+    CExpr.VoidTyCon                -> tBindgenGlobal Void_type
+    CExpr.PrimIntInfoTyCon tc      -> tBindgenGlobal $ dslIntegral tc
+    CExpr.PrimFloatInfoTyCon tc    -> tBindgenGlobal $ runtimeFloating tc
+    CExpr.PtrTyCon                 -> tBindgenGlobal Foreign_Ptr_type
+    CExpr.CharLitTyCon             -> TGlobal $ cExprGlobalType CharValue_type
 
     -- Handled by 'simpleTyConApp'
-    DSL.IntLikeTyCon   -> panicPure "Should have been handled by simpleTyConApp: IntLikeTyCon"
-    DSL.FloatLikeTyCon -> panicPure "Should have been handled by simpleTyConApp: FloatLikeTyCon"
+    CExpr.IntLikeTyCon   -> panicPure "Should have been handled by simpleTyConApp: IntLikeTyCon"
+    CExpr.FloatLikeTyCon -> panicPure "Should have been handled by simpleTyConApp: FloatLikeTyCon"
 
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1900>
     --
     -- Split the type language into types of types, and types of values.
-    DSL.MacroTypeTyCon -> panicPure "Unexpected type (kind): type"
+    CExpr.MacroTypeTyCon -> panicPure "Unexpected type (kind): type"
 
-classTyCon :: DSL.ClassTyCon args -> CExprGlobalType
+classTyCon :: CExpr.ClassTyCon args -> CExprGlobalType
 classTyCon = \case
-    DSL.NotTyCon        -> Not_class
-    DSL.LogicalTyCon    -> Logical_class
-    DSL.RelEqTyCon      -> RelEq_class
-    DSL.RelOrdTyCon     -> RelOrd_class
-    DSL.PlusTyCon       -> Plus_class
-    DSL.MinusTyCon      -> Minus_class
-    DSL.AddTyCon        -> Add_class
-    DSL.SubTyCon        -> Sub_class
-    DSL.MultTyCon       -> Mult_class
-    DSL.DivTyCon        -> Div_class
-    DSL.RemTyCon        -> Rem_class
-    DSL.ComplementTyCon -> Complement_class
-    DSL.BitwiseTyCon    -> Bitwise_class
-    DSL.ShiftTyCon      -> Shift_class
+    CExpr.NotTyCon        -> Not_class
+    CExpr.LogicalTyCon    -> Logical_class
+    CExpr.RelEqTyCon      -> RelEq_class
+    CExpr.RelOrdTyCon     -> RelOrd_class
+    CExpr.PlusTyCon       -> Plus_class
+    CExpr.MinusTyCon      -> Minus_class
+    CExpr.AddTyCon        -> Add_class
+    CExpr.SubTyCon        -> Sub_class
+    CExpr.MultTyCon       -> Mult_class
+    CExpr.DivTyCon        -> Div_class
+    CExpr.RemTyCon        -> Rem_class
+    CExpr.ComplementTyCon -> Complement_class
+    CExpr.BitwiseTyCon    -> Bitwise_class
+    CExpr.ShiftTyCon      -> Shift_class
 
-familyTyCon :: DSL.FamilyTyCon args -> CExprGlobalType
+familyTyCon :: CExpr.FamilyTyCon args -> CExprGlobalType
 familyTyCon = \case
-    DSL.PlusResTyCon       -> Plus_resTyCon
-    DSL.MinusResTyCon      -> Minus_resTyCon
-    DSL.AddResTyCon        -> Add_resTyCon
-    DSL.SubResTyCon        -> Sub_resTyCon
-    DSL.MultResTyCon       -> Mult_resTyCon
-    DSL.DivResTyCon        -> Div_resTyCon
-    DSL.RemResTyCon        -> Rem_resTyCon
-    DSL.ComplementResTyCon -> Complement_resTyCon
-    DSL.BitsResTyCon       -> Bitwise_resTyCon
-    DSL.ShiftResTyCon      -> Shift_resTyCon
+    CExpr.PlusResTyCon       -> Plus_resTyCon
+    CExpr.MinusResTyCon      -> Minus_resTyCon
+    CExpr.AddResTyCon        -> Add_resTyCon
+    CExpr.SubResTyCon        -> Sub_resTyCon
+    CExpr.MultResTyCon       -> Mult_resTyCon
+    CExpr.DivResTyCon        -> Div_resTyCon
+    CExpr.RemResTyCon        -> Rem_resTyCon
+    CExpr.ComplementResTyCon -> Complement_resTyCon
+    CExpr.BitsResTyCon       -> Bitwise_resTyCon
+    CExpr.ShiftResTyCon      -> Shift_resTyCon
 
-mfun :: DSL.VaFun arity -> SExpr ctx
+mfun :: CExpr.VaFun arity -> SExpr ctx
 mfun = \case
-    DSL.MUnaryPlus  -> cExpr Plus_plus
-    DSL.MUnaryMinus -> cExpr Minus_negate
-    DSL.MLogicalNot -> cExpr Not_not
-    DSL.MBitwiseNot -> cExpr Complement_complement
-    DSL.MMult       -> cExpr Mult_mult
-    DSL.MDiv        -> cExpr Div_div
-    DSL.MRem        -> cExpr Rem_rem
-    DSL.MAdd        -> cExpr Add_add
-    DSL.MSub        -> cExpr Sub_minus
-    DSL.MShiftLeft  -> cExpr Shift_shiftL
-    DSL.MShiftRight -> cExpr Shift_shiftR
-    DSL.MRelLT      -> cExpr RelOrd_lt
-    DSL.MRelLE      -> cExpr RelOrd_le
-    DSL.MRelGT      -> cExpr RelOrd_gt
-    DSL.MRelGE      -> cExpr RelOrd_ge
-    DSL.MRelEQ      -> cExpr RelEq_eq
-    DSL.MRelNE      -> cExpr RelEq_uneq
-    DSL.MBitwiseAnd -> cExpr Bitwise_and
-    DSL.MBitwiseXor -> cExpr Bitwise_xor
-    DSL.MBitwiseOr  -> cExpr Bitwise_or
-    DSL.MLogicalAnd -> cExpr Logical_and
-    DSL.MLogicalOr  -> cExpr Logical_or
-    DSL.MTuple @n   -> EBoxedTup $ Plus2 $ Fin.reflectToNum @n Proxy
+    CExpr.MUnaryPlus  -> cExpr Plus_plus
+    CExpr.MUnaryMinus -> cExpr Minus_negate
+    CExpr.MLogicalNot -> cExpr Not_not
+    CExpr.MBitwiseNot -> cExpr Complement_complement
+    CExpr.MMult       -> cExpr Mult_mult
+    CExpr.MDiv        -> cExpr Div_div
+    CExpr.MRem        -> cExpr Rem_rem
+    CExpr.MAdd        -> cExpr Add_add
+    CExpr.MSub        -> cExpr Sub_minus
+    CExpr.MShiftLeft  -> cExpr Shift_shiftL
+    CExpr.MShiftRight -> cExpr Shift_shiftR
+    CExpr.MRelLT      -> cExpr RelOrd_lt
+    CExpr.MRelLE      -> cExpr RelOrd_le
+    CExpr.MRelGT      -> cExpr RelOrd_gt
+    CExpr.MRelGE      -> cExpr RelOrd_ge
+    CExpr.MRelEQ      -> cExpr RelEq_eq
+    CExpr.MRelNE      -> cExpr RelEq_uneq
+    CExpr.MBitwiseAnd -> cExpr Bitwise_and
+    CExpr.MBitwiseXor -> cExpr Bitwise_xor
+    CExpr.MBitwiseOr  -> cExpr Bitwise_or
+    CExpr.MLogicalAnd -> cExpr Logical_and
+    CExpr.MLogicalOr  -> cExpr Logical_or
+    CExpr.MTuple @n   -> EBoxedTup $ Plus2 $ Fin.reflectToNum @n Proxy
   where
     cExpr = EGlobal . cExprGlobalTerm
 
@@ -327,18 +332,9 @@ tAppN :: Foldable f => SType ctx -> f (SType ctx) -> SType ctx
 tAppN = foldl' TApp
 
 -- | Construct n-ary top-level lambda
-topLevelLambdaN :: forall a.
-     Ord a
-  => (a -> NameHint)
-  -> [a]
-  -> (forall ctx. Map a (Idx ctx) -> SExpr ctx)
-  -> SExpr EmptyCtx
-topLevelLambdaN nameHint args body =
-    go Map.empty args
-  where
-    go :: forall ctx. Map a (Idx ctx) -> [a] -> SExpr ctx
-    go env []     = body env
-    go env (n:ns) = ELam (nameHint n) $ go (Map.insert n IZ (fmap IS env)) ns
+lambdaN :: Vec ctx NameHint -> SExpr ctx -> SExpr EmptyCtx
+lambdaN VNil       expr = expr
+lambdaN (n ::: ns) expr = lambdaN ns $ ELam n expr
 
 -- | Top-level quantified type
 topLevelForall :: forall n a.

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -27,6 +27,7 @@ import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
 import HsBindgen.Language.Haskell qualified as Hs
+import HsBindgen.NameHint
 
 {-------------------------------------------------------------------------------
   Declarations
@@ -54,21 +55,21 @@ getCWrappers decls = mapMaybe getCWrapper decls
 
 translateDecl :: Hs.Decl -> SDecl
 translateDecl = \case
-    Hs.DeclTypSyn         x -> translateDeclTypSyn         x
-    Hs.DeclData           x -> translateDeclData           x
-    Hs.DeclEmpty          x -> translateDeclEmpty          x
-    Hs.DeclNewtype        x -> translateNewtype            x
-    Hs.DeclDefineInstance x -> translateDefineInstanceDecl x
-    Hs.DeclDeriveInstance x -> translateDeriveInstance     x
-    Hs.DeclMacroExpr      x -> translateMacroExpr          x
-    Hs.DeclForeignImport  x -> translateForeignImportDecl  x
-    Hs.DeclForeignImportWrapper x -> translateForeignImportWrapper x
-    Hs.DeclForeignImportDynamic x -> translateForeignImportDynamic x
-    Hs.DeclFunction       x -> translateFunctionDecl       x
-    Hs.DeclPatSyn         x -> translatePatSyn             x
-    Hs.DeclUnionGetter    x -> translateUnionGetter        x
-    Hs.DeclUnionSetter    x -> translateUnionSetter        x
-    Hs.DeclVar            x -> translateDeclVar            x
+  Hs.DeclTypSyn               x -> translateDeclTypSyn           x
+  Hs.DeclData                 x -> translateDeclData             x
+  Hs.DeclEmpty                x -> translateDeclEmpty            x
+  Hs.DeclNewtype              x -> translateNewtype              x
+  Hs.DeclDefineInstance       x -> translateDefineInstanceDecl   x
+  Hs.DeclDeriveInstance       x -> translateDeriveInstance       x
+  Hs.DeclMacroValue           x -> translateMacroValue           x
+  Hs.DeclForeignImport        x -> translateForeignImportDecl    x
+  Hs.DeclForeignImportWrapper x -> translateForeignImportWrapper x
+  Hs.DeclForeignImportDynamic x -> translateForeignImportDynamic x
+  Hs.DeclFunction             x -> translateFunctionDecl         x
+  Hs.DeclPatSyn               x -> translatePatSyn               x
+  Hs.DeclUnionGetter          x -> translateUnionGetter          x
+  Hs.DeclUnionSetter          x -> translateUnionSetter          x
+  Hs.DeclVar                  x -> translateDeclVar              x
 
 translateDeclTypSyn :: Hs.TypSyn -> SDecl
 translateDeclTypSyn d = DTypSyn $ TypeSynonym {
@@ -103,7 +104,8 @@ translateDefineInstanceDecl defInst =
           , types   = []
           , comment = defInst.comment
           , decs    = [ ( bindgenGlobalTerm Flam_Offset_offset
-                        , ELam "_ty" $ EIntegral (toInteger i.offset) Nothing)
+                        , ELam (NameHint "_proxy") $
+                            EIntegral (toInteger i.offset) Nothing)
                       ]
           }
       Hs.InstanceCEnum struct i ->

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -20,7 +20,7 @@ import Language.Haskell.TH (Quote)
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
 
-import C.Expr.Syntax qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
 
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.Hs.AST qualified as Hs
@@ -77,14 +77,14 @@ mkRolledExpr env expr = case expr of
     -- Word32/Word64 and then cast back.
     EFloat f t ->
       TH.sigE
-        ( if CExpr.DSL.canBeRepresentedAsRational f
+        ( if CExpr.canBeRepresentedAsRational f
             then [| f |]
             else [| Foreign.C.Types.CFloat $ castWord32ToFloat  $( TH.lift $ castFloatToWord32  f ) |]
         )
         (mkType EmptyEnv t)
     EDouble d t ->
       TH.sigE
-        ( if CExpr.DSL.canBeRepresentedAsRational d
+        ( if CExpr.canBeRepresentedAsRational d
             then [| d |]
             else [| Foreign.C.Types.CDouble $ castWord64ToDouble $( TH.lift $ castDoubleToWord64 d ) |]
         )

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -141,7 +141,7 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
       Hs.DeclForeignImportWrapper{} -> id
       Hs.DeclForeignImportDynamic{} -> id
       Hs.DeclFunction{}             -> id
-      Hs.DeclMacroExpr{}            -> id
+      Hs.DeclMacroValue{}           -> id
       Hs.DeclUnionGetter{}          -> id
       Hs.DeclUnionSetter{}          -> id
       Hs.DeclVar{}                  -> id

--- a/hs-bindgen/src-internal/HsBindgen/Config/MangleCandidate.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config/MangleCandidate.hs
@@ -2,6 +2,7 @@ module HsBindgen.Config.MangleCandidate (
     -- * Definition
     MangleCandidate(..)
   , mangleCandidate
+  , mangleCandidateDefaultFallback
     -- * Parse
   , ParseCandidateError(..)
   , parseCandidate
@@ -140,6 +141,19 @@ mangleCandidate mc =
       = Hs.UnsafeName $ mc.onReservedName name.text
       | otherwise
       = name
+
+-- | Mangle a candidate
+--
+-- Use the default configuration 'mangleCandidateDefault'.
+--
+-- If mangling fails, return the @fallback@ value.
+mangleCandidateDefaultFallback ::
+     forall ns. Hs.SingNamespace ns
+  => Hs.Name ns -> Text -> Hs.Name ns
+mangleCandidateDefaultFallback fallback candidate =
+  case mangleCandidate mangleCandidateDefault candidate of
+    Nothing   -> fallback
+    Just name -> name
 
 {-------------------------------------------------------------------------------
   Parse

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -5,14 +5,14 @@ module HsBindgen.Frontend.AST.Deps (
   , depsOfUnion
   , depsOfField
     -- * Parsed macros
-  , MacroNameResolver
   , depsOfDeclParsedMacro
   ) where
 
 import Data.Set qualified as Set
 import GHC.Records
 
-import C.Expr.Syntax qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
 import C.Expr.Typecheck.Interface.Value qualified as V
 
 import HsBindgen.Frontend.AST.Decl qualified as C
@@ -79,25 +79,28 @@ depsOfDeclTcMacro = depsOfDeclWith (depsOfTcMacro (Proxy @p))
 
 -- | Dependencies of typechecked macro declarations
 depsOfTcMacro ::
-     (IsPass p, MacroBody p ~ CheckedMacro p)
+     forall p. (IsPass p, MacroBody p ~ CheckedMacro p)
   => Proxy p -> MacroBody p -> [(ValOrRef, Id p)]
 depsOfTcMacro proxy = \case
-    MacroType typ  -> depsOfType typ.typ
-    MacroExpr expr -> depsOfVExpr proxy (Set.fromList expr.args) expr.body
+    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
+    --
+    -- If we replace the CType with the TExpr, we need to know if the
+    -- dependencies are by value or by reference.
+    MacroType  typ -> depsOfType  typ.cType
+    MacroValue val -> depsOfValue val.value
   where
+    depsOfValue :: CExpr.CheckedMacroValueExpr (Id p) -> [(ValOrRef, Id p)]
+    depsOfValue (CExpr.CheckedMacroValueExpr _ body _) = depsOfVExpr proxy body
+
     -- Collect value-level dependencies from a checked macro body. Local
     -- arguments (lambda-bound ids) are excluded.
     depsOfVExpr ::
-         forall p. (Ord (Id p))
-      => Proxy p
-      -> Set (Id p)
-      -> V.Expr (Id p)
+         forall ctx.
+         Proxy p
+      -> V.Expr ctx (Id p)
       -> [(ValOrRef, Id p)]
-    depsOfVExpr _ localArgs =
-        map (ByValue,) . filter (not . isLocalArg) . toList
-      where
-        isLocalArg :: Id p -> Bool
-        isLocalArg x = Set.member x localArgs
+    depsOfVExpr _ =
+        map (ByValue,) . toList
 
 {-------------------------------------------------------------------------------
   Structs and unions
@@ -133,65 +136,88 @@ depsOfTypedef typedef = depsOfType typedef.typ
 --   bare names (see 'MacroNameResolver').
 depsOfDeclParsedMacro ::
      forall p. (IsPass p, MacroBody p ~ ParsedMacro, Id p ~ DeclId)
-  => MacroNameResolver -> C.DeclKind p -> [(ValOrRef, Id p)]
-depsOfDeclParsedMacro resolver = depsOfDeclWith depsOfParsedMacro
+  => Set DeclId -> C.DeclKind p -> [(ValOrRef, Id p)]
+depsOfDeclParsedMacro allDeclIds = depsOfDeclWith depsOfParsedMacro
   where
     depsOfParsedMacro :: ParsedMacro -> [(ValOrRef, DeclId)]
-    depsOfParsedMacro (ParsedMacro m) = depsOfCExprMacro resolver m
-
--- | Resolves a bare name found in a parsed macro body
---
--- Result:
---
--- - @'Just' 'CNameKind'@: This bare name refers to another declaration that is in
---   the 'DeclIndex'. For example, a macro, or a @typedef@.
---
--- - @'Nothing'@: This bare name refers to a built-in type or a system @typedef@
---   not present in the 'DeclIndex'. In this case, we /do not generate/ a
---   dependency.
-type MacroNameResolver = Text -> Maybe CNameKind
+    depsOfParsedMacro (ParsedMacro m) = depsOfCExprMacro allDeclIds m
 
 -- | Collect all references in a macro body.
 --
 -- Local macro arguments are excluded.
 depsOfCExprMacro ::
-     MacroNameResolver
-  -> CExpr.DSL.Macro
+     Set DeclId
+  -> CExpr.Macro
   -> [(ValOrRef, DeclId)]
-depsOfCExprMacro resolver macro =
-    map (ByValue,) $ goExpr (Set.fromList macro.macroArgs) macro.macroExpr
+depsOfCExprMacro allDeclIds (CExpr.Macro _ _ _ macroExpr) =
+    map (ByValue,) $ goExpr macroExpr
   where
-    goExpr :: Set CExpr.DSL.Name -> CExpr.DSL.Expr CExpr.DSL.Ps -> [DeclId]
-    goExpr localArgs = \case
-      CExpr.DSL.Term  term   -> goTerm  localArgs term
-      CExpr.DSL.TyApp _ xs   -> concatMap (goExpr localArgs) xs
-      CExpr.DSL.VaApp _ _ xs -> concatMap (goExpr localArgs) xs
+    goExpr :: CExpr.Expr ctx CExpr.Ps -> [DeclId]
+    goExpr = \case
+      CExpr.Term  term   -> goTerm term
+      CExpr.TyApp _ xs   -> concatMap goExpr xs
+      CExpr.VaApp _ _ xs -> concatMap goExpr xs
 
-    goTerm :: Set CExpr.DSL.Name -> CExpr.DSL.Term CExpr.DSL.Ps -> [DeclId]
-    goTerm localArgs = \case
-      CExpr.DSL.Literal lit -> goLit lit
+    goTerm :: CExpr.Term ctx CExpr.Ps -> [DeclId]
+    goTerm = \case
+      CExpr.Literal lit ->
+        goLit lit
+      CExpr.LocalParam{} ->
+        []
       -- Variable / function call. A bare identifier is always parsed as Var;
       -- the typechecker decides whether it is a type or value reference.
       -- We use the resolver to emit a dep of the correct kind, or skip the
       -- name entirely if it is not a known declaration (e.g. a built-in type).
-      CExpr.DSL.Var _ nm callArgs
-        | nm `Set.member` localArgs ->
-            concatMap (goExpr localArgs) callArgs
-        | Just kind <- resolver nm.getName ->
-            mkId nm.getName kind :
-            concatMap (goExpr localArgs) callArgs
+      CExpr.Var _ nm callArgs
+        | Just declId <- resolveMacroTypedef nm.getName ->
+            declId : concatMap goExpr callArgs
         | otherwise ->
-            concatMap (goExpr localArgs) callArgs
+            concatMap goExpr callArgs
 
-    goLit :: CExpr.DSL.Literal -> [DeclId]
+    goLit :: CExpr.Literal -> [DeclId]
     goLit = \case
       -- Named type specifier using an elaborated tag: struct/union/enum.
-      CExpr.DSL.TypeLit (CExpr.DSL.TypeTagged tag nm) ->
-        [ mkId nm (CNameKindTagged (convertTagKind tag)) ]
+      CExpr.TypeTagged tag nm
+        | Just declId <- resolveTaggedType (convertTagKind tag) nm.getName ->
+            [declId]
+        | otherwise ->
+            []
       -- Other built-in type specifiers (int, char, etc.) have no dependencies.
-      CExpr.DSL.TypeLit _ -> []
+      CExpr.TypeLit{}  -> []
       -- Value literals have no dependencies.
-      _ -> []
+      CExpr.ValueLit{} -> []
 
-    mkId :: Text -> CNameKind -> DeclId
-    mkId name kind = DeclId (CDeclName name kind) False
+    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1952>
+    --
+    -- We should only resolve the declaration IDs of macro dependencies one. Now
+    -- we resolve them twice: when we get the dependencies of parsed macros, and
+    -- when we typecheck macros.
+
+    -- | Resolves a bare name found in a parsed macro body
+    --
+    -- Result:
+    --
+    -- - @'Just' 'CNameKind'@: This bare name refers to another declaration that is in
+    --   the 'DeclIndex'. For example, a macro, or a @typedef@.
+    --
+    -- - @'Nothing'@: This bare name is not in the set of known declarations. It
+    --   may simply be non-existent, or refer to a built-in type or a system
+    --   @typedef@ not present in the 'DeclIndex'. In this case, we /do not
+    --   generate/ a dependency.
+    resolveMacroTypedef :: Text -> Maybe DeclId
+    resolveMacroTypedef nm
+      | macroId   `Set.member` allDeclIds = Just macroId
+      | typedefId `Set.member` allDeclIds = Just typedefId
+      | otherwise                         = Nothing
+      where
+        macroId, typedefId :: DeclId
+        macroId   = DeclId (CDeclName nm CNameKindMacro)    False
+        typedefId = DeclId (CDeclName nm CNameKindOrdinary) False
+
+    resolveTaggedType :: CTagKind -> Text -> Maybe DeclId
+    resolveTaggedType tag nm
+      | taggedId `Set.member` allDeclIds = Just taggedId
+      | otherwise                        = Nothing
+      where
+        taggedId :: DeclId
+        taggedId = DeclId (CDeclName nm $ CNameKindTagged tag) False

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -51,7 +51,7 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Data.Set qualified as Set
 
-import C.Expr.Syntax
+import C.Expr.Syntax qualified as CExpr
 
 import Clang.HighLevel.Types
 import Clang.Paths
@@ -343,14 +343,9 @@ fromParseResults results = flip execState empty $ mapM_ aux results
       -> C.DeclKind EnrichComments
       -> Bool
     sameDefinition a b = case (a, b) of
-      (C.DeclMacro macroA, C.DeclMacro macroB) -> sameMacro macroA macroB
+      (C.DeclMacro macroA, C.DeclMacro macroB) ->
+         CExpr.sameMacro macroA.parsedMacro macroB.parsedMacro
       _otherwise                               -> a == b
-
-    sameMacro :: ParsedMacro -> ParsedMacro -> Bool
-    sameMacro a b =
-        -- The location does not need to match. Everything else must be equal.
-        a.parsedMacro.macroName == b.parsedMacro.macroName &&
-        a.parsedMacro.macroExpr == b.parsedMacro.macroExpr
 
 {-------------------------------------------------------------------------------
   Filter

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph/Construction.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph/Construction.hs
@@ -46,17 +46,7 @@ fromDecls includeGraph declIndex =
     -- below).
     insertDepsOfDeclParsedMacro :: C.Decl EnrichComments -> UseDeclGraph -> UseDeclGraph
     insertDepsOfDeclParsedMacro d =
-      insertDeps d.info.id (depsOfDeclParsedMacro resolver d.kind)
-
-    resolver :: MacroNameResolver
-    resolver nm
-      | macroId   `Set.member` allDeclIds = Just CNameKindMacro
-      | typedefId `Set.member` allDeclIds = Just CNameKindOrdinary
-      | otherwise                         = Nothing
-      where
-        macroId, typedefId :: DeclId
-        macroId   = DeclId (CDeclName nm CNameKindMacro)    False
-        typedefId = DeclId (CDeclName nm CNameKindOrdinary) False
+      insertDeps d.info.id (depsOfDeclParsedMacro allDeclIds d.kind)
 
     -- We first insert all vertices. For successfully parsed declarations, we do
     -- this in source order, this ensures that we preserve source order as much

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
@@ -4,16 +4,13 @@ module HsBindgen.Frontend.Pass.AdjustTypes (
 
 import Numeric.Natural (Natural)
 
-import HsBindgen.Frontend.AST.Coerce (CoercePass (coercePass))
+import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.AdjustTypes.IsPass (AdjustTypes,
-                                                   AdjustedFrom (..))
-import HsBindgen.Frontend.Pass.MangleNames.IsPass (MangleNames)
-import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass (CheckedMacro (MacroExpr, MacroType),
-                                                       CheckedMacroExpr,
-                                                       CheckedMacroType (..))
+import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
+import HsBindgen.Frontend.Pass.MangleNames.IsPass
+import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 
 -- | Adjust function argument types
 --
@@ -145,17 +142,20 @@ processAnonEnumConstant anonEnumConstant =
 processMacro :: MacroBody MangleNames -> MacroBody AdjustTypes
 processMacro macro =
     case macro of
-      MacroType typ -> MacroType $ processMacroType typ
-      MacroExpr expr -> MacroExpr $ processMacroExpr expr
+      MacroType  typ -> MacroType  $ processMacroType typ
+      MacroValue val -> MacroValue $ processMacroExpr val
 
 processMacroType :: CheckedMacroType MangleNames -> CheckedMacroType AdjustTypes
 processMacroType macroType =
     CheckedMacroType {
-        typ = processType macroType.typ
-      , ann = macroType.ann
+        -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1953>
+        --
+        -- Be careful when we replace the CType with the TExpr.
+        cType = processType macroType.cType
+      , ann   = macroType.ann
       }
 
-processMacroExpr :: CheckedMacroExpr MangleNames -> CheckedMacroExpr AdjustTypes
+processMacroExpr :: CheckedMacroValue MangleNames -> CheckedMacroValue AdjustTypes
 processMacroExpr macroExpr =
     -- NOTE: currently macro expressions don't support function/array type
     -- parameters, if they do in the future, then we might have to recurse into

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -15,6 +15,8 @@ import Data.Map qualified as Map
 import Data.Proxy
 import Data.Set qualified as Set
 
+import C.Expr.Typecheck qualified as CExpr
+
 import Clang.HighLevel.Types
 
 import HsBindgen.BindingSpec qualified as BindingSpec
@@ -422,6 +424,12 @@ lookupVarE declId = do
           MangleNamesUnderlyingDeclNotMangled declId (NonEmpty.singleton Hs.NsVar)
       Just hsNm ->
         pure hsNm
+
+lookupVarPair :: DeclId -> E M DeclIdPair
+lookupVarPair declId = lookupVarE declId >>= \hsName -> pure $ DeclIdPair{
+        cName  = declId
+      , hsName = Hs.demoteNs hsName
+    }
 
 {-------------------------------------------------------------------------------
   Pass 2: Apply NameMap
@@ -950,55 +958,28 @@ instance Mangle C.Global where
 
 instance MangleWithDeclName CheckedMacro where
   mangleWithDeclName hsName = \case
-      MacroType typ  -> MacroType <$> mangleWithDeclName hsName typ
-      MacroExpr expr -> MacroExpr <$> mangle expr
+      MacroType  typ -> MacroType  <$> mangleWithDeclName hsName typ
+      MacroValue val -> MacroValue <$> mangle val
 
 instance MangleWithDeclName CheckedMacroType where
   mangleWithDeclName hsName macroType = do
-      strategy <- asks (.fieldNamingStrategy)
+      strategy       <- asks (.fieldNamingStrategy)
       macroTypeNames <- mkMacroTypeNames strategy hsName
-      reconstruct macroTypeNames <$> mangle macroType.typ
-    where
-      reconstruct :: NewtypeNames -> C.Type MangleNames -> CheckedMacroType MangleNames
-      reconstruct macroTypeNames typ' = CheckedMacroType{
-            typ = typ'
+      cType'         <- mangle macroType.cType
+      pure CheckedMacroType{
+            cType = cType'
           , ann = macroTypeNames
           }
 
-instance Mangle CheckedMacroExpr where
-  mangle macroExpr = do
-      args' <- traverse mangleMacroParam macroExpr.args
-      let localNameMap :: Map DeclId (Hs.Name Hs.NsVar)
-          localNameMap = Map.fromList args'
-      body' <- traverse (mangleMacroBodyVar localNameMap) macroExpr.body
-      pure CheckedMacroExpr{
-            args = map (uncurry DeclIdPair . second Hs.demoteNs) args'
-          , body = body'
-          , typ  = macroExpr.typ
+instance Mangle CheckedMacroValue where
+  mangle macroValue = CheckedMacroValue <$> case macroValue.value of
+    CExpr.CheckedMacroValueExpr params body typ -> do
+      body' <- traverse lookupVarPair body
+      pure CExpr.CheckedMacroValueExpr{
+            macroValueParams = params
+          , macroValueBody   = body'
+          , macroValueType   = typ
           }
-
--- | Mangle a macro parameter name locally.
---
--- Macro parameters (e.g., @x@ in @PLUS(x)@) are not top-level declarations
--- and therefore not present in the global 'NameMap'. We assign them Haskell
--- names directly, without a name-map lookup.
-mangleMacroParam :: DeclId -> E M (DeclId, Hs.Name Hs.NsVar)
-mangleMacroParam declId = do
-    name <- mkIdentifier (Proxy @Hs.NsVar) declId.name.text
-    pure (declId, name)
-
--- | Resolve a variable reference inside a macro body.
---
--- Body variables are first looked up in the local parameter map (for macro
--- parameters), and fall back to the global 'NameMap' for references to other
--- declarations (e.g. global macros or @typedef@s used inside the body).
-mangleMacroBodyVar ::
-  Map DeclId (Hs.Name Hs.NsVar) -> DeclId -> E M DeclIdPair
-mangleMacroBodyVar localMap declId =
-    (DeclIdPair declId) . Hs.demoteNs <$>
-      case Map.lookup declId localMap of
-        Just hsNm -> pure $ hsNm
-        Nothing   -> lookupVarE declId
 
 instance Mangle C.Type where
   mangle = \case
@@ -1057,8 +1038,8 @@ withDeclNamespace kind k =
 
       C.DeclMacro macro ->
         case macro of
-          MacroType{} -> k (Proxy @Hs.NsTypeConstr)
-          MacroExpr{} -> k (Proxy @Hs.NsVar)
+          MacroType{}  -> k (Proxy @Hs.NsTypeConstr)
+          MacroValue{} -> k (Proxy @Hs.NsVar)
 
 withDeclLoc :: forall p a.
      IsPass p

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -8,7 +8,7 @@ import Data.List qualified as List
 import Data.Text qualified as Text
 import Foreign.C (CInt)
 
-import C.Expr.Parse qualified as CExpr.DSL
+import C.Expr.Parse qualified as CExpr
 
 import Clang.CStandard
 import Clang.Enum.Simple
@@ -1018,7 +1018,7 @@ partitionAnonDecls =
 
 -- | Parse macro tokens
 --
--- We use @c-expr-dsl@ to parse the macro tokens into a 'CExpr.DSL.Macro'.
+-- We use @c-expr-dsl@ to parse the macro tokens into a 'CExpr.Macro'.
 -- No type environment is needed for this step; type resolution and
 -- expression typechecking happen later in 'TypecheckMacros'.
 parseMacroTokens ::
@@ -1030,7 +1030,7 @@ parseMacroTokens cStd name = \case
     []      -> Left $ ParseMacroEmpty name []
     [token] -> Left $ ParseMacroEmpty name [token]
     tokens  ->
-      case CExpr.DSL.runParser (CExpr.DSL.parseMacro cStd) tokens of
+      case CExpr.runParser (CExpr.parseMacro cStd) tokens of
         Right macro ->
           Right $ ParsedMacro macro
         Left errParse ->

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -11,7 +11,7 @@ module HsBindgen.Frontend.Pass.Parse.IsPass (
   , IsAnon(..)
   ) where
 
-import C.Expr.Syntax qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
 
 import Clang.HighLevel.Types
 import Clang.LowLevel.Core (CXType)
@@ -60,12 +60,12 @@ instance IsPass Parse where
 
 -- | Syntactic parse result from @c-expr-dsl@.
 --
--- A type macro (e.g. @#define FOO int@) has 'CExpr.DSL.macroBody' equal to
--- @'CExpr.DSL.MTerm' ('CExpr.DSL.MType' …)@. An expression macro has any
--- other 'CExpr.DSL.macroBody'. Type conversion and expression typechecking
+-- A type macro (e.g. @#define FOO int@) has 'CExpr.macroBody' equal to
+-- @'CExpr.MTerm' ('CExpr.MType' …)@. An expression macro has any
+-- other 'CExpr.macroBody'. Type conversion and expression typechecking
 -- happen later in "HsBindgen.Frontend.Pass.TypecheckMacros".
 newtype ParsedMacro = ParsedMacro {
-      parsedMacro :: CExpr.DSL.Macro
+      parsedMacro :: CExpr.Macro
     }
 
 deriving stock instance Show ParsedMacro

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -13,7 +13,7 @@ import Foreign.C (CInt)
 import Text.SimplePrettyPrint ((><))
 import Text.SimplePrettyPrint qualified as PP
 
-import C.Expr.Parse qualified as CExpr.DSL
+import C.Expr.Parse qualified as CExpr
 
 import Clang.Enum.Simple
 import Clang.HighLevel.Types
@@ -129,7 +129,7 @@ data DelayedParseMsg =
   | ParseMacroEmpty PrelimDeclId [Token TokenSpelling]
 
     -- | We could not parse the macro (macro def sites)
-  | ParseMacroErrorParse CExpr.DSL.MacroParseError
+  | ParseMacroErrorParse CExpr.MacroParseError
 
     -- | We could not reparse a fragment of C (to recover macro use sites)
   | ParseMacroErrorReparse LanC.Error
@@ -466,7 +466,7 @@ instance PrettyForTrace DelayedParseMsg where
           , PP.string pleaseReport
           ]
 
-      prettyMacroParseError :: CExpr.DSL.MacroParseError -> PP.CtxDoc
+      prettyMacroParseError :: CExpr.MacroParseError -> PP.CtxDoc
       prettyMacroParseError err = PP.renderedLines $ \_maxWidth -> lines err.reparseError
 
 -- | Unsupported features are warnings

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -296,8 +296,8 @@ applyPrescriptive decl cTypeSpec = \case
             C.DeclTypedef{}   -> True
             C.DeclOpaque{}    -> True
             C.DeclMacro macro -> case macro of
-              MacroType{} -> True
-              MacroExpr{} -> False
+              MacroType{}  -> True
+              MacroValue{} -> False
             _otherwise        -> False
       if isValid
         then do
@@ -489,17 +489,20 @@ instance Resolve C.FunctionArg where
 
 instance Resolve CheckedMacro where
   resolve ctx = \case
-    MacroType typ  -> MacroType <$> resolve ctx typ
-    MacroExpr expr -> return (MacroExpr $ coercePass expr)
+    MacroType  typ -> MacroType  <$> resolve ctx typ
+    MacroValue val -> MacroValue <$> pure (coercePass val)
 
 instance Resolve CheckedMacroType where
-  resolve ctx macroType = reconstruct <$> resolve ctx macroType.typ
+  resolve ctx macroType = reconstruct <$> resolve ctx macroType.cType
     where
       reconstruct ::
            C.Type ResolveBindingSpecs
         -> CheckedMacroType ResolveBindingSpecs
-      reconstruct typ' = CheckedMacroType {
-          typ = typ'
+      reconstruct cType' = CheckedMacroType {
+          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
+          --
+          -- Be careful when we replace the CType with the TExpr.
+          cType = cType'
         , ann = macroType.ann
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
@@ -2,20 +2,22 @@ module HsBindgen.Frontend.Pass.TypecheckMacros (
     typecheckMacros
   ) where
 
-import Control.Applicative (asum)
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.Reader (MonadReader (..), Reader, runReader)
 import Control.Monad.State (MonadState (..), StateT, modify, runStateT)
+import Control.Monad.Trans.Class (lift)
 import Data.Either (partitionEithers)
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 
-import C.Expr.Syntax qualified as CExpr.DSL
-import C.Expr.Typecheck qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
 import C.Expr.Typecheck.Interface.Type qualified as T
-import C.Expr.Typecheck.Type qualified as CExpr.DSL
+import C.Expr.Typecheck.Type qualified as CExpr
 
 import Clang.HighLevel.Types
 
+import HsBindgen.Errors (panicPure)
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.AST.Coerce
@@ -36,13 +38,12 @@ import HsBindgen.Language.C qualified as C
 -------------------------------------------------------------------------------}
 
 type CType = C.Type TypecheckMacros
-type TypeEnv = Map Text CType
 
 -- | We perform two traversals:
 --
--- 1. Collect known types
+-- Traversal 1: collect known types
 --
--- 2. Typecheck macros
+-- Traversal 2: typecheck macros
 --
 -- Returns the updated translation unit together with the 'LanC.ReparseEnv'
 -- that 'reparseMacroExpansions' uses to reparse declarations.
@@ -55,17 +56,21 @@ typecheckMacros ::
      , LanC.ReparseEnv
      )
 typecheckMacros unit =
-    let typedefTypes, taggedTypes :: TypeEnv
+    let typedefTypes :: Map Text CType
+        taggedTypes  :: Map CDeclName CType
+        -- Traversal 1
         (typedefTypes, taggedTypes) =
           bimap Map.fromList Map.fromList $
             partitionEithers $
               mapMaybe getKnownType unit.decls
+        -- Traversal 2
         ((failedMacros, typecheckedDecls), typecheckState) =
           runM typedefTypes taggedTypes $
             fmap partitionEithers $ mapM typecheckDecl unit.decls
     in  ( reconstructAfterTypecheck unit failedMacros typecheckedDecls
-        , Map.map coercePass $ typedefTypes <> taggedTypes
-        , Map.map coercePass $ typecheckState.macroTypes )
+        , Map.map coercePass $
+            typedefTypes <> Map.mapKeys renderCDeclNameC taggedTypes
+        , Map.map coercePass $ typecheckState.resolvedMacroTypes )
 
 {-------------------------------------------------------------------------------
   Reconstruct translation unit after typechecking
@@ -98,28 +103,43 @@ reconstructAfterTypecheck unit failedMacros decls =
   Traversal 1: Underlying types
 -------------------------------------------------------------------------------}
 
-type KnownType = (Text, CType)
-
+-- | Typedef name → CType (Left) or tagged name → CType (Right).
 getKnownType ::
-  C.Decl ConstructTranslationUnit -> Maybe (Either KnownType KnownType)
+     C.Decl ConstructTranslationUnit
+  -> Maybe (Either (Text, CType) (CDeclName, CType))
 getKnownType decl = case decl.kind of
     C.DeclMacro{}            -> Nothing
-    C.DeclTypedef typedef    -> Just $ Left  $ (name, getKnownTypedef typedef)
-    C.DeclStruct{}           -> Just $ Right $ (name, knownStructOrUnion)
-    C.DeclUnion{ }           -> Just $ Right $ (name, knownStructOrUnion)
-    C.DeclEnum enum          -> Just $ Right $ (name, getKnownEnum    enum)
+    C.DeclTypedef typedef    -> Just $ Left  (typedefName, getKnownTypedef typedef)
+    C.DeclStruct{}           -> Just $ Right (taggedName,  knownStructOrUnion)
+    C.DeclUnion{}            -> Just $ Right (taggedName,  knownStructOrUnion)
+    C.DeclEnum enum          -> Just $ Right (taggedName,  getKnownEnum enum)
     C.DeclAnonEnumConstant{} -> Nothing
-    C.DeclOpaque{}           -> Nothing
+    -- Include opaque tagged types: they can be referenced by macros (e.g. as a
+    -- pointer type). The only opaque type-like declarations carrying an
+    -- ordinary names are @typedef void foo@, which is not a valid standalone
+    -- type, so macros using them will fail anyway.
+    C.DeclOpaque{}           -> Right <$> getKnownTypeOpaque
     C.DeclFunction{}         -> Nothing
     C.DeclGlobal{}           -> Nothing
   where
     info :: C.DeclInfo ConstructTranslationUnit
     info = decl.info
 
-    name :: Text
-    name = renderCDeclNameC $ info.id.name
+    getKnownTypeOpaque :: Maybe (CDeclName, CType)
+    getKnownTypeOpaque =
+      case info.id.name.kind of
+        CNameKindTagged _ -> Just (taggedName, knownStructOrUnion)
+        _                 -> Nothing
 
-    getKnownTypedef :: C.Typedef ConstructTranslationUnit -> C.Type TypecheckMacros
+    -- | Typedef names are plain text (always 'CNameKindOrdinary').
+    typedefName :: Text
+    typedefName = info.id.name.text
+
+    -- | Tagged names carry their tag kind ('CNameKindTagged').
+    taggedName :: CDeclName
+    taggedName = info.id.name
+
+    getKnownTypedef :: C.Typedef ConstructTranslationUnit -> CType
     getKnownTypedef typedef = C.TypeTypedef $ C.Ref info.id $ coercePass typedef.typ
 
     knownStructOrUnion :: CType
@@ -185,76 +205,88 @@ newtype M a = WrapM { _unwrapM :: StateT TypecheckState (Reader TypecheckEnv) a 
     )
 
 data TypecheckEnv = TypecheckEnv {
-      -- | Known @typedef@ types from the first traversal.
-      --
-      -- The macro typechecker only needs to know about @typedef@s.
-      knownTypedefs :: TypeEnv
-      -- | Known @union@, @struct@, and @enum@ types from the first traversal.
-      --
-      -- Translation to @hs-bindgen@ C types, as well as reparsing in the next
-      -- pass, also requires knowledge about @struct@, @enum@, and @union@
-      -- types.
-    , knownTaggedTypes :: TypeEnv
-}
+      -- | Known @typedef@ types from the first traversal, keyed by bare name.
+      knownTypedefs :: Map Text CType
+      -- | Known @struct@, @union@, and @enum@ types from the first traversal,
+      --   keyed by 'CDeclName' (which carries the tag kind).
+    , knownTaggedTypes :: Map CDeclName CType
+    }
 
 data TypecheckState = TypecheckState {
-      -- | Quantified types of macro expressions.
-      macroEnv   :: CExpr.DSL.TypeEnv
-      -- | New macro C types. We need these to convert type-checked macros to C
-      --   types in @hs-bindgen@, and also when reparsing declarations with
-      --   macro expansions in the next pass.
-    , macroTypes :: TypeEnv
+      -- | The c-expr-dsl type environment, accumulating quantified types
+      --   for each macro as we typecheck them.
+      typeEnv :: CExpr.TypeEnv
+      -- | Resolved macro C types, keyed by bare name. We need these when
+      --   injecting type names (for macros that reference other macro-defined
+      --   types) and for reparsing declarations with macro expansions in the
+      --   next pass.
+    , resolvedMacroTypes :: Map Text CType
     }
   deriving stock (Generic)
 
-runM :: TypeEnv -> TypeEnv -> M a -> (a, TypecheckState)
+runM ::
+     Map Text CType
+  -> Map CDeclName CType
+  -> M a
+  -> (a, TypecheckState)
 runM knownTypedefs knownTaggedTypes (WrapM ma) = runReader (runStateT ma s) e
   where
     e :: TypecheckEnv
     e = TypecheckEnv{
-      knownTypedefs = knownTypedefs
+      knownTypedefs    = knownTypedefs
     , knownTaggedTypes = knownTaggedTypes
     }
 
     s :: TypecheckState
     s = TypecheckState{
-      macroEnv   = buildCTypeEnv knownTypedefs
-    , macroTypes = Map.empty
+      typeEnv = CExpr.buildTypedefEnv
+                  [ CExpr.Name nm | nm <- Map.keys knownTypedefs ]
+    , resolvedMacroTypes = Map.empty
     }
 
-    -- Build a 'TypeEnv' fragment for all known @typedef@ types.
-    --
-    -- Note: @struct@, @union@, and @enum@ types are kept separately in
-    -- 'knownTaggedTypes' and are looked up via 'getLookupKnownType' (through
-    -- 'convertSpecifier'). They are not added to the c-expr-dsl 'TypeEnv'
-    -- because tagged types always parse as 'CExpr.DSL.TypeTagged' literals,
-    -- never as bare 'CExpr.DSL.Var' nodes.
-    --
-    -- Use a dummy 'FunValue' that is never invoked.
-    buildCTypeEnv :: TypeEnv -> CExpr.DSL.TypeEnv
-    buildCTypeEnv types =
-        Map.fromList
-          [ ( CExpr.DSL.Name nm
-            , CExpr.DSL.Quant @Z $ \VNil ->
-                CExpr.DSL.QuantTyBody []
-                  ( CExpr.DSL.FunValue @Z nm (\VNil -> CExpr.DSL.NoValue)
-                  , CExpr.DSL.MacroTypeTy
-                  )
-            )
-          | nm <- Map.keys types
-          ]
+-- | Look up a @typedef@ or macro-defined type by bare name.
+--
+-- Searches both the known @typedef@s (from the first traversal) and the
+-- resolved macro types (accumulated during typechecking).
+--
+-- 'panicPure' is safe here: c-expr-dsl only calls the inject function for names
+-- present in 'CExpr.TypeEnv', which we built from these same maps. That is, it
+-- is a bug, if we fail to lookup an ordinary type, because the typechecker
+-- should have failed gracefully at an earlier stage.
+lookupTypeName :: TypecheckEnv -> TypecheckState -> Text -> DeclId
+lookupTypeName env st n =
+    case (Map.member n env.knownTypedefs, Map.member n st.resolvedMacroTypes) of
+      (True , _    ) -> DeclId (CDeclName n CNameKindOrdinary) False
+      (False, True ) -> DeclId (CDeclName n CNameKindMacro)    False
+      (False, False) -> panicPure $ "lookupTypeName: name not found: " <> show n
 
+-- | Look up a tagged type (struct, union, enum) by 'CDeclName'.
+--
+-- Unlike 'lookupTypeName', there is no invariant guaranteeing presence: tagged
+-- types are resolved from syntax alone and are not gated by 'CExpr.TypeEnv'.
+-- A macro may reference a tagged type we failed to parse or that was defined
+-- in an unprocessed header, so we return a proper error rather than panic.
+lookupTaggedTypeName :: TypecheckEnv -> CDeclName -> Either MacroTypecheckError DeclId
+lookupTaggedTypeName env key =
+    if Map.member key env.knownTaggedTypes
+      then Right $ DeclId key False
+      else Left  $ MacroTypecheckErrorUnresolvedTaggedType key
 
-getLookupKnownType :: M (Text -> Maybe CType)
-getLookupKnownType = do
-    st <- get
-    env <- ask
-    pure $ \n ->
-      let mKnownTypedef, mKnownTaggedType, mKnownMacroType :: Maybe CType
-          mKnownTypedef    = Map.lookup n env.knownTypedefs
-          mKnownTaggedType = Map.lookup n env.knownTaggedTypes
-          mKnownMacroType  = Map.lookup n st.macroTypes
-      in  asum [mKnownTypedef, mKnownTaggedType, mKnownMacroType]
+-- | Look up the 'CType' for a 'DeclId' produced by the inject functions.
+--
+-- 'panicPure' is safe here: the typechecker only emits 'DeclId's via the inject
+-- functions, which only inject names that were present at injection time.
+lookupTypeWith :: TypecheckEnv -> TypecheckState -> DeclId -> CType
+lookupTypeWith env st declId =
+    case mType of
+      Just t  -> t
+      Nothing -> panicPure $ "lookupTypeWith: declaration not found " <> show declId
+  where
+    mType :: Maybe CType
+    mType = case declId.name.kind of
+      CNameKindOrdinary -> Map.lookup declId.name.text env.knownTypedefs
+      CNameKindMacro    -> Map.lookup declId.name.text st.resolvedMacroTypes
+      CNameKindTagged _ -> Map.lookup declId.name      env.knownTaggedTypes
 
 {-------------------------------------------------------------------------------
   Type checking
@@ -262,44 +294,85 @@ getLookupKnownType = do
 
 -- | Type check macro.
 --
--- Delegates dispatch between type and expression bodies to 'CExpr.DSL.tcMacro'.
+-- Delegates dispatch between type and expression bodies to 'CExpr.tcMacro'.
+--
+-- Both inject functions (for type names and value names) produce 'DeclId'
+-- values used for dependency tracking. For type macros, 'convertTExpr' then
+-- maps the 'DeclId' leaves in the result back to 'CType' via 'lookupTypeWith'.
 tcMacro ::
      CDeclName
   -> ParsedMacro
   -> M (Either MacroTypecheckError (CheckedMacro TypecheckMacros))
-tcMacro name (ParsedMacro macro) = do
+tcMacro name (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
     st  <- get
-    let typeEnv = st.macroEnv
-    case CExpr.DSL.tcMacro typeEnv macro.macroName macro.macroArgs macro.macroExpr of
-      Left err ->
-        pure $ Left $ MacroTypecheckErrorCExpr err
-      Right (CExpr.DSL.MacroTcTypeExpr typeExpr quant) -> do
-        r <- convertTExpr typeExpr
-        case r of
-          Right typ -> do
-            addQuant quant
-            addNewMacroTypeToReparseEnv typ
-            pure $ Right $ MacroType $ CheckedMacroType typ NoAnn
-          Left err  -> pure $ Left err
-      Right (CExpr.DSL.MacroTcValueExpr valueExpr inf) -> do
-        modify $ #macroEnv %~ Map.insert macro.macroName inf
-        pure $ Right $ MacroExpr $ CheckedMacroExpr{
-              args = map mkId macro.macroArgs
-            , body = fmap mkId valueExpr
-            , typ  = fmap snd inf
-            }
-  where
-    mkId :: CExpr.DSL.Name -> Id TypecheckMacros
-    mkId (CExpr.DSL.Name n) = DeclId{
-          name   = CDeclName{ text = n, kind = CNameKindMacro }
-        , isAnon = False
-        }
+    env <- ask
 
-    addQuant ::
-         CExpr.DSL.Quant (CExpr.DSL.FunValue, CExpr.DSL.Type CExpr.DSL.Ty)
-      -> M ()
+    let -- Type names: resolve to a 'DeclId' via lookup in known typedefs and
+        -- previously resolved macro types.
+        injectType :: CExpr.Name -> M DeclId
+        injectType n = pure $ lookupTypeName env st n.getName
+
+        -- Tagged type names: resolve to a 'DeclId' via lookup in known tagged types.
+        -- Uses 'ExceptT' so that unknown tagged types produce a proper error
+        -- rather than a panic; see 'lookupTaggedTypeName'.
+        injectTaggedType ::
+             CExpr.TagKind
+          -> CExpr.Name
+          -> ExceptT MacroTypecheckError M DeclId
+        injectTaggedType tag n =
+            either throwError pure $
+              lookupTaggedTypeName env CDeclName{
+                  text = n.getName
+                , kind = CNameKindTagged (convertTagKind tag)
+                }
+
+        -- Value names: create a 'DeclId' for dependency tracking.
+        injectValueName :: CExpr.Name -> M DeclId
+        injectValueName (CExpr.Name n) = pure $ DeclId{
+            name   = CDeclName{ text = n, kind = CNameKindMacro }
+          , isAnon = False
+          }
+
+    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1952>
+    --
+    -- We should only resolve the declaration IDs of macro dependencies one. Now
+    -- we resolve them twice: when we get the dependencies of parsed macros, and
+    -- when we typecheck macros.
+    eTcRes <- runExceptT $ CExpr.tcMacro
+               st.typeEnv
+               (lift . injectType)
+               injectTaggedType
+               (lift . injectValueName)
+               macroName
+               macroParams
+               macroExpr
+    case eTcRes of
+      Left err    -> pure $ Left err
+      Right tcRes -> case tcRes of
+        Left err ->
+          pure $ Left $ MacroTypecheckErrorCExpr err
+        Right (CExpr.MacroTcTypeExpr mType) ->
+          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
+          --
+          -- We are still pulling along the C type.
+          case convertTExpr (lookupTypeWith env st) mType.macroTypeBody of
+            Left err  -> pure $ Left err
+            Right cType -> do
+              addQuant mType.macroTypeType
+              addNewMacroTypeToReparseEnv cType
+              pure $ Right $ MacroType $ CheckedMacroType cType NoAnn
+        Right (CExpr.MacroTcValueExpr (CExpr.CheckedMacroValueExpr params expr quant )) -> do
+          addQuant quant
+          pure $ Right $ MacroValue $ CheckedMacroValue $
+            CExpr.CheckedMacroValueExpr{
+                macroValueParams = params
+              , macroValueBody   = expr
+              , macroValueType   = quant
+              }
+  where
+    addQuant :: CExpr.Quant (CExpr.FunValue, CExpr.Type CExpr.Ty) -> M ()
     addQuant quant =
-        modify $ #macroEnv %~ Map.insert macro.macroName (quant)
+        modify $ #typeEnv %~ Map.insert macroName quant
 
     addNewMacroTypeToReparseEnv :: CType -> M ()
     addNewMacroTypeToReparseEnv typ
@@ -312,17 +385,17 @@ tcMacro name (ParsedMacro macro) = do
       -- because their underlying type is not @PrimBool@.
       | name.text == "bool"
       , C.TypePrim C.PrimBool <- typ
-      = addMacroType name typ
+      = addMacroType name.text typ
       | otherwise
-      = addMacroType name $
+      = addMacroType name.text $
           C.TypeMacro $ C.Ref {
               name = DeclId{name = name, isAnon = False}
             , underlying = typ
             }
 
-    addMacroType :: CDeclName -> CType -> M ()
+    addMacroType :: Text -> CType -> M ()
     addMacroType n typ =
-        modify $ #macroTypes %~ Map.insert (renderCDeclNameC n) typ
+        modify $ #resolvedMacroTypes %~ Map.insert n typ
 
 {-------------------------------------------------------------------------------
   Convert T.Expr to C.Type
@@ -330,28 +403,27 @@ tcMacro name (ParsedMacro macro) = do
 
 -- | Convert a typechecked macro type expression ('T.Expr') to a C type.
 --
+-- Named types appear as 'DeclId' leaves; 'lookupType' maps each 'DeclId' back
+-- to its 'CType'.
+--
 -- Correctly handles chains of @const@ and pointer modifiers (e.g.
 -- @const int *@, @int * const@, @const int * const *@).
 --
 -- Rejects bare @void@ at the top level (including @const void@), but allows
 -- @void@ as the pointee of a pointer (e.g. @void *@, @const void *@).
-convertTExpr ::
-     T.Expr CExpr.DSL.Name
-  -> M (Either MacroTypecheckError CType)
-convertTExpr expr = do
-    result <- go expr
-    pure $ result >>= checkTopLevelVoid
+convertTExpr :: (DeclId -> CType) -> T.Expr DeclId -> Either MacroTypecheckError CType
+convertTExpr lookupType expr = go expr >>= checkTopLevelVoid
   where
-    go :: T.Expr CExpr.DSL.Name -> M (Either MacroTypecheckError CType)
+    go :: T.Expr DeclId -> Either MacroTypecheckError CType
     go = \case
-      T.App T.Pointer inner -> fmap (fmap (C.TypePointers 1)) (go inner)
-      T.App T.Const   inner -> fmap (fmap (C.TypeQual C.QualConst)) (go inner)
-      T.TypeLit t           -> convertLiteral t
-      T.Var   nm            -> do
-        lookupKnownType <- getLookupKnownType
-        pure $ case lookupKnownType nm.getName of
-          Just t  -> Right t
-          Nothing -> Left $ MacroTypecheckErrorUnresolvedType nm.getName
+      T.App T.Pointer inner ->
+        C.TypePointers 1 <$> go inner
+      T.App T.Const   inner ->
+        C.TypeQual C.QualConst <$> go inner
+      T.TypeLit t ->
+        Right $ convertLiteral t
+      T.Var declId ->
+        Right $ lookupType declId
 
     -- | @void@ is not a valid standalone type; it is only valid as the
     -- pointee of a pointer (e.g. @void *@).
@@ -361,53 +433,41 @@ convertTExpr expr = do
       C.TypeQual _ C.TypeVoid -> Left MacroTypecheckErrorVoidType
       ty                      -> Right ty
 
--- | Convert a primitive type specifier to a C type.
---
--- Named types (previously 'CExpr.DSL.MSpecName' / 'CExpr.DSL.MTypeTagged')
--- are handled in 'convertTExpr' via 'T.Var'.
-convertLiteral ::
-     CExpr.DSL.TypeLit
-  -> M (Either MacroTypecheckError CType)
+-- | Convert a primitive type literal to a C type.
+convertLiteral :: CExpr.TypeLit -> CType
 convertLiteral = \case
-    CExpr.DSL.TypeInt sign size ->
-      pure $ Right $ C.TypePrim $ C.PrimIntegral (convertIntSize size) (convertSign sign)
-    CExpr.DSL.TypeChar sign ->
-      pure $ Right $ C.TypePrim $ C.PrimChar (convertCharSign sign)
-    CExpr.DSL.TypeFloat size ->
-      pure $ Right $ C.TypePrim $ C.PrimFloating (convertFloatSize size)
-    CExpr.DSL.TypeVoid ->
-      pure $ Right C.TypeVoid
-    CExpr.DSL.TypeBool ->
-      pure $ Right $ C.TypePrim C.PrimBool
-    CExpr.DSL.TypeTagged tag name -> do
-      lookupKnownType <- getLookupKnownType
-      let cname      = CDeclName name (CNameKindTagged (convertTagKind tag))
-          taggedName = renderCDeclNameC cname
-      pure $ case lookupKnownType taggedName of
-        Just typ -> Right typ
-        Nothing  -> Left $ MacroTypecheckErrorUnresolvedType taggedName
+    CExpr.TypeInt sign size ->
+      C.TypePrim $ C.PrimIntegral (convertIntSize size) (convertSign sign)
+    CExpr.TypeChar sign ->
+      C.TypePrim $ C.PrimChar (convertCharSign sign)
+    CExpr.TypeFloat size ->
+      C.TypePrim $ C.PrimFloating (convertFloatSize size)
+    CExpr.TypeVoid ->
+      C.TypeVoid
+    CExpr.TypeBool ->
+      C.TypePrim C.PrimBool
 
-convertSign :: Maybe CExpr.DSL.Sign -> C.PrimSign
+convertSign :: Maybe CExpr.Sign -> C.PrimSign
 convertSign = \case
-    Nothing                  -> C.Signed
-    Just CExpr.DSL.Signed   -> C.Signed
-    Just CExpr.DSL.Unsigned -> C.Unsigned
+    Nothing             -> C.Signed
+    Just CExpr.Signed   -> C.Signed
+    Just CExpr.Unsigned -> C.Unsigned
 
-convertCharSign :: Maybe CExpr.DSL.Sign -> C.PrimSignChar
+convertCharSign :: Maybe CExpr.Sign -> C.PrimSignChar
 convertCharSign = \case
-    Nothing                  -> C.PrimSignImplicit Nothing
-    Just CExpr.DSL.Signed   -> C.PrimSignExplicit C.Signed
-    Just CExpr.DSL.Unsigned -> C.PrimSignExplicit C.Unsigned
+    Nothing             -> C.PrimSignImplicit Nothing
+    Just CExpr.Signed   -> C.PrimSignExplicit C.Signed
+    Just CExpr.Unsigned -> C.PrimSignExplicit C.Unsigned
 
-convertIntSize :: Maybe CExpr.DSL.IntSize -> C.PrimIntType
+convertIntSize :: Maybe CExpr.IntSize -> C.PrimIntType
 convertIntSize = \case
-    Nothing                      -> C.PrimInt
-    Just CExpr.DSL.SizeShort    -> C.PrimShort
-    Just CExpr.DSL.SizeInt      -> C.PrimInt
-    Just CExpr.DSL.SizeLong     -> C.PrimLong
-    Just CExpr.DSL.SizeLongLong -> C.PrimLongLong
+    Nothing                 -> C.PrimInt
+    Just CExpr.SizeShort    -> C.PrimShort
+    Just CExpr.SizeInt      -> C.PrimInt
+    Just CExpr.SizeLong     -> C.PrimLong
+    Just CExpr.SizeLongLong -> C.PrimLongLong
 
-convertFloatSize :: CExpr.DSL.FloatSize -> C.PrimFloatType
+convertFloatSize :: CExpr.FloatSize -> C.PrimFloatType
 convertFloatSize = \case
-    CExpr.DSL.SizeFloat  -> C.PrimFloat
-    CExpr.DSL.SizeDouble -> C.PrimDouble
+    CExpr.SizeFloat  -> C.PrimFloat
+    CExpr.SizeDouble -> C.PrimDouble

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Error.hs
@@ -4,41 +4,41 @@ module HsBindgen.Frontend.Pass.TypecheckMacros.Error (
 
 import Text.SimplePrettyPrint qualified as PP
 
-import C.Expr.Typecheck qualified as CExpr.DSL
+import C.Expr.Typecheck qualified as CExpr
 
-import HsBindgen.Imports
+import HsBindgen.Frontend.Naming
 import HsBindgen.Util.Tracer
 
 data MacroTypecheckError =
     -- | We could not type-check the macro expression
-    MacroTypecheckErrorCExpr CExpr.DSL.MacroTcError
+    MacroTypecheckErrorCExpr CExpr.MacroTcError
     -- | Macro type is @void@, which is not a valid standalone type
   | MacroTypecheckErrorVoidType
-    -- | Named type in macro could not be resolved
+    -- | Macro type references a tagged type we could not resolve
     --
-    -- This is considered a 'Bug', because if we reference an non-existing
-    -- variable or tagged specifier (such as @struct Foo@), the typechecker
-    -- should fail instead.
-  | MacroTypecheckErrorUnresolvedType Text
+    -- This happens when a macro references a struct, union, or enum that
+    -- @hs-bindgen@ did not parse (e.g., defined in an unprocessed header, or
+    -- whose fields failed to parse).
+  | MacroTypecheckErrorUnresolvedTaggedType CDeclName
   deriving stock (Show)
 
 instance PrettyForTrace MacroTypecheckError where
   prettyForTrace = \case
       MacroTypecheckErrorCExpr x -> PP.hsep [
           "Failed to typecheck macro:"
-        , PP.text $ CExpr.DSL.pprMacroTcError x
+        , PP.text $ CExpr.pprMacroTcError x
         ]
       MacroTypecheckErrorVoidType ->
         "Macro type 'void' is not supported as a standalone type"
-      MacroTypecheckErrorUnresolvedType name -> PP.hsep [
-          "Unresolved type name in macro:"
-        , PP.text name
+      MacroTypecheckErrorUnresolvedTaggedType name -> PP.hsep [
+          "Macro type references unknown tagged type:"
+        , prettyForTrace name
         ]
 
 instance IsTrace Level MacroTypecheckError where
   getDefaultLogLevel = \case
-    MacroTypecheckErrorCExpr{}           -> Info
-    MacroTypecheckErrorVoidType{}        -> Info
-    MacroTypecheckErrorUnresolvedType{}  -> Bug
+    MacroTypecheckErrorCExpr{}                       -> Info
+    MacroTypecheckErrorVoidType{}                    -> Info
+    MacroTypecheckErrorUnresolvedTaggedType{}        -> Warning
   getSource          = const HsBindgen
   getTraceId         = const "macro-typecheck"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -3,18 +3,17 @@ module HsBindgen.Frontend.Pass.TypecheckMacros.IsPass (
     -- * Checked macros
   , CheckedMacro(..)
   , CheckedMacroType(..)
-  , CheckedMacroExpr(..)
+  , CheckedMacroValue(..)
     -- * Conversions
   , convertTagKind
   ) where
 
-import C.Expr.Syntax qualified as CExpr.DSL
-import C.Expr.Typecheck.Interface.Value qualified as V
-import C.Expr.Typecheck.Type qualified as CExpr.DSL
+import C.Expr.Syntax qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
 
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
-import HsBindgen.Frontend.AST.Type
+import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
@@ -55,37 +54,36 @@ instance IsPass TypecheckMacros where
 -------------------------------------------------------------------------------}
 
 data CheckedMacro p =
-    MacroType (CheckedMacroType p)
-  | MacroExpr (CheckedMacroExpr p)
+    MacroType  (CheckedMacroType p)
+  | MacroValue (CheckedMacroValue p)
 
 -- | Checked type macro
 data CheckedMacroType p = CheckedMacroType{
-      typ :: Type p
-    , ann :: Ann "CheckedMacroType" p
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
+      --
+      -- Legacy C type; replace with the typechecked type-like macro expression.
+      cType :: C.Type p
+    , ann   :: Ann "CheckedMacroType" p
     }
 
--- | Checked expression (function) macro
-data CheckedMacroExpr p = CheckedMacroExpr{
-      args :: [Id p]
-    , body :: V.Expr (Id p)
-    , typ  :: CExpr.DSL.Quant (CExpr.DSL.Type CExpr.DSL.Ty)
+newtype CheckedMacroValue p = CheckedMacroValue {
+      value :: CExpr.CheckedMacroValueExpr (Id p)
     }
-  deriving stock (Generic)
 
 deriving stock instance IsPass p => Show (CheckedMacro     p)
 deriving stock instance IsPass p => Show (CheckedMacroType p)
-deriving stock instance IsPass p => Show (CheckedMacroExpr p)
+deriving stock instance IsPass p => Show (CheckedMacroValue p)
 
 deriving stock instance IsPass p => Eq (CheckedMacro     p)
 deriving stock instance IsPass p => Eq (CheckedMacroType p)
-deriving stock instance IsPass p => Eq (CheckedMacroExpr p)
+deriving stock instance IsPass p => Eq (CheckedMacroValue p)
 
--- | Convert a @c-expr-dsl@ 'CExpr.DSL.TagKind' to an hs-bindgen 'CTagKind'
-convertTagKind :: CExpr.DSL.TagKind -> CTagKind
+-- | Convert a @c-expr-dsl@ 'CExpr.TagKind' to an hs-bindgen 'CTagKind'
+convertTagKind :: CExpr.TagKind -> CTagKind
 convertTagKind = \case
-    CExpr.DSL.TagStruct -> CTagKindStruct
-    CExpr.DSL.TagUnion  -> CTagKindUnion
-    CExpr.DSL.TagEnum   -> CTagKindEnum
+    CExpr.TagStruct -> CTagKindStruct
+    CExpr.TagUnion  -> CTagKindUnion
+    CExpr.TagEnum   -> CTagKindEnum
 
 {-------------------------------------------------------------------------------
   CoercePass for CheckedMacro (parametric; applies to any passes p, p')
@@ -93,26 +91,26 @@ convertTagKind = \case
 
 instance (
       CoercePass CheckedMacroType p p'
-    , CoercePass CheckedMacroExpr p p'
+    , CoercePassId p p'
     ) => CoercePass CheckedMacro p p' where
-  coercePass (MacroType typ)  = MacroType (coercePass typ)
-  coercePass (MacroExpr expr) = MacroExpr (coercePass expr)
+  coercePass = \case
+    MacroType  typ -> MacroType  (coercePass typ)
+    MacroValue val -> MacroValue (coercePass val)
 
 instance (
-      CoercePass Type p p'
+      CoercePass C.Type p p'
     , Ann "CheckedMacroType" p ~ Ann "CheckedMacroType" p'
     ) => CoercePass CheckedMacroType p p' where
-  coercePass macroType = CheckedMacroType{
-        typ = coercePass macroType.typ
-      , ann = macroType.ann
+  coercePass (CheckedMacroType ctype ann) =
+    CheckedMacroType{
+        cType = coercePass ctype
+      , ann   = ann
       }
 
-instance CoercePassId p p' => CoercePass CheckedMacroExpr p p' where
-  coercePass e = CheckedMacroExpr{
-        args = map  (coercePassId (Proxy @'(p, p'))) e.args
-      , body = fmap (coercePassId (Proxy @'(p, p'))) e.body
-      , typ  = e.typ
-      }
+instance CoercePassId p p' => CoercePass CheckedMacroValue p p' where
+  coercePass (CheckedMacroValue (CExpr.CheckedMacroValueExpr p b t)) =
+    let b' = fmap (coercePassId (Proxy @'(p, p'))) b
+    in  CheckedMacroValue $ CExpr.CheckedMacroValueExpr p b' t
 
 {-------------------------------------------------------------------------------
   CoercePass: ConstructTranslationUnit → TypecheckMacros

--- a/hs-bindgen/src-internal/HsBindgen/NameHint.hs
+++ b/hs-bindgen/src-internal/HsBindgen/NameHint.hs
@@ -2,18 +2,8 @@ module HsBindgen.NameHint (
     NameHint(..)
   ) where
 
-import Data.Char (toLower)
-
-import HsBindgen.Imports
-
+-- | Hint used to render bound variables
+--
+-- Invariant: the name hint must be valid Haskell for its intended context.
 newtype NameHint = NameHint String
 deriving newtype instance Show NameHint
-
--- | This instance tries to make name hints valid variable names in Haskell.
-instance IsString NameHint where
-    fromString []     = NameHint "x"
-    fromString (x:xs) = NameHint (toLower x : xs)
-
--- | All name hints are equal.
-instance Eq NameHint where
-    _ == _ = True

--- a/hs-bindgen/src-internal/HsBindgen/Orphans.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Orphans.hs
@@ -4,7 +4,7 @@ module HsBindgen.Orphans () where
 
 import Data.GADT.Compare (GEq (geq))
 import Data.Type.Equality ((:~:) (Refl))
-import DeBruijn.Idx (Idx, idxToInt)
+import DeBruijn (Idx, idxToInt)
 import Unsafe.Coerce (unsafeCoerce)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -14,8 +14,8 @@ module HsBindgen.TraceMsg (
   , ImmediateAssignAnonIdsMsg (..)
   , ImmediateParseMsg(..)
   , DelayedParseMsg(..)
-  , CExpr.DSL.MacroParseError(..)
-  , CExpr.DSL.MacroTcError(..)
+  , CExpr.MacroParseError(..)
+  , CExpr.MacroTcError(..)
   , ResolveBindingSpecsMsg(..)
   , ResolveHeaderMsg(..)
   , SelectMsg(..)
@@ -26,8 +26,8 @@ module HsBindgen.TraceMsg (
 
 import Data.List qualified as List
 
-import C.Expr.Parse qualified as CExpr.DSL
-import C.Expr.Typecheck qualified as CExpr.DSL
+import C.Expr.Parse qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
 
 import Clang.HighLevel.Types (Diagnostic (..))
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
@@ -29,6 +29,7 @@ testCases = [
     , defaultTest "edge-cases/enum_as_array_size"
     , defaultTest "edge-cases/flam_functions"
     , defaultTest "edge-cases/flam"
+    , defaultTest "edge-cases/mangle_fun_param_names"
     , defaultTest "edge-cases/names"
     , defaultTest "edge-cases/spec_examples"
     , defaultTest "edge-cases/typedef_bitfield"

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -4,6 +4,7 @@ module Test.HsBindgen.Golden.Macros (testCases) where
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Select.IsPass
+import HsBindgen.Frontend.Pass.TypecheckMacros.Error
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
 import HsBindgen.TraceMsg
@@ -32,6 +33,7 @@ testCases = [
     , defaultTest "macros/parse/macro_typedef_scope"
     , defaultTest "macros/redeclaration/identical_semantics"
       -- Bespoke tests
+    , test_macros_macro_type_unresolved_tagged
     , test_macros_macro_in_fundecl
     , test_macros_macro_in_fundecl_vs_typedef
     , test_macros_macro_redefines_global
@@ -55,6 +57,31 @@ testCases = [
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
+
+test_macros_macro_type_unresolved_tagged :: TestCase
+test_macros_macro_type_unresolved_tagged =
+    testTraceMulti "macros/macro_type_unresolved_tagged" declsWithMsgs $ \case
+      MatchSelect name@"struct Unparsable" (SelectParseFailure ParseUnsupportedLongDouble) ->
+        Just $ Expected (name, "select-parse-failure")
+      MatchSelect name@"macro PTR_UNPARSABLE" (TransitiveDependenciesMissing{}) ->
+        Just $ Expected (name, "select-transitive-dependencies-missing")
+      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMacroTypecheckFailure MacroTypecheckErrorUnresolvedTaggedType{}) ->
+        Just $ Expected (name, "macro-unresolved-tagged-type")
+      MatchSelect name@"macro PTR_DOES_NOT_EXIST" (SelectMacroTypecheckFailure MacroTypecheckErrorUnresolvedTaggedType{}) ->
+        Just $ Expected (name, "macro-unresolved-tagged-type")
+      MatchSelect name@"macro DOES_NOT_EXIST" (SelectMacroTypecheckFailure MacroTypecheckErrorUnresolvedTaggedType{}) ->
+        Just $ Expected (name, "macro-unresolved-tagged-type")
+      _otherwise ->
+        Nothing
+  where
+    declsWithMsgs :: [(CDeclName, String)]
+    declsWithMsgs = [
+        ("struct Unparsable",        "select-parse-failure")
+      , ("macro PTR_UNPARSABLE",     "select-transitive-dependencies-missing")
+      , ("macro PTR_UNPARSABLE",     "macro-unresolved-tagged-type")
+      , ("macro PTR_DOES_NOT_EXIST", "macro-unresolved-tagged-type")
+      , ("macro DOES_NOT_EXIST",     "macro-unresolved-tagged-type")
+      ]
 
 test_macros_macro_in_fundecl :: TestCase
 test_macros_macro_in_fundecl =

--- a/scripts/ci/check-stylish-ignore
+++ b/scripts/ci/check-stylish-ignore
@@ -6,4 +6,3 @@ alternatives/**/*.hs
 hs-bindgen/fixtures/*.hs
 hs-bindgen/src-internal/HsBindgen/Frontend/Macro/**/*
 c-expr-runtime/**/*.hs
-c-expr-dsl/**/*.hs


### PR DESCRIPTION
- Index local macro parameters with de Bruijn `Idx` at parse time.
- Include opaque tagged types (forward declarations) in `knownTaggedTypes`
- TypecheckMacros: handle tagged types absent from knownTaggedTypes

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
