### PR TITLE
`boot`: discover the path to the `clang` executable

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -140,9 +140,9 @@ library internal
     HsBindgen.Boot
     HsBindgen.Cache
     HsBindgen.Clang
-    HsBindgen.Clang.BuiltinIncDir
     HsBindgen.Clang.CompareVersions
     HsBindgen.Clang.CStandard
+    HsBindgen.Clang.Discover
     HsBindgen.Clang.ExtraClangArgs
     HsBindgen.Clang.Macos
     HsBindgen.Clang.Sizeof

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -61,6 +61,9 @@ runBoot tracer config uncheckedHashIncludeArgs = do
     getCStandard <- cache "cStandard" $ withTrace BootStatusCStandard $
       (.cStandard) <$> getClangArtefacts'
 
+    getClangExe <- cache "clangExe" $ withTrace BootStatusClangExe $
+      (.clangExe) <$> getClangArtefacts'
+
     getClangArgs <- cache "clangArgs" $ withTrace BootStatusClangArgs $
       (.clangArgs) <$> getClangArtefacts'
 
@@ -87,6 +90,7 @@ runBoot tracer config uncheckedHashIncludeArgs = do
     pure BootArtefact {
           baseModule              = config.boot.baseModule
         , cStandard               = getCStandard
+        , clangExe                = getClangExe
         , clangArgs               = getClangArgs
         , hashIncludeArgs         = getHashIncludeArgs
         , externalBindingSpecs    = getExternalBindingSpecs
@@ -111,6 +115,7 @@ runBoot tracer config uncheckedHashIncludeArgs = do
 
 data ClangArtefacts = ClangArtefacts {
     cStandard :: ClangCStandard
+  , clangExe  :: Maybe ClangExe
   , clangArgs :: ClangArgs
   }
 
@@ -122,15 +127,16 @@ getClangArtefacts ::
 getClangArtefacts tracer config0 = do
     compareClangVersions (contramap BootCompareClangVersions tracer)
     extraClangArgs <- getExtraClangArgs tracerExtraClangArgs
-    mBuiltinIncDir <- getBuiltinIncDir tracerDiscover config0.builtinIncDir
+    paths <- getPaths tracerDiscover config0.builtinIncDir
     let config =
             applyExtraClangArgs extraClangArgs
-          . applyBuiltinIncDir  mBuiltinIncDir
+          . applyPaths paths
           $ config0
         clangArgs' = ClangArgs.clangArgsConfigToClangArgs config
     cStandard' <- getClangCStandard' tracer clangArgs'
     return ClangArtefacts{
         cStandard = cStandard'
+      , clangExe  = paths.clangExe
       , clangArgs = clangArgs'
       }
   where
@@ -173,6 +179,7 @@ getClangCStandard' tracer clangArgs =
 data BootArtefact = BootArtefact {
       baseModule              :: BaseModuleName
     , cStandard               :: Cached ClangCStandard
+    , clangExe                :: Cached (Maybe ClangExe)
     , clangArgs               :: Cached ClangArgs
     , hashIncludeArgs         :: Cached [HashIncludeArg]
     , externalBindingSpecs    :: Cached MergedBindingSpecs
@@ -187,6 +194,7 @@ data BootArtefact = BootArtefact {
 data BootStatusMsg =
     BootStatusStart                   BindgenConfig
   | BootStatusCStandard               ClangCStandard
+  | BootStatusClangExe                (Maybe ClangExe)
   | BootStatusClangArgs               ClangArgs
   | BootStatusHashIncludeArgs         [HashIncludeArg]
   | BootStatusExternalBindingSpecs    MergedBindingSpecs
@@ -201,6 +209,7 @@ instance PrettyForTrace BootStatusMsg where
   prettyForTrace = \case
     BootStatusStart                   x -> bootStatus "BindgenConfig"           x
     BootStatusCStandard               x -> bootStatus "ClangCStandard"          x
+    BootStatusClangExe                x -> bootStatus "ClangExe"                x
     BootStatusClangArgs               x -> bootStatus "ClangArgs"               x
     BootStatusHashIncludeArgs         x -> bootStatus "HashIncludeArgs"         x
     BootStatusExternalBindingSpecs    x -> bootStatus "ExternalBindingSpecs"    x

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -16,10 +16,10 @@ import HsBindgen.Backend.Category (Category (..))
 import HsBindgen.BindingSpec
 import HsBindgen.Cache
 import HsBindgen.Clang
-import HsBindgen.Clang.BuiltinIncDir
 import HsBindgen.Clang.CompareVersions (CompareVersionsMsg,
                                         compareClangVersions)
 import HsBindgen.Clang.CStandard
+import HsBindgen.Clang.Discover
 import HsBindgen.Clang.ExtraClangArgs
 import HsBindgen.Clang.Macos
 import HsBindgen.Clang.Sizeof (getSizeofs)

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -122,7 +122,7 @@ getClangArtefacts ::
 getClangArtefacts tracer config0 = do
     compareClangVersions (contramap BootCompareClangVersions tracer)
     extraClangArgs <- getExtraClangArgs tracerExtraClangArgs
-    mBuiltinIncDir <- getBuiltinIncDir tracerBuiltinIncDir config0.builtinIncDir
+    mBuiltinIncDir <- getBuiltinIncDir tracerDiscover config0.builtinIncDir
     let config =
             applyExtraClangArgs extraClangArgs
           . applyBuiltinIncDir  mBuiltinIncDir
@@ -134,8 +134,8 @@ getClangArtefacts tracer config0 = do
       , clangArgs = clangArgs'
       }
   where
-    tracerBuiltinIncDir :: Tracer BuiltinIncDirMsg
-    tracerBuiltinIncDir = contramap BootBuiltinIncDir tracer
+    tracerDiscover :: Tracer DiscoverMsg
+    tracerDiscover = contramap BootDiscover tracer
 
     tracerExtraClangArgs :: Tracer ExtraClangArgsMsg
     tracerExtraClangArgs = contramap BootExtraClangArgs tracer
@@ -236,7 +236,7 @@ data BootMsg =
     BootBackendConfig        BackendConfigMsg
   | BootMacos                MacosMsg
   | BootBindingSpec          BindingSpecMsg
-  | BootBuiltinIncDir        BuiltinIncDirMsg
+  | BootDiscover             DiscoverMsg
   | BootClang                ClangMsg
   | BootCStandard            BootCStandardMsg
   | BootExtraClangArgs       ExtraClangArgsMsg

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -4,7 +4,7 @@ module HsBindgen.Clang.Discover (
     -- * Types
     BuiltinIncDir
     -- * Trace messages
-  , BuiltinIncDirMsg(..)
+  , DiscoverMsg(..)
     -- * API
   , getBuiltinIncDir
   , applyBuiltinIncDir
@@ -47,106 +47,106 @@ type BuiltinIncDir = FilePath
   Trace messages
 -------------------------------------------------------------------------------}
 
-data BuiltinIncDirMsg =
-    BuiltinIncDirEnvNone
-  | BuiltinIncDirEnvSet BuiltinIncDirConfig
-  | BuiltinIncDirEnvInvalid String
-  | BuiltinIncDirLlvmPathNotFound FilePath
-  | BuiltinIncDirLlvmConfigEnvNotFound FilePath
-  | BuiltinIncDirLlvmConfigEnvFound FilePath
-  | BuiltinIncDirLlvmConfigPathFound FilePath
-  | BuiltinIncDirLlvmConfigPrefixUnexpected String
-  | BuiltinIncDirLlvmConfigPrefixIOError IOError
-  | BuiltinIncDirClangNotFound
-  | BuiltinIncDirClangVersionMismatch Text Text
-  | BuiltinIncDirClangIncDirNotFound BuiltinIncDir
-  | BuiltinIncDirClangIncDirFound BuiltinIncDir
-  | BuiltinIncDirLlvmPathClangExeNotFound FilePath
-  | BuiltinIncDirLlvmPathClangExeFound FilePath
-  | BuiltinIncDirLlvmConfigClangExeNotFound FilePath
-  | BuiltinIncDirLlvmConfigClangExeFound FilePath
-  | BuiltinIncDirClangPathFound FilePath
-  | BuiltinIncDirClangVersionUnexpected String
-  | BuiltinIncDirClangVersionIOError IOError
-  | BuiltinIncDirClangPrintResourceDirUnexpected String
-  | BuiltinIncDirClangPrintResourceDirIOError IOError
+data DiscoverMsg =
+    DiscoverEnvNone
+  | DiscoverEnvSet BuiltinIncDirConfig
+  | DiscoverEnvInvalid String
+  | DiscoverLlvmPathNotFound FilePath
+  | DiscoverLlvmConfigEnvNotFound FilePath
+  | DiscoverLlvmConfigEnvFound FilePath
+  | DiscoverLlvmConfigPathFound FilePath
+  | DiscoverLlvmConfigPrefixUnexpected String
+  | DiscoverLlvmConfigPrefixIOError IOError
+  | DiscoverClangNotFound
+  | DiscoverClangVersionMismatch Text Text
+  | DiscoverClangIncDirNotFound BuiltinIncDir
+  | DiscoverClangIncDirFound BuiltinIncDir
+  | DiscoverLlvmPathClangExeNotFound FilePath
+  | DiscoverLlvmPathClangExeFound FilePath
+  | DiscoverLlvmConfigClangExeNotFound FilePath
+  | DiscoverLlvmConfigClangExeFound FilePath
+  | DiscoverClangPathFound FilePath
+  | DiscoverClangVersionUnexpected String
+  | DiscoverClangVersionIOError IOError
+  | DiscoverClangPrintResourceDirUnexpected String
+  | DiscoverClangPrintResourceDirIOError IOError
   deriving stock (Show)
 
-instance PrettyForTrace BuiltinIncDirMsg where
+instance PrettyForTrace DiscoverMsg where
   prettyForTrace = \case
-    BuiltinIncDirEnvNone ->
+    DiscoverEnvNone ->
       PP.string envName <+> "not set"
-    BuiltinIncDirEnvSet config ->
+    DiscoverEnvSet config ->
       PP.string envName <+> "set:" <+> PP.string (show config)
-    BuiltinIncDirEnvInvalid s ->
+    DiscoverEnvInvalid s ->
       PP.string envName <+> "invalid:" <+> PP.string (show s) <+> "(ignored)"
-    BuiltinIncDirLlvmPathNotFound path ->
+    DiscoverLlvmPathNotFound path ->
       "$LLVM_PATH path not found or not directory (skipping):" <+> string path
-    BuiltinIncDirLlvmConfigEnvNotFound path ->
+    DiscoverLlvmConfigEnvNotFound path ->
       "$LLVM_CONFIG path not found or not file (skipping):" <+> string path
-    BuiltinIncDirLlvmConfigEnvFound path ->
+    DiscoverLlvmConfigEnvFound path ->
       "llvm-config found using $LLVM_CONFIG:" <+> string path
-    BuiltinIncDirLlvmConfigPathFound path ->
+    DiscoverLlvmConfigPathFound path ->
       "llvm-config found using $PATH:" <+> string path
-    BuiltinIncDirLlvmConfigPrefixUnexpected s ->
+    DiscoverLlvmConfigPrefixUnexpected s ->
       "llvm-config --prefix output is unexpected:" <+> string (show s)
-    BuiltinIncDirLlvmConfigPrefixIOError e ->
+    DiscoverLlvmConfigPrefixIOError e ->
       "IO error calling llvm-config --prefix:" <+> string (displayException e)
-    BuiltinIncDirClangNotFound ->
+    DiscoverClangNotFound ->
       "clang not found"
-    BuiltinIncDirClangVersionMismatch libclangVersion clangVersion ->
+    DiscoverClangVersionMismatch libclangVersion clangVersion ->
       PP.hangs' "clang version mismatch:" 2 [
           "libclang version:" <+> PP.text libclangVersion
         , "clang version:   " <+> PP.text clangVersion
         ]
-    BuiltinIncDirClangIncDirNotFound path ->
+    DiscoverClangIncDirNotFound path ->
       "builtin include directory not found using clang:" <+> string path
-    BuiltinIncDirClangIncDirFound path ->
+    DiscoverClangIncDirFound path ->
       "builtin include directory found using clang:" <+> string path
-    BuiltinIncDirLlvmPathClangExeNotFound path ->
+    DiscoverLlvmPathClangExeNotFound path ->
       "clang not found using $LLVM_PATH:" <+> string path
-    BuiltinIncDirLlvmPathClangExeFound path ->
+    DiscoverLlvmPathClangExeFound path ->
       "clang found using $LLVM_PATH:" <+> string path
-    BuiltinIncDirLlvmConfigClangExeNotFound path ->
+    DiscoverLlvmConfigClangExeNotFound path ->
       "clang not found using llvm-config:" <+> string path
-    BuiltinIncDirLlvmConfigClangExeFound path ->
+    DiscoverLlvmConfigClangExeFound path ->
       "clang found using llvm-config:" <+> string path
-    BuiltinIncDirClangPathFound path ->
+    DiscoverClangPathFound path ->
       "clang found using $PATH:" <+> string path
-    BuiltinIncDirClangVersionUnexpected s ->
+    DiscoverClangVersionUnexpected s ->
       "clang --version output is unexpected:" <+> string (show s)
-    BuiltinIncDirClangVersionIOError e ->
+    DiscoverClangVersionIOError e ->
       "IO error calling clang --version:" <+> string (displayException e)
-    BuiltinIncDirClangPrintResourceDirUnexpected s ->
+    DiscoverClangPrintResourceDirUnexpected s ->
       "clang -print-resource-dir output is unexpected:" <+> string (show s)
-    BuiltinIncDirClangPrintResourceDirIOError e ->
+    DiscoverClangPrintResourceDirIOError e ->
       "IO error calling clang -print-resource-dir:"
         <+> string (displayException e)
 
-instance IsTrace Level BuiltinIncDirMsg where
+instance IsTrace Level DiscoverMsg where
   getDefaultLogLevel = \case
-    BuiltinIncDirEnvNone                           -> Debug
-    BuiltinIncDirEnvSet{}                          -> Info
-    BuiltinIncDirEnvInvalid{}                      -> Warning
-    BuiltinIncDirLlvmPathNotFound{}                -> Warning
-    BuiltinIncDirLlvmConfigEnvNotFound{}           -> Warning
-    BuiltinIncDirLlvmConfigEnvFound{}              -> Debug
-    BuiltinIncDirLlvmConfigPathFound{}             -> Debug
-    BuiltinIncDirLlvmConfigPrefixUnexpected{}      -> Warning
-    BuiltinIncDirLlvmConfigPrefixIOError{}         -> Warning
-    BuiltinIncDirClangNotFound                     -> Debug
-    BuiltinIncDirClangVersionMismatch _ _          -> Warning
-    BuiltinIncDirClangIncDirNotFound _             -> Warning
-    BuiltinIncDirClangIncDirFound{}                -> Info
-    BuiltinIncDirLlvmPathClangExeNotFound{}        -> Debug
-    BuiltinIncDirLlvmPathClangExeFound{}           -> Debug
-    BuiltinIncDirLlvmConfigClangExeNotFound{}      -> Debug
-    BuiltinIncDirLlvmConfigClangExeFound{}         -> Debug
-    BuiltinIncDirClangPathFound{}                  -> Debug
-    BuiltinIncDirClangVersionUnexpected _          -> Warning
-    BuiltinIncDirClangVersionIOError _             -> Warning
-    BuiltinIncDirClangPrintResourceDirUnexpected _ -> Warning
-    BuiltinIncDirClangPrintResourceDirIOError _    -> Warning
+    DiscoverEnvNone                           -> Debug
+    DiscoverEnvSet{}                          -> Info
+    DiscoverEnvInvalid{}                      -> Warning
+    DiscoverLlvmPathNotFound{}                -> Warning
+    DiscoverLlvmConfigEnvNotFound{}           -> Warning
+    DiscoverLlvmConfigEnvFound{}              -> Debug
+    DiscoverLlvmConfigPathFound{}             -> Debug
+    DiscoverLlvmConfigPrefixUnexpected{}      -> Warning
+    DiscoverLlvmConfigPrefixIOError{}         -> Warning
+    DiscoverClangNotFound                     -> Debug
+    DiscoverClangVersionMismatch _ _          -> Warning
+    DiscoverClangIncDirNotFound _             -> Warning
+    DiscoverClangIncDirFound{}                -> Info
+    DiscoverLlvmPathClangExeNotFound{}        -> Debug
+    DiscoverLlvmPathClangExeFound{}           -> Debug
+    DiscoverLlvmConfigClangExeNotFound{}      -> Debug
+    DiscoverLlvmConfigClangExeFound{}         -> Debug
+    DiscoverClangPathFound{}                  -> Debug
+    DiscoverClangVersionUnexpected _          -> Warning
+    DiscoverClangVersionIOError _             -> Warning
+    DiscoverClangPrintResourceDirUnexpected _ -> Warning
+    DiscoverClangPrintResourceDirIOError _    -> Warning
 
   getSource  = const HsBindgen
 
@@ -203,7 +203,7 @@ builtinIncDirState = unsafePerformIO $ IORef.newIORef BuiltinIncDirInitial
 -- Calling 'getBuiltinIncDir' caches the result, and any subsequent calls simply
 -- returns the cached value.
 getBuiltinIncDir ::
-     Tracer BuiltinIncDirMsg
+     Tracer DiscoverMsg
   -> BuiltinIncDirConfig
   -> IO (Maybe BuiltinIncDir)
 getBuiltinIncDir tracer config =
@@ -238,38 +238,38 @@ envName :: String
 envName = "BINDGEN_BUILTIN_INCLUDE_DIR"
 
 -- | Load configuration from system environment, when available
-getEnvConfig :: Tracer BuiltinIncDirMsg -> IO (Maybe BuiltinIncDirConfig)
+getEnvConfig :: Tracer DiscoverMsg -> IO (Maybe BuiltinIncDirConfig)
 getEnvConfig tracer = Env.lookupEnv envName >>= \case
-    Nothing        -> Nothing <$ traceWith tracer (withCallStack BuiltinIncDirEnvNone)
+    Nothing        -> Nothing <$ traceWith tracer (withCallStack DiscoverEnvNone)
     Just "disable" -> aux BuiltinIncDirDisable
     Just "clang"   -> aux BuiltinIncDirClang
-    Just s         -> Nothing <$ traceWith tracer (withCallStack $ BuiltinIncDirEnvInvalid s)
+    Just s         -> Nothing <$ traceWith tracer (withCallStack $ DiscoverEnvInvalid s)
   where
     aux :: BuiltinIncDirConfig -> IO (Maybe BuiltinIncDirConfig)
-    aux config = Just config <$ traceWith tracer (withCallStack $ BuiltinIncDirEnvSet config)
+    aux config = Just config <$ traceWith tracer (withCallStack $ DiscoverEnvSet config)
 
 -- | Get the builtin include directory using @clang@
 --
 -- @clang -print-file-name=include@ is called to get the builtin include
 -- directory.
-getBuiltinIncDirWithClang :: Tracer BuiltinIncDirMsg -> MaybeT IO BuiltinIncDir
+getBuiltinIncDirWithClang :: Tracer DiscoverMsg -> MaybeT IO BuiltinIncDir
 getBuiltinIncDirWithClang tracer = do
     exe <- findClangExe tracer <|> do
-      traceWith tracer (withCallStack BuiltinIncDirClangNotFound)
+      traceWith tracer (withCallStack DiscoverClangNotFound)
       MaybeT $ return Nothing
     clangVersionString <- getClangVersion tracer exe
     let clangVersion = parseClangVersion clangVersionString
     unless (isCompatibleClangVersion runtimeClangVersion clangVersion) $ do
       traceWith tracer . withCallStack $
-        BuiltinIncDirClangVersionMismatch
+        DiscoverClangVersionMismatch
           runtimeClangVersionString
           clangVersionString
       MaybeT $ return Nothing
     resourceDir <- getClangResourceDir tracer exe
     ifM
      tracer
-     BuiltinIncDirClangIncDirNotFound
-     BuiltinIncDirClangIncDirFound
+     DiscoverClangIncDirNotFound
+     DiscoverClangIncDirFound
      Dir.doesDirectoryExist
      (FilePath.joinPath [resourceDir, "include"])
 
@@ -279,7 +279,7 @@ getBuiltinIncDirWithClang tracer = do
 -- 2. @$(${LLVM_CONFIG} --prefix)/bin/clang@
 -- 3. @$(llvm-config --prefix)/bin/clang@
 -- 4. Search @${PATH}@
-findClangExe :: Tracer BuiltinIncDirMsg -> MaybeT IO FilePath
+findClangExe :: Tracer DiscoverMsg -> MaybeT IO FilePath
 findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
   where
     auxLlvmPath :: MaybeT IO FilePath
@@ -287,8 +287,8 @@ findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
       prefix <- lookupLlvmPath tracer
       ifM
         tracer
-        BuiltinIncDirLlvmPathClangExeNotFound
-        BuiltinIncDirLlvmPathClangExeFound
+        DiscoverLlvmPathClangExeNotFound
+        DiscoverLlvmPathClangExeFound
         Dir.doesFileExist
         (FilePath.joinPath [prefix, "bin", clangExe])
 
@@ -298,15 +298,15 @@ findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
       prefix <- getLlvmConfigPrefix tracer exe
       ifM
         tracer
-        BuiltinIncDirLlvmConfigClangExeNotFound
-        BuiltinIncDirLlvmConfigClangExeFound
+        DiscoverLlvmConfigClangExeNotFound
+        DiscoverLlvmConfigClangExeFound
         Dir.doesFileExist
         (FilePath.joinPath [prefix, "bin", clangExe])
 
     auxPath :: MaybeT IO FilePath
     auxPath = do
       exe <- MaybeT $ Dir.findExecutable clangExe
-      traceWith tracer (withCallStack $ BuiltinIncDirClangPathFound exe)
+      traceWith tracer (withCallStack $ DiscoverClangPathFound exe)
       return exe
 
 -- | @clang@ executable name for the current platform
@@ -319,20 +319,20 @@ clangExe =
 #endif
 
 -- | Lookup @LLVM_PATH@ environment variable
-lookupLlvmPath :: Tracer BuiltinIncDirMsg -> MaybeT IO FilePath
+lookupLlvmPath :: Tracer DiscoverMsg -> MaybeT IO FilePath
 lookupLlvmPath tracer = do
     prefix <- MaybeT $ fmap normWinPath <$> Env.lookupEnv "LLVM_PATH"
     MaybeT $ Dir.doesDirectoryExist prefix >>= \case
       True  -> return (Just prefix)
       False -> do
-        traceWith tracer (withCallStack $ BuiltinIncDirLlvmPathNotFound prefix)
+        traceWith tracer (withCallStack $ DiscoverLlvmPathNotFound prefix)
         return Nothing
 
 -- | Find the @llvm-config@ executable
 --
 -- 1. @${LLVM_CONFIG}@
 -- 2. Search @${PATH}@
-findLlvmConfigExe :: Tracer BuiltinIncDirMsg -> MaybeT IO FilePath
+findLlvmConfigExe :: Tracer DiscoverMsg -> MaybeT IO FilePath
 findLlvmConfigExe tracer = asum [auxLlvmConfigEnv, auxPath]
   where
     auxLlvmConfigEnv :: MaybeT IO FilePath
@@ -340,15 +340,15 @@ findLlvmConfigExe tracer = asum [auxLlvmConfigEnv, auxPath]
       exe <- MaybeT $ fmap normWinPath <$> Env.lookupEnv "LLVM_CONFIG"
       ifM
         tracer
-        BuiltinIncDirLlvmConfigEnvNotFound
-        BuiltinIncDirLlvmConfigEnvFound
+        DiscoverLlvmConfigEnvNotFound
+        DiscoverLlvmConfigEnvFound
         Dir.doesFileExist
         exe
 
     auxPath :: MaybeT IO FilePath
     auxPath = do
       exe <- MaybeT $ Dir.findExecutable llvmConfigExe
-      traceWith tracer (withCallStack $ BuiltinIncDirLlvmConfigPathFound exe)
+      traceWith tracer (withCallStack $ DiscoverLlvmConfigPathFound exe)
       return exe
 
 -- | @llvm-config@ executable name for the current platform
@@ -364,14 +364,14 @@ llvmConfigExe =
 --
 -- This function calls @llvm-config --prefix@ and captures the output.
 getLlvmConfigPrefix ::
-     Tracer BuiltinIncDirMsg
+     Tracer DiscoverMsg
   -> FilePath  -- ^ @llvm-config@ path
   -> MaybeT IO FilePath
 getLlvmConfigPrefix tracer exe = MaybeT $
     checkOutput
       tracer
-      BuiltinIncDirLlvmConfigPrefixUnexpected
-      BuiltinIncDirLlvmConfigPrefixIOError
+      DiscoverLlvmConfigPrefixUnexpected
+      DiscoverLlvmConfigPrefixIOError
       (fmap normWinPath . parseSingleLine)
       (readProcess exe ["--prefix"] "")
 
@@ -380,14 +380,14 @@ getLlvmConfigPrefix tracer exe = MaybeT $
 -- This function calls @clang --version@ and captures the output.  The full
 -- version string in the first line is returned.
 getClangVersion ::
-     Tracer BuiltinIncDirMsg
+     Tracer DiscoverMsg
   -> FilePath  -- ^ @clang@ path
   -> MaybeT IO Text
 getClangVersion tracer exe = MaybeT $
     checkOutput
       tracer
-      BuiltinIncDirClangVersionUnexpected
-      BuiltinIncDirClangVersionIOError
+      DiscoverClangVersionUnexpected
+      DiscoverClangVersionIOError
       (fmap Text.pack . parseFirstLine)
       (readProcess exe ["--version"] "")
 
@@ -395,14 +395,14 @@ getClangVersion tracer exe = MaybeT $
 --
 -- This function calls @clang -print-resource-dir@ and captures the output.
 getClangResourceDir ::
-     Tracer BuiltinIncDirMsg
+     Tracer DiscoverMsg
   -> FilePath  -- ^ @clang@ path
   -> MaybeT IO FilePath
 getClangResourceDir tracer exe = MaybeT $
     checkOutput
       tracer
-      BuiltinIncDirClangPrintResourceDirUnexpected
-      BuiltinIncDirClangPrintResourceDirIOError
+      DiscoverClangPrintResourceDirUnexpected
+      DiscoverClangPrintResourceDirIOError
       (fmap normWinPath . parseSingleLine)
       (readProcess exe ["-print-resource-dir"] "")
 
@@ -434,9 +434,9 @@ normWinPath = id
 
 -- | Return a path only if it passes a predicate, tracing result
 ifM ::
-     Tracer BuiltinIncDirMsg
-  -> (FilePath -> BuiltinIncDirMsg)  -- ^ not found constructor
-  -> (FilePath -> BuiltinIncDirMsg)  -- ^ found constructor
+     Tracer DiscoverMsg
+  -> (FilePath -> DiscoverMsg)  -- ^ not found constructor
+  -> (FilePath -> DiscoverMsg)  -- ^ found constructor
   -> (FilePath -> IO Bool)           -- ^ predicate
   -> FilePath                        -- ^ path
   -> MaybeT IO FilePath

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -2,7 +2,9 @@
 
 module HsBindgen.Clang.Discover (
     -- * Types
-    BuiltinIncDir
+    Paths(..)
+  , ClangExe
+  , BuiltinIncDir
     -- * Trace messages
   , DiscoverMsg(..)
     -- * API
@@ -40,7 +42,16 @@ import Text.SimplePrettyPrint qualified as PP
   Types
 -------------------------------------------------------------------------------}
 
--- | Builtin include directory
+-- | Discovered path information
+data Paths = Paths {
+    clangExe :: Maybe ClangExe
+  , builtinIncDir :: Maybe BuiltinIncDir
+  }
+
+-- | Path to the @clang@ executable
+type ClangExe = FilePath
+
+-- | Path to the builtin include directory
 type BuiltinIncDir = FilePath
 
 {-------------------------------------------------------------------------------
@@ -156,19 +167,18 @@ instance IsTrace Level DiscoverMsg where
   Global state
 -------------------------------------------------------------------------------}
 
--- | Builtin include directory state
-data BuiltinIncDirState =
-    BuiltinIncDirInitial
-  | BuiltinIncDirCached (Maybe BuiltinIncDir)
+data DiscoverState =
+    DiscoverStateInitial
+  | DiscoverStateCached Paths
 
--- | Builtin include directory global state
+-- | Global state for caching discovered paths
 --
--- The builtin include directory should only be determined a single time.
--- Calling 'getBuiltinIncDir' stores the result in this global state, and any
--- subsequent calls simply returns the cached value.
-builtinIncDirState :: IORef BuiltinIncDirState
-builtinIncDirState = unsafePerformIO $ IORef.newIORef BuiltinIncDirInitial
-{-# NOINLINE builtinIncDirState #-}
+-- Paths should only be discovered a single time. Calling 'getBuiltinIncDir'
+-- stores the result in this global state, and any subsequent calls simply
+-- returns the cached value.
+discoverState :: IORef DiscoverState
+discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
+{-# NOINLINE discoverState #-}
 
 {-------------------------------------------------------------------------------
   API
@@ -207,14 +217,18 @@ getBuiltinIncDir ::
   -> BuiltinIncDirConfig
   -> IO (Maybe BuiltinIncDir)
 getBuiltinIncDir tracer config =
-    IORef.readIORef builtinIncDirState >>= \case
-      BuiltinIncDirCached mBuiltinIncDir -> return mBuiltinIncDir
-      BuiltinIncDirInitial -> do
+    IORef.readIORef discoverState >>= \case
+      DiscoverStateCached paths -> return paths.builtinIncDir
+      DiscoverStateInitial -> do
         mEnvConfig <- getEnvConfig tracer
         mBuiltinIncDir <- case fromMaybe config mEnvConfig of
           BuiltinIncDirDisable -> return Nothing
           BuiltinIncDirClang -> runMaybeT $ getBuiltinIncDirWithClang tracer
-        IORef.writeIORef builtinIncDirState (BuiltinIncDirCached mBuiltinIncDir)
+        let paths = Paths {
+                clangExe = Nothing
+              , builtinIncDir = mBuiltinIncDir
+              }
+        IORef.writeIORef discoverState (DiscoverStateCached paths)
         return mBuiltinIncDir
 
 -- | Apply the builtin include directory to 'Clang.Args.ClangArgs'
@@ -279,10 +293,10 @@ getBuiltinIncDirWithClang tracer = do
 -- 2. @$(${LLVM_CONFIG} --prefix)/bin/clang@
 -- 3. @$(llvm-config --prefix)/bin/clang@
 -- 4. Search @${PATH}@
-findClangExe :: Tracer DiscoverMsg -> MaybeT IO FilePath
+findClangExe :: Tracer DiscoverMsg -> MaybeT IO ClangExe
 findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
   where
-    auxLlvmPath :: MaybeT IO FilePath
+    auxLlvmPath :: MaybeT IO ClangExe
     auxLlvmPath = do
       prefix <- lookupLlvmPath tracer
       ifM
@@ -292,7 +306,7 @@ findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
         Dir.doesFileExist
         (FilePath.joinPath [prefix, "bin", clangExe])
 
-    auxLlvmConfig :: MaybeT IO FilePath
+    auxLlvmConfig :: MaybeT IO ClangExe
     auxLlvmConfig = do
       exe <- findLlvmConfigExe tracer
       prefix <- getLlvmConfigPrefix tracer exe
@@ -303,7 +317,7 @@ findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
         Dir.doesFileExist
         (FilePath.joinPath [prefix, "bin", clangExe])
 
-    auxPath :: MaybeT IO FilePath
+    auxPath :: MaybeT IO ClangExe
     auxPath = do
       exe <- MaybeT $ Dir.findExecutable clangExe
       traceWith tracer (withCallStack $ DiscoverClangPathFound exe)

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -8,8 +8,8 @@ module HsBindgen.Clang.Discover (
     -- * Trace messages
   , DiscoverMsg(..)
     -- * API
-  , getBuiltinIncDir
-  , applyBuiltinIncDir
+  , getPaths
+  , applyPaths
   ) where
 
 import Control.Applicative ((<|>), asum)
@@ -173,9 +173,9 @@ data DiscoverState =
 
 -- | Global state for caching discovered paths
 --
--- Paths should only be discovered a single time. Calling 'getBuiltinIncDir'
--- stores the result in this global state, and any subsequent calls simply
--- returns the cached value.
+-- Paths should only be discovered a single time. Calling 'getPaths' stores the
+-- result in this global state, and any subsequent calls simply returns the
+-- cached value.
 discoverState :: IORef DiscoverState
 discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
 {-# NOINLINE discoverState #-}
@@ -257,12 +257,6 @@ getPaths tracer config =
     myHoistMaybe :: Maybe a -> MaybeT IO a
     myHoistMaybe = MaybeT . pure
 
-getBuiltinIncDir ::
-     Tracer DiscoverMsg
-  -> BuiltinIncDirConfig
-  -> IO (Maybe BuiltinIncDir)
-getBuiltinIncDir tracer config = (.builtinIncDir) <$> getPaths tracer config
-
 -- | Apply the discovered paths to 'Clang.Args.ClangArgs'
 --
 -- When configured, the builtin include directory is passed with @-isystem@ as
@@ -275,11 +269,6 @@ applyPaths ::
 applyPaths paths = case paths.builtinIncDir of
     Nothing            -> id
     Just builtinIncDir -> #argsAfter %~ (++ ["-isystem", builtinIncDir])
-
-applyBuiltinIncDir ::
-     Maybe BuiltinIncDir
-  -> ClangArgsConfig path -> ClangArgsConfig path
-applyBuiltinIncDir = applyPaths . Paths Nothing
 
 {-------------------------------------------------------------------------------
   Auxiliary functions

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module HsBindgen.Clang.BuiltinIncDir (
+module HsBindgen.Clang.Discover (
     -- * Types
     BuiltinIncDir
     -- * Trace messages

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -184,12 +184,32 @@ discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
   API
 -------------------------------------------------------------------------------}
 
--- | Try to get the builtin include directory
+-- | Try to discover paths for the @clang@ executable, and the builtin include
+-- directory
+--
+-- Discovered paths should should only be determined a single time. Calling
+-- 'getPaths' caches the result, and any subsequent call simply returns the
+-- cached value.
+--
+-- === Clang executable
+--
+-- The @clang@ executable is run to discover the builtin include directory, and it
+-- is run by the @hs-bingen@ frontend to preprocess macro invocations.
+--
+-- This function tries to determine the path to the @clang@ executable by using
+-- the first successful result of the following strategies:
+--
+-- 1. @${LLVM_PATH}/bin/clang@
+-- 2. @$(${LLVM_CONFIG} --prefix)/bin/clang@
+-- 3. @$(llvm-config --prefix)/bin/clang@
+-- 4. Search @${PATH}@
+--
+-- === Builtin include directory
 --
 -- LLVM/Clang determines the builtin include directory based on the path of the
--- executable being run.  When using @libclang@, there is not enough information
--- to determine the absolute builtin include directory.  @hs-bindgen@ can
--- attempt to determine and configure the builtin include directory
+-- @clang@ executable being run. When using @libclang@, there is not enough
+-- information to determine the absolute builtin include directory. @hs-bindgen@
+-- can attempt to determine and configure the builtin include directory
 -- automatically so that users do not have to do so manually.
 --
 -- Upstream issues:
@@ -209,39 +229,57 @@ discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
 -- 3. @$($(llvm-config --prefix)/bin/clang -print-resource-dir)/include@
 -- 4. @$(clang -print-resource-dir)/include@
 --
--- The builtin include directory should only be determined a single time.
--- Calling 'getBuiltinIncDir' caches the result, and any subsequent calls simply
--- returns the cached value.
+-- Note that this uses the @clang@ executable that we discovered before (see the
+-- "Clang executable" section).
+--
+getPaths ::
+     Tracer DiscoverMsg
+  -> BuiltinIncDirConfig
+  -> IO Paths
+getPaths tracer config =
+    IORef.readIORef discoverState >>= \case
+      DiscoverStateCached paths -> return paths
+      DiscoverStateInitial -> do
+        mClangExe <- runMaybeT $ findClangExe tracer
+        mEnvConfig <- getEnvConfig tracer
+        mBuiltinIncDir <- case fromMaybe config mEnvConfig of
+          BuiltinIncDirDisable -> return Nothing
+          BuiltinIncDirClang -> runMaybeT $
+            getBuiltinIncDirWithClang tracer (myHoistMaybe mClangExe)
+        let paths = Paths {
+                clangExe = mClangExe
+              , builtinIncDir = mBuiltinIncDir
+              }
+        IORef.writeIORef discoverState (DiscoverStateCached paths)
+        return paths
+  where
+    -- | hoistMaybe was only added in transformers-0.6.0.0
+    myHoistMaybe :: Maybe a -> MaybeT IO a
+    myHoistMaybe = MaybeT . pure
+
 getBuiltinIncDir ::
      Tracer DiscoverMsg
   -> BuiltinIncDirConfig
   -> IO (Maybe BuiltinIncDir)
-getBuiltinIncDir tracer config =
-    IORef.readIORef discoverState >>= \case
-      DiscoverStateCached paths -> return paths.builtinIncDir
-      DiscoverStateInitial -> do
-        mEnvConfig <- getEnvConfig tracer
-        mBuiltinIncDir <- case fromMaybe config mEnvConfig of
-          BuiltinIncDirDisable -> return Nothing
-          BuiltinIncDirClang -> runMaybeT $ getBuiltinIncDirWithClang tracer
-        let paths = Paths {
-                clangExe = Nothing
-              , builtinIncDir = mBuiltinIncDir
-              }
-        IORef.writeIORef discoverState (DiscoverStateCached paths)
-        return mBuiltinIncDir
+getBuiltinIncDir tracer config = (.builtinIncDir) <$> getPaths tracer config
 
--- | Apply the builtin include directory to 'Clang.Args.ClangArgs'
+-- | Apply the discovered paths to 'Clang.Args.ClangArgs'
 --
 -- When configured, the builtin include directory is passed with @-isystem@ as
 -- the last argument.  This ensures that it is prioritized as close to the
 -- default include directories as possible.
+applyPaths ::
+     Paths
+  -> ClangArgsConfig path
+  -> ClangArgsConfig path
+applyPaths paths = case paths.builtinIncDir of
+    Nothing            -> id
+    Just builtinIncDir -> #argsAfter %~ (++ ["-isystem", builtinIncDir])
+
 applyBuiltinIncDir ::
      Maybe BuiltinIncDir
   -> ClangArgsConfig path -> ClangArgsConfig path
-applyBuiltinIncDir = \case
-    Nothing            -> id
-    Just builtinIncDir -> #argsAfter %~ (++ ["-isystem", builtinIncDir])
+applyBuiltinIncDir = applyPaths . Paths Nothing
 
 {-------------------------------------------------------------------------------
   Auxiliary functions
@@ -266,9 +304,12 @@ getEnvConfig tracer = Env.lookupEnv envName >>= \case
 --
 -- @clang -print-file-name=include@ is called to get the builtin include
 -- directory.
-getBuiltinIncDirWithClang :: Tracer DiscoverMsg -> MaybeT IO BuiltinIncDir
-getBuiltinIncDirWithClang tracer = do
-    exe <- findClangExe tracer <|> do
+getBuiltinIncDirWithClang ::
+     Tracer DiscoverMsg
+  -> MaybeT IO ClangExe
+  -> MaybeT IO BuiltinIncDir
+getBuiltinIncDirWithClang tracer getExe = do
+    exe <- getExe <|> do
       traceWith tracer (withCallStack DiscoverClangNotFound)
       MaybeT $ return Nothing
     clangVersionString <- getClangVersion tracer exe

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -206,6 +206,9 @@ runFrontend tracer config boot = do
     parsePass <- cache "parse" $ do
       setup      <- getSetup
       cStd       <- boot.cStandard
+      -- TODO <https://github.com/well-typed/hs-bindgen/pull/1892>: use the
+      -- clang executable to preprocess macro invocations
+      !_clangExe <- boot.clangExe
       liftIO $ withClang (contramap FrontendClang tracer) setup $ \unit -> do
         (includeGraph, isMainHeader, isInMainHeaderDir, getMainHeadersAndInclude, mainHeaderPaths) <-
           processIncludes unit

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -34,7 +34,6 @@ import Clang.HighLevel.Types (Diagnostic (..))
 import HsBindgen.BindingSpec (BindingSpecMsg (..))
 import HsBindgen.Boot
 import HsBindgen.Clang (ClangMsg (..))
-import HsBindgen.Clang.Discover (BuiltinIncDirMsg (..))
 import HsBindgen.Frontend (FrontendMsg (..))
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass (ImmediateAssignAnonIdsMsg (..))
@@ -61,7 +60,6 @@ import HsBindgen.Util.Tracer
 data TraceMsg =
     TraceBoot          BootMsg
   | TraceFrontend      FrontendMsg
-  | TraceBuiltinIncDir BuiltinIncDirMsg
   | TraceResolveHeader ResolveHeaderMsg
   deriving stock    (Show, Generic)
   deriving anyclass (PrettyForTrace, IsTrace Level)

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -34,7 +34,7 @@ import Clang.HighLevel.Types (Diagnostic (..))
 import HsBindgen.BindingSpec (BindingSpecMsg (..))
 import HsBindgen.Boot
 import HsBindgen.Clang (ClangMsg (..))
-import HsBindgen.Clang.BuiltinIncDir (BuiltinIncDirMsg (..))
+import HsBindgen.Clang.Discover (BuiltinIncDirMsg (..))
 import HsBindgen.Frontend (FrontendMsg (..))
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass (ImmediateAssignAnonIdsMsg (..))


### PR DESCRIPTION
Finding the `clang` executable is a prerequisite for #1892. Since the boot phase already performs the search as part of the  `BuiltinIncDir` module, we can reuse that bit of code and pass on the discovered path to the frontend.