### PR TITLE
`ReparseMacroExpansions`: add underlying types to macro references

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -209,6 +209,8 @@ library internal
     HsBindgen.Frontend.Pass.Parse.Result
     HsBindgen.Frontend.Pass.Parse.Type
     HsBindgen.Frontend.Pass.ReparseMacroExpansions
+    HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align
+    HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error
     HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
     HsBindgen.Frontend.Pass.ResolveBindingSpecs
     HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Type.hs
@@ -26,6 +26,11 @@ module HsBindgen.Frontend.AST.Type (
   , TypeFunArg
   , TypeFunArgF (..)
   , TypeQual(..)
+
+    -- * References
+  , EnumRef
+  , MacroRef
+  , TypedefRef
   , Ref (..)
 
     -- * Normal forms

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -24,6 +24,7 @@ import HsBindgen.Errors
 import HsBindgen.Frontend.LanguageC.Error qualified as LanC
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId (AnonId, PrelimDeclId)
+import HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error qualified as Align
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer
 
@@ -133,6 +134,12 @@ data DelayedParseMsg =
 
     -- | We could not reparse a fragment of C (to recover macro use sites)
   | ParseMacroErrorReparse LanC.Error
+
+    -- | We could not align the C AST before reparsing with the C AST after
+    -- reparsing
+  | ParseMacroErrorReparseAlign
+      -- | Error that occurred during alignment
+      Align.Error
 
     -- | While reparsing a declaration with a macro expansion, we do not know
     --   the type of an expanded macro.
@@ -363,6 +370,11 @@ instance PrettyForTrace DelayedParseMsg where
           "Failed to reparse: "
         , prettyForTrace x
         ]
+      ParseMacroErrorReparseAlign err -> PP.hsep [
+          "Failed to align the C AST before reparsing with"
+        , "the C AST after reparsing: "
+        , prettyForTrace err
+        ]
       ParseMacroReparseUnknownType x -> PP.hsep [
           "During reparse:"
         , "Unknown type of expanded macro"
@@ -477,6 +489,7 @@ instance IsTrace Level DelayedParseMsg where
       ParseMacroEmpty{}                 -> Info
       ParseMacroErrorParse{}            -> Info
       ParseMacroErrorReparse{}          -> Info
+      ParseMacroErrorReparseAlign x     -> getDefaultLogLevel x
       ParseMacroReparseUnknownType{}    -> Info
       ParsePotentialDuplicateSymbol{}   -> Notice
       ParseDeclarationNotVisible{}      -> Warning
@@ -510,6 +523,7 @@ instance IsTrace Level DelayedParseMsg where
       ParseMacroEmpty{}              -> "parse-macro"
       ParseMacroErrorParse{}         -> "parse-macro"
       ParseMacroErrorReparse{}       -> "parse-macro"
+      ParseMacroErrorReparseAlign e  -> getTraceId e
       ParseMacroReparseUnknownType{} -> "parse-macro"
       _ -> "parse"
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -26,6 +26,7 @@ import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
+import HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -330,34 +331,31 @@ processFunction ::
      C.DeclInfo ReparseMacroExpansions
   -> C.Function TypecheckMacros
   -> M (C.Decl ReparseMacroExpansions)
-processFunction info function =
-    reparseWith info.id LanC.reparseFunDecl function.ann withoutReparse withReparse
+processFunction info function = do
+    function' <- reparseWith info.id LanC.reparseFunDecl function.ann withoutReparse withReparse
+    pure C.Decl {
+        info = info
+      , ann = NoAnn
+      , kind = C.DeclFunction function'
+      }
   where
-    withoutReparse :: C.Decl ReparseMacroExpansions
-    withoutReparse = C.Decl{
-          info = info
-        , ann  = NoAnn
-        , kind = C.DeclFunction C.Function{
-              args  = map coercePass function.args
-            , res   = coercePass function.res
-            , attrs = function.attrs
-            , ann   = NoAnn
-            }
+    withoutReparse :: C.Function ReparseMacroExpansions
+    withoutReparse = C.Function{
+          args  = map coercePass function.args
+        , res   = coercePass function.res
+        , attrs = function.attrs
+        , ann   = NoAnn
         }
 
     withReparse ::
          (([(Maybe Text, CType)] , CType) , Text)
-      -> M (C.Decl ReparseMacroExpansions)
-    withReparse ((tys, ty), _name) = pure C.Decl{
-           info = info
-         , ann  = NoAnn
-         , kind = C.DeclFunction C.Function{
-               args  = map (uncurry mkFunctionArg) tys
-             , res   = ty
-             , attrs = function.attrs
-             , ann   = NoAnn
-             }
-         }
+      -> M (C.Function ReparseMacroExpansions)
+    withReparse ((tys, ty), _name) = pure C.Function{
+          args  = map (uncurry mkFunctionArg) tys
+        , res   = ty
+        , attrs = function.attrs
+        , ann   = NoAnn
+        }
 
     mkFunctionArg :: Maybe Text -> CType -> C.FunctionArg ReparseMacroExpansions
     mkFunctionArg mname typ = C.FunctionArg{
@@ -370,27 +368,24 @@ processGlobal ::
      C.DeclInfo ReparseMacroExpansions
   -> C.Global TypecheckMacros
   -> M (C.Decl ReparseMacroExpansions)
-processGlobal info global =
-    reparseWith info.id LanC.reparseGlobal global.ann withoutReparse withReparse
+processGlobal info global = do
+    global' <- reparseWith info.id LanC.reparseGlobal global.ann withoutReparse withReparse
+    pure C.Decl {
+        info = info
+      , ann = NoAnn
+      , kind = C.DeclGlobal global'
+      }
   where
-    withoutReparse :: C.Decl ReparseMacroExpansions
-    withoutReparse = C.Decl{
-          info = info
-        , ann  = NoAnn
-        , kind = C.DeclGlobal C.Global{
-              typ = coercePass global.typ
-            , ann = NoAnn
-            }
+    withoutReparse :: C.Global ReparseMacroExpansions
+    withoutReparse = C.Global{
+          typ = coercePass global.typ
+        , ann = NoAnn
         }
 
-    withReparse :: CType -> M (C.Decl ReparseMacroExpansions)
-    withReparse ty = pure C.Decl{
-          info = info
-        , ann  = NoAnn
-        , kind = C.DeclGlobal C.Global{
-              typ = ty
-            , ann = NoAnn
-            }
+    withReparse :: CType -> M (C.Global ReparseMacroExpansions)
+    withReparse ty = pure C.Global{
+          typ = ty
+        , ann = NoAnn
         }
 
 {-------------------------------------------------------------------------------
@@ -455,10 +450,14 @@ runM cStd knownTypes knownMacroTypes (WrapM ma) = runReader (runStateT ma s) e
 
 -- | Run reparser if needed; use fallback on failure or if not needed.
 --
--- On failure, records @(declId, ParseMacroErrorReparse e)@ in
+-- On reparsing failure, records @(declId, ParseMacroErrorReparse e)@ in
+-- 'ReparseState.reparseWarnings' and uses the fallback value.
+--
+-- On alignment failure, records @(declId, ParseMacroErrorReparseAlign e)@ in
 -- 'ReparseState.reparseWarnings' and uses the fallback value.
 reparseWith ::
-     DeclId
+     Align r
+  => DeclId
   -> LanC.Parser a
   -> ReparseInfo
   -> r
@@ -481,8 +480,15 @@ reparseWith declId parser reparseInfo fallback onSuccess = case reparseInfo of
           reparseEnv = LanC.ReparseEnv env.knownTypes usedKnownMacros
       case parser reparseEnv tokens of
         Right a -> do
-          modify $ #reparseSuccesses %~ Set.insert declId
-          onSuccess a
+          r <- onSuccess a
+          case alignEither fallback r of
+            Left msgs -> do
+              forM_ msgs $ \msg ->
+                modify $ #reparseWarnings %~ ((declId, msg) :)
+              pure fallback
+            Right r' -> do
+              modify $ #reparseSuccesses %~ Set.insert declId
+              pure r'
         Left  e -> do
           modify $ #reparseWarnings %~ ((declId, ParseMacroErrorReparse e) :)
           pure fallback

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Align.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Align.hs
@@ -1,0 +1,308 @@
+-- | Align the C ASTs before and after reparsing
+--
+-- Intended to be imported qualified:
+--
+-- > import HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error qualified as Align
+module HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align (
+    AlignResult (..)
+  , Align (..)
+  , alignEither
+  ) where
+
+import Control.Monad (zipWithM)
+
+import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.Type qualified as C
+import HsBindgen.Frontend.Pass (IsPass (Ann))
+import HsBindgen.Frontend.Pass.Parse.Msg (DelayedParseMsg (ParseMacroErrorReparseAlign))
+import HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error qualified as Align
+import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass (ReparseMacroExpansions)
+import HsBindgen.Language.C qualified as C
+
+{-------------------------------------------------------------------------------
+  Shorthand
+-------------------------------------------------------------------------------}
+
+type P = ReparseMacroExpansions
+
+{-------------------------------------------------------------------------------
+  AlignResult
+-------------------------------------------------------------------------------}
+
+-- | The result of the 'align' function is either a successfully aligned value,
+-- or an 'AlignError'.
+--
+-- Note: this type is equivalent to @Either Alignerror a@
+data AlignResult a =
+    AlignSuccess a
+  | AlignFailure [Align.Error]
+  deriving stock Functor
+
+instance Applicative AlignResult where
+  pure = AlignSuccess
+  AlignSuccess f <*> m  = fmap f m
+  AlignFailure e <*> _m = AlignFailure e
+
+instance Monad AlignResult where
+  AlignSuccess x >>= k = k x
+  AlignFailure e >>= _ = AlignFailure e
+
+success :: a -> AlignResult a
+success = AlignSuccess
+
+failure :: [Align.Error] -> AlignResult a
+failure = AlignFailure
+
+checkEq :: (Show a, Eq a) => a -> a -> AlignResult a
+checkEq lhs rhs
+  | lhs == rhs = success rhs
+  | otherwise = failure $ Align.errNotEqual lhs rhs
+
+{-------------------------------------------------------------------------------
+  Class
+-------------------------------------------------------------------------------}
+
+-- | Align the C ASTs before and after rearsing
+--
+-- The reparser parses raw @libclang@ tokens and replaces parts of the C AST
+-- with the parse results. To ensure correct Haskell bindings, this replacement
+-- must adhere to certain rules. For example, if we have a global variable of
+-- type @int@ before reparsing, then it is fine if the reparser replaces that
+-- @int@ with some syntactical sugar (e.g., a @typedef@) representing an @int@.
+-- However, it is not okay to replace that @int@ by a reference to a @struct@,
+-- for example.
+--
+-- The 'align' function operates recursively on sub-trees of C ASTs. It takes a
+-- tree from before reparsing, \( t_{pre} \), and a tree from after reparsing,
+-- \( t_{post} \), and produces an aligned tree, \( t_{aligned} \). Firstly, the
+-- 'align' function checks that \( t_{pre} \) has undergone a small set of
+-- allowed modifications with respect to \( t_{post} \). Moreover, 'align'
+-- combines information from both trees to produce a new \( t_{aligned} \),
+-- which is sometimes necessary because the reparser has access to limited
+-- information that is readily available in \( t_{pre} \).
+--
+-- For the most part, the process of 'align' is simple:
+--
+-- * It checks that the root nodes of \( t_{pre} \) and \( t_{post} \) are of
+--   the same type (for example, a 'C.TypeFun').
+-- * If the root nodes are of the same type, then recursively align sub-trees.
+-- * If that was successful, produce a new \( t_{align} \) from the recursively
+--   aligned sub-trees with the same type of root node as before.
+-- * If any previous step fails, we return an error.
+--
+-- There are also more interesting cases (that only apply to C types):
+--
+-- * Before reparsing, there are no references to macro types, but after
+--   reparsing there may be. As such, if \( t_{pre} \) is a C type, and \( t_{post} \)
+--   is a reference to a macro type, then we consider the trees to be
+--   aligned. However, the reparser does not know what the underlying type of
+--   the macro reference is, but we know that the underlying type is precisely
+--   the C type that was replaced. So, 'align' produces a \( t_{align} \) that
+--   is the macro reference from \( t_{post} \) with \( t_{pre} \) as the
+--   underlying type.
+--
+-- * Before reparsing, all @char@ C types have a /known/ implicit sign. The
+--   reparser is not smart enough to do the same, and only produces /unknown/
+--   implicit signs. In such cases, \( t_{pre} \) and \( t_{post} \) are
+--   considered to be aligned, but we produce \( t_{pre} \) as \( t_{aligned} \),
+--   so that the implicit sign is also known from this point onward.
+--
+-- NOTE: This alignment algorithm assumes that the reparser only produces
+-- \( t_{post} \) that differ from \( t_{pre} \) exactly at single nodes in our
+-- tree representation of the C AST. This assumption is warrented: the reparser
+-- only replaces nodes in our tree representation of C types with macro
+-- reference sugar, which behave just like @typedef@s. If the reparser were
+-- changed in the future to produce \( t_{post} \) that are more generally
+-- allowed to differ from \( t_{pre} \), then this algorithm might not work
+-- anymore.
+--
+-- NOTE: the description of PR #1979 describes historically why we implemented
+-- the 'align' function, which mainly had to do with supporting underlying types
+-- for macro references.
+--
+-- <https://github.com/well-typed/hs-bindgen/pull/1979>
+--
+class Align a where
+  align :: a -> a -> AlignResult a
+
+alignEither :: Align a => a -> a -> Either [DelayedParseMsg] a
+alignEither x y =
+    case align x y of
+      AlignFailure es -> Left $ fmap ParseMacroErrorReparseAlign es
+      AlignSuccess z -> Right z
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+instance Align (C.StructField P) where
+  align field1 field2 = do
+      typ' <- align field1.typ field2.typ
+      ann' <- checkEq field1.ann field2.ann
+      offset' <- checkEq field1.offset field2.offset
+      width' <- checkEq field1.width field2.width
+      info' <- checkEq field1.info field2.info
+      pure C.StructField {
+          typ = typ'
+        , ann = ann'
+        , offset = offset'
+        , width = width'
+        , info = info'
+        }
+
+instance Align (C.UnionField P)where
+  align field1 field2 = do
+      typ' <- align field1.typ field2.typ
+      ann' <- checkEq field1.ann field2.ann
+      info' <- checkEq field1.info field2.info
+      pure C.UnionField {
+          typ = typ'
+        , ann = ann'
+        , info = info'
+        }
+
+instance Align (C.Function P) where
+  align fun1 fun2 = do
+      args' <- align fun1.args fun2.args
+      res' <- align fun1.res fun2.res
+      attrs' <- checkEq fun1.attrs fun2.attrs
+      ann' <- checkEq fun1.ann fun2.ann
+      pure C.Function {
+          args = args'
+        , res = res'
+        , attrs = attrs'
+        , ann = ann'
+        }
+
+instance Align [C.FunctionArg P] where
+  align = zipWithM align
+
+instance Align (C.FunctionArg P) where
+  align arg1 arg2 = do
+      name' <- checkEq arg1.name arg2.name
+      argTyp' <- align arg1.argTyp arg2.argTyp
+      pure C.FunctionArg {
+          name = name'
+        , argTyp = argTyp'
+        }
+
+instance Align (C.Global P) where
+  align global1 global2 = do
+      typ' <- align global1.typ global2.typ
+      ann' <- checkEq global1.ann global2.ann
+      pure C.Global {
+          typ = typ'
+        , ann = ann'
+        }
+
+instance Align (C.Type P) where
+  align t1 t2 = case (t1, t2) of
+      -- impossible case: macro references don't exist in our C AST before
+      -- reparsing
+      (C.TypeMacro m1, _) -> failure $ Align.errMacroRefBefore m1 t1 t2
+
+      -- interesting case: an arbitrary type is replaced by a macro reference
+      (_, C.TypeMacro m2) -> do
+        underlying' <- align t1 m2.underlying
+        success $ C.TypeMacro C.Ref {
+            name = m2.name
+          , underlying = underlying'
+          }
+
+      -- boring recursive cases
+      (C.TypePrim pt1, C.TypePrim pt2) ->
+        C.TypePrim <$> align pt1 pt2
+      (C.TypeComplex pt1, C.TypeComplex pt2) ->
+        C.TypeComplex <$> align pt1 pt2
+      (C.TypeRef id1, C.TypeRef id2) ->
+        C.TypeRef <$> checkEq id1 id2
+      (C.TypeEnum e1, C.TypeEnum e2) ->
+        C.TypeEnum <$> alignEnumRef e1 e2
+      (C.TypeTypedef td1, C.TypeTypedef td2) ->
+        C.TypeTypedef <$> alignTypedefRef td1 td2
+      (C.TypePointers n1 t1', C.TypePointers n2 t2') ->
+        C.TypePointers <$> checkEq n1 n2 <*> align t1' t2'
+      (C.TypeConstArray n1 et1, C.TypeConstArray n2 et2) ->
+        C.TypeConstArray <$> checkEq n1 n2 <*> align et1 et2
+      (C.TypeIncompleteArray et1, C.TypeIncompleteArray et2) ->
+        C.TypeIncompleteArray <$> align et1 et2
+      (C.TypeFun args1 res1, C.TypeFun args2 res2) ->
+        C.TypeFun <$> zipWithM align args1 args2 <*> align res1 res2
+      (C.TypeVoid, C.TypeVoid) ->
+        pure C.TypeVoid
+      (C.TypeBlock t1', C.TypeBlock t2') ->
+        C.TypeBlock <$> align t1' t2'
+      (C.TypeQual q1 t1', C.TypeQual q2 t2') ->
+        C.TypeQual <$> align q1 q2 <*> align t1' t2'
+
+      -- fail in any other case
+      (_, _) -> failure $ Align.errNotAligned t1 t2
+    where
+      _coveredAllCases :: C.Type P -> ()
+      _coveredAllCases = \case
+        C.TypePrim{} -> ()
+        C.TypeComplex{} -> ()
+        C.TypeRef{} -> ()
+        C.TypeEnum{} -> ()
+        C.TypeMacro{} -> ()
+        C.TypeTypedef{} -> ()
+        C.TypePointers{} -> ()
+        C.TypeConstArray{} -> ()
+        C.TypeIncompleteArray{} -> ()
+        C.TypeFun{} -> ()
+        C.TypeVoid{} -> ()
+        C.TypeBlock{} -> ()
+        C.TypeQual{} -> ()
+
+instance Align C.TypeQual where
+  align C.QualConst C.QualConst = success C.QualConst
+
+instance Align C.PrimType where
+  align t1 t2 = case (t1, t2) of
+      (C.PrimChar csign1, C.PrimChar csign2) ->
+          C.PrimChar <$> align csign1 csign2
+      _ -> checkEq t1 t2
+    where
+      _coveredAllCases :: C.PrimType -> ()
+      _coveredAllCases = \case
+        C.PrimChar{}     -> ()
+        C.PrimIntegral{} -> ()
+        C.PrimFloating{} -> ()
+        C.PrimBool{}     -> ()
+
+instance Align C.PrimSignChar where
+  align csign1 csign2 = case (csign1, csign2) of
+      -- interesting case: the reparser does not know the sign of a character
+      -- when it is implicit, but @libclang@ does know this
+      (C.PrimSignImplicit (Just psign1), C.PrimSignImplicit Nothing) ->
+        pure $ C.PrimSignImplicit (Just psign1)
+      _ -> checkEq csign1 csign2
+    where
+      _coveredAllCases :: C.PrimSignChar -> ()
+      _coveredAllCases = \case
+          C.PrimSignExplicit{} -> ()
+          C.PrimSignImplicit{} -> ()
+
+instance Align (C.TypeFunArg P) where
+  align arg1 arg2 =
+      C.TypeFunArgF <$> align arg1.typ arg2.typ <*> alignAnnTypeFunArg arg1.ann arg2.ann
+
+alignEnumRef ::
+     C.EnumRef P
+  -> C.EnumRef P
+  -> AlignResult (C.EnumRef P)
+alignEnumRef ref1 ref2 =
+    C.Ref <$> checkEq ref1.name ref2.name <*> align ref1.underlying ref2.underlying
+
+alignTypedefRef ::
+     C.EnumRef P
+  -> C.EnumRef P
+  -> AlignResult (C.EnumRef P)
+alignTypedefRef ref1 ref2 =
+    C.Ref <$> checkEq ref1.name ref2.name <*> align ref1.underlying ref2.underlying
+
+alignAnnTypeFunArg ::
+     Ann "TypeFunArg" P
+  -> Ann "TypeFunArg" P
+  -> AlignResult (Ann "TypeFunArg" P)
+alignAnnTypeFunArg ann1 ann2 = checkEq ann1 ann2

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Align/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Align/Error.hs
@@ -1,0 +1,108 @@
+-- | Errors arising while aligning C ASTs before and after reparsing
+--
+-- Defined in its own module to avoid cyclic module dependencies.
+--
+-- Intended to be imported qualified:
+--
+-- > import HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error qualified as Align
+module HsBindgen.Frontend.Pass.ReparseMacroExpansions.Align.Error (
+    Error(..)
+  , errMacroRefBefore
+  , errNotAligned
+  , errNotEqual
+  ) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Text.SimplePrettyPrint qualified as PP
+
+import HsBindgen.Frontend.AST.Type (MacroRef, Ref (name))
+import HsBindgen.Frontend.Naming (CDeclName (text), DeclId (name))
+import HsBindgen.Frontend.Pass (IsPass (MacroId))
+import HsBindgen.Util.Tracer (IsTrace (..), Level (Bug, Debug, Info),
+                              PrettyForTrace (..), Source (HsBindgen))
+
+{-------------------------------------------------------------------------------
+  Type
+-------------------------------------------------------------------------------}
+
+-- | Errors arising while aligning C ASTs before and after reparsing
+data Error =
+    -- | Encountered unexpected reference to a macro in a C type before
+    -- reparsing
+    --
+    -- References to a macro type should only exist /after/ reparsing
+    MacroRefExistsBeforeReparsing
+      -- | Name of the referenced macro
+      Text
+    -- | Expected two sub-trees to be aligned, but they were not
+  | SubTreesNotAligned
+    -- | Expected two sub-trees to be equal, but they were not
+  | SubTreesNotEqual
+    -- | Printed LHS sub-tree
+  | SubTreeLHS Text
+    -- | Printed RHS sub-tree
+  | SubTreeRHS  Text
+  deriving stock (Show, Eq)
+
+-- | Smart constructor for 'MacroRefExistsBeforeReparsing'
+errMacroRefBefore ::
+     (MacroId p ~ DeclId, Show a)
+  => MacroRef p -> a -> a -> [Error]
+errMacroRefBefore ref lhs rhs =
+    withDebugTraces lhs rhs $ MacroRefExistsBeforeReparsing ref.name.name.text
+
+-- | Smart constructor for 'SubTreesNotAligned'
+errNotAligned :: Show a => a -> a -> [Error]
+errNotAligned lhs rhs = withDebugTraces lhs rhs SubTreesNotAligned
+
+-- | Smart constructor for 'SubTreesNotEqual'
+errNotEqual :: Show a => a -> a -> [Error]
+errNotEqual lhs rhs = withDebugTraces lhs rhs SubTreesNotEqual
+
+-- | Add debug trace messages that print the LHS and RHS sub-trees at the point
+-- where alignment failed
+withDebugTraces :: (Show a, Show b) => a -> b -> Error -> [Error]
+withDebugTraces lhs rhs err = concat [
+      [ err ]
+    , [ SubTreeLHS $ Text.pack $ show lhs
+      , SubTreeRHS $ Text.pack $ show rhs
+      ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Tracing
+-------------------------------------------------------------------------------}
+
+instance PrettyForTrace Error where
+  prettyForTrace = \case
+    MacroRefExistsBeforeReparsing macroName -> PP.hsep [
+          "Encountered unexpected reference to macro"
+        , PP.text macroName
+        , "in a C type before reparsing."
+        ]
+    SubTreesNotAligned -> PP.hsep [
+          "Expected two sub-trees in the C ASTs before and after reparsing to be"
+        , "aligned, but they were not."
+        ]
+    SubTreesNotEqual -> PP.hsep [
+          "Expected two sub-trees in the C ASTs before and after reparsing to be"
+        , "equal, but they were not."
+        ]
+    SubTreeLHS lhs -> "Sub-tree before reparsing:" PP.<+> PP.text lhs
+    SubTreeRHS rhs -> "Sub-tree after reparsing:" PP.<+> PP.text rhs
+
+instance IsTrace Level Error where
+  getDefaultLogLevel = \case
+      -- This is a genuine bug in our implementation, because macro references
+      -- should not exist in our C AST before reparsing
+      MacroRefExistsBeforeReparsing{} -> Bug
+      -- Reparsing is best effort, so we report "regular" failures at 'Info'
+      -- level rather than a higher verbosity level
+      SubTreesNotAligned{}            -> Info
+      SubTreesNotEqual{}              -> Info
+      -- Sub-trees are useful for debugging
+      SubTreeLHS{} -> Debug
+      SubTreeRHS{} -> Debug
+  getSource = const HsBindgen
+  getTraceId = const "reparse-align"


### PR DESCRIPTION
The goal of #1953 is to avoid converting parsed macros to C types. As a result, macro-defined types (or just macro types) would only have to be translated to Haskell. The C type language is not very powerful, but the Haskell type language is. Without the intermediate conversion to C types we could parse macros as polymorphic types for example:

```c
// A can not be written as a C typedef!
#define A(x) x * 
```
```hs
-- but A can be translated to Haskell!
newtype A x = A (Ptr x) 
```

Removing the conversion to C types is somewhat tricky because we have an invariant on C types that we can always look through "sugar" like references to macro-defined types (or typedefs) to inspect the *underlying* C type of that reference. If we don't translate macros to C types directly, then we also lose the ability to easily get the underlying C type of a reference to a macro type.

For monomorphic macro types, the underlying type of a reference to a macro type is always going to be the same. However, with polymorphic macro types (like `A`), the underlying type depends on the use site. For example, the (underlying) type of global variable `x` is an `int`, whereas the underlying type of global variable `y` is `char`, even though both global variables reference the same macro. So at the point where we parse a macro, we may not know the underlying type anyway. Only at use sites the underlying type becomes clear.

```c
A(int) x;
A(char) y;
```

Underlying types are important for `hs-bindgen`. Underlying types allow us to desugar C types, which we inspect to determine requirements for the Haskell bindings. For example, we look at underlying types to decide whether a function argument/result has to be passed by a pointer or not. Such is the case if the underlying type is a struct. So it is important to still be able desugar types after we resolve #1953, or we might produce incorrect Haskell bindings.

The `ReparseMacroExpansions` pass takes care of reparsing raw `libclang` tokens. The parse results (primarily types) are used to replace parts of the C AST. These new types may now contain references to macro types for which we do not know the underlying type. One important observation is this: we know what the C AST was before and after replacing parts of the C AST. If we replace a type with a reference  to a macro-defined type, then the underlying type *must* be the the type we replaced!

This PR makes use of this observation. We add a `fixup` function that compares the C AST before and after reparsing, and enhances references to macro types in the after-AST with underlying types taken from the before-AST. 

Note: this `fixup` function is generally useful as a sanity check, even if we don't go with this approach of adding underlying types to macro references. For example, it checks that we don't do anything silly like replacing an `int` with a reference to a struct. The check even found a bug where a macro expanion is parsed as an argument name:

```c
#define A const
void foo (int A);
```

The reparser thinks `A` is an argument name and discards the `const` qualifier. The `fixup` function catches this case and prevents us from adopting the wrong type

EDIT: note that `fixup` is now renamed to `align`