### PR TITLE
CLI: add --log-squashed-as-info flag to silence squash notices

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### New features
 
+* A new CLI option `--log-squashed-as-info` (and matching
+  `CustomLogLevelSetting` constructor `MakeMangleNamesSquashedInfo`) demotes
+  the `select-mangle-names-squashed` trace from `Notice` to `Info`, so the
+  per-typedef squash messages no longer appear at the default verbosity.
+  See [#1574](https://github.com/well-typed/hs-bindgen/issues/1574).
 * When using the Template Haskell backend, external types referenced via
   external binding specifications that are not in scope now produce a helpful
   compile error suggesting the missing import.

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -115,9 +115,11 @@ parseCustomLogLevel = do
     makeBugsErrors     <- optional parseMakeBugsErrors
     makeWarningsErrors <- optional parseMakeWarningsErrors
     -- Specific setters
-    enableMacroWarnings <- optional parseEnableMacroWarnings
+    enableMacroWarnings         <- optional parseEnableMacroWarnings
+    makeMangleNamesSquashedInfo <- optional parseMakeMangleNamesSquashedInfo
     pure $ getCustomLogLevel $ catMaybes [
         enableMacroWarnings
+      , makeMangleNamesSquashedInfo
       , makeBugsErrors
       , makeWarningsErrors
       ]
@@ -154,6 +156,16 @@ parseCustomLogLevel = do
           , " (default: info)"
           ]
       ]
+
+    parseMakeMangleNamesSquashedInfo :: Parser CustomLogLevelSetting
+    parseMakeMangleNamesSquashedInfo =
+        flag' MakeMangleNamesSquashedInfo $ mconcat [
+            long "log-squashed-as-info"
+          , help $ concat [
+                "Set log level of squashed-typedef traces to info"
+              , " (default: notice)"
+              ]
+          ]
 
 parseShowTimeStamp :: Parser ShowTimeStamp
 parseShowTimeStamp = flag DisableTimeStamp EnableTimeStamp $ mconcat [

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -94,6 +94,16 @@ data CustomLogLevelSetting =
     -- implementations. Using this custom log level setting, users make them
     -- 'Warning' instead.
   | EnableMacroWarnings
+
+    -- | Set the log level of squashed-typedef traces (trace id
+    -- @select-mangle-names-squashed@) to 'Info'.
+    --
+    -- By default, the 'Select' pass reports squashed typedefs at log level
+    -- 'Notice', which is visible at the default verbosity. Headers that
+    -- chain many typedefs can produce a lot of these messages; this setting
+    -- demotes them to 'Info' so they are hidden at default verbosity but
+    -- still visible with @-v3@.
+  | MakeMangleNamesSquashedInfo
   deriving stock (Eq, Show, Ord)
 
 -- | Get a custom log level function from a set of available settings.
@@ -113,13 +123,16 @@ fromSetting ::
   -> CustomLogLevel Level TraceMsg
 fromSetting = \case
     -- Generic setters.
-    MakeTrace level traceId -> makeTrace level traceId
+    MakeTrace level traceId     -> makeTrace level traceId
     -- Generic modifiers.
-    MakeWarningsErrors      -> makeLevelErrors Warning
+    MakeWarningsErrors          -> makeLevelErrors Warning
     -- Generic modifiers.
-    MakeBugsErrors          -> makeLevelErrors Bug
+    MakeBugsErrors              -> makeLevelErrors Bug
     -- Specific setters.
-    EnableMacroWarnings     -> enableMacroWarnings
+    EnableMacroWarnings         -> enableMacroWarnings
+    -- Trace id defined at
+    -- 'HsBindgen.Frontend.Pass.Select.IsPass.SelectMangleNamesSquashed'.
+    MakeMangleNamesSquashedInfo -> makeTrace Info "select-mangle-names-squashed"
   where
     makeTrace :: Level -> TraceId -> CustomLogLevel Level TraceMsg
     makeTrace desiredLevel traceId = CustomLogLevel $ \trace actualLevel ->


### PR DESCRIPTION
Closes #1574 