### PR TITLE
`ReparseMacroExpansions`: skip over attribute specifier sequences

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -106,6 +106,10 @@
   The pragma was previously added unconditionally for every foreign import,
   even though the generated bindings only use the `ccall` calling convention.
   See [issue #1868][is-1868].
+* Fix the reparser to ignore attribute specifier sequences. Previously,
+  declarations carrying macro expansions and attribute specifier sequences
+  failed to reparse and silently fell back to the un-reparsed type, dropping
+  macro typedef names from generated bindings. See [PR #1955][pr-1955].
 
 ## 0.1.0-alpha2 -- 2026-03-27
 
@@ -229,6 +233,7 @@
 [pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917
 [pr-1921]: https://github.com/well-typed/hs-bindgen/pull/1921
 [is-1868]: https://github.com/well-typed/hs-bindgen/issues/1868
+[pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
 
 ## 0.1.0-alpha -- 2026-02-06
 

--- a/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/FunPtr.hs
@@ -27,7 +27,7 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , "/* test_macrosreparsegnu_attributes_Example_get_bar */"
   , "__attribute__ ((const))"
   , "void (*hs_bindgen_30ffbacf53832dc4 (void)) ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  return &bar;"
@@ -35,7 +35,7 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , "/* test_macrosreparsegnu_attributes_Example_get_dash */"
   , "__attribute__ ((const))"
   , "void (*hs_bindgen_3cc756628379222d (void)) ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  return &dash;"
@@ -82,7 +82,7 @@ foreign import ccall unsafe "hs_bindgen_30ffbacf53832dc4" hs_bindgen_30ffbacf538
      IO (RIP.FunPtr RIP.Void)
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_bar@
-hs_bindgen_30ffbacf53832dc4 :: IO (RIP.FunPtr (RIP.CInt -> IO ()))
+hs_bindgen_30ffbacf53832dc4 :: IO (RIP.FunPtr (BOOL -> IO ()))
 hs_bindgen_30ffbacf53832dc4 =
   RIP.fromFFIType hs_bindgen_30ffbacf53832dc4_base
 
@@ -93,7 +93,7 @@ hs_bindgen_30ffbacf53832dc4 =
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-bar :: RIP.FunPtr (RIP.CInt -> IO ())
+bar :: RIP.FunPtr (BOOL -> IO ())
 bar = RIP.unsafePerformIO hs_bindgen_30ffbacf53832dc4
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_dash@
@@ -101,7 +101,7 @@ foreign import ccall unsafe "hs_bindgen_3cc756628379222d" hs_bindgen_3cc75662837
      IO (RIP.FunPtr RIP.Void)
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_dash@
-hs_bindgen_3cc756628379222d :: IO (RIP.FunPtr (RIP.CInt -> IO ()))
+hs_bindgen_3cc756628379222d :: IO (RIP.FunPtr (BOOL -> IO ()))
 hs_bindgen_3cc756628379222d =
   RIP.fromFFIType hs_bindgen_3cc756628379222d_base
 
@@ -112,7 +112,7 @@ hs_bindgen_3cc756628379222d =
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-dash :: RIP.FunPtr (RIP.CInt -> IO ())
+dash :: RIP.FunPtr (BOOL -> IO ())
 dash =
   RIP.unsafePerformIO hs_bindgen_3cc756628379222d
 

--- a/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/Safe.hs
@@ -23,13 +23,13 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , "  (foo)(arg1);"
   , "}"
   , "void hs_bindgen_432c6480e8c1355b ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  (bar)(arg1);"
   , "}"
   , "void hs_bindgen_b7cd534964204668 ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  (dash)(arg1);"
@@ -78,7 +78,7 @@ foreign import ccall safe "hs_bindgen_432c6480e8c1355b" hs_bindgen_432c6480e8c13
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_bar@
 hs_bindgen_432c6480e8c1355b ::
-     RIP.CInt
+     BOOL
   -> IO ()
 hs_bindgen_432c6480e8c1355b =
   RIP.fromFFIType hs_bindgen_432c6480e8c1355b_base
@@ -90,7 +90,7 @@ hs_bindgen_432c6480e8c1355b =
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
 bar ::
-     RIP.CInt
+     BOOL
   -> IO ()
 bar = hs_bindgen_432c6480e8c1355b
 
@@ -101,7 +101,7 @@ foreign import ccall safe "hs_bindgen_b7cd534964204668" hs_bindgen_b7cd534964204
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_dash@
 hs_bindgen_b7cd534964204668 ::
-     RIP.CInt
+     BOOL
   -> IO ()
 hs_bindgen_b7cd534964204668 =
   RIP.fromFFIType hs_bindgen_b7cd534964204668_base
@@ -113,7 +113,7 @@ hs_bindgen_b7cd534964204668 =
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
 dash ::
-     RIP.CInt
+     BOOL
   -> IO ()
 dash = hs_bindgen_b7cd534964204668
 

--- a/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/reparse/gnu_attributes/Example/Unsafe.hs
@@ -23,13 +23,13 @@ $(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.un
   , "  (foo)(arg1);"
   , "}"
   , "void hs_bindgen_04dc8fc0c78d4f3a ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  (bar)(arg1);"
   , "}"
   , "void hs_bindgen_8e06931d2ef7ccdb ("
-  , "  signed int arg1"
+  , "  BOOL arg1"
   , ")"
   , "{"
   , "  (dash)(arg1);"
@@ -78,7 +78,7 @@ foreign import ccall unsafe "hs_bindgen_04dc8fc0c78d4f3a" hs_bindgen_04dc8fc0c78
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_bar@
 hs_bindgen_04dc8fc0c78d4f3a ::
-     RIP.CInt
+     BOOL
   -> IO ()
 hs_bindgen_04dc8fc0c78d4f3a =
   RIP.fromFFIType hs_bindgen_04dc8fc0c78d4f3a_base
@@ -90,7 +90,7 @@ hs_bindgen_04dc8fc0c78d4f3a =
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
 bar ::
-     RIP.CInt
+     BOOL
   -> IO ()
 bar = hs_bindgen_04dc8fc0c78d4f3a
 
@@ -101,7 +101,7 @@ foreign import ccall unsafe "hs_bindgen_8e06931d2ef7ccdb" hs_bindgen_8e06931d2ef
 
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_dash@
 hs_bindgen_8e06931d2ef7ccdb ::
-     RIP.CInt
+     BOOL
   -> IO ()
 hs_bindgen_8e06931d2ef7ccdb =
   RIP.fromFFIType hs_bindgen_8e06931d2ef7ccdb_base
@@ -113,7 +113,7 @@ hs_bindgen_8e06931d2ef7ccdb =
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
 dash ::
-     RIP.CInt
+     BOOL
   -> IO ()
 dash = hs_bindgen_8e06931d2ef7ccdb
 

--- a/hs-bindgen/fixtures/macros/reparse/gnu_attributes/th.txt
+++ b/hs-bindgen/fixtures/macros/reparse/gnu_attributes/th.txt
@@ -7,13 +7,13 @@
 --   (foo)(arg1);
 -- }
 -- void hs_bindgen_432c6480e8c1355b (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   (bar)(arg1);
 -- }
 -- void hs_bindgen_b7cd534964204668 (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   (dash)(arg1);
@@ -37,13 +37,13 @@
 --   (foo)(arg1);
 -- }
 -- void hs_bindgen_04dc8fc0c78d4f3a (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   (bar)(arg1);
 -- }
 -- void hs_bindgen_8e06931d2ef7ccdb (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   (dash)(arg1);
@@ -71,7 +71,7 @@
 -- /* test_macrosreparsegnu_attributes_Example_get_bar */
 -- __attribute__ ((const))
 -- void (*hs_bindgen_30ffbacf53832dc4 (void)) (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   return &bar;
@@ -79,7 +79,7 @@
 -- /* test_macrosreparsegnu_attributes_Example_get_dash */
 -- __attribute__ ((const))
 -- void (*hs_bindgen_3cc756628379222d (void)) (
---   signed int arg1
+--   BOOL arg1
 -- )
 -- {
 --   return &dash;
@@ -156,7 +156,7 @@ foreign import ccall safe "hs_bindgen_432c6480e8c1355b" hs_bindgen_432c6480e8c13
     Int32
  -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_bar@
-hs_bindgen_432c6480e8c1355b :: CInt -> IO ()
+hs_bindgen_432c6480e8c1355b :: BOOL -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_bar@
 hs_bindgen_432c6480e8c1355b = fromFFIType hs_bindgen_432c6480e8c1355b_base
 {-| __C declaration:__ @bar@
@@ -165,7 +165,7 @@ hs_bindgen_432c6480e8c1355b = fromFFIType hs_bindgen_432c6480e8c1355b_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-bar_safe :: CInt -> IO ()
+bar_safe :: BOOL -> IO ()
 {-| __C declaration:__ @bar@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 6:46@
@@ -178,7 +178,7 @@ foreign import ccall safe "hs_bindgen_b7cd534964204668" hs_bindgen_b7cd534964204
     Int32
  -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_dash@
-hs_bindgen_b7cd534964204668 :: CInt -> IO ()
+hs_bindgen_b7cd534964204668 :: BOOL -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_dash@
 hs_bindgen_b7cd534964204668 = fromFFIType hs_bindgen_b7cd534964204668_base
 {-| __C declaration:__ @dash@
@@ -187,7 +187,7 @@ hs_bindgen_b7cd534964204668 = fromFFIType hs_bindgen_b7cd534964204668_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-dash_safe :: CInt -> IO ()
+dash_safe :: BOOL -> IO ()
 {-| __C declaration:__ @dash@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 7:46@
@@ -266,7 +266,7 @@ foreign import ccall unsafe "hs_bindgen_04dc8fc0c78d4f3a" hs_bindgen_04dc8fc0c78
     Int32
  -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_bar@
-hs_bindgen_04dc8fc0c78d4f3a :: CInt -> IO ()
+hs_bindgen_04dc8fc0c78d4f3a :: BOOL -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_bar@
 hs_bindgen_04dc8fc0c78d4f3a = fromFFIType hs_bindgen_04dc8fc0c78d4f3a_base
 {-| __C declaration:__ @bar@
@@ -275,7 +275,7 @@ hs_bindgen_04dc8fc0c78d4f3a = fromFFIType hs_bindgen_04dc8fc0c78d4f3a_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-bar_unsafe :: CInt -> IO ()
+bar_unsafe :: BOOL -> IO ()
 {-| __C declaration:__ @bar@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 6:46@
@@ -288,7 +288,7 @@ foreign import ccall unsafe "hs_bindgen_8e06931d2ef7ccdb" hs_bindgen_8e06931d2ef
     Int32
  -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_dash@
-hs_bindgen_8e06931d2ef7ccdb :: CInt -> IO ()
+hs_bindgen_8e06931d2ef7ccdb :: BOOL -> IO ()
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Unsafe_dash@
 hs_bindgen_8e06931d2ef7ccdb = fromFFIType hs_bindgen_8e06931d2ef7ccdb_base
 {-| __C declaration:__ @dash@
@@ -297,7 +297,7 @@ hs_bindgen_8e06931d2ef7ccdb = fromFFIType hs_bindgen_8e06931d2ef7ccdb_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-dash_unsafe :: CInt -> IO ()
+dash_unsafe :: BOOL -> IO ()
 {-| __C declaration:__ @dash@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 7:46@
@@ -375,7 +375,7 @@ foo_funptr = unsafePerformIO hs_bindgen_82e23f370cc161df
 foreign import ccall unsafe "hs_bindgen_30ffbacf53832dc4" hs_bindgen_30ffbacf53832dc4_base ::
     IO (FunPtr Void)
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_bar@
-hs_bindgen_30ffbacf53832dc4 :: IO (FunPtr (CInt -> IO ()))
+hs_bindgen_30ffbacf53832dc4 :: IO (FunPtr (BOOL -> IO ()))
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_bar@
 hs_bindgen_30ffbacf53832dc4 = fromFFIType hs_bindgen_30ffbacf53832dc4_base
 {-# NOINLINE bar_funptr #-}
@@ -385,7 +385,7 @@ hs_bindgen_30ffbacf53832dc4 = fromFFIType hs_bindgen_30ffbacf53832dc4_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-bar_funptr :: FunPtr (CInt -> IO ())
+bar_funptr :: FunPtr (BOOL -> IO ())
 {-| __C declaration:__ @bar@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 6:46@
@@ -397,7 +397,7 @@ bar_funptr = unsafePerformIO hs_bindgen_30ffbacf53832dc4
 foreign import ccall unsafe "hs_bindgen_3cc756628379222d" hs_bindgen_3cc756628379222d_base ::
     IO (FunPtr Void)
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_dash@
-hs_bindgen_3cc756628379222d :: IO (FunPtr (CInt -> IO ()))
+hs_bindgen_3cc756628379222d :: IO (FunPtr (BOOL -> IO ()))
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_get_dash@
 hs_bindgen_3cc756628379222d = fromFFIType hs_bindgen_3cc756628379222d_base
 {-# NOINLINE dash_funptr #-}
@@ -407,7 +407,7 @@ hs_bindgen_3cc756628379222d = fromFFIType hs_bindgen_3cc756628379222d_base
 
     __exported by:__ @macros\/reparse\/gnu_attributes.h@
 -}
-dash_funptr :: FunPtr (CInt -> IO ())
+dash_funptr :: FunPtr (BOOL -> IO ())
 {-| __C declaration:__ @dash@
 
     __defined at:__ @macros\/reparse\/gnu_attributes.h 7:46@

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
@@ -249,6 +249,7 @@ instance Apply (LanC.CTypeQualifier a) UnknownType where
   apply = \case
       LanC.CConstQual _a ->
         return . Optics.set #isConst True
+      LanC.CAttrQual  _ -> return
       other -> \_ ->
         unexpectedF other
 
@@ -280,6 +281,7 @@ instance Apply (LanC.CTypeQualifier a) (C.Type ReparseMacroExpansions) where
   apply = \case
       LanC.CConstQual _ -> return . C.TypeQual C.QualConst
       LanC.CRestrQual _ -> return -- ignore @__restrict@
+      LanC.CAttrQual _  -> return
       other             -> \_ -> unexpectedF other
 
 instance Apply (LanC.CDerivedDeclarator a) (C.Type ReparseMacroExpansions) where


### PR DESCRIPTION
Previously, declarations carrying macro expansions and attribute specifier sequences failed to reparse and silently fell back to the un-reparsed type, dropping macro typedef names from generated bindings.

