### PR TITLE
Skip CXCursor_DLLImport / CXCursor_DLLExport when parsing

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -112,6 +112,12 @@
   declarations carrying macro expansions and attribute specifier sequences
   failed to reparse and silently fell back to the un-reparsed type, dropping
   macro typedef names from generated bindings. See [PR #1955][pr-1955].
+* Silently ignore `__declspec(dllimport)` and `__declspec(dllexport)` attribute
+  cursors (`CXCursor_DLLImport` / `CXCursor_DLLExport`) when parsing function,
+  variable, and enum declarations. Previously, these cursors triggered a
+  `Bug`-level `Unexpected cursor kind` trace on Windows for every CRT
+  declaration carrying `__declspec(dllimport)`. See [issue
+  #1910](https://github.com/well-typed/hs-bindgen/issues/1910).
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -119,6 +119,11 @@ parseDecl' enclosing mCtx = withCursorKindNoCtx $ \case
       -- @visibility@ attributes. The visibility itself the value could be
       -- obtained using 'getCursorVisibility'.
       Right CXCursor_VisibilityAttr     -> \_curr -> foldContinue
+      -- Windows @__declspec(dllimport)@ / @__declspec(dllexport)@ attributes.
+      -- These do not affect the generated Haskell bindings: foreign imports
+      -- are resolved by the linker regardless of the DLL annotation.
+      Right CXCursor_DLLImport          -> \_curr -> foldContinue
+      Right CXCursor_DLLExport          -> \_curr -> foldContinue
 
       -- Report error for declarations we don't recognize
       eKind -> case mCtx of
@@ -487,6 +492,10 @@ enumDecl _enclosing ctx info = \curr -> do
                   -- @visibility@ attributes. The visibility itself the value can be
                   -- obtained using 'getCursorVisibility'.
                   Right CXCursor_VisibilityAttr -> foldContinue
+                  -- Windows @__declspec(dllimport)@ / @__declspec(dllexport)@.
+                  -- These don't affect the generated Haskell bindings.
+                  Right CXCursor_DLLImport -> foldContinue
+                  Right CXCursor_DLLExport -> foldContinue
                   unexpectedKind -> foldContinueWith
                     (Left $ ParseUnexpectedCursorKind unexpectedKind)
 
@@ -656,6 +665,11 @@ functionDecl enclosing ctx info =
           -- obtained using 'getCursorVisibility'.
           Right CXCursor_VisibilityAttr -> foldContinue
 
+          -- Windows @__declspec(dllimport)@ / @__declspec(dllexport)@
+          -- attributes. These do not affect the generated Haskell bindings.
+          Right CXCursor_DLLImport -> foldContinue
+          Right CXCursor_DLLExport -> foldContinue
+
           -- Attributes we (probably?) want to ignore
           Right CXCursor_WarnUnusedResultAttr -> foldContinue
 
@@ -790,6 +804,11 @@ varDecl enclosing ctx info = do
           -- @visibility@ attributes, where the value is obtained using
           -- @clang_getCursorVisibility@.
           CXCursor_VisibilityAttr -> skip
+
+          -- Windows @__declspec(dllimport)@ / @__declspec(dllexport)@
+          -- attributes. These do not affect the generated Haskell bindings.
+          CXCursor_DLLImport -> skip
+          CXCursor_DLLExport -> skip
 
           -- We are not interested in assembler labels.
           CXCursor_AsmLabelAttr -> skip


### PR DESCRIPTION
On Windows, shared code lives in DLLs. When a program calls a function that lives in a DLL, the Windows loader populates an [Import Address Table (IAT)](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format) at load time, and calls are dispatched through it. [`__declspec(dllimport)`](https://learn.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport?view=msvc-170) is a hint on a C declaration that tells the C compiler that the definition is in a DLL, so it should emit an IAT-indirect call directly. Without the hint, the compiler still emits a working call, but the hint avoids an indirection layer. [`__declspec(dllexport)`](https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170) is the mirror: it goes on a definition and tells the linker to include the symbol in the DLL's export table.

These attributes appear in Windows system headers.

hs-bindgen generates Haskell FFI bindings, and [Haskell's FFI](https://downloads.haskell.org/ghc/9.8.1/docs/users_guide/exts/ffi.html) has no analogue of `__declspec(dllimport)`. A `foreign import` references a symbol by name and leaves resolution to the system linker. When a Haskell program links against `msvcrt.lib` on Windows, the linker arranges the IAT correctly whether or not the original C declaration carried `__declspec(dllimport)`. The attribute is therefore information that has no destination in the generated bindings.

Before this PR, the parser didn't recognise [these cursor kinds](https://www.mail-archive.com/cfe-commits@lists.llvm.org/msg09773.html) and treated them as a possible bug. This PR skips these cursor kinds.

Closes #1910 