### PR TITLE
Update Nix Flake lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1778580735,
+        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/nix/libclang-bindings.nix
+++ b/nix/libclang-bindings.nix
@@ -8,11 +8,9 @@
   llvmPackages,
 }:
 let
-  libclang-bindings-base = callCabal2nix "libclang-bindings" "${libclang-bindings-src}" {
-    # Truly override the LLVM version used. Use `cabal2nix` and drectly inspect
-    # the derivation created by `callCabal2nix`.
-    inherit (llvmPackages) libclang;
-  };
+  libclang-bindings-base =
+    callCabal2nix "libclang-bindings" "${libclang-bindings-src}/libclang-bindings"
+      { };
   libclang-bindings = haskellLib.compose.addBuildDepends [
     llvmPackages.libclang
     llvmPackages.llvm


### PR DESCRIPTION
This updates the lock file and includes changes to accomodate restructures in `libclang-bindings` (see #1963).