### PR TITLE
Macro type pipeline: Translate `T.Expr` directly to `HsType` in the backend

### DIFF
--- a/c-expr-dsl/CHANGELOG.md
+++ b/c-expr-dsl/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Local macro parameters in function-like macros are resolved to de Bruijn
   indices (`LocalParam (Idx ctx)`) at parse time, distinguishing them from
   free variables (`Var`).
+* `tcMacro` now rejects type-like macros that expand to an incomplete type
+  (`void` or `const void` at the top level) with a new `TcIncompleteTypeMacro`
+  error. Pointer-to-incomplete types (e.g. `void *`) are still accepted.
 
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 

--- a/c-expr-dsl/src/C/Expr/Typecheck.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck.hs
@@ -69,7 +69,7 @@ deriving stock instance (Show var) => Show (MacroTcResult var)
 -- | Typecheck a macro
 tcMacro ::
      forall m ctx var.
-     Applicative m
+     Monad m
   => TypeEnv
   -> (Name -> m var)              -- ^ Inject type
   -> (M.TagKind -> Name -> m var) -- ^ Inject tagged type
@@ -87,12 +87,24 @@ tcMacro tyEnv injectType injectTaggedType injectValue name params expr =
          (Type Ty, Quant (FunValue, Type Ty))
       -> m (Either MacroTcError (MacroTcResult var))
     classify = \case
-      (MacroTypeTy, quant) ->
-        if Vec.null params then
-          let toRes texpr = MacroTcTypeExpr $ CheckedMacroTypeExpr texpr quant
-          in  Right . toRes <$> T.fromExpr injectType injectTaggedType expr
-        else
+      (MacroTypeTy, quant)
+        | not (Vec.null params) ->
           pure $ Left $ TcUnsupportedTypeWithLocalParameters name (Vec.toList params)
-      (_, quant)           ->
-        let toRes vexpr = MacroTcValueExpr $ CheckedMacroValueExpr params vexpr quant
-        in  Right . toRes <$> V.fromExpr injectValue expr
+        | otherwise -> do
+          texpr <- T.fromExpr injectType injectTaggedType expr
+          pure $ if isIncompleteType texpr then
+            Left $ TcIncompleteTypeMacro name
+          else
+            Right $ MacroTcTypeExpr $ CheckedMacroTypeExpr texpr quant
+      (_, quant) -> do
+        vexpr <- V.fromExpr injectValue expr
+        pure $ Right $ MacroTcValueExpr $ CheckedMacroValueExpr params vexpr quant
+
+    -- | An incomplete type at the top level of a type-like macro: 'void' or
+    -- 'const'-wrapped 'void'. Pointer indirection makes the type complete, so
+    -- 'void *' (and 'const void *') are not flagged.
+    isIncompleteType :: T.Expr var -> Bool
+    isIncompleteType = \case
+        T.TypeLit M.TypeVoid -> True
+        T.App T.Const e      -> isIncompleteType e
+        _                    -> False

--- a/c-expr-dsl/src/C/Expr/Typecheck/Expr.hs
+++ b/c-expr-dsl/src/C/Expr/Typecheck/Expr.hs
@@ -2015,6 +2015,11 @@ data MacroTcError
   -- | A collection of class constraints was inconsistent.
   | TcInconsistentConstraints !( NE.NonEmpty Cts )
   | TcUnsupportedTypeWithLocalParameters Name [Name]
+  -- | A type-like macro reduces to an incomplete type (e.g. @void@,
+  -- @const void@) at the top level. Such a type cannot be used to declare
+  -- a value, so the macro cannot be translated to a usable Haskell binding.
+  -- Pointer-to-incomplete (e.g. @void *@) is fine and is not rejected here.
+  | TcIncompleteTypeMacro Name
   deriving stock ( Show, Generic )
 
 instance Eq MacroTcError where
@@ -2037,6 +2042,10 @@ pprMacroTcError tcMacroErr =
       TcUnsupportedTypeWithLocalParameters nm ps -> [
           "Unsupported type-like macro expression with local parameters:"
         , getName nm <> " with parameters " <> Text.pack (show ps)
+        ]
+      TcIncompleteTypeMacro nm -> [
+          "Type-like macro " <> getName nm <> " expands to an incomplete type"
+        , "(such as 'void' or 'const void') at the top level."
         ]
 
 mapMaybeA :: Applicative m => ( a -> m ( Maybe b ) ) -> [ a ] -> m [ b ]

--- a/c-expr-dsl/test/Test/CExpr/Typecheck/Classify.hs
+++ b/c-expr-dsl/test/Test/CExpr/Typecheck/Classify.hs
@@ -28,8 +28,7 @@ tests = testGroup "classify" [
 
 tests_keywordTypes :: TestTree
 tests_keywordTypes = testGroup "keyword type bodies" [
-      testCase "void"       $ assertTypeMacro $ classifyOne "M" VNil (tyLit TypeVoid)
-    , testCase "int"        $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeInt Nothing (Just SizeInt)))
+      testCase "int"        $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeInt Nothing (Just SizeInt)))
     , testCase "unsigned"   $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeInt (Just Unsigned) Nothing))
     , testCase "float"      $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeFloat SizeFloat))
     , testCase "double"     $ assertTypeMacro $ classifyOne "M" VNil (tyLit (TypeFloat SizeDouble))
@@ -137,6 +136,24 @@ tests_errors = testGroup "error cases" [
           Right r ->
             assertFailure $ unlines [
                 "expected Left for type macro with unused parameter; but got"
+              , show r
+              ]
+
+    , testCase "bare void type macro is rejected" $
+        case classifyOne "M" VNil (tyLit TypeVoid) of
+          Left  _ -> pure ()
+          Right r ->
+            assertFailure $ unlines [
+                "expected Left for bare 'void' type macro; but got"
+              , show r
+              ]
+
+    , testCase "const void type macro is rejected" $
+        case classifyOne "M" VNil (constOf (tyLit TypeVoid)) of
+          Left  _ -> pure ()
+          Right r ->
+            assertFailure $ unlines [
+                "expected Left for 'const void' type macro; but got"
               , show r
               ]
     ]

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -15,7 +15,9 @@
   whose bodies contain macro expansions. See [PR #1862][pr-1862].
 * Type-like macro expressions (e.g. `#define A int`) are now parsed and
   typechecked together with value-like macro expressions (e.q., `#define FOO 1`)
-  using `c-expr-dsl` rather than `language-c`.
+  using `c-expr-dsl` rather than `language-c`. The typechecked type expression
+  is translated directly to a Haskell type in the backend (see
+  [#1953](https://github.com/well-typed/hs-bindgen/issues/1953)).
 * Scoped reparse: when reparsing a declaration that uses macro expansions, only
   macros actually expanded by Clang *in that declaration* are substituted,
   avoiding spurious substitutions.

--- a/hs-bindgen/examples/golden/macros/macro_ext_binding_dep.h
+++ b/hs-bindgen/examples/golden/macros/macro_ext_binding_dep.h
@@ -1,0 +1,8 @@
+// A typedef that is replaced by an external binding spec
+typedef int A;
+
+// A type-macro whose body references A. Its var slot should resolve to
+// Left ext after ResolveBindingSpecs runs.
+#define B A
+
+void use_b(B x);

--- a/hs-bindgen/examples/golden/macros/macro_ext_binding_dep.yaml
+++ b/hs-bindgen/examples/golden/macros/macro_ext_binding_dep.yaml
@@ -1,0 +1,15 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: M
+ctypes:
+- headers: macros/macro_ext_binding_dep.h
+  cname: A
+  hsname: A
+hstypes:
+- hsname: A
+  representation:
+    newtype:
+      constructor: A
+      fields:
+      - unwrapA

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example.hs
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.B(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified M
+
+{-| __C declaration:__ @macro B@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 6:9@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+newtype B = B
+  { unwrapB :: M.A
+  }
+  deriving stock (RIP.Generic)
+
+instance (ty ~ M.A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
+
+instance HasCField.HasCField B "unwrapB" where
+
+  type CFieldType B "unwrapB" = M.A
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/FunPtr.hs
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/FunPtr.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.FunPtr
+    ( Example.FunPtr.use_b
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/macro_ext_binding_dep.h>"
+  , "/* test_macrosmacro_ext_binding_dep_Example_get_use_b */"
+  , "__attribute__ ((const))"
+  , "void (*hs_bindgen_b341ec07f48c8cc1 (void)) ("
+  , "  B arg1"
+  , ")"
+  , "{"
+  , "  return &use_b;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_get_use_b@
+foreign import ccall unsafe "hs_bindgen_b341ec07f48c8cc1" hs_bindgen_b341ec07f48c8cc1_base ::
+     IO (RIP.FunPtr RIP.Void)
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_get_use_b@
+hs_bindgen_b341ec07f48c8cc1 :: IO (RIP.FunPtr (B -> IO ()))
+hs_bindgen_b341ec07f48c8cc1 =
+  RIP.fromFFIType hs_bindgen_b341ec07f48c8cc1_base
+
+{-# NOINLINE use_b #-}
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b :: RIP.FunPtr (B -> IO ())
+use_b =
+  RIP.unsafePerformIO hs_bindgen_b341ec07f48c8cc1

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/Safe.hs
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/Safe.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Safe
+    ( Example.Safe.use_b
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/macro_ext_binding_dep.h>"
+  , "void hs_bindgen_f70130e6504e0e5e ("
+  , "  B arg1"
+  , ")"
+  , "{"
+  , "  (use_b)(arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
+foreign import ccall safe "hs_bindgen_f70130e6504e0e5e" hs_bindgen_f70130e6504e0e5e_base ::
+     RIP.Int32
+  -> IO ()
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
+hs_bindgen_f70130e6504e0e5e ::
+     B
+  -> IO ()
+hs_bindgen_f70130e6504e0e5e =
+  RIP.fromFFIType hs_bindgen_f70130e6504e0e5e_base
+
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b ::
+     B
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+use_b = hs_bindgen_f70130e6504e0e5e

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/Unsafe.hs
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/Example/Unsafe.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Unsafe
+    ( Example.Unsafe.use_b
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/macro_ext_binding_dep.h>"
+  , "void hs_bindgen_432a5c7b5df51cfa ("
+  , "  B arg1"
+  , ")"
+  , "{"
+  , "  (use_b)(arg1);"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Unsafe_use_b@
+foreign import ccall unsafe "hs_bindgen_432a5c7b5df51cfa" hs_bindgen_432a5c7b5df51cfa_base ::
+     RIP.Int32
+  -> IO ()
+
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Unsafe_use_b@
+hs_bindgen_432a5c7b5df51cfa ::
+     B
+  -> IO ()
+hs_bindgen_432a5c7b5df51cfa =
+  RIP.fromFFIType hs_bindgen_432a5c7b5df51cfa_base
+
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b ::
+     B
+     -- ^ __C declaration:__ @x@
+  -> IO ()
+use_b = hs_bindgen_432a5c7b5df51cfa

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/bindingspec.yaml
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/bindingspec.yaml
@@ -1,0 +1,19 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/macro_ext_binding_dep.h
+  cname: macro B
+  hsname: B
+hstypes:
+- hsname: B
+  representation:
+    newtype:
+      constructor: B
+      fields:
+      - unwrapB
+  instances:
+  - Generic
+  - HasCField
+  - HasField

--- a/hs-bindgen/fixtures/macros/macro_ext_binding_dep/th.txt
+++ b/hs-bindgen/fixtures/macros/macro_ext_binding_dep/th.txt
@@ -1,0 +1,100 @@
+-- addDependentFile examples/golden/macros/macro_ext_binding_dep.h
+-- #include <macros/macro_ext_binding_dep.h>
+-- void hs_bindgen_f70130e6504e0e5e (
+--   B arg1
+-- )
+-- {
+--   (use_b)(arg1);
+-- }
+-- void hs_bindgen_432a5c7b5df51cfa (
+--   B arg1
+-- )
+-- {
+--   (use_b)(arg1);
+-- }
+-- /* test_macrosmacro_ext_binding_dep_Example_get_use_b */
+-- __attribute__ ((const))
+-- void (*hs_bindgen_b341ec07f48c8cc1 (void)) (
+--   B arg1
+-- )
+-- {
+--   return &use_b;
+-- }
+{-| __C declaration:__ @macro B@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 6:9@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+newtype B = B {unwrapB :: M.A} deriving stock Generic
+instance (~) ty M.A => HasField "unwrapB" (Ptr B) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapB")
+instance HasCField B "unwrapB"
+    where type CFieldType B "unwrapB" = M.A
+          offset# = \_ -> \_ -> 0
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
+foreign import ccall safe "hs_bindgen_f70130e6504e0e5e" hs_bindgen_f70130e6504e0e5e_base ::
+    Int32
+ -> IO ()
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
+hs_bindgen_f70130e6504e0e5e :: B -> IO ()
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
+hs_bindgen_f70130e6504e0e5e = fromFFIType hs_bindgen_f70130e6504e0e5e_base
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_safe :: B -> IO ()
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_safe = hs_bindgen_f70130e6504e0e5e
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Unsafe_use_b@
+foreign import ccall unsafe "hs_bindgen_432a5c7b5df51cfa" hs_bindgen_432a5c7b5df51cfa_base ::
+    Int32
+ -> IO ()
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Unsafe_use_b@
+hs_bindgen_432a5c7b5df51cfa :: B -> IO ()
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Unsafe_use_b@
+hs_bindgen_432a5c7b5df51cfa = fromFFIType hs_bindgen_432a5c7b5df51cfa_base
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_unsafe :: B -> IO ()
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_unsafe = hs_bindgen_432a5c7b5df51cfa
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_get_use_b@
+foreign import ccall unsafe "hs_bindgen_b341ec07f48c8cc1" hs_bindgen_b341ec07f48c8cc1_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_get_use_b@
+hs_bindgen_b341ec07f48c8cc1 :: IO (FunPtr (B -> IO ()))
+-- __unique:__ @test_macrosmacro_ext_binding_dep_Example_get_use_b@
+hs_bindgen_b341ec07f48c8cc1 = fromFFIType hs_bindgen_b341ec07f48c8cc1_base
+{-# NOINLINE use_b_funptr #-}
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_funptr :: FunPtr (B -> IO ())
+{-| __C declaration:__ @use_b@
+
+    __defined at:__ @macros\/macro_ext_binding_dep.h 8:6@
+
+    __exported by:__ @macros\/macro_ext_binding_dep.h@
+-}
+use_b_funptr = unsafePerformIO hs_bindgen_b341ec07f48c8cc1

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -104,6 +104,7 @@ library internal
     HsBindgen.Backend.Hs.Translation.ForeignImport
     HsBindgen.Backend.Hs.Translation.Function
     HsBindgen.Backend.Hs.Translation.Instances
+    HsBindgen.Backend.Hs.Translation.MacroType
     HsBindgen.Backend.Hs.Translation.Newtype
     HsBindgen.Backend.Hs.Translation.State
     HsBindgen.Backend.Hs.Translation.Structure

--- a/hs-bindgen/src-internal/Data/DynGraph/Labelled.hs
+++ b/hs-bindgen/src-internal/Data/DynGraph/Labelled.hs
@@ -147,7 +147,6 @@ insertEdge vFrom l vTo graph =
     panicWith which vertex =
       panicPure $ which <> " vertex " <> show vertex <> " not in the graph"
 
-
 {-------------------------------------------------------------------------------
   Query
 -------------------------------------------------------------------------------}

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -25,6 +25,7 @@ import HsBindgen.Backend.Hs.Origin qualified as Origin
 import HsBindgen.Backend.Hs.Translation.ForeignImport qualified as Hs.ForeignImport
 import HsBindgen.Backend.Hs.Translation.Function
 import HsBindgen.Backend.Hs.Translation.Instances qualified as Hs
+import HsBindgen.Backend.Hs.Translation.MacroType qualified as MacroType
 import HsBindgen.Backend.Hs.Translation.Newtype qualified as Hs
 import HsBindgen.Backend.Hs.Translation.State (HsM, TranslationState)
 import HsBindgen.Backend.Hs.Translation.State qualified as State
@@ -760,7 +761,7 @@ macroDecsTypedef supInsts haddockConfig info macroType spec = do
         newtypeField :: Hs.Field
         newtypeField = Hs.Field {
               name    = macroType.names.field
-            , typ     = Type.topLevel macroType.cType
+            , typ     = MacroType.macroTypeToHsType macroType.typ
             , origin  = Origin.GeneratedField
             , comment = Nothing
             }

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/ForeignImport.hs
@@ -272,58 +272,58 @@ toFFIType sizeofs = go
 
     go :: HsType -> Maybe FFI.FFIType
     go = \case
-      HsPrimType pt -> goPrim pt
-      HsTypRef _ t -> t >>= go
-      HsConstArray{} -> no
-      HsIncompleteArray{} -> no
-      HsPtrArrayElem {} -> yes $ FFI.Basic FFI.Ptr
+      HsPrimType pt          -> goPrim pt
+      HsTypRef _ t           -> t >>= go
+      HsConstArray{}         -> no
+      HsIncompleteArray{}    -> no
+      HsPtrArrayElem {}      -> yes $ FFI.Basic FFI.Ptr
       HsPtrConstArrayElem {} -> yes $ FFI.Basic FFI.Ptr
-      HsPtr{} -> yes $ FFI.Basic FFI.Ptr
-      HsFunPtr{} -> yes $ FFI.Basic FFI.FunPtr
-      HsStablePtr{} -> no
-      HsPtrConst{} -> yes $ FFI.Basic FFI.Ptr
-      HsIO t' -> FFI.IO <$> go t'
-      HsFun s t' -> FFI.FunArrow <$> go s <*> go t'
-      HsExtBinding _ _ _ t' -> go t'
-      HsByteArray -> no
-      HsSizedByteArray{} -> no
-      HsBlock{} -> yes $ FFI.Basic FFI.Ptr
-      HsComplexType{} -> no
-      HsStrLit{} -> no
-      HsWithFlam{} -> no
-      HsEquivStorable{} -> no
+      HsPtr{}                -> yes $ FFI.Basic FFI.Ptr
+      HsFunPtr{}             -> yes $ FFI.Basic FFI.FunPtr
+      HsStablePtr{}          -> no
+      HsPtrConst{}           -> yes $ FFI.Basic FFI.Ptr
+      HsIO t'                -> FFI.IO <$> go t'
+      HsFun s t'             -> FFI.FunArrow <$> go s <*> go t'
+      HsExtBinding _ _ _ t'  -> go t'
+      HsByteArray            -> no
+      HsSizedByteArray{}     -> no
+      HsBlock{}              -> yes $ FFI.Basic FFI.Ptr
+      HsComplexType{}        -> no
+      HsStrLit{}             -> no
+      HsWithFlam{}           -> no
+      HsEquivStorable{}      -> no
 
     goPrim :: HsPrimType -> Maybe FFI.FFIType
     goPrim pt = case pt of
-        HsPrimVoid -> no
-        HsPrimUnit -> yes $ FFI.Unit
-        HsPrimChar -> yes $ FFI.Basic FFI.Char
-        HsPrimInt -> yes $ FFI.Basic FFI.Int
-        HsPrimDouble -> yes $ FFI.Basic FFI.Double
-        HsPrimFloat -> yes $ FFI.Basic FFI.Float
-        HsPrimBool -> yes $ FFI.Basic FFI.Bool
-        HsPrimInt8 -> yes $ FFI.Basic FFI.Int8
-        HsPrimInt16 -> yes $ FFI.Basic FFI.Int16
-        HsPrimInt32 -> yes $ FFI.Basic FFI.Int32
-        HsPrimInt64 -> yes $ FFI.Basic FFI.Int64
-        HsPrimWord -> yes $ FFI.Basic FFI.Word
-        HsPrimWord8 -> yes $ FFI.Basic FFI.Word8
-        HsPrimWord16 -> yes $ FFI.Basic FFI.Word16
-        HsPrimWord32 -> yes $ FFI.Basic FFI.Word32
-        HsPrimWord64 -> yes $ FFI.Basic FFI.Word64
-        HsPrimCChar -> yes $ FFI.Basic $ signedType sizeofs.char
-        HsPrimCSChar -> yes $ FFI.Basic $ signedType sizeofs.schar
-        HsPrimCUChar -> yes $ FFI.Basic $ unsignedType sizeofs.uchar
-        HsPrimCShort -> yes $ FFI.Basic $ signedType sizeofs.short
+        HsPrimVoid    -> no
+        HsPrimUnit    -> yes $ FFI.Unit
+        HsPrimChar    -> yes $ FFI.Basic FFI.Char
+        HsPrimInt     -> yes $ FFI.Basic FFI.Int
+        HsPrimDouble  -> yes $ FFI.Basic FFI.Double
+        HsPrimFloat   -> yes $ FFI.Basic FFI.Float
+        HsPrimBool    -> yes $ FFI.Basic FFI.Bool
+        HsPrimInt8    -> yes $ FFI.Basic FFI.Int8
+        HsPrimInt16   -> yes $ FFI.Basic FFI.Int16
+        HsPrimInt32   -> yes $ FFI.Basic FFI.Int32
+        HsPrimInt64   -> yes $ FFI.Basic FFI.Int64
+        HsPrimWord    -> yes $ FFI.Basic FFI.Word
+        HsPrimWord8   -> yes $ FFI.Basic FFI.Word8
+        HsPrimWord16  -> yes $ FFI.Basic FFI.Word16
+        HsPrimWord32  -> yes $ FFI.Basic FFI.Word32
+        HsPrimWord64  -> yes $ FFI.Basic FFI.Word64
+        HsPrimCChar   -> yes $ FFI.Basic $ signedType sizeofs.char
+        HsPrimCSChar  -> yes $ FFI.Basic $ signedType sizeofs.schar
+        HsPrimCUChar  -> yes $ FFI.Basic $ unsignedType sizeofs.uchar
+        HsPrimCShort  -> yes $ FFI.Basic $ signedType sizeofs.short
         HsPrimCUShort -> yes $ FFI.Basic $ unsignedType sizeofs.ushort
-        HsPrimCInt -> yes $ FFI.Basic $ signedType sizeofs.int
-        HsPrimCUInt -> yes $ FFI.Basic $ unsignedType sizeofs.uint
-        HsPrimCLong -> yes $ FFI.Basic $ signedType sizeofs.long
-        HsPrimCULong -> yes $ FFI.Basic $ unsignedType sizeofs.ulong
-        HsPrimCLLong -> yes $ FFI.Basic $ signedType sizeofs.longlong
+        HsPrimCInt    -> yes $ FFI.Basic $ signedType sizeofs.int
+        HsPrimCUInt   -> yes $ FFI.Basic $ unsignedType sizeofs.uint
+        HsPrimCLong   -> yes $ FFI.Basic $ signedType sizeofs.long
+        HsPrimCULong  -> yes $ FFI.Basic $ unsignedType sizeofs.ulong
+        HsPrimCLLong  -> yes $ FFI.Basic $ signedType sizeofs.longlong
         HsPrimCULLong -> yes $ FFI.Basic $ unsignedType sizeofs.ulonglong
-        HsPrimCBool -> yes $ FFI.Basic $ unsignedType sizeofs.bool
-        HsPrimCFloat -> yes $ FFI.Basic FFI.Float
+        HsPrimCBool   -> yes $ FFI.Basic $ unsignedType sizeofs.bool
+        HsPrimCFloat  -> yes $ FFI.Basic FFI.Float
         HsPrimCDouble -> yes $ FFI.Basic FFI.Double
 
 signedType :: C.NumBytes -> FFI.BasicFFIType
@@ -349,26 +349,26 @@ fromFFIType = goBase
     goBase :: FFI.FFIType -> HsType
     goBase t = case t of
         FFI.FunArrow s t' -> goBase s `HsFun` goBase t'
-        FFI.Unit -> prim HsPrimUnit
-        FFI.IO t' -> HsIO (goBase t')
-        FFI.Basic t' -> goBasic t'
+        FFI.Unit          -> prim HsPrimUnit
+        FFI.IO t'         -> HsIO (goBase t')
+        FFI.Basic t'      -> goBasic t'
 
     goBasic :: FFI.BasicFFIType -> HsType
     goBasic t = case t of
-        FFI.Char -> prim HsPrimChar
-        FFI.Int -> prim HsPrimInt
-        FFI.Double -> prim HsPrimDouble
-        FFI.Float -> prim HsPrimFloat
-        FFI.Bool -> prim HsPrimBool
-        FFI.Int8 -> prim HsPrimInt8
-        FFI.Int16 -> prim HsPrimInt16
-        FFI.Int32 -> prim HsPrimInt32
-        FFI.Int64 -> prim HsPrimInt64
-        FFI.Word -> prim HsPrimWord
-        FFI.Word8 -> prim HsPrimWord8
-        FFI.Word16 -> prim HsPrimWord16
-        FFI.Word32 -> prim HsPrimWord32
-        FFI.Word64 -> prim HsPrimWord64
-        FFI.Ptr -> HsPtr $ prim HsPrimVoid
-        FFI.FunPtr -> HsFunPtr $ prim HsPrimVoid
+        FFI.Char      -> prim HsPrimChar
+        FFI.Int       -> prim HsPrimInt
+        FFI.Double    -> prim HsPrimDouble
+        FFI.Float     -> prim HsPrimFloat
+        FFI.Bool      -> prim HsPrimBool
+        FFI.Int8      -> prim HsPrimInt8
+        FFI.Int16     -> prim HsPrimInt16
+        FFI.Int32     -> prim HsPrimInt32
+        FFI.Int64     -> prim HsPrimInt64
+        FFI.Word      -> prim HsPrimWord
+        FFI.Word8     -> prim HsPrimWord8
+        FFI.Word16    -> prim HsPrimWord16
+        FFI.Word32    -> prim HsPrimWord32
+        FFI.Word64    -> prim HsPrimWord64
+        FFI.Ptr       -> HsPtr       $ prim HsPrimVoid
+        FFI.FunPtr    -> HsFunPtr    $ prim HsPrimVoid
         FFI.StablePtr -> HsStablePtr $ prim HsPrimVoid

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/MacroType.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/MacroType.hs
@@ -1,0 +1,119 @@
+-- | Translate typechecked macro type expressions to Haskell types
+--
+-- Intended for qualified import
+--
+-- > import HsBindgen.Backend.Hs.Translation.MacroType qualified as MacroType
+--
+-- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
+--
+-- == Temporary: Two conversions from @T.Expr@
+--
+-- There are two independent conversions from 'T.Expr' (the typechecked
+-- macro-type tree):
+--
+-- * __Macro → C type__
+--   ('HsBindgen.Frontend.Pass.TypecheckMacros.convertTExpr'): converts a
+--   'T.Expr' to a 'C.Type'. Used during the 'TypecheckMacros' pass to populate
+--   the language-c reparse environment so that machinery relying on the
+--   **underlying C type** (e.g., FFI type) keeps working.
+--
+-- * __Macro → Haskell type__ ('macroTypeToHsType', this module): converts a
+--   'T.Expr' to an 'Hs.HsType'. Used in the backend when generating the newtype
+--   wrapper for a type-like macro. This is the desired end state, allowing
+--   users to employ different macro frameworks.
+module HsBindgen.Backend.Hs.Translation.MacroType (
+    macroTypeToHsType
+  ) where
+
+import Data.Proxy (Proxy (..))
+
+import C.Expr.Syntax qualified as CExpr
+import C.Expr.Typecheck qualified as CExpr
+import C.Expr.Typecheck.Interface.Type qualified as T
+
+import HsBindgen.Backend.Hs.AST qualified as Hs
+import HsBindgen.Backend.Hs.Translation.Type qualified as Type
+import HsBindgen.Frontend.Naming
+import HsBindgen.Frontend.Pass.Final
+import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
+import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
+import HsBindgen.Language.C qualified as C
+import HsBindgen.Language.Haskell qualified as Hs
+
+{-------------------------------------------------------------------------------
+  API
+-------------------------------------------------------------------------------}
+
+-- | Convert a typechecked macro type expression to a Haskell type.
+--
+-- Top-level incomplete types (@void@, @const void@) are rejected by
+-- 'CExpr.tcMacro' before this function is reached; 'CExpr.TypeVoid' can
+-- therefore only appear as the pointee of a pointer (e.g. @void *@).
+macroTypeToHsType :: CExpr.CheckedMacroTypeExpr (MacroTypeBodyVar Final) -> Hs.HsType
+macroTypeToHsType expr = go expr.macroTypeBody
+  where
+    go :: T.Expr (MacroTypeBodyVar Final) -> Hs.HsType
+    go = \case
+      T.TypeLit lit ->
+        Hs.HsPrimType (convertLiteral lit)
+      T.Var (MacroTypeExtBinding ext) ->
+        Hs.HsExtBinding ext.hsName ext.cSpec ext.hsSpec $
+          Hs.HsTypRef
+            (Hs.assertNs (Proxy @Hs.NsTypeConstr)
+            (extDeclIdPair ext).hsName)
+            Nothing
+      T.Var (MacroTypeBodyVar pair) ->
+        Hs.HsTypRef (Hs.assertNs (Proxy @Hs.NsTypeConstr) pair.hsName) Nothing
+      T.App T.Pointer t ->
+        ptrOf t
+      T.App T.Const t ->
+        go t
+
+    -- Mirrors the const-pointer distinction in 'Type.topLevel'
+    ptrOf :: T.Expr (MacroTypeBodyVar Final) -> Hs.HsType
+    ptrOf (T.App T.Const t) = Hs.HsPtrConst (go t)
+    ptrOf t                 = Hs.HsPtr (go t)
+
+{-------------------------------------------------------------------------------
+  Literals
+-------------------------------------------------------------------------------}
+
+convertLiteral :: CExpr.TypeLit -> Hs.HsPrimType
+convertLiteral = \case
+    CExpr.TypeInt  sign size ->
+      Type.primType $ C.PrimIntegral (convertIntSize size) (convertSign sign)
+    CExpr.TypeChar sign ->
+      Type.primType $ C.PrimChar (convertCharSign sign)
+    CExpr.TypeFloat size ->
+      Type.primType $ C.PrimFloating (convertFloatSize size)
+    CExpr.TypeBool ->
+      Type.primType C.PrimBool
+    -- Only reachable as the pointee of a pointer (e.g. @void *@, @const void *@);
+    -- bare 'void' and 'const void' macro types are rejected by 'tcMacro'.
+    CExpr.TypeVoid ->
+      Hs.HsPrimVoid
+
+convertSign :: Maybe CExpr.Sign -> C.PrimSign
+convertSign = \case
+    Nothing             -> C.Signed
+    Just CExpr.Signed   -> C.Signed
+    Just CExpr.Unsigned -> C.Unsigned
+
+convertCharSign :: Maybe CExpr.Sign -> C.PrimSignChar
+convertCharSign = \case
+    Nothing             -> C.PrimSignImplicit Nothing
+    Just CExpr.Signed   -> C.PrimSignExplicit C.Signed
+    Just CExpr.Unsigned -> C.PrimSignExplicit C.Unsigned
+
+convertIntSize :: Maybe CExpr.IntSize -> C.PrimIntType
+convertIntSize = \case
+    Nothing                 -> C.PrimInt
+    Just CExpr.SizeShort    -> C.PrimShort
+    Just CExpr.SizeInt      -> C.PrimInt
+    Just CExpr.SizeLong     -> C.PrimLong
+    Just CExpr.SizeLongLong -> C.PrimLongLong
+
+convertFloatSize :: CExpr.FloatSize -> C.PrimFloatType
+convertFloatSize = \case
+    CExpr.SizeFloat  -> C.PrimFloat
+    CExpr.SizeDouble -> C.PrimDouble

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
@@ -7,6 +7,7 @@ module HsBindgen.Backend.Hs.Translation.Type (
     topLevel
   , TypeContext(..)
   , InContext(..)
+  , primType
   ) where
 
 import Data.Proxy (Proxy (..))

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Macro.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Macro.hs
@@ -47,7 +47,7 @@ translateMacroValue macro = DBinding Binding{
     , comment    = macro.comment
     }
   where
-    typ = fmap snd $ macro.expr.value.macroValueType
+    typ = fmap snd $ macro.expr.val.macroValueType
 
 {-------------------------------------------------------------------------------
   Translate type
@@ -129,7 +129,7 @@ simpleTyConApp _ _ =
 -------------------------------------------------------------------------------}
 
 translateBody :: CheckedMacroValue Final -> SExpr EmptyCtx
-translateBody expr = case expr.value of
+translateBody expr = case expr.val of
   (CExpr.CheckedMacroValueExpr p b _) ->
     lambdaN (Vec.reverse $ idNameHint <$> p) $ mexpr b
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -8,11 +8,13 @@ module HsBindgen.Frontend.AST.Deps (
   , depsOfDeclParsedMacro
   ) where
 
+import Data.Maybe
 import Data.Set qualified as Set
 import GHC.Records
 
 import C.Expr.Syntax qualified as CExpr
 import C.Expr.Typecheck qualified as CExpr
+import C.Expr.Typecheck.Interface.Type qualified as T
 import C.Expr.Typecheck.Interface.Value qualified as V
 
 import HsBindgen.Frontend.AST.Decl qualified as C
@@ -79,28 +81,42 @@ depsOfDeclTcMacro = depsOfDeclWith (depsOfTcMacro (Proxy @p))
 
 -- | Dependencies of typechecked macro declarations
 depsOfTcMacro ::
-     forall p. (IsPass p, MacroBody p ~ CheckedMacro p)
+     forall p. (MacroBody p ~ CheckedMacro p)
   => Proxy p -> MacroBody p -> [(ValOrRef, Id p)]
 depsOfTcMacro proxy = \case
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
-    --
-    -- If we replace the CType with the TExpr, we need to know if the
-    -- dependencies are by value or by reference.
-    MacroType  typ -> depsOfType  typ.cType
-    MacroValue val -> depsOfValue val.value
+    MacroType  typ -> maybeToList $ depsOfMacroType typ.typ
+    MacroValue val -> depsOfMacroValue val.val
   where
-    depsOfValue :: CExpr.CheckedMacroValueExpr (Id p) -> [(ValOrRef, Id p)]
-    depsOfValue (CExpr.CheckedMacroValueExpr _ body _) = depsOfVExpr proxy body
+    -- 'T.Expr' is a linear chain of 'App' constructors ending in a single
+    -- 'TypeLit' or 'Var' leaf, so there is at most one non-external dependency.
+    depsOfMacroType ::
+         CExpr.CheckedMacroTypeExpr (MacroTypeBodyVar p)
+      -> Maybe (ValOrRef, Id p)
+    depsOfMacroType x = go ByValue x.macroTypeBody
+      where
+        go :: ValOrRef -> T.Expr (MacroTypeBodyVar p) -> Maybe (ValOrRef, Id p)
+        go depTy = \case
+          T.TypeLit{}          -> Nothing
+          -- Pointer: switch the dependency type to 'ByRef'.
+          T.App T.Pointer expr         -> go ByRef expr
+          T.App T.Const   expr         -> go depTy expr
+          T.Var MacroTypeExtBinding{}  -> Nothing
+          T.Var (MacroTypeBodyVar var) -> Just (depTy, var)
+
+    depsOfMacroValue :: CExpr.CheckedMacroValueExpr (Id p) -> [(ValOrRef, Id p)]
+    depsOfMacroValue  = \case
+      CExpr.CheckedMacroValueExpr _ body _ -> depsOfVExpr proxy body
 
     -- Collect value-level dependencies from a checked macro body. Local
     -- arguments (lambda-bound ids) are excluded.
+    --
+    -- On the value-level, all dependencies must be 'ByValue'.
     depsOfVExpr ::
          forall ctx.
          Proxy p
       -> V.Expr ctx (Id p)
       -> [(ValOrRef, Id p)]
-    depsOfVExpr _ =
-        map (ByValue,) . toList
+    depsOfVExpr _ = map (ByValue,) . toList
 
 {-------------------------------------------------------------------------------
   Structs and unions
@@ -142,26 +158,26 @@ depsOfDeclParsedMacro allDeclIds = depsOfDeclWith depsOfParsedMacro
     depsOfParsedMacro :: ParsedMacro -> [(ValOrRef, DeclId)]
     depsOfParsedMacro (ParsedMacro m) = depsOfCExprMacro allDeclIds m
 
--- | Collect all references in a macro body.
---
--- Local macro arguments are excluded.
+-- | Collect all external (i.e., non-local) references in a macro body
 depsOfCExprMacro ::
      Set DeclId
   -> CExpr.Macro
   -> [(ValOrRef, DeclId)]
 depsOfCExprMacro allDeclIds (CExpr.Macro _ _ _ macroExpr) =
-    map (ByValue,) $ goExpr macroExpr
+    goExpr ByValue macroExpr
   where
-    goExpr :: CExpr.Expr ctx CExpr.Ps -> [DeclId]
-    goExpr = \case
-      CExpr.Term  term   -> goTerm term
-      CExpr.TyApp _ xs   -> concatMap goExpr xs
-      CExpr.VaApp _ _ xs -> concatMap goExpr xs
+    goExpr :: ValOrRef -> CExpr.Expr ctx CExpr.Ps -> [(ValOrRef, DeclId)]
+    goExpr depTy = \case
+      CExpr.Term  term             -> goTerm depTy term
+      -- Pointer: switch the dependency type to 'ByRef'.
+      CExpr.TyApp CExpr.Pointer xs -> concatMap (goExpr ByRef) xs
+      CExpr.TyApp CExpr.Const   xs -> concatMap (goExpr depTy) xs
+      CExpr.VaApp _ _ xs           -> concatMap (goExpr depTy) xs
 
-    goTerm :: CExpr.Term ctx CExpr.Ps -> [DeclId]
-    goTerm = \case
+    goTerm :: ValOrRef -> CExpr.Term ctx CExpr.Ps -> [(ValOrRef, DeclId)]
+    goTerm depTy = \case
       CExpr.Literal lit ->
-        goLit lit
+        goLit depTy lit
       CExpr.LocalParam{} ->
         []
       -- Variable / function call. A bare identifier is always parsed as Var;
@@ -170,16 +186,16 @@ depsOfCExprMacro allDeclIds (CExpr.Macro _ _ _ macroExpr) =
       -- name entirely if it is not a known declaration (e.g. a built-in type).
       CExpr.Var _ nm callArgs
         | Just declId <- resolveMacroTypedef nm.getName ->
-            declId : concatMap goExpr callArgs
+            (depTy, declId) : concatMap (goExpr depTy) callArgs
         | otherwise ->
-            concatMap goExpr callArgs
+            concatMap (goExpr depTy) callArgs
 
-    goLit :: CExpr.Literal -> [DeclId]
-    goLit = \case
+    goLit :: ValOrRef -> CExpr.Literal -> [(ValOrRef, DeclId)]
+    goLit depTy = \case
       -- Named type specifier using an elaborated tag: struct/union/enum.
       CExpr.TypeTagged tag nm
         | Just declId <- resolveTaggedType (convertTagKind tag) nm.getName ->
-            [declId]
+            [(depTy, declId)]
         | otherwise ->
             []
       -- Other built-in type specifiers (int, char, etc.) have no dependencies.
@@ -189,9 +205,9 @@ depsOfCExprMacro allDeclIds (CExpr.Macro _ _ _ macroExpr) =
 
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1952>
     --
-    -- We should only resolve the declaration IDs of macro dependencies one. Now
-    -- we resolve them twice: when we get the dependencies of parsed macros, and
-    -- when we typecheck macros.
+    -- We should only resolve the declaration IDs of macro dependencies once.
+    -- Now we resolve them twice: when we get the dependencies of parsed macros,
+    -- and when we typecheck macros.
 
     -- | Resolves a bare name found in a parsed macro body
     --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Type.hs
@@ -65,10 +65,10 @@ data TypeF tag p =
     -- | Complex type (such as @float complex@)
   | TypeComplex C.PrimType
 
-    -- | Reference to named type other than an enum, macro type or typedef
+    -- | Reference to named type other than an @enum@, macro type or @typedef@
   | TypeRef (Id p)
 
-    -- | Reference to an enum
+    -- | Reference to an @enum@
     --
     -- NOTE: has a strictness annotation, which allows GHC to infer that
     -- pattern matches are redundant when @TypeEnumRefF tag p ~ Void@.
@@ -76,11 +76,15 @@ data TypeF tag p =
 
     -- | Reference to a macro type
     --
+    -- Structurally identical to 'TypeRef' (both carry just an 'Id'), but kept
+    -- separate so pattern matches can distinguish macro use-sites from
+    -- struct/union/opaque ones without inspecting 'CDeclName.kind'.
+    --
     -- NOTE: has a strictness annotation, which allows GHC to infer that
     -- pattern matches are redundant when @TypeMacroRefF tag p ~ Void@.
   | TypeMacro !(TypeMacroRefF tag p)
 
-    -- | Reference to typedef
+    -- | Reference to @typedef@
     --
     -- NOTE: has a strictness annotation, which allows GHC to infer that
     -- pattern matches are redundant when @TypedefRefF tag p ~ Void@.
@@ -239,7 +243,7 @@ type ExtBindingRef p = Ref (ExtBinding p) p
 --
 -- The type of the global variable @x@ is roughly:
 --
--- > Ref { name = "T", underlying = TypePrim int }
+-- > Ref { name = macroIdOfT, underlying = TypePrim int }
 --
 type MacroRef p = Ref (MacroId p) p
 
@@ -291,9 +295,13 @@ data Ref a p = Ref {
 -------------------------------------------------------------------------------}
 
 data TypeTag =
-    Full       -- ^ A full C type includes all C type constructs.
-  | Erased     -- ^ No @typedef@s.
-  | Canonical  -- ^ All sugar (typedefs and qualifiers like @const@) removed
+    -- | A full C type includes all C type constructs.
+    Full
+    -- | No @typedef@s, external binding specification references, macro-defined
+    -- types, and @enum@s.
+  | Erased
+    -- | All sugar (typedefs and qualifiers like @const@) removed.
+  | Canonical
 
 -- | Normal forms of types
 class ( IsPass p
@@ -426,7 +434,7 @@ buildPointersF n inner
 -------------------------------------------------------------------------------}
 
 class Normalize tag tag' where
-  normalize :: TypeF tag p -> TypeF tag' p
+  normalize :: IsPass p => TypeF tag p -> TypeF tag' p
 
 instance Normalize tag tag where
   normalize = id
@@ -441,6 +449,7 @@ instance Normalize tag tag where
 -- probably not that long, so we do not expect this algorithm to have
 -- problematic performance.
 instance Normalize Full Erased where
+  normalize :: forall p. IsPass p => TypeF Full p -> TypeF Erased p
   normalize = mapTypeF fTypedefRef fQual fExtBindingRef fMacroRef fEnumRef
     where
       fTypedefRef :: TypedefRef p -> TypeF Erased p
@@ -461,16 +470,22 @@ instance Normalize Full Erased where
 instance Normalize Erased Canonical where
   normalize = mapTypeF absurd fQual absurd absurd absurd
     where
-      fQual :: TypeQual -> TypeF Erased p -> TypeF Canonical p
+      fQual :: IsPass p => TypeQual -> TypeF Erased p -> TypeF Canonical p
       fQual _qual typ = normalize typ
 
 instance Normalize Full Canonical where
   normalize = getCanonicalType . getErasedType
 
-getCanonicalType :: Normalize tag Canonical => TypeF tag p -> CanonicalType p
+getCanonicalType ::
+     (Normalize tag Canonical, IsPass p)
+  => TypeF tag p
+  -> CanonicalType p
 getCanonicalType = normalize
 
-getErasedType :: Normalize tag Erased => TypeF tag p -> ErasedType p
+getErasedType ::
+     (Normalize tag Erased, IsPass p)
+  => TypeF tag p
+  -> ErasedType p
 getErasedType = normalize
 
 {-------------------------------------------------------------------------------
@@ -533,6 +548,7 @@ hasUnsupportedType = aux . getCanonicalType
     aux TypeVoid              = False
     aux TypeBlock{}           = False
 
+    -- 'Normalize Full Erased' erases @typedef@s, @enum@s, and type macros.
     auxRef :: CNameKind -> Bool
     auxRef = \case
       CNameKindOrdinary              -> panicPure "Unexpected CNameKindOrdinary"
@@ -550,14 +566,20 @@ isVoid TypeVoid = True
 isVoid _        = False
 
 -- | Is the canonical type a complex type?
-isCanonicalTypeComplex :: Normalize tag Canonical => TypeF tag p -> Bool
+isCanonicalTypeComplex ::
+     (Normalize tag Canonical, IsPass p)
+  => TypeF tag p
+  -> Bool
 isCanonicalTypeComplex ty =
     case getCanonicalType ty of
       TypeComplex{} -> True
       _otherwise    -> False
 
 -- | Is the canonical type a function type?
-isCanonicalTypeFunction :: Normalize tag Canonical => TypeF tag p -> Bool
+isCanonicalTypeFunction ::
+     (Normalize tag Canonical, IsPass p)
+  => TypeF tag p
+  -> Bool
 isCanonicalTypeFunction ty =
     case getCanonicalType ty of
       TypeFun{} -> True
@@ -582,7 +604,10 @@ isCanonicalTypeUnion ty =
       _otherwise  -> False
 
 -- | Is the erased type @const@-qualified?
-isErasedTypeConstQualified :: Normalize tag Erased => TypeF tag p -> Bool
+isErasedTypeConstQualified ::
+     (Normalize tag Erased, IsPass p)
+  => TypeF tag p
+  -> Bool
 isErasedTypeConstQualified ty =
     case getErasedType ty of
       -- Types can be directly @const@-qualified,
@@ -598,7 +623,10 @@ isErasedTypeConstQualified ty =
       _ -> False
 
 -- | Is the canonical type an array type?
-isCanonicalTypeArray :: Normalize tag Canonical => TypeF tag p -> Bool
+isCanonicalTypeArray ::
+     (Normalize tag Canonical, IsPass p)
+  => TypeF tag p
+  -> Bool
 isCanonicalTypeArray ty =
     case getCanonicalType ty of
       TypeConstArray{}   -> True

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC.hs
@@ -16,13 +16,16 @@ module HsBindgen.Frontend.LanguageC (
   , reparseField
   , reparseGlobal
     -- * Scoping
-  , ReparseEnv
-  , initReparseEnv
+  , CName
+  , ReparseEnv(..)
+  , bespokeTypes
   ) where
 
 import Control.Monad.State (State)
 import Control.Monad.State qualified as State
+import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Tuple (swap)
 import Language.C qualified as LanC
@@ -107,7 +110,7 @@ parseUsingLanC mloc raw = do
     let predefinedTypes' :: [LanC.Ident]
         uniqNameSupply   :: [LanC.Name]
         (predefinedTypes', uniqNameSupply) = runWithNewNameSupply $ do
-            mapM declarePredefined $ Map.keys reparseEnv
+            mapM declarePredefined $ Set.toList $ getKnownTypes reparseEnv
 
     case LanC.execParser
            LanC.extDeclP
@@ -198,17 +201,11 @@ prependToken token rest = concat [
   Construct type environment
 -------------------------------------------------------------------------------}
 
--- | Initial 'ReparseEnv'
+-- | \"Primitives\" we expect the reparser to recognize
 --
--- This is not quite empty: it contains some "built in" types.
-initReparseEnv :: ClangCStandard -> ReparseEnv
-initReparseEnv standard = Map.fromList (bespokeTypes standard)
-
--- | \"Primitive\" we expect the reparser to recognize
---
--- The language-c parser does not support these explicitly.
-bespokeTypes :: ClangCStandard -> [(CName, C.Type p)]
-bespokeTypes = \case
+-- The @language-c@ parser does not support these explicitly.
+bespokeTypes :: ClangCStandard -> Map CName (C.Type p)
+bespokeTypes = Map.fromList . \case
 #if !MIN_VERSION_language_c(0,10,2)
     -- Make sure that we really only replace keywords lacking definitions.
     --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Monad.hs
@@ -3,9 +3,11 @@
 -- Intended for unqualified import.
 module HsBindgen.Frontend.LanguageC.Monad (
     FromLanC(..)
-  , ReparseEnv
+  , ReparseEnv(..)
   , runFromLanC
   , getReparseEnv
+  , getKnownTypes
+  , lookupType
     -- * Throwing errors
   , unexpected
   , unsupported
@@ -16,11 +18,13 @@ module HsBindgen.Frontend.LanguageC.Monad (
   , optionally
   ) where
 
+import Control.Applicative
 import Control.Monad.Except (ExceptT, MonadError (..))
 import Control.Monad.Except qualified as Except
 import Control.Monad.Reader (Reader)
 import Control.Monad.Reader qualified as Reader
 import Data.Foldable qualified as Foldable
+import Data.Map qualified as Map
 import GHC.Stack
 
 import HsBindgen.Frontend.AST.Type qualified as C
@@ -49,7 +53,22 @@ newtype FromLanC a = WrapFromLanC (
     )
 
 -- | Types in scope when reparsing a particular declaration
-type ReparseEnv = Map CName (C.Type ReparseMacroExpansions)
+data ReparseEnv = ReparseEnv {
+    -- | Known @typedef@s
+    knownTypes      :: Map CName (C.Type ReparseMacroExpansions)
+    -- | Known type-like macros
+    --
+    -- We store macros in a separate field, because in the future we may not
+    -- translate macros to their full C types anymore.
+    --
+    -- Furthermore, we only add the macros /expanded in the reparsed
+    -- declaration/ to the environment.
+    --
+    -- At the moment, we translate to C.Type using @addNewMacroTypeToReparseEnv@
+    -- in @TypecheckMacros@.
+  , knownMacroTypes :: Map CName (C.Type ReparseMacroExpansions)
+  }
+  deriving (Show, Eq)
 
 runFromLanC :: ReparseEnv -> FromLanC a -> Either Error a
 runFromLanC typeEnv (WrapFromLanC ma) =
@@ -58,6 +77,15 @@ runFromLanC typeEnv (WrapFromLanC ma) =
 
 getReparseEnv :: FromLanC ReparseEnv
 getReparseEnv = WrapFromLanC Reader.ask
+
+getKnownTypes :: ReparseEnv -> Set CName
+getKnownTypes env = Map.keysSet env.knownTypes <> Map.keysSet env.knownMacroTypes
+
+lookupType :: CName -> ReparseEnv -> Maybe (C.Type ReparseMacroExpansions)
+lookupType nm env =
+    -- Macro types take priority: a typedef and a type-like macro may share the
+    -- same bare name (e.g. 'bool' from stdbool.h alongside a typedef 'bool').
+    Map.lookup nm env.knownMacroTypes <|> Map.lookup nm env.knownTypes
 
 {-------------------------------------------------------------------------------
   Throwing errors

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
@@ -7,7 +7,6 @@ module HsBindgen.Frontend.LanguageC.PartialAST.FromLanC (
   ) where
 
 import Control.Monad
-import Data.Map qualified as Map
 import Data.Text qualified as Text
 import GHC.Stack
 import Language.C qualified as LanC
@@ -166,8 +165,8 @@ instance Apply (LanC.CTypeSpecifier a) PartialType where
       -- away by 'addKnownType' in the ReparseMacroExpansions pass, so the
       -- lookup returns @TypePrim PrimBool@ in that case.
       LanC.CBoolType   _a -> \partial -> do
-        typeEnv <- getReparseEnv
-        case Map.lookup "bool" typeEnv of
+        env <- getReparseEnv
+        case lookupType "bool" env of
           Just typ -> notFun typ partial
           Nothing  -> notFun (C.TypePrim C.PrimBool) partial
 #else
@@ -205,14 +204,14 @@ instance Apply (LanC.CTypeSpecifier a) PartialType where
       LanC.CEnumType (LanC.CEnum mTag mDef _attrs _a) _a' -> \partial -> do
         name <- checkNotAnon mTag CTagKindEnum
         checkNoDef "enum definition" mDef
-        typeEnv <- getReparseEnv
-        case Map.lookup (renderCDeclNameC name) typeEnv of
+        env <- getReparseEnv
+        case lookupType (renderCDeclNameC name) env of
           Nothing  -> unexpected $ "enum reference " ++ show name
           Just typ -> notFun typ partial
       LanC.CTypeDef name _a -> \partial -> do
         let name' = mkCName name
-        typeEnv <- getReparseEnv
-        case Map.lookup name' typeEnv of
+        env <- getReparseEnv
+        case lookupType name' env of
           Nothing  -> unexpected $ "typedef reference " ++ show name
           Just typ -> notFun typ partial
     where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
@@ -145,21 +145,17 @@ processMacro macro =
       MacroType  typ -> MacroType  $ processMacroType typ
       MacroValue val -> MacroValue $ processMacroExpr val
 
+-- NOTE: currently type-like macro expressions don't support array or function
+-- constructors. If they do in the future, then we might have to recurse into
+-- the macro expression.
 processMacroType :: CheckedMacroType MangleNames -> CheckedMacroType AdjustTypes
-processMacroType macroType =
-    CheckedMacroType {
-        -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1953>
-        --
-        -- Be careful when we replace the CType with the TExpr.
-        cType = processType macroType.cType
-      , ann   = macroType.ann
-      }
+processMacroType macroType = coercePass macroType
 
+-- NOTE: currently value-like macro expressions don't support array or function
+-- constructors. If they do in the future, then we might have to recurse into
+-- the macro expression.
 processMacroExpr :: CheckedMacroValue MangleNames -> CheckedMacroValue AdjustTypes
 processMacroExpr macroExpr =
-    -- NOTE: currently macro expressions don't support function/array type
-    -- parameters, if they do in the future, then we might have to recurse into
-    -- the type of the macro expression?
     coercePass macroExpr
 
 processFunction :: C.Function MangleNames -> C.Function AdjustTypes

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -394,10 +394,12 @@ lookupTypeE declId = do
         pure hsNm
 
 lookupTypePair :: DeclId -> E M DeclIdPair
-lookupTypePair declId = lookupTypeE declId >>= \hsName -> pure $ DeclIdPair{
-        cName  = declId
-      , hsName = Hs.demoteNs hsName
-    }
+lookupTypePair declId = do
+    hsName <- lookupTypeE declId
+    pure $ DeclIdPair{
+          cName  = declId
+        , hsName = Hs.demoteNs hsName
+      }
 
 lookupData :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsConstr)
 lookupData declId nameMap = Map.lookup declId nameMap.dataConstrs
@@ -962,17 +964,28 @@ instance MangleWithDeclName CheckedMacro where
       MacroValue val -> MacroValue <$> mangle val
 
 instance MangleWithDeclName CheckedMacroType where
-  mangleWithDeclName hsName macroType = do
+  mangleWithDeclName hsName macroType = case macroType.typ of
+    (CExpr.CheckedMacroTypeExpr body typ) -> do
       strategy       <- asks (.fieldNamingStrategy)
       macroTypeNames <- mkMacroTypeNames strategy hsName
-      cType'         <- mangle macroType.cType
+      body'          <- traverse mangleMacroTypeVar body
       pure CheckedMacroType{
-            cType = cType'
-          , ann = macroTypeNames
-          }
+          typ = CExpr.CheckedMacroTypeExpr{
+              macroTypeBody = body'
+            , macroTypeType = typ
+            }
+        , ann = macroTypeNames
+        }
+    where
+      mangleMacroTypeVar ::
+           MacroTypeBodyVar ResolveBindingSpecs
+        -> E M (MacroTypeBodyVar MangleNames)
+      mangleMacroTypeVar = \case
+        MacroTypeExtBinding ext -> pure $ MacroTypeExtBinding ext
+        MacroTypeBodyVar declId -> MacroTypeBodyVar <$> lookupTypePair declId
 
 instance Mangle CheckedMacroValue where
-  mangle macroValue = CheckedMacroValue <$> case macroValue.value of
+  mangle macroValue = CheckedMacroValue <$> case macroValue.val of
     CExpr.CheckedMacroValueExpr params body typ -> do
       body' <- traverse lookupVarPair body
       pure CExpr.CheckedMacroValueExpr{
@@ -989,7 +1002,7 @@ instance Mangle C.Type where
       C.TypeEnum ref -> fmap C.TypeEnum $
         C.Ref <$> lookupTypePair ref.name <*> mangle ref.underlying
       C.TypeMacro ref -> fmap C.TypeMacro $
-        C.Ref <$>  lookupTypePair ref.name <*> mangle ref.underlying
+        C.Ref <$> lookupTypePair ref.name <*> mangle ref.underlying
       C.TypeTypedef ref -> fmap C.TypeTypedef $
         C.Ref <$>  lookupTypePair ref.name <*> mangle ref.underlying
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -39,10 +39,10 @@ type CType = C.Type ReparseMacroExpansions
 -- using the known-types environment from 'typecheckMacros'.
 reparseMacroExpansions ::
      ClangCStandard
-  -> LanC.ReparseEnv
+  -> Map LanC.CName CType
      -- ^ Known non-macro type (see 'ReparseEnv')
-  -> LanC.ReparseEnv
-     -- ^ Known macro type names (see 'ReparseEnv')
+  -> Map LanC.CName CType
+     -- ^ Known macro types with their underlying C types (see 'ReparseEnv')
   -> C.TranslationUnit TypecheckMacros
   -> C.TranslationUnit ReparseMacroExpansions
 reparseMacroExpansions cStd knownNonMacroTypes knownMacroTypes unit =
@@ -408,11 +408,10 @@ newtype M a = WrapM { _unwrapM :: StateT ReparseState (Reader ReparseEnv) a }
 -- | Environment used when reparsing declarations with macro expansions.
 data ReparseEnv = ReparseEnv {
       -- | Known non-macro type names (e.g., @typedef@s or @struct@s)
-      knownTypes :: LanC.ReparseEnv
-      -- | Known macro type names; we keep the known macros separate, because we
-      --   need to restrict the reparse environment to macros actually
-      --   /expanded/.
-    , knownMacroTypes :: LanC.ReparseEnv
+      knownTypes :: Map LanC.CName CType
+      -- | Known macro types with their underlying C types; kept separate so we
+      --   can restrict the reparse environment to macros actually /expanded/.
+    , knownMacroTypes :: Map LanC.CName CType
     }
 
 data ReparseState = ReparseState {
@@ -429,17 +428,17 @@ data ReparseState = ReparseState {
 
 runM ::
      ClangCStandard
-  -> LanC.ReparseEnv
-  -> LanC.ReparseEnv
+  -> Map LanC.CName CType
+  -> Map LanC.CName CType
   -> M a
   -> (a, ReparseState)
 runM cStd knownTypes knownMacroTypes (WrapM ma) = runReader (runStateT ma s) e
   where
     e :: ReparseEnv
     e = ReparseEnv {
-        -- Add the initial reparse environment as a fallback (note, 'Map.union'
-        -- is left-biased).
-        knownTypes      = knownTypes `Map.union` LanC.initReparseEnv cStd
+        -- Add the bespoke types as a fallback (note, 'Map.union' is
+        -- left-biased).
+        knownTypes      = knownTypes `Map.union` LanC.bespokeTypes cStd
       , knownMacroTypes = knownMacroTypes
       }
 
@@ -456,9 +455,7 @@ runM cStd knownTypes knownMacroTypes (WrapM ma) = runReader (runStateT ma s) e
 -- | Run reparser if needed; use fallback on failure or if not needed.
 --
 -- On failure, records @(declId, ParseMacroErrorReparse e)@ in
--- 'ReparseState.reparseWarnings' and uses the fallback value. Note that
--- 'knownTypes' doubles as the language-c parse environment since both have
--- type 'Map Text CType'.
+-- 'ReparseState.reparseWarnings' and uses the fallback value.
 reparseWith ::
      DeclId
   -> LanC.Parser a
@@ -471,17 +468,16 @@ reparseWith declId parser reparseInfo fallback onSuccess = case reparseInfo of
       pure fallback
     ReparseNeeded tokens usedMacros -> do
       env <- ask
-      let usedMacroTypes :: LanC.ReparseEnv
-          usedMacroTypes = Map.restrictKeys env.knownMacroTypes usedMacros
-          unknownMacros :: Set Text
-          unknownMacros = Set.difference usedMacros (Map.keysSet usedMacroTypes)
-      forM_ unknownMacros $ \u ->
+      let usedKnownMacros :: Map LanC.CName CType
+          usedKnownMacros = Map.restrictKeys env.knownMacroTypes usedMacros
+          usedUnknownMacros :: Set LanC.CName
+          usedUnknownMacros = Set.difference usedMacros (Map.keysSet env.knownMacroTypes)
+      forM_ usedUnknownMacros $ \u ->
           modify $ #reparseWarnings %~
             ((declId, ParseMacroReparseUnknownType u) :)
 
       let reparseEnv :: LanC.ReparseEnv
-          -- Macro types override other types ('Map.union' is left-biased).
-          reparseEnv = usedMacroTypes `Map.union` env.knownTypes
+          reparseEnv = LanC.ReparseEnv env.knownTypes usedKnownMacros
       case parser reparseEnv tokens of
         Right a -> do
           modify $ #reparseSuccesses %~ Set.insert declId

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -10,6 +10,8 @@ import Control.Monad.State qualified as State
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
+import C.Expr.Typecheck qualified as CExpr
+
 import Clang.HighLevel.Types
 import Clang.Paths
 
@@ -344,6 +346,13 @@ resolveDeep decl (cSpec, hsSpec) = do
   Instances
 -------------------------------------------------------------------------------}
 
+-- | Resolve references to external declarations
+--
+-- This is part of the second pass ('resolveDeep').
+--
+-- We do not need to handle references to omitted declarations here since
+-- declarations depending on unavailable declarations will be removed in the
+-- @Select@ pass.
 class Resolve a where
   resolve ::
        HasCallStack
@@ -493,18 +502,27 @@ instance Resolve CheckedMacro where
     MacroValue val -> MacroValue <$> pure (coercePass val)
 
 instance Resolve CheckedMacroType where
-  resolve ctx macroType = reconstruct <$> resolve ctx macroType.cType
-    where
-      reconstruct ::
-           C.Type ResolveBindingSpecs
-        -> CheckedMacroType ResolveBindingSpecs
-      reconstruct cType' = CheckedMacroType {
-          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
-          --
-          -- Be careful when we replace the CType with the TExpr.
-          cType = cType'
-        , ann = macroType.ann
+  resolve ctx (CheckedMacroType (CExpr.CheckedMacroTypeExpr body typ) ann) = do
+      body' <- traverse resolveVar body
+      pure CheckedMacroType{
+          typ = CExpr.CheckedMacroTypeExpr body' typ
+        , ann = ann
         }
+    where
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1969>
+      --
+      -- Usage of 'MacroTypeBodyVar' hints at possible drawbacks of our design
+      -- of 'DeclId'. Maybe we can directly refer to external bindings from
+      -- 'DeclId'?
+      resolveVar ::
+           MacroTypeBodyVar ReparseMacroExpansions
+        -> M (MacroTypeBodyVar ResolveBindingSpecs)
+      resolveVar (MacroTypeExtBinding   x) = absurd x
+      resolveVar (MacroTypeBodyVar declId) = do
+          mExt <- auxExt ctx declId
+          pure $ case mExt of
+            Just ext -> MacroTypeExtBinding ext
+            Nothing  -> MacroTypeBodyVar declId
 
 instance Resolve C.Type where
   resolve ctx = \case
@@ -551,31 +569,9 @@ instance Resolve C.Type where
       C.TypeComplex t      -> return (C.TypeComplex t)
     where
       aux :: HasCallStack => DeclId -> M (Maybe (C.Type ResolveBindingSpecs -> C.Type ResolveBindingSpecs))
-      aux cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
-        -- Check for selected external binding
-        case Map.lookup cDeclId state.extTypes of
-          Just ty -> do
-            State.modify' $ insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
-            pure $ Just $ \uTy -> C.TypeExtBinding $ C.Ref ty uTy
-          Nothing -> do
-            -- In the first pass we have looked at all "usable" declarations.
-            -- Now we check for external bindings of types of "unusable"
-            -- declarations.
-            case DeclIndex.lookupUnusableLoc cDeclId env.declIndex of
-              []   -> return Nothing
-              locs -> do
-                let declPaths =
-                      foldMap
-                        (IncludeGraph.reaches env.includeGraph . singleLocPath)
-                        locs
-                mTy <- resolveExtBinding cDeclId declPaths Nothing
-                case mTy of
-                  Just ty -> do
-                    State.modify' $
-                        insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
-                      . insertExtType cDeclId ty
-                    pure $ Just $ \uTy -> C.TypeExtBinding $ C.Ref ty uTy
-                  Nothing -> return Nothing
+      aux cDeclId = fmap reconstruct <$> auxExt ctx cDeclId
+        where
+          reconstruct ty uTy = C.TypeExtBinding $ C.Ref ty uTy
 
 instance Resolve C.TypeFunArg where
   resolve ctx arg = do
@@ -584,6 +580,33 @@ instance Resolve C.TypeFunArg where
           typ = typ'
         , ann = arg.ann
         }
+
+auxExt ::
+     HasCallStack
+  => DeclId
+  -> DeclId
+  -> M (Maybe ResolvedExtBinding)
+auxExt ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
+    case Map.lookup cDeclId state.extTypes of
+      Just ty -> do
+        State.modify' $ insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
+        pure (Just ty)
+      Nothing ->
+        case DeclIndex.lookupUnusableLoc cDeclId env.declIndex of
+          []   -> pure Nothing
+          locs -> do
+            let declPaths =
+                  foldMap
+                    (IncludeGraph.reaches env.includeGraph . singleLocPath)
+                    locs
+            mTy <- resolveExtBinding cDeclId declPaths Nothing
+            case mTy of
+              Just ty -> do
+                State.modify' $
+                    insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
+                  . insertExtType cDeclId ty
+                pure (Just ty)
+              Nothing -> pure Nothing
 
 {-------------------------------------------------------------------------------
   Internal: auxiliary functions

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
@@ -28,6 +28,7 @@ import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
+import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass (ReparseMacroExpansions)
 import HsBindgen.Frontend.Pass.TypecheckMacros.Error
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -52,8 +53,8 @@ type CType = C.Type TypecheckMacros
 typecheckMacros ::
      C.TranslationUnit ConstructTranslationUnit
   -> ( C.TranslationUnit TypecheckMacros
-     , LanC.ReparseEnv
-     , LanC.ReparseEnv
+     , Map LanC.CName (C.Type ReparseMacroExpansions)
+     , Map LanC.CName (C.Type ReparseMacroExpansions)
      )
 typecheckMacros unit =
     let typedefTypes :: Map Text CType
@@ -70,7 +71,8 @@ typecheckMacros unit =
     in  ( reconstructAfterTypecheck unit failedMacros typecheckedDecls
         , Map.map coercePass $
             typedefTypes <> Map.mapKeys renderCDeclNameC taggedTypes
-        , Map.map coercePass $ typecheckState.resolvedMacroTypes )
+        , Map.map coercePass $ typecheckState.resolvedMacroTypes
+        )
 
 {-------------------------------------------------------------------------------
   Reconstruct translation unit after typechecking
@@ -178,7 +180,7 @@ typecheckMacro ::
   -> ParsedMacro
   -> M (Either FailedMacro (C.Decl TypecheckMacros))
 typecheckMacro info parsedMacro = do
-    result <- tcMacro info.id.name parsedMacro
+    result <- tcMacro info.id parsedMacro
     pure $ bimap addInfo toDecl result
   where
     addInfo :: MacroTypecheckError -> FailedMacro
@@ -213,13 +215,12 @@ data TypecheckEnv = TypecheckEnv {
     }
 
 data TypecheckState = TypecheckState {
-      -- | The c-expr-dsl type environment, accumulating quantified types
+      -- | The @c-expr-dsl@ type environment, accumulating quantified types
       --   for each macro as we typecheck them.
       typeEnv :: CExpr.TypeEnv
-      -- | Resolved macro C types, keyed by bare name. We need these when
-      --   injecting type names (for macros that reference other macro-defined
-      --   types) and for reparsing declarations with macro expansions in the
-      --   next pass.
+      -- | Resolved macro C types, keyed by bare name. Used to populate the
+      --   reparse environment in the next pass, and to distinguish macro-defined
+      --   types from @typedef@s in 'lookupTypeName'.
     , resolvedMacroTypes :: Map Text CType
     }
   deriving stock (Generic)
@@ -247,12 +248,12 @@ runM knownTypedefs knownTaggedTypes (WrapM ma) = runReader (runStateT ma s) e
 -- | Look up a @typedef@ or macro-defined type by bare name.
 --
 -- Searches both the known @typedef@s (from the first traversal) and the
--- resolved macro types (accumulated during typechecking).
+-- names of macros that previously typechecked as type expressions.
 --
 -- 'panicPure' is safe here: c-expr-dsl only calls the inject function for names
--- present in 'CExpr.TypeEnv', which we built from these same maps. That is, it
--- is a bug, if we fail to lookup an ordinary type, because the typechecker
--- should have failed gracefully at an earlier stage.
+-- present in 'CExpr.TypeEnv', which is populated from the same two sources.
+-- Failing to resolve an ordinary type is a bug; the typechecker should have
+-- failed gracefully at an earlier stage.
 lookupTypeName :: TypecheckEnv -> TypecheckState -> Text -> DeclId
 lookupTypeName env st n =
     case (Map.member n env.knownTypedefs, Map.member n st.resolvedMacroTypes) of
@@ -300,10 +301,12 @@ lookupTypeWith env st declId =
 -- values used for dependency tracking. For type macros, 'convertTExpr' then
 -- maps the 'DeclId' leaves in the result back to 'CType' via 'lookupTypeWith'.
 tcMacro ::
-     CDeclName
+     DeclId
+     -- ^ The macro's own declaration id (used to build the 'MacroRef' entry
+     --   in the reparse environment).
   -> ParsedMacro
   -> M (Either MacroTypecheckError (CheckedMacro TypecheckMacros))
-tcMacro name (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
+tcMacro macroDeclId (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
     st  <- get
     env <- ask
 
@@ -351,45 +354,47 @@ tcMacro name (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
       Right tcRes -> case tcRes of
         Left err ->
           pure $ Left $ MacroTypecheckErrorCExpr err
-        Right (CExpr.MacroTcTypeExpr mType) ->
-          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
-          --
-          -- We are still pulling along the C type.
-          case convertTExpr (lookupTypeWith env st) mType.macroTypeBody of
-            Left err  -> pure $ Left err
-            Right cType -> do
-              addQuant mType.macroTypeType
-              addNewMacroTypeToReparseEnv cType
-              pure $ Right $ MacroType $ CheckedMacroType cType NoAnn
-        Right (CExpr.MacroTcValueExpr (CExpr.CheckedMacroValueExpr params expr quant )) -> do
-          addQuant quant
-          pure $ Right $ MacroValue $ CheckedMacroValue $
-            CExpr.CheckedMacroValueExpr{
-                macroValueParams = params
-              , macroValueBody   = expr
-              , macroValueType   = quant
-              }
+        Right (CExpr.MacroTcTypeExpr typ) -> do
+          let cType = convertTExpr (lookupTypeWith env st) typ.macroTypeBody
+          addQuant typ.macroTypeType
+          addNewMacroTypeToReparseEnv cType
+          let typ' = typ{
+                CExpr.macroTypeBody = fmap MacroTypeBodyVar typ.macroTypeBody
+                }
+          pure $ Right $ MacroType $ CheckedMacroType typ' NoAnn
+        Right (CExpr.MacroTcValueExpr val) ->
+          case val of
+            (CExpr.CheckedMacroValueExpr params expr quant ) -> do
+              addQuant quant
+              pure $ Right $ MacroValue $ CheckedMacroValue $
+                CExpr.CheckedMacroValueExpr{
+                    macroValueParams = params
+                  , macroValueBody   = expr
+                  , macroValueType   = quant
+                  }
   where
     addQuant :: CExpr.Quant (CExpr.FunValue, CExpr.Type CExpr.Ty) -> M ()
     addQuant quant =
         modify $ #typeEnv %~ Map.insert macroName quant
 
+    -- Add this macro's underlying C type to 'resolvedMacroTypes', making it
+    -- available for the reparse environment and 'lookupTypeName'.
+    --
+    -- Special case: stdbool.h defines @#define bool _Bool@. We normalise this
+    -- away: if @bool@ maps to @PrimBool@, we store @TypePrim PrimBool@
+    -- directly instead of wrapping it in @TypeMacro@. This ensures that @bool@
+    -- from stdbool.h renders identically to @_Bool@, regardless of
+    -- language-c version. Genuine redefinitions like @#define bool int@ are
+    -- not affected because their underlying type is not @PrimBool@.
     addNewMacroTypeToReparseEnv :: CType -> M ()
     addNewMacroTypeToReparseEnv typ
-      -- stdbool.h defines @#define bool _Bool@, which is just an alias for
-      -- the primitive boolean type. We normalise this away: if @bool@ maps
-      -- to @PrimBool@, we store @TypePrim PrimBool@ directly instead of
-      -- wrapping it in @TypeMacro@. This ensures that @bool@ from stdbool.h
-      -- renders identically to @_Bool@, regardless of language-c version.
-      -- Genuine redefinitions like @#define bool int@ are not affected
-      -- because their underlying type is not @PrimBool@.
-      | name.text == "bool"
+      | macroDeclId.name.text == "bool"
       , C.TypePrim C.PrimBool <- typ
-      = addMacroType name.text typ
+      = addMacroType macroDeclId.name.text typ
       | otherwise
-      = addMacroType name.text $
+      = addMacroType macroDeclId.name.text $
           C.TypeMacro $ C.Ref {
-              name = DeclId{name = name, isAnon = False}
+              name       = macroDeclId
             , underlying = typ
             }
 
@@ -399,6 +404,10 @@ tcMacro name (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
 
 {-------------------------------------------------------------------------------
   Convert T.Expr to C.Type
+
+  See 'HsBindgen.Backend.Hs.Translation.MacroType'.
+
+  Will be removed in the future.
 -------------------------------------------------------------------------------}
 
 -- | Convert a typechecked macro type expression ('T.Expr') to a C type.
@@ -406,32 +415,17 @@ tcMacro name (ParsedMacro (CExpr.Macro _ macroName macroParams macroExpr)) = do
 -- Named types appear as 'DeclId' leaves; 'lookupType' maps each 'DeclId' back
 -- to its 'CType'.
 --
--- Correctly handles chains of @const@ and pointer modifiers (e.g.
--- @const int *@, @int * const@, @const int * const *@).
---
--- Rejects bare @void@ at the top level (including @const void@), but allows
--- @void@ as the pointee of a pointer (e.g. @void *@, @const void *@).
-convertTExpr :: (DeclId -> CType) -> T.Expr DeclId -> Either MacroTypecheckError CType
-convertTExpr lookupType expr = go expr >>= checkTopLevelVoid
+-- Top-level @void@ and @const void@ are already rejected by 'CExpr.tcMacro'
+-- ('TcIncompleteTypeMacro'), so this conversion is total.
+convertTExpr :: (DeclId -> CType) -> T.Expr DeclId -> CType
+convertTExpr lookupType = go
   where
-    go :: T.Expr DeclId -> Either MacroTypecheckError CType
+    go :: T.Expr DeclId -> CType
     go = \case
-      T.App T.Pointer inner ->
-        C.TypePointers 1 <$> go inner
-      T.App T.Const   inner ->
-        C.TypeQual C.QualConst <$> go inner
-      T.TypeLit t ->
-        Right $ convertLiteral t
-      T.Var declId ->
-        Right $ lookupType declId
-
-    -- | @void@ is not a valid standalone type; it is only valid as the
-    -- pointee of a pointer (e.g. @void *@).
-    checkTopLevelVoid :: CType -> Either MacroTypecheckError CType
-    checkTopLevelVoid = \case
-      C.TypeVoid              -> Left MacroTypecheckErrorVoidType
-      C.TypeQual _ C.TypeVoid -> Left MacroTypecheckErrorVoidType
-      ty                      -> Right ty
+      T.App T.Pointer inner -> C.TypePointers 1 (go inner)
+      T.App T.Const   inner -> C.TypeQual C.QualConst (go inner)
+      T.TypeLit t           -> convertLiteral t
+      T.Var declId          -> lookupType declId
 
 -- | Convert a primitive type literal to a C type.
 convertLiteral :: CExpr.TypeLit -> CType

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Error.hs
@@ -12,8 +12,6 @@ import HsBindgen.Util.Tracer
 data MacroTypecheckError =
     -- | We could not type-check the macro expression
     MacroTypecheckErrorCExpr CExpr.MacroTcError
-    -- | Macro type is @void@, which is not a valid standalone type
-  | MacroTypecheckErrorVoidType
     -- | Macro type references a tagged type we could not resolve
     --
     -- This happens when a macro references a struct, union, or enum that
@@ -28,8 +26,6 @@ instance PrettyForTrace MacroTypecheckError where
           "Failed to typecheck macro:"
         , PP.text $ CExpr.pprMacroTcError x
         ]
-      MacroTypecheckErrorVoidType ->
-        "Macro type 'void' is not supported as a standalone type"
       MacroTypecheckErrorUnresolvedTaggedType name -> PP.hsep [
           "Macro type references unknown tagged type:"
         , prettyForTrace name
@@ -37,8 +33,7 @@ instance PrettyForTrace MacroTypecheckError where
 
 instance IsTrace Level MacroTypecheckError where
   getDefaultLogLevel = \case
-    MacroTypecheckErrorCExpr{}                       -> Info
-    MacroTypecheckErrorVoidType{}                    -> Info
-    MacroTypecheckErrorUnresolvedTaggedType{}        -> Warning
+    MacroTypecheckErrorCExpr{}               -> Info
+    MacroTypecheckErrorUnresolvedTaggedType{} -> Warning
   getSource          = const HsBindgen
   getTraceId         = const "macro-typecheck"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -4,6 +4,7 @@ module HsBindgen.Frontend.Pass.TypecheckMacros.IsPass (
   , CheckedMacro(..)
   , CheckedMacroType(..)
   , CheckedMacroValue(..)
+  , MacroTypeBodyVar(..)
     -- * Conversions
   , convertTagKind
   ) where
@@ -13,7 +14,6 @@ import C.Expr.Typecheck qualified as CExpr
 
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
-import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
@@ -59,15 +59,12 @@ data CheckedMacro p =
 
 -- | Checked type macro
 data CheckedMacroType p = CheckedMacroType{
-      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1953>
-      --
-      -- Legacy C type; replace with the typechecked type-like macro expression.
-      cType :: C.Type p
-    , ann   :: Ann "CheckedMacroType" p
+      typ :: CExpr.CheckedMacroTypeExpr (MacroTypeBodyVar p)
+    , ann :: Ann "CheckedMacroType" p
     }
 
 newtype CheckedMacroValue p = CheckedMacroValue {
-      value :: CExpr.CheckedMacroValueExpr (Id p)
+      val :: CExpr.CheckedMacroValueExpr (Id p)
     }
 
 deriving stock instance IsPass p => Show (CheckedMacro     p)
@@ -77,6 +74,15 @@ deriving stock instance IsPass p => Show (CheckedMacroValue p)
 deriving stock instance IsPass p => Eq (CheckedMacro     p)
 deriving stock instance IsPass p => Eq (CheckedMacroType p)
 deriving stock instance IsPass p => Eq (CheckedMacroValue p)
+
+-- | We have to be specific, when a macro type refers to an external binding.
+data MacroTypeBodyVar p =
+    MacroTypeExtBinding (ExtBinding p)
+  | MacroTypeBodyVar    (Id p)
+
+deriving stock instance IsPass p => Eq   (MacroTypeBodyVar p)
+deriving stock instance IsPass p => Ord  (MacroTypeBodyVar p)
+deriving stock instance IsPass p => Show (MacroTypeBodyVar p)
 
 -- | Convert a @c-expr-dsl@ 'CExpr.TagKind' to an hs-bindgen 'CTagKind'
 convertTagKind :: CExpr.TagKind -> CTagKind
@@ -98,19 +104,31 @@ instance (
     MacroValue val -> MacroValue (coercePass val)
 
 instance (
-      CoercePass C.Type p p'
+      CoercePassId p p'
+    , ExtBinding p ~ ExtBinding p'
+    ) => CoercePass MacroTypeBodyVar p p' where
+  coercePass = \case
+    MacroTypeExtBinding x -> MacroTypeExtBinding x
+    MacroTypeBodyVar    x -> MacroTypeBodyVar (coercePassId (Proxy @'(p, p')) x)
+
+instance (
+      CoercePassId p p'
+    , ExtBinding p ~ ExtBinding p'
     , Ann "CheckedMacroType" p ~ Ann "CheckedMacroType" p'
     ) => CoercePass CheckedMacroType p p' where
-  coercePass (CheckedMacroType ctype ann) =
-    CheckedMacroType{
-        cType = coercePass ctype
-      , ann   = ann
-      }
+  coercePass (CheckedMacroType (CExpr.CheckedMacroTypeExpr body typ) ann) =
+    let body' = fmap coercePass body
+    in  CheckedMacroType{
+          typ = CExpr.CheckedMacroTypeExpr body' typ
+        , ann = ann
+        }
 
 instance CoercePassId p p' => CoercePass CheckedMacroValue p p' where
-  coercePass (CheckedMacroValue (CExpr.CheckedMacroValueExpr p b t)) =
-    let b' = fmap (coercePassId (Proxy @'(p, p'))) b
-    in  CheckedMacroValue $ CExpr.CheckedMacroValueExpr p b' t
+  coercePass (CheckedMacroValue (CExpr.CheckedMacroValueExpr params body typ)) =
+    let body' = fmap (coercePassId (Proxy @'(p, p'))) body
+    in  CheckedMacroValue{
+            val = CExpr.CheckedMacroValueExpr params body' typ
+          }
 
 {-------------------------------------------------------------------------------
   CoercePass: ConstructTranslationUnit → TypecheckMacros

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Fixtures/TestCases.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Fixtures/TestCases.hs
@@ -80,6 +80,7 @@ commonFixtureStatus tc
       = Just $ FixtureSkip "Expected failure test"
   -- Tests with external binding specs not yet supported
   | "binding-specs/fun_arg/" `isPrefixOf` tc.name
+    || tc.name == "macros/macro_ext_binding_dep"
       = Just $ FixtureSkip "External binding specs not yet supported (issue #1495)"
   -- Trans-dep fixtures deliberately reference a missing module to
   -- exercise the helpful compile-error path; they are not meant to

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Frontend/LanguageC.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Frontend/LanguageC.hs
@@ -279,7 +279,7 @@ prop_reparseGlobal ::
 prop_reparseGlobal input expectedOutput =
     ioProperty $ do
       tokens <- tokenize contents
-      let output = LanC.reparseGlobal Map.empty tokens
+      let output = LanC.reparseGlobal (LanC.ReparseEnv Map.empty Map.empty) tokens
       pure $
         counterexample ("reparser input: " <> contents) $
         tabulate "reparser input" [contents] $

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -34,6 +34,7 @@ testCases = [
     , defaultTest "macros/redeclaration/identical_semantics"
     , defaultTest "macros/undef"
       -- Bespoke tests
+    , test_macros_macro_ext_binding_dep
     , test_macros_macro_type_unresolved_tagged
     , test_macros_macro_in_fundecl
     , test_macros_macro_in_fundecl_vs_typedef
@@ -58,6 +59,13 @@ testCases = [
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
+
+test_macros_macro_ext_binding_dep :: TestCase
+test_macros_macro_ext_binding_dep =
+    defaultTest "macros/macro_ext_binding_dep"
+      & #specExternal .~
+          [ "examples/golden/macros/macro_ext_binding_dep.yaml"
+          ]
 
 test_macros_macro_type_unresolved_tagged :: TestCase
 test_macros_macro_type_unresolved_tagged =


### PR DESCRIPTION
This is a large step towards separating the macro framework; issues
- https://github.com/well-typed/hs-bindgen/issues/942
- https://github.com/well-typed/hs-bindgen/issues/1953

Remove `cType :: C.Type p` from `CheckedMacroType`; replace it with
`typ :: CExpr.CheckedMacroTypeExpr (MacroTypeBodyVar p)`. The new backend
module `HsBindgen.Backend.Hs.Translation.MacroType` translates it directly
to `Hs.HsType`, bypassing the intermediate `C.Type` roundtrip.

`MacroTypeBodyVar p = Either (ExtBinding p) (Id p)`. `ResolveBindingSpecs`
rewrites externally-bound `DeclId` leaves to `ExtBinding`, so the backend
emits correct external references in generated newtype wrappers. Golden test
`macro_ext_binding_dep` exercises a type macro whose body depends on an
externally-bound typedef.

The underlying `C.Type` is still kept for the language-c reparse environment
(temporary; to be resolved).

Further changes: `ReparseEnv` separates `knownTypes` from `knownMacroTypes`;
macro dependency kinds (`ByValue`/`ByRef`) are now correctly propagated
through `Pointer`/`Const` applications; `tcMacro` rejects incomplete type
macros (`void`, `const void` at top level) with `TcIncompleteTypeMacro`.

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
