### PR TITLE
Update comment in hs-bindgen-dev.nix with the new nixos wiki link

### DIFF
--- a/nix/hs-bindgen-dev.nix
+++ b/nix/hs-bindgen-dev.nix
@@ -48,7 +48,7 @@ let
       # only Clang), the GCC includes end up in BINDGEN_EXTRA_CLANG_ARGS which
       # is suboptimal. We could use a `clangStdenv` Nixpkgs overlay, but that
       # requires recompilation of the complete toolchain; see, e.g.,
-      # https://nixos.wiki/wiki/Using_Clang_instead_of_GCC.
+      # https://wiki.nixos.org/wiki/Using_Clang_instead_of_GCC.
       pkgsOverlay.hsBindgenHook
     ]
     ++


### PR DESCRIPTION
I'm working on replacing all references to `nixos.wiki` with `wiki.nixos.org` across all nix-related repos. This increases visibility of the official wiki so that someday there will no longer be any confusion.