### PR TITLE
Update `libclang-bindings`, rewrite installation documentation

### DIFF
--- a/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
@@ -50,7 +50,7 @@ tests :: TestTree
 tests = testGroup "Parse.Golden" $ [goldenWith CExprC17] ++ mbC23
   where
     mbC23 =
-      case clangVersion of
+      case runtimeClangVersion of
         ClangVersion x | x >= (15,0,0) -> [goldenWith CExprC23]
         _                              -> []
 

--- a/cabal.project.base
+++ b/cabal.project.base
@@ -1,11 +1,12 @@
 -- curent date: 3-month update
 index-state: 2026-03-12T10:22:50Z
 
--- Note: this should point to a commit on libclang's main branch
+-- Note: this should point to a commit on the libclang-bindings main branch
 source-repository-package
     type: git
-    location: https://github.com/well-typed/libclang
-    tag: cdbf817187a261ebf8c31b32c85c5693eedf298d
+    location: https://github.com/well-typed/libclang-bindings
+    tag: eacb433c36008409f3d1394270e51b2c27ff9530
+    subdir: libclang-bindings
 
 source-repository-package
     type: git

--- a/examples/bundled-c/README.md
+++ b/examples/bundled-c/README.md
@@ -21,8 +21,9 @@ Cabal compiles `rect.c` and links it into the executable automatically.
 on Linux), while `hs-bindgen` uses `libclang` to parse headers and derive type
 layouts. For simple types this is unlikely to cause problems, but GCC and Clang
 can disagree on memory layout for more exotic constructs (bitfields, packed
-structs, platform-specific alignment). See the [Compiler choice (GCC vs.
-Clang)](../../manual/installation.md#compiler-choice-gcc-vs-clang)
+structs, platform-specific alignment). See the
+[Clang vs. GCC](../../manual/installation.md#clang-vs-gcc) documentation in the
+manual.
 
 ## Prerequisites
 

--- a/examples/c-qrcode/hs-project/cabal.project
+++ b/examples/c-qrcode/hs-project/cabal.project
@@ -4,9 +4,10 @@ packages: .
           ../../../c-expr-dsl
           ../../../hs-bindgen
 
+-- TODO When updating libclang-bindings, add `subdir: libclang-bindings`
 source-repository-package
     type: git
-    location: https://github.com/well-typed/libclang
+    location: https://github.com/well-typed/libclang-bindings
     tag: d4ae9a5fcca9ae71fcb4df2c0b0ea37c6b15c48c
 
 source-repository-package

--- a/examples/c-rogueutil/hs-project/cabal.project
+++ b/examples/c-rogueutil/hs-project/cabal.project
@@ -4,9 +4,10 @@ packages: .
           ../../../c-expr-dsl
           ../../../hs-bindgen
 
+-- TODO When updating libclang-bindings, add `subdir: libclang-bindings`
 source-repository-package
     type: git
-    location: https://github.com/well-typed/libclang
+    location: https://github.com/well-typed/libclang-bindings
     tag: d4ae9a5fcca9ae71fcb4df2c0b0ea37c6b15c48c
 
 source-repository-package

--- a/examples/c-rpm/hs-project/cabal.project
+++ b/examples/c-rpm/hs-project/cabal.project
@@ -4,9 +4,10 @@ packages: .
           ../../../c-expr-dsl
           ../../../hs-bindgen
 
+-- TODO When updating libclang-bindings, add `subdir: libclang-bindings`
 source-repository-package
     type: git
-    location: https://github.com/well-typed/libclang
+    location: https://github.com/well-typed/libclang-bindings
     tag: d4ae9a5fcca9ae71fcb4df2c0b0ea37c6b15c48c
 
 source-repository-package

--- a/flake.lock
+++ b/flake.lock
@@ -38,17 +38,17 @@
     "libclang-bindings-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776409433,
-        "narHash": "sha256-Hmv9XBUhsEsq5BVCYUoISbZLSlPbPgvhFuwdzbnbVa4=",
+        "lastModified": 1778635491,
+        "narHash": "sha256-4MiCD+Joyc26gCqTKT6v7POek5/0vbdkb2pW68wjvz8=",
         "owner": "well-typed",
-        "repo": "libclang",
-        "rev": "cdbf817187a261ebf8c31b32c85c5693eedf298d",
+        "repo": "libclang-bindings",
+        "rev": "eacb433c36008409f3d1394270e51b2c27ff9530",
         "type": "github"
       },
       "original": {
         "owner": "well-typed",
-        "repo": "libclang",
-        "rev": "cdbf817187a261ebf8c31b32c85c5693eedf298d",
+        "repo": "libclang-bindings",
+        "rev": "eacb433c36008409f3d1394270e51b2c27ff9530",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     libclang-bindings-src = {
-      url = "github:well-typed/libclang?rev=cdbf817187a261ebf8c31b32c85c5693eedf298d";
+      url = "github:well-typed/libclang-bindings?rev=eacb433c36008409f3d1394270e51b2c27ff9530";
       flake = false;
     };
     doxygen-parser-src = {

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -9,7 +9,7 @@ import Options.Applicative.Help qualified as Help
 import Prettyprinter.Util qualified as PP
 import System.Exit (ExitCode, exitFailure)
 
-import Clang.Version (runtimeClangVersionString)
+import Clang.Version (compileTimeClangVersionString, runtimeClangVersionString)
 
 import HsBindgen.App
 import HsBindgen.BindingSpec qualified as BindingSpec
@@ -56,7 +56,9 @@ execCliParser = customExecParser prefs' opts
     vers = List.intercalate "\n" [
         "hs-bindgen " ++ showVersion Package.version
       , "binding specification " ++ show BindingSpec.currentBindingSpecVersion
-      , Text.unpack runtimeClangVersionString
+      , "clang compile time version: "
+          ++ Text.unpack compileTimeClangVersionString
+      , "clang runtime version:      " ++ Text.unpack runtimeClangVersionString
       ]
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -9,7 +9,7 @@ import Options.Applicative.Help qualified as Help
 import Prettyprinter.Util qualified as PP
 import System.Exit (ExitCode, exitFailure)
 
-import Clang.Version (clang_getClangVersion)
+import Clang.Version (runtimeClangVersionString)
 
 import HsBindgen.App
 import HsBindgen.BindingSpec qualified as BindingSpec
@@ -35,20 +35,13 @@ parseCli =
       <*> Cli.parseCmd
 
 execCliParser :: IO Cli
-execCliParser = do
-    clangVersion <- Text.unpack <$> clang_getClangVersion
-    let vers = List.intercalate "\n" [
-            "hs-bindgen " ++ showVersion Package.version
-          , "binding specification " ++ show BindingSpec.currentBindingSpecVersion
-          , clangVersion
-          ]
-    customExecParser prefs' (opts vers)
+execCliParser = customExecParser prefs' opts
   where
     prefs' :: ParserPrefs
     prefs' = prefs $ helpShowGlobals <> subparserInline
 
-    opts :: String -> ParserInfo Cli
-    opts vers = info (parseCli <**> simpleVersioner vers <**> helper) $
+    opts :: ParserInfo Cli
+    opts = info (parseCli <**> simpleVersioner vers <**> helper) $
       mconcat [
           header "hs-bindgen - generate Haskell bindings from C headers"
         , footerDoc . Just . Help.vcat $ List.intersperse "" [
@@ -58,6 +51,13 @@ execCliParser = do
             , exitCodeFooter
             ]
         ]
+
+    vers :: String
+    vers = List.intercalate "\n" [
+        "hs-bindgen " ++ showVersion Package.version
+      , "binding specification " ++ show BindingSpec.currentBindingSpecVersion
+      , Text.unpack runtimeClangVersionString
+      ]
 
 {-------------------------------------------------------------------------------
   Execution

--- a/hs-bindgen/examples/minimal.h
+++ b/hs-bindgen/examples/minimal.h
@@ -1,0 +1,1 @@
+typedef char sym;

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -461,6 +461,7 @@ test-suite test-hs-bindgen
     Test.HsBindgen.THFixtures.Generate
     Test.HsBindgen.THFixtures.TestCases
     Test.HsBindgen.Unit.ClangArgs
+    Test.HsBindgen.Unit.Frontend
     Test.HsBindgen.Unit.Pretty
     Test.HsBindgen.Unit.Tracer
 

--- a/hs-bindgen/src-internal/HsBindgen/Clang/BuiltinIncDir.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/BuiltinIncDir.hs
@@ -12,7 +12,6 @@ module HsBindgen.Clang.BuiltinIncDir (
 
 import Control.Applicative ((<|>), asum)
 import Control.Exception (Exception(displayException))
-import Control.Monad.Trans.Class (MonadTrans(lift))
 import Control.Monad.Trans.Maybe
 import Data.IORef (IORef)
 import Data.IORef qualified as IORef
@@ -29,7 +28,7 @@ import System.FilePath.Posix qualified as Posix
 import System.FilePath.Windows qualified as Windows
 #endif
 
-import Clang.Version (clang_getClangVersion)
+import Clang.Version
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Imports
 import HsBindgen.Util.Process
@@ -258,12 +257,13 @@ getBuiltinIncDirWithClang tracer = do
     exe <- findClangExe tracer <|> do
       traceWith tracer (withCallStack BuiltinIncDirClangNotFound)
       MaybeT $ return Nothing
-    clangVer <- getClangVersion tracer exe
-    libclangVer <- lift clang_getClangVersion
-    unless (clangVer == libclangVer) $ do
-      traceWith tracer $
-        withCallStack  $
-        BuiltinIncDirClangVersionMismatch libclangVer clangVer
+    clangVersionString <- getClangVersion tracer exe
+    let clangVersion = parseClangVersion clangVersionString
+    unless (isCompatibleClangVersion runtimeClangVersion clangVersion) $ do
+      traceWith tracer . withCallStack $
+        BuiltinIncDirClangVersionMismatch
+          runtimeClangVersionString
+          clangVersionString
       MaybeT $ return Nothing
     resourceDir <- getClangResourceDir tracer exe
     ifM

--- a/hs-bindgen/src-internal/HsBindgen/Clang/CompareVersions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/CompareVersions.hs
@@ -6,7 +6,7 @@ module HsBindgen.Clang.CompareVersions (
 import Text.SimplePrettyPrint ((<+>))
 import Text.SimplePrettyPrint qualified as PP
 
-import Clang.Version (clangVersionCompileTime, clang_getClangVersion)
+import Clang.Version
 
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer
@@ -39,14 +39,15 @@ instance IsTrace Level CompareVersionsMsg where
   Comparison functions
 -------------------------------------------------------------------------------}
 
--- | Check if the compile time version of clang is different than the
--- runtime version, issue a warning if that's the case to inform the user
--- of this fact.
+-- | Check that the runtime version of libclang is compatible with the
+-- compile-time version
 --
+-- A warning is issued if they are incompatible.
 compareClangVersions :: Tracer CompareVersionsMsg -> IO ()
-compareClangVersions tracer = do
-  let compileTimeVersion = clangVersionCompileTime
-  runtimeVersion <- liftIO clang_getClangVersion
-  when (compileTimeVersion /= runtimeVersion) $
-    traceWith tracer $ withCallStack $ CompileTimeAndRuntimeVersionMismatch compileTimeVersion runtimeVersion
-
+compareClangVersions tracer
+    | isCompatibleClangVersion compileTimeClangVersion runtimeClangVersion =
+        return ()
+    | otherwise = traceWith tracer . withCallStack $
+        CompileTimeAndRuntimeVersionMismatch
+          compileTimeClangVersionString
+          runtimeClangVersionString

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -88,7 +88,7 @@ testTreeFor getTestResources = goTree
     goCase :: TestCase -> TestTree
     goCase test
       | Just versionPred <- test.clangVersion
-      , case clangVersion of
+      , case runtimeClangVersion of
           ClangVersion version  -> not (versionPred version)
           ClangVersionUnknown _ -> True
       = testGroup test.name []

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
@@ -92,11 +92,11 @@ check getTestResources test =
     --
     normalizeQuotes :: String -> String
     normalizeQuotes =
-      case clangVersion of
+      case runtimeClangVersion of
         ClangVersionUnknown _ -> id
         ClangVersion v
           -- Put your clang version here
-          | v >= (19, 0 ,0) -> go False
+          | v >= (19, 0, 0) -> go False
           | otherwise       -> id
       where
         go _ [] = []

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/TestCases.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/TestCases.hs
@@ -31,7 +31,7 @@ determineTHStatus tc
       = status
   -- Check clangVersion requirement
   | Just versionPred <- tc.clangVersion
-  , case clangVersion of
+  , case runtimeClangVersion of
       ClangVersion version  -> not (versionPred version)
       ClangVersionUnknown _ -> True
       = FixtureSkip "Requires newer clang version"

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
@@ -59,7 +59,7 @@ testWhenClangVersion p name assertion
     | otherwise  = testGroup name []
   where
     isRunnable :: Bool
-    isRunnable = case clangVersion of
+    isRunnable = case runtimeClangVersion of
       ClangVersion version  -> p version
       ClangVersionUnknown _ -> False
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
@@ -1,0 +1,90 @@
+module Test.HsBindgen.Unit.Frontend (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clang.Version
+
+import HsBindgen.Boot
+import HsBindgen.Cache
+import HsBindgen.Config.Internal
+import HsBindgen.Frontend
+import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.Pass.Parse.IsPass
+import HsBindgen.Frontend.Pass.Parse.Result
+import HsBindgen.Imports
+import HsBindgen.TraceMsg
+import HsBindgen.Util.Tracer
+
+import Test.Common.HsBindgen.Trace.Predicate
+import Test.HsBindgen.Resources
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+tests :: IO TestResources -> TestTree
+tests getTestResources = testGroup "Test.HsBindgen.Unit.Frontend" [
+      testGroup "Parse" [
+          testParseSequenceNumber getTestResources
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Parse pass tests
+-------------------------------------------------------------------------------}
+
+testParseSequenceNumber :: IO TestResources -> TestTree
+testParseSequenceNumber getTestResources =
+  testWhenClangVersion (>= (20, 1, 0)) "ParseSequenceNumber" $ do
+    results <-
+      execFrontend getTestResources c89 ["examples"] "minimal.h" getParseResults
+    forM_ results $ \result -> case getParseResultMaybeDecl result of
+      Nothing   -> assertFailure $ "parse failed: " ++ show result
+      Just decl -> do
+        let msg = "no sequence number for declaration " ++ show decl.info.id
+        assertBool msg (isJust decl.info.seqNr)
+
+{-------------------------------------------------------------------------------
+  Auxiliary functions
+-------------------------------------------------------------------------------}
+
+testWhenClangVersion ::
+     ((Int, Int, Int) -> Bool)
+  -> TestName
+  -> Assertion
+  -> TestTree
+testWhenClangVersion p name assertion
+    | isRunnable = testCase  name assertion
+    | otherwise  = testGroup name []
+  where
+    isRunnable :: Bool
+    isRunnable = case clangVersion of
+      ClangVersion version  -> p version
+      ClangVersionUnknown _ -> False
+
+execFrontend ::
+     IO TestResources
+  -> CStandard
+  -> [FilePath]  -- ^ Include directories
+  -> FilePath    -- ^ Header
+  -> (FrontendArtefact -> IO a)
+  -> IO a
+execFrontend getTestResources cStd incDirs header k =
+    withTracePredicate noReport defaultTracePredicate $ \tracer -> do
+      clangArgs <- getTestClangArgsConfig cStd incDirs <$> getTestResources
+      let bootConfig     = BootConfig clangArgs def def
+          frontendConfig = def
+          backendConfig  = def{ uniqueId = UniqueId "test" }
+          config         = BindgenConfig bootConfig frontendConfig backendConfig
+          bootTracer     = contramap TraceBoot tracer
+          frontendTracer = contramap TraceFrontend tracer
+      bootArtefact <- runBoot bootTracer config [header]
+      frontendArtefact <- runFrontend frontendTracer frontendConfig bootArtefact
+      k frontendArtefact
+  where
+    noReport :: a -> IO ()
+    noReport = const $ pure ()
+
+getParseResults :: FrontendArtefact -> IO [ParseResult Parse]
+getParseResults = getCached . (.parse)

--- a/hs-bindgen/test/hs-bindgen/test-hs-bindgen.hs
+++ b/hs-bindgen/test/hs-bindgen/test-hs-bindgen.hs
@@ -12,6 +12,7 @@ import Test.HsBindgen.Prop.Selection qualified as Prop.Selection
 import Test.HsBindgen.Resources
 import Test.HsBindgen.THFixtures qualified as THFixtures
 import Test.HsBindgen.Unit.ClangArgs qualified as Unit.ClangArgs
+import Test.HsBindgen.Unit.Frontend qualified as Unit.Frontend
 import Test.HsBindgen.Unit.Pretty qualified as Unit.Pretty
 import Test.HsBindgen.Unit.Tracer qualified as Unit.Tracer
 
@@ -26,6 +27,7 @@ main = defaultMain $
         Frontend.LanguageC.tests
       , testGroup "unit tests" [
             Unit.ClangArgs.tests testResources
+          , Unit.Frontend.tests testResources
           , Unit.Tracer.tests
           , Unit.Pretty.tests
           ]

--- a/manual/installation.md
+++ b/manual/installation.md
@@ -1,344 +1,412 @@
 # Installation
 
-Depending on the system, specific steps ensure a smooth experience with
-`hs-bindgen`. This guide will walk you through the setup process for Linux,
-macOS, and Windows.
+In addition to covering installation, this part of the manual provides
+system-related details about using `hs-bindgen`.
 
-## Linux
+We distinguish the following *phases* of installing and using `hs-bindgen`,
+where *user bindings* refers to the bindings that `hs-bindgen` generates.
 
-We recommend using the Clang compiler toolchain on Linux for best compatibility
-with `hs-bindgen`. GCC should normally work, but there are edge cases where GCC
-and Clang differ.
+1. [Build `hs-bindgen`][t:build-hs-bindgen]
+    * [Requirements][t:requirements]
+    * [Get `hs-bindgen`][t:get-hs-bindgen]
+    * [Configure `libclang-bindings`][t:configure-libclang-bindings]
+    * [Configure `hs-bindgen`][t:configure-hs-bindgen]
+    * [Build and test][t:build-and-test]
+2. [Run `hs-bindgen`][t:run-hs-bindgen], generating user bindings
+3. [Build the user project][t:build-the-user-project] that includes those
+  bindings
+4. [Run the user project][t:run-the-user-project]
 
-### Compiler choice (GCC vs. Clang)
+When using the `hs-bindgen` Template Haskell API, the second and third steps are
+done together.
 
-`hs-bindgen` uses `libclang` internally to parse C code. GCC is the default
-compiler on many Linux distributions and is also the compiler used by GHC.
-While GCC and Clang are mostly compatible, they can exhibit differences in
-memory layout for some constructs. Using Clang for both generation of and
-compilation of the bindings ensures consistency and correctness.
+This part of the manual also includes information about
+[Clang vs. GCC][t:clang-vs-gcc] and
+[common errors and solutions][t:common-errors-and-solutions].
 
-Note that `static inline` functions in a C header file are compiled using the C
-compiler that GHC is configured to use. One should beware of any Clang/GCC
-discrepancies in such functions when GCC is used.
+## Build `hs-bindgen`
+[t:build-hs-bindgen]: #build-hs-bindgen
 
-Unfortunately, it is not straightforward to make GHC use Clang without
-effectively building GHC from scratch. There are flags like `-pgmc` and `-pgml`
-([see the GHC user guide][ghc:guide:phases-programs]) which allow specification
-of the C compiler used by GHC; however, experiments showed that just setting
-these flags was not enough. For more details see the discussions at issues
-[#846](https://github.com/well-typed/hs-bindgen/issues/846), and
-[#847](https://github.com/well-typed/hs-bindgen/issues/847).
+### Requirements
+[t:requirements]: #requirements
 
-Using Clang for both, generation of and compilation of the bindings ensures
-consistency and correctness, but we currently do not thoroughly test compilation
-of code using the generated bindings with Clang.
+`hs-bindgen` requires the following:
 
-### Installation of LLVM and Clang
+* [GHC][] 9.2 through 9.14
+* [Cabal][] 3.0 or later
+* [LLVM/Clang][] 16 or later, current tested through LLVM/Clang 22
 
-You need to install LLVM and Clang. The specific package names may vary
-depending on your distribution.
+> [!NOTE]
+> We maintain a [Nix flake][] for using `hs-bindgen` with Nix.  We also provide
+> a [Nix-focused tutorial][hs-bindgen-tutorial-nix].
 
-### Adding `cabal.project.local`
+`hs-bindgen` uses LLVM/Clang to parse and introspect C headers, via the
+`libclang` C API.  There are frequent releases, and a smoother experience is
+more likely when using versions that we test against.  The `libclang` bindings
+are implemented in the [`libclang-bindings`][libclang-bindings] package.  See
+the [`libclang-bindings` manual][libclang-bindings:manual] for details about
+installing LLVM/Clang.
 
-We need to inform the program about the location of the C sources. We can do so
-by creating a `cabal.project.local` file that defines `extra-include-dirs` and
-`extra-lib-dirs`.
+> [!WARNING]
+> Windows users are recommended to use the LLVM/Clang that is installed with
+> recent versions of GHC.  LLVM/Clang versions installed from official releases
+> or with Visual Studio target MSVC, which is not supported by GHC, and are
+> therefore not suitable.
 
-For example, to build the manual you will need the following:
+### Get `hs-bindgen`
+[t:get-hs-bindgen]: #get-hs-bindgen
+
+A Hackage package will be made available from the first official release.  Until
+then, it is necessary to clone the repository.
+
+```bash
+$ git clone https://github.com/well-typed/hs-bindgen.git
+$ cd hs-bindgen
+```
+
+`hs-bindgen` uses trunk-based development on the `main` branch.  Use the `HEAD`
+of the `main` branch to use the latest commits, or checkout a tag to use a
+well-tested snapshot of the project.  Example:
+
+```bash
+$ git checkout -b release-0.1-alpha2 release-0.1-alpha2
+```
+
+### Configure `libclang-bindings`
+[t:configure-libclang-bindings]: #configure-libclang-bindings
+
+You can try out `hs-bindgen` without any special configuration as long as you
+have the `llvm-config` (`llvm-config.exe` on Windows) and `clang` (`clang.exe`
+on Windows) executables in your `PATH`.  You can confirm this as follows:
+
+```bash
+$ which llvm-config
+$ which clang
+$ llvm-config --version
+```
+
+Special configuration in a `cabal.project.local` file may be required to work
+around some Cabal linking issues, however, if you want to test against multiple
+versions of LLVM/Clang or even upgrade the version of LLVM/Clang that you use.
+See the [`libclang-bindings` manual][libclang-bindings:manual] for details.
+
+### Configure `hs-bindgen`
+[t:configure-hs-bindgen]: #configure-hs-bindgen
+
+The `hs-bindgen` library and `hs-bindgen-cli` executable do not require any
+additional configuration to be built.  When building the tests, however, the
+system include directories must be determined.
+
+By default, `hs-bindgen` uses the `clang` executable to determine the system
+include directories, so nothing needs be configured manually.  This is described
+in the
+[`hs-bindgen` section of the includes documentation][manual:includes-hs-bindgen].
+In cases where this does not work, the `BINDGEN_EXTRA_CLANG_ARGS` environment
+variable can be used to configure Clang options that `hs-bindgen` always
+applies.  This is described in the
+[environment variables section of the Clang options documentation][manual:clang-options-env].
+
+On macOS, the `SDKROOT` environment variable must be set to instruct LLVM/Clang
+which SDK to use.  The default can generally be determined using
+`xcrun --sdk macosx --show-sdk-path`.  If `SDKROOT` is not set, `hs-bindgen`
+attempts to run this command and automatically set it to the default.
+
+### Build and test
+[t:build-and-test]: #build-and-test
+
+Build the `hs-bindgen` library, the `hs-bindgen-cli` executable, and all tests
+as follows.
+
+```bash
+$ cabal build all
+```
+
+If you would like to run the test suites, that can be done as follows.
+
+```bash
+$ cabal test all
+```
+
+## Run `hs-bindgen`
+[t:run-hs-bindgen]: #run-hs-bindgen
+
+When generating bindings, `hs-bindgen` must be able to find the specified
+headers as well as any headers that are transitively included by those specified
+headers.  This is typically done using `-I` options to the CLI or `hashInclude`
+calls when using Template Haskell.
+
+In cases when you are generating bindings for software that is installed on your
+system and the headers are in a system include directory (such as
+`/usr/include`), then you generally do not need to configure header directories.
+
+It is possible to configure header directories using the `C_INCLUDE_PATH` or
+`BINDGEN_EXTRA_CLANG_ARGS` environment variables, as described in the
+[Clang options documentation][manual:clang-options].  While such environment
+variables are helpful for configuring general system paths, they are not
+recommended for configuring project-specific paths.
+
+See the [includes documentation][manual:includes] for details.
+
+## Build the user project
+[t:build-the-user-project]: #build-the-user-project
+
+To build the user project that includes generated user bindings, GHC must be
+configured so that it can find the headers as well as libraries.  This is done
+in different ways, depending on the software that you are creating bindings for.
+
+For software that has [`pkg-config`][pkg-config] support, the
+`.cabal` file should be configured using
+[`pkgconfig-depends`][cabal:docs:pkgconfig-depends].  (In this case, using
+`pkg-config` to get the include directories to configure `hs-bindgen` ensures
+consistency.)  Example:
+
+```cabal
+executable example
+  ...
+  pkgconfig-depends:
+      acme
+  ...
+```
+
+For software that lacks `pkg-config` support, the `.cabal` file can be
+configured using [`include-dirs`][cabal:docs:include-dirs] and
+[`extra-lib-dirs`][cabal:docs:extra-lib-dirs].  Example:
+
+```cabal
+executable example
+  ...
+  include-dirs:
+      /path/to/acme/include
+  extra-lib-dirs:
+      /path/to/acme/lib
+  ...
+```
+
+In cases where the paths are specific to each system, the `cabal.project.local`
+file can be configured using
+[`extra-include-dirs`][cabal:docs:project/extra-include-dirs] and
+[`extra-lib-dirs`][cabal:docs:project/extra-lib-dirs] instead.  Example:
 
 ```cabal
 package manual
   extra-include-dirs:
-      <path-to-hs-bindgen>/manual/c
+      /path/to/hs-bindgen/manual/c
   extra-lib-dirs:
-      <path-to-hs-bindgen>/manual/c
-
-package hs-game
-  extra-include-dirs:
-      <path-to-hs-bindgen>/manual/c
-  extra-lib-dirs:
-      <path-to-hs-bindgen>/manual/c
-
-package hs-vector
-  extra-include-dirs:
-      <path-to-hs-bindgen>/manual/c
-  extra-lib-dirs:
-      <path-to-hs-bindgen>/manual/c
+      /path/to/hs-bindgen/manual/c
 ```
 
-Note that the example above enables compilation of the manual from this
-repository. For a custom project, `extra-include-dirs` and `extra-lib-dirs`
-should be set in the `.cabal` file.
+## Run the user project
+[t:run-the-user-project]: #run-the-user-project
 
-### Setting environment variables
+To run the user project, the loader needs to be able to find any linked
+libraries.
 
-* `LD_LIBRARY_PATH`: Ensures that the C libraries you build can be linked at
-  runtime, you need to add their locations to this variable.
+In cases when you are generating bindings for software that is installed on your
+system and the libraries are in a system library directory (such as `/usr/lib`),
+then you generally do not need to configure the library directory.
 
-  * Example: If your shared library `libexample.so` is in
-    `/path/to/your/c/libs`, run:
+If you linked against a library in a non-standard directory, however, you may
+need to configure the library directory.  This is done differently on different
+operating systems.
 
-    ```bash
-    export LD_LIBRARY_PATH=/path/to/your/c/libs:$LD_LIBRARY_PATH
-    ```
+### Linux
 
-* `BINDGEN_EXTRA_CLANG_ARGS`: Contains extra arguments passed to `libclang`.
-  This is particularly useful for specifying include directories.
+You can configure a loader library directory using the `LD_LIBRARY_PATH`
+environment variable.  Example:
 
-  * Find your system's default include paths with
-
-    ```bash
-    clang -v -E -xc /dev/null
-    ```
-
-  * Set the variable accordingly,
-
-    ```bash
-    export BINDGEN_EXTRA_CLANG_ARGS="-nostdinc -I/usr/lib/clang/14/include -I/usr/include"
-    ```
-
-    > [!NOTE]
-    > Without `-nostdinc`, there are likely multiple directories in the C
-    > include path that provide the same headers. Which header is ultimately
-    > used depends on the order of directories in the include path.
-
-  * Note that the common use of this environment variable is to set preprocessor
-    flags. Include paths can be directly set with the `-I` flag of
-    `hs-bindgen-cli`.
-
-* `LLVM_PATH`, `LLVM_CONFIG`: `hs-bindgen` may need to know where to find
-  your LLVM installation.
-
-  ```bash
-  export LLVM_PATH=/usr/lib/llvm-14
-  export LLVM_CONFIG=$LLVM_PATH/bin/llvm-config
-  ```
-
-  This is only needed when you want to use a version of LLVM/Clang that is
-  not in your current `PATH`.
-
-### Cabal store maintenance
-
-The `libclang` bindings used by `hs-bindgen` are implemented in package
-`libclang-bindings`.  When built, it is linked to the `libclang` and `libLLVM`
-shared objects for the version of LLVM/Clang that you are using, and the built
-`libclang-bindings` library is cached in the Cabal store.  Cabal does not
-consider such system dependencies to determine when a package needs to be
-rebuilt, however, so you might continue to use a library built with an older
-version of LLVM/Clang even after a system upgrade installs a newer version.
-
-Links to LLVM/Clang shared objects generally specify the minor version.  If an
-upgrade replaces an older version of LLVM/Clang with a newer version that has
-the same minor version (and a newer patch version), then the link in the
-cached `libclang-bindings` build is not broken.  The newer version *should*
-still work, though we recommend rebuilding `hs-bindgen`/`libclang-bindings`
-using the newer version.  In this case, `hs-bindgen` displays a warning like
-the following, where the "compile time version" is the version of LLVM/Clang
-used to to build the cached `libclang-bindings` library, and the "runtime
-version" is the version for the shared object that is dynamically linked at
-runtime.
-
-```
-[Warning] [HsBindgen] [boot] clang version mismatch:
-  clang compile time version: 22.1.2
-  clang runtime version:      22.1.3
+```bash
+$ export LD_LIBRARY_PATH=/path/to/your/project/lib:$LD_LIBRARY_PATH
 ```
 
-If an upgrade installs a new major version and removes the older version, then
-the link in the cached `libclang-bindings` build is broken.  In this case, the
-dynamic library loader fails with an error like the following, preventing
-`hs-bindgen` from running at all.
+> [!NOTE]
+> Configure the directory that contains the `.so` file, not the `.so` file
+> itself.
 
-```
-libclang.so.20.1: cannot open shared object file: No such file or directory
-```
+### macOS
 
-Cabal does not provide an easy way to resolve this issue.  Note that this is an
-issue for any Haskell package that links to system libraries that do not have
-`pkg-config` support (in which case Cabal can track the dependency versions).
-It is particularly problematic with LLVM/Clang, however, because LLVM/Clang has
-frequent releases.  Currently, we suggest two ways to work around the issue.
+You can configure a loader library directory using the `DYLD_LIBRARY_PATH`
+environment variable.  Example:
 
-The easiest way to force Cabal to rebuild out-of-date/broken packages is to
-clear the cache.  You can determine your Cabal store directory by running
-`cabal path --store-dir`.  The Cabal store has separate caches for each version
-of GHC.  Recursively remove a GHC directory to clear the cache for that version.
-Note that deleting just a package directory is not advised because it can break
-the package database.  The downside to clearing your cache is that doing so may
-result in time-consuming recompilation of many other packages.
-
-Since we understand that clearing the cache might not be desirable, `hs-bindgen`
-offers a bespoke workaround, in the form of a compile-time setting specifying
-the LLVM/Clang version.  This forces Cabal to distinguish `libclang-bindings`
-builds that link to different versions, forcing a new build if one for the
-specified version is not already in the Cabal store.  Do this by adding the
-following to a `cabal.project.local` file for your project, with the desired
-version.
-
-```
-package libclang-bindings
-  ghc-options: -optc=-DCLANG_VERSION=22.1.3
+```bash
+$ export DYLD_LIBRARY_PATH=/path/to/your/project/lib:$DYLD_LIBRARY_PATH
 ```
 
-When configured like this, `libclang-bindings` confirms that the version matches
-the version of LLVM/Clang used at compile time.  The following checks are
-supported:
+> [!NOTE]
+> Configure the directory that contains the `.dylib` file, not the `.dylib` file
+> itself.
 
-* `MAJOR` to just check the major version (example: `22`)
-* `MAJOR.MINOR` to check the major and minor versions (example: `22.1`)
-* `MAJOR.MINOR.PATCH` to check the major, minor, and patch versions
-  (example: `22.1.3`)
+### Windows
 
-Note that `ghc-options` specifying an `-optc` option must be used, as
-`cc-options` is *not* sufficient.
-
-This issue affects any project that uses `hs-bindgen`, even if it is used as a
-transitive dependency.
-
-### Common errors and solutions
-
-* Missing headers (`stddef.h`, etc.): If you encounter errors about missing
-  standard headers, `libclang` cannot find the system include directories. Try
-  setting `BINDGEN_EXTRA_CLANG_ARGS` as described above.
-
-* Missing shared libraries (`libexample.so`): If you see an error like `cannot
-  open shared object file: No such file or directory`, it means the dynamic
-  linker cannot find your C library. Try adding the directory of the library to
-  `LD_LIBRARY_PATH` or adapting your `cabal.project.local`.
-
-* Unicode character issues with LLVM backend: When using the LLVM backend,
-  you might encounter issues with Unicode characters in your C code. This can
-  sometimes manifest as errors at the assembler level. Ensure your source
-  files do not include Unicode.
-
-## macOS
-
-On macOS, the setup is similar to Linux, but with its own specific environment
-variables and considerations, especially concerning the system's default Clang
-installation. Note that Apple's assembler does not support Unicode, so avoid
-using Unicode-specific characters in C function definitions.
-
-### Environment variables
-
-* `SDKROOT`: This environment variable must be set to instruct LLVM/Clang which
-  SDK to use.  The default can generally be determined using
-  `xcrun --sdk macosx --show-sdk-path`.  If `SDKROOT` is not set, `hs-bindgen`
-  attempts to run this command and automatically set it to the default.
-
-* `DYLD_LIBRARY_PATH`: This is the macOS equivalent of `LD_LIBRARY_PATH`. It
-  tells the dynamic linker where to find dynamic libraries (`.dylib` files).
-
-  Example:
-
-  ```bash
-  export DYLD_LIBRARY_PATH=/path/to/your/c/libs:$DYLD_LIBRARY_PATH
-  ```
-
-* `BINDGEN_EXTRA_CLANG_ARGS`: On macOS, setting the include paths like we
-  suggest for Linux is not required. If you need to, see the corresponding
-  section for Linux.
-
-## Windows
-
-MSVC, the default Windows toolchain, is currently not supported by GHC.  GHC is
-therefore distributed with a MinGW environment, which includes a GNU standard
-library.
-
-### LLVM/Clang
-
-Official distributions of GHC 9.4 and later use Clang as the C compiler.  The
-easiest way to use `hs-bindgen` on Windows is to use the LLVM/Clang installation
-that is distributed with GHC.
-
-Since GHC does not support MSVC, LLVM/Clang installed by Visual Studio or from
-the LLVM project releases should not be used.
-
-### Environment Variables
-
-* `LLVM_PATH`, `LLVM_CONFIG`, `LIBCLANG_PATH`: These environment variables
-  configure which LLVM/Clang installation is used by `hs-bindgen`.  For example,
-  configuration like the following instruct `hs-bindgen` to use a version of GHC
-  installed by GHCup.
-
-    ```powershell
-    $env:LLVM_PATH = "C:\ghcup\ghc\<your-ghc-version>\mingw"
-    $env:LLVM_CONFIG = "$env:LLVM_PATH\bin\llvm-config.exe"
-    $env:LIBCLANG_PATH = "$env:LLVM_PATH\lib"
-    ```
-
-* `BINDGEN_EXTRA_CLANG_ARGS`: This environment variable works the same on
-  Windows as it does on Linux.
-
-### DLLs
-
-Windows shared libraries are called "dynamic-link libraries" (DLLs).  All DLLs
-needed by an executable as well as any libraries it loads must be loaded when
-the executable is run.  Unlike Linux and macOS, Windows uses the `PATH`
-environment variable to search for DLLs (in addition to searching for
-executables).
-
-When building `hs-bindgen`, the `libclang-bindings` library is built.  It is
-linked to `libclang` and `LLVM` DLLs as determined using the environment
-variables described above.  When you run `hs-bindgen`, the `libclang.dll`
-library is loaded by searching for that file in the directories listed in the
-`PATH` environment variable.  The `PATH` environment variable should be
-configured so that it loads the same installation of LLVM/Clang that
-`hs-bindgen` and `libclang-bindings` was built with.  Note that the
-`libclang.dll` filename is not versioned, and `hs-bindgen` can warn you when
-the versions do not match.
+Windows searches for libraries (DLLs) using the `PATH` environment variable.
+This is the same `PATH` that is used to search for executables, and it is common
+to install libraries in the same directory as executables.  Configure your
+`PATH` so that both the executable and libraries are found.  Example:
 
 ```powershell
-$env:Path = "$env:LLVM_PATH\bin;" + $env:Path
+$env:Path = "C:\path\to\your\project\bin;" + $env:Path
 ```
 
-Similarly, when you create bindings that use a shared library, the directory
-where that DLL can be found should be in your `PATH` environment variable at
-runtime.
+## Clang vs. GCC
+[t:clang-vs-gcc]: #clang-vs-gcc
 
-```powershell
-$env:Path = "C:\path\to\your\c\libs;" + $env:Path
+Since `hs-bindgen` uses [LLVM/Clang][] to parse and introspect C headers, using
+Clang to compile C code ensures compatibility.  There are many cases where GCC
+is used, however.  In practice, Clang is highly ABI-compatible with GCC.  While
+we have not observed any incompatibility issues yet, such issues are possible.
+
+GHC is built using a specific C compiler, generally either Clang or GCC.  GHC
+uses this C compiler to build any C code that is part of the Haskell package,
+including `static inline` functions in C headers as well as wrapper functions
+such as those generated by `hs-bindgen` to support APIs that pass `struct`s by
+value.
+
+You can check which C compiler a specific build of GHC uses by running
+`ghc --info` and looking at the "C compiler command."  When using a build of GHC
+that uses GCC, it is *not* straightforward to configure it to use Clang instead.
+There are [GHC program options][ghc:guide:phases-programs] such as `-pgmc` and
+`-pgml` that look promising, but experiments indicate that setting such options
+is insufficient.  If you would like to use Clang with GHC to ensure
+compatibility, and no GHC build that uses Clang is already available, building
+GHC with Clang is recommended.
+
+When linking to existing shared libraries, such as those that are installed on
+your system via a package manager, those shared libraries may have been built
+using GCC.  If you would like to only use Clang to ensure compatibility, you
+need to (re)build such libraries using Clang.
+
+This is a problem that Nix should solve.  Beware, however, that Nix uses GCC by
+default.
+
+## Common errors and solutions
+[t:common-errors-and-solutions]: #common-errors-and-solutions
+
+### LLVM/Clang version mismatch
+[t:llvm-clang-version-mismatch]: #llvmclang-version-mismatch
+
+Three LLVM/Clang versions are relevant:
+
+* **Clang compile time version**: The `libclang-bindings` library is built
+  using a specific version of LLVM/Clang, as described in the
+  [`libclang-bindings` manual][libclang-bindings:manual].
+* **Clang runtime version**: The `libclang-bindings` library, `hs-bindgen`
+  libraries, and `hs-bindgen-cli` executable are linked to the `libclang` shared
+  library.  When running `hs-bindgen`, this shared library is loaded.
+* **Clang executable version**: In addition, `hs-bindgen` uses the `clang`
+  executable to get information that is not available via the `libclang` C API,
+  when the executable is available.  It searches for the `clang` executable
+  using the same logic used to configure `libclang-bindings`.
+
+The major/minor version of all of these should be consistent.  There should be
+warnings/errors if there are any inconsistencies, but you can also check for
+inconsistencies on the command line.  Example:
+
+```bash
+$ cabal run hs-bindgen-cli -- --version
+hs-bindgen 0.1.0
+binding specification 1.0
+clang compile time version: clang version 21.1.8
+clang runtime version:      clang version 21.1.8
+$ clang --version
+clang version 21.1.8
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/lib/llvm21/bin
 ```
 
-### Common Errors and Solutions
+See the [`libclang-bindings` manual][libclang-bindings:manual] for details about
+configuring `libclang-bindings`.  First, ensure that your environment matches
+the environment used to build `libclang-bindings`.  If you have upgraded
+LLVM/Clang or want to test against multiple versions, note that you may need
+special configuration to work around Cabal issues.
 
-* LLVM/Clang version mismatch: If the version of the LLVM/Clang DLL that is
-  loaded at runtime does not match the version used to build `hs-bindgen` and
-  `libclang-bindings`, a warning it emitted.  The version does not change when
-  using the installation of LLVM/Clang that is distributed with GHC, so this
-  generally indicates that your `PATH` environment variable is incorrect.  Be
-  sure that the `bin` directory for that LLVM/Clang installation is listed
-  before any other LLVM/Clang installation directories.
+### Missing standard header
+[t:missing-standard-header]: #missing-standard-header
 
-  Use the `ldd` in a MinGW shell to debug DLL loading.
+Errors about missing standard headers (such as `stddef.h`) when generating
+bindings indicate that the system include directories are not being configured
+correctly.  As described in the [Configure `hs-bindgen`][t:configure-hs-bindgen]
+section above, `hs-bindgen` uses the `clang` executable to determine the system
+include directories by default.  Such errors may occur when the `clang`
+executable does not match the `libclang` library.  See
+[LLVM/Clang version mismatch][t:llvm-clang-version-mismatch] above for
+information about this case.
 
-* DLL loading failure: If a linked library is not found, Windows applications
-  generally fail silently with a negative exit code.  Use `ldd` in a MinGW shell
-  to determine if a DLL is not found.  Resolve such issues by adding directories
-  to your `PATH` environment variable.
+As a last resort, you may be able to work around such issues using the
+`BINDGEN_EXTRA_CLANG_ARGS` environment variable.  Configure it with `-nostdinc`
+and `-I` options to effectively override all system include directories.
+Example:
 
-  In GitHub CI, be sure to always use Windows-style paths (such as
-  `C:\ghcup\ghc\9.14.1\mingw\bin`), *not* POSIX-style paths (such as
-  `/c/ghcup/ghc/9.14.1/mingw/bin`), in the `PATH` environment variable.
+```bash
+$ export BINDGEN_EXTRA_CLANG_ARGS="-nostdinc -I/usr/lib/clang/21/include -I/usr/include"
+```
 
-* Unicode issues: The Windows assembler does not support Unicode, so avoid using
-  Unicode-specific characters in C function definitions.
+There are details about debugging include issues in the
+[includes documentation][manual:includes].
 
-* Resolving issues with underlying type mismatches (`FC.CInt` vs.
-  `FC.CUInt`): You might encounter Haskell type errors where, for example, a C
-  `int` is being interpreted as a `CUInt` instead of a `CInt`. This is often
-  due to how different compilers and platforms define basic types. Carefully
-  check your C and Haskell type definitions to ensure they match.
+### Missing shared libraries
+[t:missing-shared-libraries]: #missing-shared-libraries
 
-## Nix
+An error like `cannot open shared object file: No such file or directory`
+indicates that a linked library cannot be loaded.
 
-We provide and maintain a [Nix Flake][flake.nix], and a
-[Nix-focused tutorial][hs-bindgen-tutorial-nix].
+> [!WARNING]
+> Windows generally does not display an error when a DLL cannot be found.  It
+> fails silently, with a negative exit code, making the issue more difficult to
+> diagnose.
+
+You can use the `ldd` command to determine which libraries are linked to an
+executable or library, as well as determine which cannot be loaded.
+
+If a `libclang` shared library is missing, see the
+[`libclang-bindings` manual][libclang-bindings:manual] for details about
+configuring `libclang-bindings`.  First, ensure that your environment matches
+the environment used to build `libclang-bindings`.  If you have upgraded
+LLVM/Clang or want to test against multiple versions, note that you may need
+special configuration to work around Cabal issues.
+
+If a different library is missing, see the
+[run the user project][t:run-the-user-project] section above for details about
+configuring loader library directories.
+
+### Underlying type mismatches
+[t:underlying type mismatches]: #underlying-type-mismatches
+
+You might encounter Haskell type errors where, for example, a C `int` is being
+interpreted as a `CUInt` instead of a `CInt`.  This is often due to how
+different compilers and platforms define basic types.  Carefully check your C
+and Haskell type definitions to ensure they match.
+
+### Unicode errors
+[t:unicode-errors]: #unicode-errors
+
+Various systems do not support Unicode identifiers:
+
+* The GHC LLVM backend does not support Unicode.
+* The macOS assembler does not support Unicode.
+* The Windows assembler does not support Unicode.
+
+Avoid using Unicode-specific characters in C function definitions to work around
+such limitations.
 
 
 
 <!-- sources and references -->
 
+[Cabal]: https://www.haskell.org/cabal/
+[cabal:docs:extra-lib-dirs]: https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-extra-lib-dirs
+[cabal:docs:include-dirs]: https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-include-dirs
+[cabal:docs:pkgconfig-depends]: https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-pkgconfig-depends
+[cabal:docs:project/extra-include-dirs]: https://cabal.readthedocs.io/en/stable/cabal-project-description-file.html#cfg-field-extra-include-dirs
+[cabal:docs:project/extra-lib-dirs]: https://cabal.readthedocs.io/en/stable/cabal-project-description-file.html#cfg-field-extra-lib-dirs
+[GHC]: https://www.haskell.org/ghc/
 [ghc:guide:phases-programs]: https://downloads.haskell.org/ghc/latest/docs/users_guide/phases.html#replacing-the-program-for-one-or-more-phases
-[flake.nix]: ../flake.nix
 [hs-bindgen-tutorial-nix]: https://github.com/well-typed/hs-bindgen-tutorial-nix
+[libclang-bindings]: https://github.com/well-typed/libclang-bindings
+[libclang-bindings:manual]: https://github.com/well-typed/libclang-bindings/blob/main/manual/README.md
+[LLVM/Clang]: https://github.com/llvm/llvm-project
+[manual:clang-options]: low-level/usage/clang-options.md
+[manual:clang-options-env]: low-level/usage/clang-options.md#environment-variables
+[manual:includes]: low-level/usage/includes.md
+[manual:includes-hs-bindgen]: low-level/usage/includes.md#hs-bindgen
+[Nix flake]: ../flake.nix
+[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -415,8 +415,8 @@ Since the C code is compiled by Cabal, there is no need to update
 > parse the headers and derive type layouts.  For simple types this is
 > unlikely to cause problems, but GCC and Clang can disagree on memory layout
 > for more exotic constructs (bitfields, packed structs, platform-specific
-> alignment).  See [Compiler choice (GCC vs.
-> Clang)](../../installation.md#compiler-choice-gcc-vs-clang) for details.
+> alignment).  See [Clang vs. GCC][manual:installation-clang-vs-gcc] for
+> details.
 
 A complete working example is available in
 [`examples/bundled-c`][example:bundled-c].
@@ -429,4 +429,5 @@ A complete working example is available in
 [example:literate-example]: ../../../examples/literate-example
 [manual:clang-options]: clang-options.md
 [manual:installation]: ../../installation.md
+[manual:installation-clang-vs-gcc]: ../../installation.md#clang-vs-gcc
 [manual:selecting-and-program-slicing]: selecting-and-program-slicing.md

--- a/scripts/update-libclang-bindings.sh
+++ b/scripts/update-libclang-bindings.sh
@@ -3,7 +3,7 @@
 set -e
 
 nix_flakes_equal_revision() {
-    grep "github:well-typed/libclang" "${NIX_FLAKE}" |
+    grep "github:well-typed/libclang-bindings" "${NIX_FLAKE}" |
         grep "${REV_OLD}" \
             >/dev/null 2>&1
 }
@@ -19,12 +19,12 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 CABAL_PROJECT_BASE="${PROJECT_ROOT}/cabal.project.base"
 NIX_FLAKE="${PROJECT_ROOT}/flake.nix"
 
-REV_OLD=$(grep -C 2 'github.com/well-typed/libclang' "${CABAL_PROJECT_BASE}" |
+REV_OLD=$(grep -C 2 'github.com/well-typed/libclang-bindings' "${CABAL_PROJECT_BASE}" |
     grep 'tag:' |
     awk '{print $NF}')
 
 if [ -z "$REV_OLD" ]; then
-    echo "Error: Could not find current libclang tag in $CABAL_PROJECT_BASE"
+    echo "Error: Could not find current libclang-bindings tag in $CABAL_PROJECT_BASE"
     exit 1
 fi
 
@@ -35,7 +35,7 @@ else
     exit 1
 fi
 
-REV_NEW=$(git ls-remote https://github.com/well-typed/libclang HEAD | cut -f 1)
+REV_NEW=$(git ls-remote https://github.com/well-typed/libclang-bindings HEAD | cut -f 1)
 echo "New libclang-bindings revision: ${REV_NEW}"
 
 sed -i 's/'"${REV_OLD}"'/'"${REV_NEW}"'/' "$CABAL_PROJECT_BASE"


### PR DESCRIPTION
The `libclang-bindings` repository is renamed, and the package has been moved into a subdirectory.  The `scripts/update-libclang-bindings.sh` script is updated accordingly.  All links are updated to use the new name.  Comments are added to example `cabal.project` configurations about adding `subdir: libclang-bindings` when the revisions are next updated.

Note that the Nix configuration may need additional work.  I have notified Dominik.

The `libclang-bindings` update adds `--with-so` support.  The `Clang.Version` module is refactored, and `libclang` version checking in `hs-bindgen` is refactored, so that we compare the major/minor version to determine compatibility.

The `hs-bindgen-cli` version output is changed to output both the compile time and runtime versions, to aid in debugging.

The `libclang-bindings` configuration check for `clang_isBeforeInTranslationUnit` was broken, resulting in sequence numbers not being registered even in recent versions of LLVM/Clang.  The underlying issue is fixed, and a new unit test is added to check that we register sequence numbers in recent versions of LLVM/Clang.

The installation documentation is rewritten, making various improvements as well as adjusting for the above changes.  Not all of the documentation is related to installation.  I kept it there for now in order to move forward, and we can consider reorganization separately, if desired.

The `hs-bindgen` manual now references the new (single page) `libclang-bindings` manual, reducing duplication.